### PR TITLE
feat: add DNS rebinding protection environment variable and related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ The server merges settings from **environment variables**, an optional `.env` fi
 | `UNIFI_ENABLED_CATEGORIES` | Comma-separated list of tool categories to load (eager mode). See table below |
 | `UNIFI_ENABLED_TOOLS` | Comma-separated list of specific tool names to register (eager mode) |
 | `UNIFI_MCP_ALLOWED_HOSTS` | Comma-separated list of allowed hostnames for reverse proxy support. Required when running behind Nginx/Cloudflare/etc. Default `localhost,127.0.0.1` |
+| `UNIFI_MCP_ENABLE_DNS_REBINDING_PROTECTION` | Enable/disable DNS rebinding protection. Set to `false` for Kubernetes/proxy deployments where `UNIFI_MCP_ALLOWED_HOSTS` is insufficient. Default `true` |
 
 ### Tool Categories (for UNIFI_ENABLED_CATEGORIES)
 
@@ -794,7 +795,9 @@ See [docs/permissions.md](docs/permissions.md) for complete documentation includ
 * **Review permissions carefully** before enabling high-risk operations. Use environment variables for runtime control.
 * Create, update, and delete tools should be used with caution and only enabled when necessary.
 * Do not host outside of your network unless using a secure reverse proxy like Cloudflare Tunnel or Ngrok. Even then, an additional layer of authentication is recommended.
-* **Reverse Proxy Configuration:** When running behind a reverse proxy, set `UNIFI_MCP_ALLOWED_HOSTS` to include your external domain (e.g., `localhost,127.0.0.1,unifi-mcp.example.com`) to bypass FastMCP's DNS rebinding protection.
+* **Reverse Proxy Configuration:** When running behind a reverse proxy (Kubernetes ingress, Nginx, Cloudflare, etc.):
+  * First try: Set `UNIFI_MCP_ALLOWED_HOSTS` to include your external domain (e.g., `localhost,127.0.0.1,unifi-mcp.example.com`)
+  * If that's insufficient: Set `UNIFI_MCP_ENABLE_DNS_REBINDING_PROTECTION=false` to disable host validation entirely. Only use this in trusted network environments.
 
 ---
 

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -80,10 +80,22 @@ def get_server() -> FastMCP:
     allowed_hosts_str = os.getenv("UNIFI_MCP_ALLOWED_HOSTS", "localhost,127.0.0.1")
     allowed_hosts = [h.strip() for h in allowed_hosts_str.split(",") if h.strip()]
 
-    # Configure transport security settings
-    transport_security = TransportSecuritySettings(allowed_hosts=allowed_hosts)
+    # Allow disabling DNS rebinding protection entirely (default: enabled)
+    # Set to "false" for Kubernetes/proxy deployments where allowed_hosts is insufficient
+    enable_dns_rebinding = (
+        os.getenv("UNIFI_MCP_ENABLE_DNS_REBINDING_PROTECTION", "true").lower() == "true"
+    )
 
-    logger.debug(f"Configuring FastMCP with allowed_hosts: {allowed_hosts}")
+    # Configure transport security settings
+    transport_security = TransportSecuritySettings(
+        allowed_hosts=allowed_hosts,
+        enable_dns_rebinding_protection=enable_dns_rebinding,
+    )
+
+    logger.debug(
+        f"Configuring FastMCP with allowed_hosts: {allowed_hosts}, "
+        f"dns_rebinding_protection: {enable_dns_rebinding}"
+    )
 
     server = FastMCP(
         name="unifi-network-mcp",


### PR DESCRIPTION
This pull request introduces a new environment variable to control DNS rebinding protection for the FastMCP server, improving deployment flexibility for Kubernetes and reverse proxy setups. The changes update documentation, server configuration logic, and add comprehensive unit tests for the new feature.

fixes #57 #59 

**Configuration and Documentation Updates:**

* Added support for the `UNIFI_MCP_ENABLE_DNS_REBINDING_PROTECTION` environment variable, allowing DNS rebinding protection to be enabled or disabled at runtime. This is particularly useful for proxy or Kubernetes deployments where host validation may be insufficient.
* Updated the `README.md` to document the new environment variable and provide clearer reverse proxy configuration instructions, including when to disable DNS rebinding protection. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R526) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L797-R800)

**Testing Improvements:**

* Added a new test class `TestDnsRebindingProtection` in `tests/unit/test_allowed_hosts.py` to verify correct behavior of the DNS rebinding protection setting across various environment variable values, ensuring robust and predictable configuration.