### PR TITLE
docs: clarify permissions and tool discovery relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,8 @@ These tools will give any LLM or agent configured to use them full access to you
 
 The server includes a comprehensive permission system with **safe defaults**:
 
+> **Permissions control tool visibility.** Tools with disabled permissions are **not registered** with the MCP server and will not appear in your client's tool list. If you're missing expected tools, check that the relevant permissions are enabled. All tools remain discoverable via `unifi_tool_index` regardless of permission settings — but disabled tools cannot be called. See [docs/permissions.md](docs/permissions.md) for full details.
+
 **Disabled by Default (High-Risk):**
 - Network creation/modification (`unifi_create_network`, `unifi_update_network`)
 - Wireless configuration (`unifi_create_wlan`, `unifi_update_wlan`)


### PR DESCRIPTION
## Summary

- Add a prominent callout in the README Permission System section explaining that disabled tools are **not registered** with the MCP server and won't appear in the client's tool list
- Fix contradictory language in `docs/permissions.md` — one section claimed disabled tools appear in `unifi_tool_index`, while the troubleshooting section said they don't
- Replace vague "user experience" section with a clear per-mode behavior table (eager vs lazy vs meta_only)
- Rewrite troubleshooting section with mode-specific guidance

Closes #46

## Test plan

- [x] Documentation-only change, no code modified
- [x] Review rendered markdown for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)