### PR TITLE
fix: preserve function signature in diagnostics wrapper for correct schema generation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -82,17 +82,21 @@ def permissioned_tool(*d_args, **d_kwargs):  # acts like @server.tool
                     param_type = "string"  # default
                     if param.annotation != inspect.Parameter.empty:
                         ann = param.annotation
-                        # Basic type mapping
-                        if ann in (int, "int"):
+                        # Handle generic types like Dict[str, Any], List[str]
+                        from typing import get_origin
+
+                        origin = get_origin(ann)
+                        # Basic type mapping (check origin first for generics)
+                        if origin is dict or ann in (dict, "dict"):
+                            param_type = "object"
+                        elif origin is list or ann in (list, "list"):
+                            param_type = "array"
+                        elif ann in (int, "int"):
                             param_type = "integer"
                         elif ann in (bool, "bool"):
                             param_type = "boolean"
                         elif ann in (float, "float"):
                             param_type = "number"
-                        elif ann in (list, "list"):
-                            param_type = "array"
-                        elif ann in (dict, "dict"):
-                            param_type = "object"
 
                     properties[param_name] = {"type": param_type}
 

--- a/src/tools_manifest.json
+++ b/src/tools_manifest.json
@@ -82,7 +82,7 @@
         "input": {
           "properties": {
             "policy_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -99,7 +99,7 @@
         "input": {
           "properties": {
             "network_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -116,7 +116,7 @@
         "input": {
           "properties": {
             "port_forward_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -133,7 +133,7 @@
         "input": {
           "properties": {
             "qos_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -153,7 +153,7 @@
               "type": "boolean"
             },
             "policy": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -173,7 +173,7 @@
               "type": "boolean"
             },
             "rule": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -193,7 +193,7 @@
               "type": "boolean"
             },
             "rule": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -213,7 +213,7 @@
               "type": "boolean"
             },
             "route": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -230,7 +230,7 @@
         "input": {
           "properties": {
             "route_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -247,7 +247,7 @@
         "input": {
           "properties": {
             "wlan_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -930,7 +930,7 @@
               "type": "string"
             },
             "update_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -954,7 +954,7 @@
               "type": "string"
             },
             "update_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -978,7 +978,7 @@
               "type": "string"
             },
             "update_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -1002,7 +1002,7 @@
               "type": "string"
             },
             "update_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -1026,7 +1026,7 @@
               "type": "string"
             },
             "update_data": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
@@ -1089,7 +1089,7 @@
               "type": "boolean"
             },
             "update_data": {
-              "type": "string"
+              "type": "object"
             },
             "wlan_id": {
               "type": "string"

--- a/src/utils/diagnostics.py
+++ b/src/utils/diagnostics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+import inspect
 import json
 import logging
 import os
@@ -144,6 +146,13 @@ def log_tool_call(
 
 
 def wrap_tool(func, tool_name: str):
+    """Wrap a tool function with diagnostics logging.
+
+    IMPORTANT: Preserves the original function's signature so that FastMCP
+    can correctly generate the JSON schema for tool parameters.
+    """
+
+    @functools.wraps(func)
     async def _wrapper(*args, **kwargs):
         if not diagnostics_enabled():
             return await func(*args, **kwargs)
@@ -164,6 +173,8 @@ def wrap_tool(func, tool_name: str):
                 # Never let diagnostics break the tool
                 pass
 
+    # Preserve the original function's signature for FastMCP schema generation
+    _wrapper.__signature__ = inspect.signature(func)
     return _wrapper
 
 


### PR DESCRIPTION
## Summary
- Fixed `wrap_tool` in `diagnostics.py` to preserve the original function's signature using `functools.wraps` and explicit `__signature__` copying
- Fixed type inference in `main.py` to correctly identify generic types like `Dict[str, Any]` as `"object"` instead of `"string"`
- Regenerated `tools_manifest.json` with correct schemas

## Problem
The diagnostics wrapper was replacing the original function signature with `(*args, **kwargs)`, causing FastMCP to generate incorrect JSON schemas. Tools with `Dict[str, Any]` parameters (like `create_simple_port_forward`) were showing:

```json
{
  "inputSchema": {
    "properties": {
      "args": { "type": "string" },
      "kwargs": { "type": "string" }
    }
  }
}
```

Instead of the correct schema:

```json
{
  "inputSchema": {
    "properties": {
      "rule": { "type": "object" },
      "confirm": { "type": "boolean" }
    }
  }
}
```

## Solution
1. Use `functools.wraps(func)` decorator on the wrapper function
2. Explicitly copy `__signature__` from the original function so FastMCP can correctly introspect parameters
3. Use `typing.get_origin()` to detect generic types like `Dict[str, Any]`

## Test plan
- [x] Tested with `create_simple_port_forward` - now correctly accepts `{"rule": {...}, "confirm": false}` instead of erroring with `_wrapperArguments` validation errors
- [x] Verified schema generation via MCP `tools/list` endpoint
- [x] Regenerated manifest with correct schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)