### PR TITLE
feat: add MAC ACL rules (Policy Engine) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ When using eager mode with category filtering, these are the valid category name
 | `config` | Configuration management | - |
 | `devices` | Device listing, radio config, reboot, locate, upgrade | `unifi_list_devices`, `unifi_get_device_radio` |
 | `events` | Events and alarms | `unifi_list_events`, `unifi_list_alarms` |
+| `acl` | MAC ACL rules (Policy Engine, Layer 2 access control) | `unifi_list_acl_rules`, `unifi_create_acl_rule` |
 | `firewall` | Firewall rules and groups | `unifi_list_firewall_rules`, `unifi_create_firewall_rule` |
 | `hotspot` | Vouchers for guest network | `unifi_list_vouchers`, `unifi_create_voucher` |
 | `network` | Network/VLAN management | `unifi_list_networks`, `unifi_create_network` |
@@ -832,6 +833,18 @@ See [docs/permissions.md](docs/permissions.md) for complete documentation includ
 * `unifi_create_simple_firewall_policy`
 * `unifi_list_firewall_zones`
 * `unifi_list_ip_groups`
+
+### MAC ACL Rules (Policy Engine)
+
+* `unifi_list_acl_rules` — List MAC ACL rules, optionally filtered by network/VLAN
+* `unifi_get_acl_rule_details` — Get full configuration of a specific ACL rule
+* `unifi_create_acl_rule` — Create a new MAC ACL rule for Layer 2 access control
+* `unifi_update_acl_rule` — Update an existing MAC ACL rule (full object replacement)
+* `unifi_delete_acl_rule` — Delete a MAC ACL rule
+
+> **Note:** MAC ACL rules require UniFi Network Application with Policy Engine support.
+> These rules control Layer 2 (MAC address) communication within a VLAN.
+> Use `CLIENT_MAC` type with an empty `specific_mac_addresses` list to match any device.
 
 ### Traffic Routes
 

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -28,6 +28,7 @@ server:
   #     - config         # Configuration management
   #     - devices        # Device listing, radio config, reboot, locate, upgrade
   #     - events         # Events and alarms
+  #     - acl            # MAC ACL rules (Policy Engine, Layer 2 access control)
   #     - firewall       # Firewall rules and groups
   #     - hotspot        # Vouchers for guest network
   #     - network        # Network/VLAN management
@@ -62,6 +63,10 @@ server:
 permissions:
 
   default:
+    create: true
+    update: true
+
+  acl_rules:
     create: true
     update: true
 

--- a/src/managers/acl_manager.py
+++ b/src/managers/acl_manager.py
@@ -1,0 +1,191 @@
+"""Manager for MAC ACL rules (Policy Engine) on the UniFi controller.
+
+MAC ACL rules control Layer 2 access within a VLAN by whitelisting
+specific MAC address pairs that are allowed to communicate. All
+traffic not explicitly allowed is blocked by a default-deny rule.
+
+Requires UniFi Network Application with Policy Engine support.
+API endpoint: /proxy/network/v2/api/site/{site}/acl-rules
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiounifi.models.api import ApiRequestV2
+
+from .connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_ACL_RULES = "acl_rules"
+
+
+class AclManager:
+    """Manages MAC ACL rules on the UniFi controller."""
+
+    def __init__(self, connection_manager: ConnectionManager):
+        self._connection = connection_manager
+
+    async def get_acl_rules(self, network_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Get all MAC ACL rules, optionally filtered by network.
+
+        Args:
+            network_id: Optional network ID to filter rules by VLAN.
+
+        Returns:
+            List of ACL rule dictionaries.
+        """
+        cache_key = f"{CACHE_PREFIX_ACL_RULES}_{network_id}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key)
+        if cached_data is not None:
+            return cached_data
+
+        if not await self._connection.ensure_connected():
+            return []
+
+        try:
+            api_request = ApiRequestV2(method="get", path="/acl-rules")
+            response = await self._connection.request(api_request)
+
+            rules = (
+                response
+                if isinstance(response, list)
+                else response.get("data", [])
+                if isinstance(response, dict)
+                else []
+            )
+
+            if network_id:
+                rules = [r for r in rules if r.get("mac_acl_network_id") == network_id]
+
+            self._connection._update_cache(cache_key, rules)
+            return rules
+        except Exception as e:
+            logger.error(f"Error getting ACL rules: {e}")
+            return []
+
+    async def get_acl_rule_by_id(self, rule_id: str) -> Optional[Dict[str, Any]]:
+        """Get a specific ACL rule by ID.
+
+        Args:
+            rule_id: The ID of the ACL rule.
+
+        Returns:
+            The ACL rule dictionary, or None if not found.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        try:
+            api_request = ApiRequestV2(method="get", path=f"/acl-rules/{rule_id}")
+            response = await self._connection.request(api_request)
+
+            if isinstance(response, dict):
+                return response if "_id" in response else response.get("data", None)
+            return None
+        except Exception as e:
+            logger.error(f"Error getting ACL rule {rule_id}: {e}")
+            return None
+
+    async def create_acl_rule(self, rule_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Create a new MAC ACL rule.
+
+        Args:
+            rule_data: Dictionary containing the ACL rule configuration.
+                Required fields:
+                - name (str): Rule name
+                - acl_index (int): Position in the rule chain
+                - action (str): "ALLOW" or "BLOCK"
+                - mac_acl_network_id (str): Network ID this rule applies to
+                - traffic_source (dict): Source matching config
+                - traffic_destination (dict): Destination matching config
+                - type (str): "MAC"
+
+        Returns:
+            The created ACL rule dictionary, or None on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        required_keys = {"name", "acl_index", "action", "mac_acl_network_id", "type"}
+        missing = required_keys - rule_data.keys()
+        if missing:
+            logger.error(f"Missing required keys for ACL rule: {missing}")
+            return None
+
+        try:
+            api_request = ApiRequestV2(method="post", path="/acl-rules", data=rule_data)
+            response = await self._connection.request(api_request)
+
+            self._invalidate_cache()
+
+            if isinstance(response, dict) and "_id" in response:
+                return response
+            elif isinstance(response, dict) and "data" in response:
+                return response["data"]
+            elif isinstance(response, list) and len(response) > 0:
+                return response[0] if isinstance(response[0], dict) else {"_id": str(response[0])}
+            elif response is None or response == "":
+                # Some API versions return empty on success — fetch the rule back
+                logger.info("Create returned empty response, verifying via list")
+                rules = await self.get_acl_rules()
+                created = next(
+                    (r for r in rules if r.get("name") == rule_data.get("name")),
+                    None,
+                )
+                return created
+            else:
+                logger.error(f"Unexpected response creating ACL rule: {type(response)} {response}")
+                return None
+        except Exception as e:
+            logger.error(f"Error creating ACL rule: {e}", exc_info=True)
+            return None
+
+    async def update_acl_rule(self, rule_id: str, rule_data: Dict[str, Any]) -> bool:
+        """Update an existing MAC ACL rule.
+
+        Args:
+            rule_id: The ID of the ACL rule to update.
+            rule_data: Complete rule data (PUT replaces the entire object).
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="put", path=f"/acl-rules/{rule_id}", data=rule_data)
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error(f"Error updating ACL rule {rule_id}: {e}", exc_info=True)
+            return False
+
+    async def delete_acl_rule(self, rule_id: str) -> bool:
+        """Delete a MAC ACL rule.
+
+        Args:
+            rule_id: The ID of the ACL rule to delete.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="delete", path=f"/acl-rules/{rule_id}")
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting ACL rule {rule_id}: {e}", exc_info=True)
+            return False
+
+    def _invalidate_cache(self):
+        """Invalidate all ACL rule caches."""
+        self._connection._invalidate_cache(CACHE_PREFIX_ACL_RULES)

--- a/src/runtime.py
+++ b/src/runtime.py
@@ -26,6 +26,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
 from src.bootstrap import load_config, logger
+from src.managers.acl_manager import AclManager
 from src.managers.client_manager import ClientManager
 from src.managers.connection_manager import ConnectionManager
 from src.managers.device_manager import DeviceManager
@@ -135,6 +136,11 @@ def get_connection_manager() -> ConnectionManager:
 
 
 @lru_cache
+def get_acl_manager() -> AclManager:
+    return AclManager(get_connection_manager())
+
+
+@lru_cache
 def get_client_manager() -> ClientManager:
     return ClientManager(get_connection_manager())
 
@@ -215,6 +221,7 @@ def get_tool_registry() -> dict[str, Any]:
 config = get_config()
 server = get_server()
 connection_manager = get_connection_manager()
+acl_manager = get_acl_manager()
 client_manager = get_client_manager()
 device_manager = get_device_manager()
 stats_manager = get_stats_manager()

--- a/src/tools/acl.py
+++ b/src/tools/acl.py
@@ -8,7 +8,7 @@ Application with Policy Engine support.
 
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from src.runtime import acl_manager, config, server
 from src.utils.confirmation import create_preview, should_auto_confirm
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
     description="List MAC ACL rules (Policy Engine) for Layer 2 access control. "
     "These rules control which devices can communicate at Layer 2 within a VLAN.",
 )
-async def list_acl_rules(network_id: str = None) -> Dict[str, Any]:
+async def list_acl_rules(network_id: Optional[str] = None) -> Dict[str, Any]:
     """
     Lists MAC ACL rules configured in the Policy Engine.
 
@@ -119,8 +119,8 @@ async def create_acl_rule(
     acl_index: int,
     action: str,
     mac_acl_network_id: str,
-    traffic_source: dict = None,
-    traffic_destination: dict = None,
+    traffic_source: Optional[dict] = None,
+    traffic_destination: Optional[dict] = None,
     confirm: bool = False,
 ) -> Dict[str, Any]:
     """

--- a/src/tools/acl.py
+++ b/src/tools/acl.py
@@ -1,0 +1,262 @@
+"""
+MAC ACL rule tools for UniFi Network MCP server.
+
+MAC ACL rules (Policy Engine) control Layer 2 access within a VLAN
+by whitelisting specific MAC address pairs. Requires UniFi Network
+Application with Policy Engine support.
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+from src.runtime import acl_manager, config, server
+from src.utils.confirmation import create_preview, should_auto_confirm
+from src.utils.permissions import parse_permission
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_acl_rules",
+    description="List MAC ACL rules (Policy Engine) for Layer 2 access control. "
+    "These rules control which devices can communicate at Layer 2 within a VLAN.",
+)
+async def list_acl_rules(network_id: str = None) -> Dict[str, Any]:
+    """
+    Lists MAC ACL rules configured in the Policy Engine.
+
+    Args:
+        network_id (str, optional): Filter by network/VLAN ID.
+
+    Returns:
+        A dictionary containing:
+        - success (bool): Indicates if the operation was successful.
+        - count (int): Number of ACL rules found.
+        - rules (List[Dict]): List of ACL rules with summary info.
+    """
+    if not parse_permission(config.permissions, "acl_rules", "read"):
+        return {"success": False, "error": "Permission denied to list ACL rules."}
+
+    try:
+        rules = await acl_manager.get_acl_rules(network_id=network_id)
+        formatted = [
+            {
+                "id": r.get("_id"),
+                "name": r.get("name"),
+                "acl_index": r.get("acl_index"),
+                "action": r.get("action"),
+                "enabled": r.get("enabled"),
+                "network_id": r.get("mac_acl_network_id"),
+                "source_type": r.get("traffic_source", {}).get("type"),
+                "source_macs": r.get("traffic_source", {}).get("specific_mac_addresses", []),
+                "destination_type": r.get("traffic_destination", {}).get("type"),
+                "destination_macs": r.get("traffic_destination", {}).get("specific_mac_addresses", []),
+            }
+            for r in rules
+        ]
+        return {
+            "success": True,
+            "site": acl_manager._connection.site,
+            "count": len(formatted),
+            "rules": formatted,
+        }
+    except Exception as e:
+        logger.error(f"Error listing ACL rules: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
+@server.tool(
+    name="unifi_get_acl_rule_details",
+    description="Get detailed configuration for a specific MAC ACL rule by ID.",
+)
+async def get_acl_rule_details(rule_id: str) -> Dict[str, Any]:
+    """
+    Gets the detailed configuration of a specific MAC ACL rule.
+
+    Args:
+        rule_id (str): The unique identifier of the ACL rule.
+
+    Returns:
+        A dictionary containing the full rule configuration.
+    """
+    if not parse_permission(config.permissions, "acl_rules", "read"):
+        return {"success": False, "error": "Permission denied to get ACL rule details."}
+
+    try:
+        if not rule_id:
+            return {"success": False, "error": "rule_id is required"}
+
+        rule = await acl_manager.get_acl_rule_by_id(rule_id)
+        if not rule:
+            # Fallback: search in list
+            rules = await acl_manager.get_acl_rules()
+            rule = next((r for r in rules if r.get("_id") == rule_id), None)
+
+        if not rule:
+            return {"success": False, "error": f"ACL rule '{rule_id}' not found."}
+
+        return {
+            "success": True,
+            "rule_id": rule_id,
+            "details": json.loads(json.dumps(rule, default=str)),
+        }
+    except Exception as e:
+        logger.error(f"Error getting ACL rule {rule_id}: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
+@server.tool(
+    name="unifi_create_acl_rule",
+    description="Create a new MAC ACL rule for Layer 2 access control within a VLAN. "
+    "Requires confirmation. IMPORTANT: traffic_source and traffic_destination type MUST be 'CLIENT_MAC' "
+    "(not 'ANY'). Use an empty specific_mac_addresses list to match any device.",
+    permission_category="acl_rules",
+    permission_action="create",
+)
+async def create_acl_rule(
+    name: str,
+    acl_index: int,
+    action: str,
+    mac_acl_network_id: str,
+    traffic_source: dict = None,
+    traffic_destination: dict = None,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """
+    Creates a new MAC ACL rule in the Policy Engine.
+
+    Args:
+        name (str): Name of the rule.
+        acl_index (int): Position in the rule chain (lower = evaluated first).
+        action (str): "ALLOW" or "BLOCK".
+        mac_acl_network_id (str): Network ID of the VLAN this rule applies to.
+        traffic_source (dict): Source config with keys:
+            - type (str): "CLIENT_MAC"
+            - specific_mac_addresses (list): List of source MAC addresses. Empty list = any.
+        traffic_destination (dict): Destination config with same structure as source.
+        confirm (bool): Must be True to execute. False returns a preview.
+
+    Returns:
+        Preview of changes or the created rule.
+    """
+    if traffic_source is None:
+        traffic_source = {
+            "ips_or_subnets": [],
+            "network_ids": [],
+            "ports": [],
+            "specific_mac_addresses": [],
+            "type": "CLIENT_MAC",
+        }
+    if traffic_destination is None:
+        traffic_destination = {
+            "ips_or_subnets": [],
+            "network_ids": [],
+            "ports": [],
+            "specific_mac_addresses": [],
+            "type": "CLIENT_MAC",
+        }
+
+    rule_data = {
+        "name": name,
+        "acl_index": acl_index,
+        "action": action.upper(),
+        "enabled": True,
+        "mac_acl_network_id": mac_acl_network_id,
+        "specific_enforcers": [],
+        "traffic_source": traffic_source,
+        "traffic_destination": traffic_destination,
+        "type": "MAC",
+    }
+
+    if not confirm and not should_auto_confirm():
+        return create_preview(
+            resource_type="acl_rule",
+            resource_data=rule_data,
+            resource_name=name,
+        )
+
+    try:
+        result = await acl_manager.create_acl_rule(rule_data)
+        if result:
+            return {
+                "success": True,
+                "message": f"ACL rule '{name}' created successfully.",
+                "rule": json.loads(json.dumps(result, default=str)),
+            }
+        return {"success": False, "error": "Failed to create ACL rule."}
+    except Exception as e:
+        logger.error(f"Error creating ACL rule: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
+@server.tool(
+    name="unifi_update_acl_rule",
+    description="Update an existing MAC ACL rule. Requires the full rule object (PUT replaces entire resource). "
+    "Requires confirmation. IMPORTANT: traffic source/destination type MUST be 'CLIENT_MAC' (not 'ANY').",
+    permission_category="acl_rules",
+    permission_action="update",
+)
+async def update_acl_rule(rule_id: str, rule_data: dict, confirm: bool = False) -> Dict[str, Any]:
+    """
+    Updates an existing MAC ACL rule.
+
+    Args:
+        rule_id (str): The ID of the rule to update.
+        rule_data (dict): The complete updated rule object (PUT replaces the entire resource).
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview of changes or success/failure status.
+    """
+    if not confirm and not should_auto_confirm():
+        return create_preview(
+            resource_type="acl_rule",
+            resource_data=rule_data,
+            resource_name=rule_id,
+        )
+
+    try:
+        success = await acl_manager.update_acl_rule(rule_id, rule_data)
+        if success:
+            return {"success": True, "message": f"ACL rule '{rule_id}' updated successfully."}
+        return {"success": False, "error": f"Failed to update ACL rule '{rule_id}'."}
+    except Exception as e:
+        logger.error(f"Error updating ACL rule {rule_id}: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+
+
+@server.tool(
+    name="unifi_delete_acl_rule",
+    description="Delete a MAC ACL rule. Requires confirmation. WARNING: Removing an ALLOW rule "
+    "may block device communication. Removing a BLOCK rule may open access.",
+    permission_category="acl_rules",
+    permission_action="update",
+)
+async def delete_acl_rule(rule_id: str, confirm: bool = False) -> Dict[str, Any]:
+    """
+    Deletes a MAC ACL rule.
+
+    Args:
+        rule_id (str): The ID of the rule to delete.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview or success/failure status.
+    """
+    if not confirm and not should_auto_confirm():
+        return create_preview(
+            resource_type="acl_rule",
+            resource_data={"rule_id": rule_id},
+            resource_name=rule_id,
+            warnings=["Removing an ALLOW rule may block device communication. Removing a BLOCK rule may open access."],
+        )
+
+    try:
+        success = await acl_manager.delete_acl_rule(rule_id)
+        if success:
+            return {"success": True, "message": f"ACL rule '{rule_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete ACL rule '{rule_id}'."}
+    except Exception as e:
+        logger.error(f"Error deleting ACL rule {rule_id}: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}

--- a/src/tools_manifest.json
+++ b/src/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 86,
+  "count": 91,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "src.tools.devices",
@@ -7,6 +7,7 @@
     "unifi_archive_all_alarms": "src.tools.events",
     "unifi_authorize_guest": "src.tools.clients",
     "unifi_block_client": "src.tools.clients",
+    "unifi_create_acl_rule": "src.tools.acl",
     "unifi_create_firewall_policy": "src.tools.firewall",
     "unifi_create_network": "src.tools.network",
     "unifi_create_port_forward": "src.tools.port_forwards",
@@ -18,7 +19,9 @@
     "unifi_create_usergroup": "src.tools.usergroups",
     "unifi_create_voucher": "src.tools.hotspot",
     "unifi_create_wlan": "src.tools.network",
+    "unifi_delete_acl_rule": "src.tools.acl",
     "unifi_force_reconnect_client": "src.tools.clients",
+    "unifi_get_acl_rule_details": "src.tools.acl",
     "unifi_get_alerts": "src.tools.stats",
     "unifi_get_client_details": "src.tools.clients",
     "unifi_get_client_stats": "src.tools.stats",
@@ -34,7 +37,7 @@
     "unifi_get_port_forward": "src.tools.port_forwards",
     "unifi_get_qos_rule_details": "src.tools.qos",
     "unifi_get_route_details": "src.tools.routing",
-    "unifi_get_site_settings": "src.tools.config",
+    "unifi_get_site_settings": "src.tools.system",
     "unifi_get_snmp_settings": "src.tools.system",
     "unifi_get_system_info": "src.tools.system",
     "unifi_get_top_clients": "src.tools.stats",
@@ -44,6 +47,7 @@
     "unifi_get_vpn_client_details": "src.tools.vpn",
     "unifi_get_vpn_server_details": "src.tools.vpn",
     "unifi_get_wlan_details": "src.tools.network",
+    "unifi_list_acl_rules": "src.tools.acl",
     "unifi_list_active_routes": "src.tools.routing",
     "unifi_list_alarms": "src.tools.events",
     "unifi_list_blocked_clients": "src.tools.clients",
@@ -75,6 +79,7 @@
     "unifi_toggle_traffic_route": "src.tools.traffic_routes",
     "unifi_unauthorize_guest": "src.tools.clients",
     "unifi_unblock_client": "src.tools.clients",
+    "unifi_update_acl_rule": "src.tools.acl",
     "unifi_update_device_radio": "src.tools.devices",
     "unifi_update_firewall_policy": "src.tools.firewall",
     "unifi_update_network": "src.tools.network",
@@ -192,6 +197,44 @@
           },
           "required": [
             "mac_address"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Requires confirmation. IMPORTANT: traffic_source and traffic_destination type MUST be 'CLIENT_MAC' (not 'ANY'). Use an empty specific_mac_addresses list to match any device.",
+      "name": "unifi_create_acl_rule",
+      "schema": {
+        "input": {
+          "properties": {
+            "acl_index": {
+              "type": "integer"
+            },
+            "action": {
+              "type": "string"
+            },
+            "confirm": {
+              "type": "boolean"
+            },
+            "mac_acl_network_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "traffic_destination": {
+              "type": "object"
+            },
+            "traffic_source": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "name",
+            "acl_index",
+            "action",
+            "mac_acl_network_id"
           ],
           "type": "object"
         }
@@ -450,6 +493,26 @@
       }
     },
     {
+      "description": "Delete a MAC ACL rule. Requires confirmation. WARNING: Removing an ALLOW rule may block device communication. Removing a BLOCK rule may open access.",
+      "name": "unifi_delete_acl_rule",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "type": "boolean"
+            },
+            "rule_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
       "description": "Force a client to reconnect to the network (kick) by MAC address",
       "name": "unifi_force_reconnect_client",
       "schema": {
@@ -464,6 +527,23 @@
           },
           "required": [
             "mac_address"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "Get detailed configuration for a specific MAC ACL rule by ID.",
+      "name": "unifi_get_acl_rule_details",
+      "schema": {
+        "input": {
+          "properties": {
+            "rule_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_id"
           ],
           "type": "object"
         }
@@ -851,6 +931,20 @@
           "required": [
             "wlan_id"
           ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "List MAC ACL rules (Policy Engine) for Layer 2 access control. These rules control which devices can communicate at Layer 2 within a VLAN.",
+      "name": "unifi_list_acl_rules",
+      "schema": {
+        "input": {
+          "properties": {
+            "network_id": {
+              "type": "string"
+            }
+          },
           "type": "object"
         }
       }
@@ -1341,6 +1435,30 @@
           },
           "required": [
             "mac_address"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "description": "Update an existing MAC ACL rule. Requires the full rule object (PUT replaces entire resource). Requires confirmation. IMPORTANT: traffic source/destination type MUST be 'CLIENT_MAC' (not 'ANY').",
+      "name": "unifi_update_acl_rule",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "type": "boolean"
+            },
+            "rule_data": {
+              "type": "object"
+            },
+            "rule_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_id",
+            "rule_data"
           ],
           "type": "object"
         }

--- a/src/tools_manifest.json
+++ b/src/tools_manifest.json
@@ -37,7 +37,7 @@
     "unifi_get_port_forward": "src.tools.port_forwards",
     "unifi_get_qos_rule_details": "src.tools.qos",
     "unifi_get_route_details": "src.tools.routing",
-    "unifi_get_site_settings": "src.tools.system",
+    "unifi_get_site_settings": "src.tools.config",
     "unifi_get_snmp_settings": "src.tools.system",
     "unifi_get_system_info": "src.tools.system",
     "unifi_get_top_clients": "src.tools.stats",

--- a/src/utils/permissions.py
+++ b/src/utils/permissions.py
@@ -36,6 +36,7 @@ CATEGORY_MAP = {
     "usergroup": "usergroups",
     "route": "routes",
     "snmp": "snmp",
+    "acl": "acl_rules",
 }
 
 DEFAULT_PERMISSIONS_KEY = "default"

--- a/tests/unit/test_acl_manager.py
+++ b/tests/unit/test_acl_manager.py
@@ -1,0 +1,333 @@
+"""Tests for the AclManager class.
+
+This module tests MAC ACL rule operations (Policy Engine).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestAclManager:
+    """Tests for the AclManager class."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def acl_manager(self, mock_connection):
+        """Create an AclManager with mocked connection."""
+        from src.managers.acl_manager import AclManager
+
+        return AclManager(mock_connection)
+
+    # ---- get_acl_rules ----
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rules_returns_list(self, acl_manager, mock_connection):
+        """Test get_acl_rules returns a list of rules."""
+        mock_rules = [
+            {"_id": "r1", "name": "Allow A", "action": "ALLOW", "mac_acl_network_id": "net1"},
+            {"_id": "r2", "name": "Block All", "action": "BLOCK", "mac_acl_network_id": "net1"},
+        ]
+        mock_connection.request.return_value = mock_rules
+
+        rules = await acl_manager.get_acl_rules()
+
+        assert len(rules) == 2
+        assert rules[0]["name"] == "Allow A"
+        mock_connection._update_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rules_filters_by_network(self, acl_manager, mock_connection):
+        """Test get_acl_rules filters by network_id."""
+        mock_rules = [
+            {"_id": "r1", "name": "Rule Net1", "mac_acl_network_id": "net1"},
+            {"_id": "r2", "name": "Rule Net2", "mac_acl_network_id": "net2"},
+            {"_id": "r3", "name": "Rule Net1 Again", "mac_acl_network_id": "net1"},
+        ]
+        mock_connection.request.return_value = mock_rules
+
+        rules = await acl_manager.get_acl_rules(network_id="net1")
+
+        assert len(rules) == 2
+        assert all(r["mac_acl_network_id"] == "net1" for r in rules)
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rules_uses_cache(self, acl_manager, mock_connection):
+        """Test get_acl_rules returns cached data when available."""
+        cached = [{"_id": "cached", "name": "Cached Rule"}]
+        mock_connection.get_cached.return_value = cached
+
+        rules = await acl_manager.get_acl_rules()
+
+        assert rules == cached
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rules_handles_error(self, acl_manager, mock_connection):
+        """Test get_acl_rules returns empty list on error."""
+        mock_connection.request.side_effect = Exception("Network error")
+
+        rules = await acl_manager.get_acl_rules()
+
+        assert rules == []
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rules_not_connected(self, acl_manager, mock_connection):
+        """Test get_acl_rules returns empty list when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        rules = await acl_manager.get_acl_rules()
+
+        assert rules == []
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rules_handles_dict_response(self, acl_manager, mock_connection):
+        """Test get_acl_rules handles dict response with data key."""
+        mock_connection.request.return_value = {"data": [{"_id": "r1", "name": "Rule"}]}
+
+        rules = await acl_manager.get_acl_rules()
+
+        assert len(rules) == 1
+
+    # ---- get_acl_rule_by_id ----
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rule_by_id_found(self, acl_manager, mock_connection):
+        """Test get_acl_rule_by_id returns rule when found."""
+        mock_connection.request.return_value = {"_id": "r1", "name": "Test Rule"}
+
+        rule = await acl_manager.get_acl_rule_by_id("r1")
+
+        assert rule is not None
+        assert rule["name"] == "Test Rule"
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rule_by_id_not_connected(self, acl_manager, mock_connection):
+        """Test get_acl_rule_by_id returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        rule = await acl_manager.get_acl_rule_by_id("r1")
+
+        assert rule is None
+
+    @pytest.mark.asyncio
+    async def test_get_acl_rule_by_id_handles_error(self, acl_manager, mock_connection):
+        """Test get_acl_rule_by_id returns None on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        rule = await acl_manager.get_acl_rule_by_id("r1")
+
+        assert rule is None
+
+    # ---- create_acl_rule ----
+
+    @pytest.mark.asyncio
+    async def test_create_acl_rule_success(self, acl_manager, mock_connection):
+        """Test create_acl_rule with valid data."""
+        rule_data = {
+            "name": "New Rule",
+            "acl_index": 5,
+            "action": "ALLOW",
+            "mac_acl_network_id": "net1",
+            "type": "MAC",
+            "traffic_source": {"type": "CLIENT_MAC", "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"]},
+            "traffic_destination": {"type": "CLIENT_MAC", "specific_mac_addresses": []},
+        }
+        mock_connection.request.return_value = {"_id": "new1", **rule_data}
+
+        result = await acl_manager.create_acl_rule(rule_data)
+
+        assert result is not None
+        assert result["_id"] == "new1"
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_create_acl_rule_missing_required_keys(self, acl_manager, mock_connection):
+        """Test create_acl_rule returns None when required keys are missing."""
+        result = await acl_manager.create_acl_rule({"name": "Incomplete"})
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_acl_rule_not_connected(self, acl_manager, mock_connection):
+        """Test create_acl_rule returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await acl_manager.create_acl_rule({
+            "name": "Test",
+            "acl_index": 0,
+            "action": "ALLOW",
+            "mac_acl_network_id": "net1",
+            "type": "MAC",
+        })
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_acl_rule_handles_error(self, acl_manager, mock_connection):
+        """Test create_acl_rule returns None on API error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await acl_manager.create_acl_rule({
+            "name": "Test",
+            "acl_index": 0,
+            "action": "ALLOW",
+            "mac_acl_network_id": "net1",
+            "type": "MAC",
+        })
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_acl_rule_handles_data_wrapper(self, acl_manager, mock_connection):
+        """Test create_acl_rule handles response with data key."""
+        mock_connection.request.return_value = {"data": {"_id": "new1", "name": "Test"}}
+
+        result = await acl_manager.create_acl_rule({
+            "name": "Test",
+            "acl_index": 0,
+            "action": "ALLOW",
+            "mac_acl_network_id": "net1",
+            "type": "MAC",
+        })
+
+        assert result == {"_id": "new1", "name": "Test"}
+
+    # ---- update_acl_rule ----
+
+    @pytest.mark.asyncio
+    async def test_update_acl_rule_success(self, acl_manager, mock_connection):
+        """Test update_acl_rule with valid data."""
+        mock_connection.request.return_value = {}
+
+        result = await acl_manager.update_acl_rule("r1", {"_id": "r1", "name": "Updated"})
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_acl_rule_not_connected(self, acl_manager, mock_connection):
+        """Test update_acl_rule returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await acl_manager.update_acl_rule("r1", {"name": "Test"})
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_update_acl_rule_handles_error(self, acl_manager, mock_connection):
+        """Test update_acl_rule returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await acl_manager.update_acl_rule("r1", {"name": "Test"})
+
+        assert result is False
+
+    # ---- delete_acl_rule ----
+
+    @pytest.mark.asyncio
+    async def test_delete_acl_rule_success(self, acl_manager, mock_connection):
+        """Test delete_acl_rule with valid ID."""
+        mock_connection.request.return_value = {}
+
+        result = await acl_manager.delete_acl_rule("r1")
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_acl_rule_not_connected(self, acl_manager, mock_connection):
+        """Test delete_acl_rule returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await acl_manager.delete_acl_rule("r1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_acl_rule_handles_error(self, acl_manager, mock_connection):
+        """Test delete_acl_rule returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await acl_manager.delete_acl_rule("r1")
+
+        assert result is False
+
+    # ---- API path verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_uses_correct_path(self, acl_manager, mock_connection):
+        """Test get_acl_rules calls the correct API endpoint."""
+        mock_connection.request.return_value = []
+
+        await acl_manager.get_acl_rules()
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/acl-rules"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_uses_correct_path(self, acl_manager, mock_connection):
+        """Test get_acl_rule_by_id calls the correct API endpoint."""
+        mock_connection.request.return_value = {"_id": "r1"}
+
+        await acl_manager.get_acl_rule_by_id("r1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/acl-rules/r1"
+
+    @pytest.mark.asyncio
+    async def test_create_uses_correct_path_and_method(self, acl_manager, mock_connection):
+        """Test create_acl_rule uses POST to the correct endpoint."""
+        mock_connection.request.return_value = {"_id": "new1"}
+
+        await acl_manager.create_acl_rule({
+            "name": "Test",
+            "acl_index": 0,
+            "action": "ALLOW",
+            "mac_acl_network_id": "net1",
+            "type": "MAC",
+        })
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/acl-rules"
+        assert api_request.method == "post"
+
+    @pytest.mark.asyncio
+    async def test_update_uses_correct_path_and_method(self, acl_manager, mock_connection):
+        """Test update_acl_rule uses PUT to the correct endpoint."""
+        mock_connection.request.return_value = {}
+
+        await acl_manager.update_acl_rule("r1", {"name": "Updated"})
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/acl-rules/r1"
+        assert api_request.method == "put"
+
+    @pytest.mark.asyncio
+    async def test_delete_uses_correct_path_and_method(self, acl_manager, mock_connection):
+        """Test delete_acl_rule uses DELETE to the correct endpoint."""
+        mock_connection.request.return_value = {}
+
+        await acl_manager.delete_acl_rule("r1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/acl-rules/r1"
+        assert api_request.method == "delete"


### PR DESCRIPTION
## Summary

Adds 5 new tools for managing MAC ACL rules via the Policy Engine. MAC ACL rules control Layer 2 (MAC address) communication within a VLAN — enabling private-VLAN-style isolation where only explicitly whitelisted MAC pairs can communicate.

**New tools:**
- `unifi_list_acl_rules` — List rules, optionally filtered by network/VLAN
- `unifi_get_acl_rule_details` — Get full configuration of a specific rule
- `unifi_create_acl_rule` — Create a new rule (preview-then-confirm)
- `unifi_update_acl_rule` — Update an existing rule (full object replacement)
- `unifi_delete_acl_rule` — Delete a rule (with warning about access impact)

**API endpoint:** `GET/POST/PUT/DELETE /proxy/network/v2/api/site/default/acl-rules[/{id}]`

## Files changed

| File | Change |
|---|---|
| `src/managers/acl_manager.py` | **New** — Manager with CRUD operations, caching, error handling |
| `src/tools/acl.py` | **New** — 5 tool functions following anchor patterns |
| `tests/unit/test_acl_manager.py` | **New** — 25 unit tests |
| `src/runtime.py` | Added `AclManager` factory + alias |
| `src/config/config.yaml` | Added `acl` category + `acl_rules` permissions |
| `src/utils/permissions.py` | Added `"acl": "acl_rules"` to `CATEGORY_MAP` |
| `src/tools_manifest.json` | Regenerated (86 → 91 tools) |
| `README.md` | Added ACL section to Tool Categories table and Tool Catalog |

## Live testing

All 5 tools were tested end-to-end against a live controller, including create → get → update → verify → delete round-trip.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.12 |
| **Firmware** | 5.0.12.30269 |
| **Network Application** | 10.1.85 |
| **MCP Client** | Claude Code 2.1.76 |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Tool | Test | Result |
|---|---|---|
| `list_acl_rules` | List all + filter by network_id | ✅ Pass |
| `get_acl_rule_details` | Fetch by ID | ✅ Pass |
| `create_acl_rule` | Preview mode (confirm=false) | ✅ Pass |
| `create_acl_rule` | Create with confirm=true, verify returned object | ✅ Pass |
| `update_acl_rule` | Update name, action, MACs — verified changes via get | ✅ Pass |
| `delete_acl_rule` | Delete + verify removed | ✅ Pass |

## Unit tests

25 tests covering: CRUD success paths, cache behavior, error handling, not-connected states, API path verification, response format handling.

```
tests/unit/test_acl_manager.py — 25 passed
Full suite — 217 passed, 0 failed
```

## Constitution notes

A few areas where I followed existing code conventions rather than the letter of the constitution:

1. **Logger f-strings vs `%s`** (§5.4): Uses f-strings, matching all 15 existing managers. Happy to convert if strict adherence is preferred going forward.

2. **Delete permission** (§3.4): `delete_acl_rule` uses `permission_action="update"` rather than `"delete"`, following the same pattern as `revoke_voucher` in `hotspot.py`.

3. **TOOL_MODULE_MAP** (§4.3): Auto-discovered via `src/tools/*.py` scanning — no manual entry needed. Manifest regenerated and committed.

## Notes

- Requires UniFi Network Application with Policy Engine support (available on UDM Pro, UDM Pro Max, and other gateway devices with recent firmware)
- Controllers without Policy Engine support will return a graceful error rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)