### PR TITLE
feat: add unifi_delete_network and unifi_delete_wlan tools

### DIFF
--- a/src/tools_manifest.json
+++ b/src/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 81,
+  "count": 83,
   "generated_by": "scripts/generate_tool_manifest.py",
   "note": "Auto-generated with full schemas from tool decorators. Do not edit manually.",
   "tools": [
@@ -356,6 +356,46 @@
           },
           "required": [
             "wlan_data"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "Delete a network (LAN/VLAN) from the UniFi controller. WARNING: This is a destructive operation that cannot be undone. All clients on this network will be disconnected. Requires confirmation.",
+      "name": "unifi_delete_network",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "type": "boolean"
+            },
+            "network_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "network_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "Delete a wireless network (WLAN/SSID) from the UniFi controller. WARNING: This is a destructive operation that cannot be undone. All wireless clients on this SSID will be disconnected. Requires confirmation.",
+      "name": "unifi_delete_wlan",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "type": "boolean"
+            },
+            "wlan_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "wlan_id"
           ],
           "type": "object"
         }

--- a/src/utils/lazy_tool_loader.py
+++ b/src/utils/lazy_tool_loader.py
@@ -86,11 +86,11 @@ _STATIC_TOOL_MODULE_MAP: Dict[str, str] = {
     "unifi_power_cycle_port": "src.tools.devices",
     "unifi_set_port_profile": "src.tools.devices",
     # Network tools
-    "unifi_list_networks": "src.tools.networks",
-    "unifi_get_network_details": "src.tools.networks",
-    "unifi_create_network": "src.tools.networks",
-    "unifi_update_network": "src.tools.networks",
-    "unifi_delete_network": "src.tools.networks",
+    "unifi_list_networks": "src.tools.network",
+    "unifi_get_network_details": "src.tools.network",
+    "unifi_create_network": "src.tools.network",
+    "unifi_update_network": "src.tools.network",
+    "unifi_delete_network": "src.tools.network",
     # Firewall tools
     "unifi_list_firewall_rules": "src.tools.firewall",
     "unifi_get_firewall_rule": "src.tools.firewall",
@@ -179,6 +179,7 @@ _STATIC_TOOL_MODULE_MAP: Dict[str, str] = {
     "unifi_get_wlan_details": "src.tools.network",
     "unifi_create_wlan": "src.tools.network",
     "unifi_update_wlan": "src.tools.network",
+    "unifi_delete_wlan": "src.tools.network",
     # Device tools (additional)
     "unifi_rename_device": "src.tools.devices",
 }

--- a/src/utils/permissions.py
+++ b/src/utils/permissions.py
@@ -60,14 +60,16 @@ def parse_permission(permissions: Dict[str, Any], category: str, action: str) ->
 
     Environment Variable Examples:
         UNIFI_PERMISSIONS_NETWORKS_CREATE=true
+        UNIFI_PERMISSIONS_NETWORKS_DELETE=true
+        UNIFI_PERMISSIONS_WLANS_DELETE=true
         UNIFI_PERMISSIONS_DEVICES_UPDATE=true
         UNIFI_PERMISSIONS_CLIENTS_UPDATE=false
-    """
-    # Never allow delete operations regardless of configuration
-    if action == "delete":
-        logger.info(f"Delete operation requested for category '{category}'. All delete operations are disabled.")
-        return False
 
+    Security Note:
+        Delete operations are disabled by default and require explicit opt-in via
+        environment variable (e.g., UNIFI_PERMISSIONS_NETWORKS_DELETE=true).
+        This prevents accidental destructive operations.
+    """
     # 0. Check environment variable override first (highest priority)
     config_category_key = CATEGORY_MAP.get(category, category)
     env_var = f"UNIFI_PERMISSIONS_{config_category_key.upper()}_{action.upper()}"


### PR DESCRIPTION
## Summary

Adds two new MCP tools for deleting networks and WLANs with comprehensive security safeguards:

- `unifi_delete_network`: Delete LAN/VLAN networks from the UniFi controller
- `unifi_delete_wlan`: Delete wireless SSIDs from the UniFi controller

## Security Features

These tools are designed with defense-in-depth:

1. **Disabled by default** - Requires explicit environment variable opt-in:
   - `UNIFI_PERMISSIONS_NETWORKS_DELETE=true`
   - `UNIFI_PERMISSIONS_WLANS_DELETE=true`

2. **Two-step confirmation** - Returns a preview when `confirm=false` (default), showing exactly what will be deleted with clear warnings

3. **Management network protection** - Prevents deletion of the default/management network that would lock users out

4. **Audit logging** - All delete operations logged at WARNING level

## Changes

- `src/tools/network.py`: Added `delete_network` and `delete_wlan` tool functions
- `src/utils/confirmation.py`: Added `delete_preview()` helper for consistent destructive operation previews
- `src/utils/permissions.py`: Modified to allow delete operations via env var override (previously hardcoded to deny)
- `src/utils/lazy_tool_loader.py`: Fixed static TOOL_MODULE_MAP to use correct module name, added delete tools
- `src/tools_manifest.json`: Regenerated with new tools

## Usage Example

```python
# Preview what will be deleted (safe, no action taken)
unifi_delete_network(network_id="67cd225123e57842221fa7f9")
# Returns: preview with warnings

# Execute deletion after review
unifi_delete_network(network_id="67cd225123e57842221fa7f9", confirm=True)
# Returns: success or error
```

## Test plan

- [x] All 96 existing unit tests pass
- [x] Manifest regenerated successfully with 83 tools
- [x] Linting passes (ruff)
- [x] Code formatted (ruff format)
- [ ] Manual testing with real UniFi controller (requires opt-in env vars)

## Note

The manager methods `delete_network()` and `delete_wlan()` already existed in `NetworkManager` - this PR simply exposes them via MCP tools with appropriate security controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)