### PR TITLE
fix: enable on-demand tool loading in meta_only mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -253,6 +253,13 @@ async def main_async():
         logger.info("   Meta-tools: unifi_tool_index, unifi_execute, unifi_batch, unifi_batch_status")
         logger.info("   Use unifi_execute to run any tool discovered via unifi_tool_index")
         logger.info("   To load all tools directly: set UNIFI_TOOL_REGISTRATION_MODE=eager")
+
+        # Setup lazy loading interceptor so unifi_execute/unifi_batch can load tools on demand
+        setup_lazy_loading(server, _original_tool_decorator)
+
+        from src.utils.lazy_tool_loader import TOOL_MODULE_MAP
+
+        logger.info(f"   On-demand loader ready - {len(TOOL_MODULE_MAP)} tools available via unifi_execute")
     elif UNIFI_TOOL_REGISTRATION_MODE == "lazy":
         logger.info("⚡ Tool registration mode: lazy")
         logger.info("   Meta-tools: unifi_tool_index, unifi_execute, unifi_batch, unifi_batch_status, unifi_load_tools")


### PR DESCRIPTION
## Summary

- Wire up `setup_lazy_loading()` in `meta_only` mode so `unifi_execute` and `unifi_batch` can load tools on demand
- Previously, `meta_only` mode only registered 4 meta-tools and had no lazy interceptor, causing all `unifi_execute` calls to fail with `Unknown tool`
- The distinction between `meta_only` and `lazy` is preserved: `lazy` additionally registers `unifi_load_tools` for clients supporting `tool_list_changed` notifications

Fixes #63
Relates to #62

## Test plan

- [x] All 153 unit tests pass
- [x] Ruff linter clean
- [x] Manual: start server with `UNIFI_TOOL_REGISTRATION_MODE=meta_only`, call `unifi_execute` with a tool name — should auto-load and succeed
- [x] Manual: verify `lazy` and `eager` modes still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)