### PR TITLE
fix: redirect uvicorn access logs to stderr for dual transport support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ CONFIG_PATH="src/config/config.yaml"
 # Security note: Only enable in local development environments
 UNIFI_MCP_HTTP_ENABLED="false"
 
+# Optional: Force HTTP in non-container environments
+# By default, HTTP SSE only starts when running as PID 1 (container main process)
+# Set to 'true' to force HTTP SSE in local development (default: false)
+# UNIFI_MCP_HTTP_FORCE="false"
+
 # Optional: Enable diagnostics/logging
 # Set to 'true' to enable detailed logging for debugging (default: false)
 UNIFI_MCP_DIAGNOSTICS="false"

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ format:
 	@echo "✨ Formatting code..."
 	uv run ruff format src/ tests/
 
+format-fix:
+	uv run ruff check src/ tests/ --fix
+
 format-check:
 	@echo "🔍 Checking code formatting..."
 	uv run ruff format --check src/ tests/

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -51,6 +51,7 @@ server:
 
   http:
     enabled: ${oc.env:UNIFI_MCP_HTTP_ENABLED,false}
+    force: ${oc.env:UNIFI_MCP_HTTP_FORCE,false}
   diagnostics:
     enabled: ${oc.env:UNIFI_MCP_DIAGNOSTICS,false}
     log_tool_args: ${oc.env:UNIFI_MCP_DIAG_LOG_TOOL_ARGS,true}

--- a/src/utils/config_helpers.py
+++ b/src/utils/config_helpers.py
@@ -1,0 +1,38 @@
+"""Configuration parsing utilities.
+
+This module provides helpers for parsing configuration values that may come
+from OmegaConf-resolved environment variables (which can be strings like
+"true"/"false") or direct boolean values.
+"""
+
+from typing import Any
+
+
+def parse_config_bool(value: Any, default: bool = False) -> bool:
+    """Parse a config value as boolean, handling string values from env vars.
+
+    OmegaConf resolves ${oc.env:VAR,default} to strings when the env var is set,
+    so "true"/"false" strings need to be parsed explicitly.
+
+    Args:
+        value: The config value to parse (string, bool, or None)
+        default: Default value if value is None
+
+    Returns:
+        Boolean interpretation of the value
+
+    Examples:
+        >>> parse_config_bool("true")
+        True
+        >>> parse_config_bool("false")
+        False
+        >>> parse_config_bool(True)
+        True
+        >>> parse_config_bool(None, default=True)
+        True
+    """
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)

--- a/tests/unit/test_allowed_hosts.py
+++ b/tests/unit/test_allowed_hosts.py
@@ -36,8 +36,13 @@ class TestAllowedHostsParsing:
             **env_vars,
         }
 
+        # Remove UNIFI_MCP_ALLOWED_HOSTS if set in shell environment
+        # (load_dotenv is mocked, so .env won't reload it during import)
+        os.environ.pop("UNIFI_MCP_ALLOWED_HOSTS", None)
+
         with (
             patch.dict(os.environ, test_env),
+            patch("dotenv.load_dotenv"),  # Prevent .env from being reloaded during import
             patch("mcp.server.fastmcp.FastMCP") as mock_fastmcp,
         ):
             try:

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -1,0 +1,149 @@
+"""Tests for HTTP transport configuration and uvicorn logging fix."""
+
+
+import pytest
+
+from src.utils.config_helpers import parse_config_bool
+
+
+class TestUvicornLoggingConfig:
+    """Tests for uvicorn access log redirection to stderr."""
+
+    def test_uvicorn_default_access_log_uses_stdout(self):
+        """Verify uvicorn's default config uses stdout for access logs (the problem)."""
+        import uvicorn.config
+
+        # Get fresh default config
+        default_stream = uvicorn.config.LOGGING_CONFIG["handlers"]["access"]["stream"]
+        assert default_stream == "ext://sys.stdout", "Expected uvicorn default access log to use stdout"
+
+    def test_uvicorn_config_modification_redirects_to_stderr(self):
+        """Verify our fix redirects access logs to stderr."""
+        import uvicorn.config
+
+        # Save original
+        original = uvicorn.config.LOGGING_CONFIG["handlers"]["access"]["stream"]
+
+        try:
+            # Apply our fix
+            uvicorn.config.LOGGING_CONFIG["handlers"]["access"]["stream"] = "ext://sys.stderr"
+
+            # Verify it took effect
+            assert uvicorn.config.LOGGING_CONFIG["handlers"]["access"]["stream"] == "ext://sys.stderr"
+
+            # Verify uvicorn.Config uses our modified config
+            config = uvicorn.Config(app=None, host="127.0.0.1", port=8000)
+            assert config.log_config["handlers"]["access"]["stream"] == "ext://sys.stderr", (
+                "uvicorn.Config should use the modified LOGGING_CONFIG"
+            )
+        finally:
+            # Restore original to not affect other tests
+            uvicorn.config.LOGGING_CONFIG["handlers"]["access"]["stream"] = original
+
+
+class TestParseConfigBool:
+    """Tests for parse_config_bool utility function."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            # Truthy string values
+            ("true", True),
+            ("TRUE", True),
+            ("True", True),
+            ("1", True),
+            ("yes", True),
+            ("YES", True),
+            ("on", True),
+            ("ON", True),
+            # Falsy string values
+            ("false", False),
+            ("FALSE", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+            ("", False),
+            ("invalid", False),
+            # Whitespace handling
+            ("  true  ", True),
+            ("  false  ", False),
+            # Boolean values pass through
+            (True, True),
+            (False, False),
+            # None uses default
+            (None, False),
+        ],
+    )
+    def test_parse_config_bool(self, value, expected: bool):
+        """Verify config bool parsing handles all expected inputs."""
+        result = parse_config_bool(value)
+        assert result == expected, f"Expected parse_config_bool({value!r}) to be {expected}"
+
+    def test_parse_config_bool_default_true(self):
+        """Verify default=True is used when value is None."""
+        assert parse_config_bool(None, default=True) is True
+
+    def test_parse_config_bool_default_false(self):
+        """Verify default=False is used when value is None."""
+        assert parse_config_bool(None, default=False) is False
+
+
+class TestHttpForceFlag:
+    """Tests for UNIFI_MCP_HTTP_FORCE configuration option."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", True),
+            ("TRUE", True),
+            ("True", True),
+            ("1", True),
+            ("yes", True),
+            ("YES", True),
+            ("false", False),
+            ("FALSE", False),
+            ("0", False),
+            ("no", False),
+            ("", False),
+            ("invalid", False),
+        ],
+    )
+    def test_http_force_flag_parsing(self, value: str, expected: bool):
+        """Verify HTTP force flag is parsed correctly using parse_config_bool."""
+        result = parse_config_bool(value)
+        assert result == expected, f"Expected '{value}' to parse as {expected}"
+
+    def test_http_enabled_with_force_flag_bypasses_pid_check(self):
+        """Verify force flag allows HTTP even when PID != 1."""
+        # Simulate the logic from main.py
+        http_enabled = True
+        force_http = True
+        is_main_container_process = False  # PID != 1
+
+        # With force flag, HTTP should remain enabled
+        if http_enabled and not is_main_container_process and not force_http:
+            http_enabled = False
+
+        assert http_enabled is True, "Force flag should bypass PID check"
+
+    def test_http_disabled_without_force_flag_when_not_pid_1(self):
+        """Verify HTTP is disabled when PID != 1 and no force flag."""
+        http_enabled = True
+        force_http = False
+        is_main_container_process = False  # PID != 1
+
+        if http_enabled and not is_main_container_process and not force_http:
+            http_enabled = False
+
+        assert http_enabled is False, "HTTP should be disabled when PID != 1 without force flag"
+
+    def test_http_enabled_when_pid_1(self):
+        """Verify HTTP is enabled when running as PID 1 (container main process)."""
+        http_enabled = True
+        force_http = False
+        is_main_container_process = True  # PID == 1
+
+        if http_enabled and not is_main_container_process and not force_http:
+            http_enabled = False
+
+        assert http_enabled is True, "HTTP should be enabled when PID == 1"


### PR DESCRIPTION
When running both stdio and HTTP SSE transports simultaneously, uvicorn's access logger writing to stdout causes JSON-RPC protocol corruption because MCP stdio transport uses stdout for communication.

Changes:
- Redirect uvicorn access logs from stdout to stderr via config modification
- Add UNIFI_MCP_HTTP_FORCE config option to bypass PID 1 check for local dev
- Add src/utils/config_helpers.py with parse_config_bool() utility
- Add comprehensive tests for uvicorn config, parse_config_bool, and force flag

Closes: Related to PR #43 (alternative solution)

---

This pull request improves configuration handling for enabling HTTP SSE in local development, introduces a utility for robust boolean config parsing, and ensures uvicorn access logs are redirected to stderr to avoid conflicts. It also adds comprehensive unit tests for these changes.

**Configuration handling and HTTP SSE startup:**

* Adds a new `UNIFI_MCP_HTTP_FORCE` environment variable and corresponding `force` option in `config.yaml` to allow HTTP SSE to be enabled even when not running as PID 1 (useful for local development/testing). (`.env.example`, `src/config/config.yaml`, `src/main.py`) [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR25-R29) [[2]](diffhunk://#diff-e9c80e728fb4364c4eb0cc0612e65bfae27ceb9501b8ca275902bc1fbd5c6f6dR54) [[3]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L313-R325)
* Refactors HTTP enable/disable logic in `src/main.py` to use a new `parse_config_bool` helper, ensuring consistent parsing of boolean config values from environment variables or config files. (`src/main.py`, `src/utils/config_helpers.py`) [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R31) [[2]](diffhunk://#diff-13669ee14075f1bbdc114e7f5ed80d4b3d9b5205154cccb7797e5291a93a27ecR1-R38)

**Logging and diagnostics:**

* Redirects uvicorn access logs from stdout to stderr to prevent conflicts with JSON-RPC communication over stdout. (`src/main.py`)

**Testing and utilities:**

* Adds `parse_config_bool` utility for robust boolean parsing of config values, with full test coverage. (`src/utils/config_helpers.py`, `tests/unit/test_http_transport.py`) [[1]](diffhunk://#diff-13669ee14075f1bbdc114e7f5ed80d4b3d9b5205154cccb7797e5291a93a27ecR1-R38) [[2]](diffhunk://#diff-abc70a32b15f1c0937783513cd7881052eff19eaf6d545b790f9ae4b3e6b85bdR1-R149)
* Adds and expands unit tests for HTTP force flag parsing, uvicorn logging configuration, and config helpers. (`tests/unit/test_http_transport.py`)
* Improves test isolation for allowed hosts by ensuring environment variables are properly cleared and `.env` is not reloaded during tests. (`tests/unit/test_allowed_hosts.py`)

**Developer tooling:**

* Adds a `format-fix` target to the `Makefile` for auto-fixing code style issues using ruff. (`Makefile`)