### PR TITLE
docs: Document network isolation constraint for UniFi networks

### DIFF
--- a/src/tools/network.py
+++ b/src/tools/network.py
@@ -170,7 +170,7 @@ async def get_network_details(network_id: str) -> Dict[str, Any]:
 
 @server.tool(
     name="unifi_update_network",
-    description="Update specific fields of an existing network (LAN/VLAN). Requires confirmation.",
+    description="Update specific fields of an existing network (LAN/VLAN). Requires confirmation. Note: Network isolation is only supported on 'corporate' networks, not 'guest' networks.",
     permission_category="networks",
     permission_action="update",
 )
@@ -193,8 +193,14 @@ async def update_network(network_id: str, update_data: Dict[str, Any], confirm: 
             - dhcp_start (string): New DHCP start IP.
             - dhcp_stop (string): New DHCP stop IP.
             - enabled (boolean): Enable/disable the entire network.
+            - network_isolation_enabled (boolean): Enable network isolation (IMPORTANT: Only works on networks with purpose="corporate").
             # Add other relevant fields from NetworkSchema here if needed
         confirm (bool): Must be set to `True` to execute. Defaults to `False`.
+
+    Important Constraints:
+        - Network isolation (network_isolation_enabled) is ONLY supported on networks with purpose="corporate".
+        - Attempting to enable isolation on "guest" or other network types will fail with an API error.
+        - To isolate a guest network: (1) Change its purpose from "guest" to "corporate", then (2) enable network_isolation_enabled.
 
     Returns:
         Dict: Success status, ID, updated fields, details, or error message.
@@ -317,6 +323,11 @@ async def create_network(network_data: Dict[str, Any], confirm: bool = False) ->
     - vlan (integer): VLAN ID (required if vlan_enabled is true)
     - dhcp_enabled (boolean): Whether DHCP is enabled (default: true)
     - enabled (boolean): Whether the network is enabled (default: true)
+    - network_isolation_enabled (boolean): Enable network isolation (IMPORTANT: Only works on networks with purpose="corporate")
+
+    Important Constraints:
+    - Network isolation (network_isolation_enabled) is ONLY supported on networks with purpose="corporate".
+    - It cannot be enabled on "guest" networks.
 
     Example:
     {


### PR DESCRIPTION
## Description

Adds explicit documentation for an **undocumented API constraint** in UniFi regarding network isolation.

### The Problem

Users attempting to enable `network_isolation_enabled` on guest networks encounter a cryptic API error:
```
api.err.NetworkIsolationAppliedOnNonCorporateNetwork
```

This occurs because the UniFi API **only supports network isolation on networks with `purpose=\"corporate\"`**, not on "guest" networks. This limitation is **not documented in official Ubiquiti documentation** and only surfaces when using the API programmatically.

### Tested Environment

- **UniFi Network Version:** 9.5.21
- **Controller:** UDMP Rose (UniFi OS)
- **Constraint applies to:** API/programmatic access (UniFi Console UI prevents this by design)

### Solution

Updated tool documentation to clearly explain:
- When network isolation can be used (corporate networks only)
- What error occurs when attempting to use it on guest networks  
- Step-by-step workaround for isolating guest networks
- Version information for debugging and reference

## Changes Made

- **`src/tools/network.py`** (12 insertions)
  - Updated `unifi_update_network` tool description to mention constraint
  - Added "Important Constraints" section to `update_network()` docstring
  - Documented `network_isolation_enabled` parameter with clear warnings
  - Added constraint documentation to `unifi_create_network()` docstring
  - Included workaround steps: change purpose to "corporate" first, then enable isolation

## Verification

- [x] Commit message follows conventional commits format (`docs:` prefix)
- [x] Documentation-only change (no functional code changes)
- [x] Changes are backward compatible
- [x] No new dependencies added
- [x] Tool manifest does not need regeneration (documentation-only)
- [x] Tested and verified on UniFi Network 9.5.21
- [x] Undocumented limitation - not in official Ubiquiti docs or release notes

## Related Issues

Resolves the undocumented API limitation that users discover when attempting to secure guest networks with VLAN isolation through programmatic APIs (MCP, REST, etc.).

## Testing

Documentation-only change - no functional code modifications to test.

Users can verify the documented workaround by:
1. Creating a guest network
2. Attempting to change purpose to "corporate"
3. Then enabling `network_isolation_enabled`

## Note on Undocumented Status

This limitation is **not mentioned in**:
- UniFi Network 9.5.21 release notes
- Official Ubiquiti Help Center documentation on network isolation
- API documentation

It only appears when using the API directly, suggesting the UniFi Console UI prevents this scenario by design (not offering isolation options for guest networks).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>