### PR TITLE
fix: use REST endpoint for client rename with legacy fallback

### DIFF
--- a/src/managers/client_manager.py
+++ b/src/managers/client_manager.py
@@ -142,8 +142,15 @@ class ClientManager:
                 return False
             client_id = client.raw["_id"]
 
-            api_request = ApiRequest(method="put", path=f"/upd/user/{client_id}", data={"name": name})
-            await self._connection.request(api_request)
+            # Use REST endpoint (consistent with set_client_ip_settings).
+            # Fall back to legacy /upd/user/ for older standalone controllers.
+            try:
+                api_request = ApiRequest(method="put", path=f"/rest/user/{client_id}", data={"name": name})
+                await self._connection.request(api_request)
+            except Exception:
+                logger.debug(f"REST endpoint failed for rename, falling back to legacy /upd/user/ for {client_mac}")
+                api_request = ApiRequest(method="put", path=f"/upd/user/{client_id}", data={"name": name})
+                await self._connection.request(api_request)
             logger.info(f"Rename command sent for client {client_mac} to '{name}'")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True

--- a/src/managers/client_manager.py
+++ b/src/managers/client_manager.py
@@ -147,8 +147,11 @@ class ClientManager:
             try:
                 api_request = ApiRequest(method="put", path=f"/rest/user/{client_id}", data={"name": name})
                 await self._connection.request(api_request)
-            except Exception:
-                logger.debug(f"REST endpoint failed for rename, falling back to legacy /upd/user/ for {client_mac}")
+            except Exception as e:
+                logger.debug(
+                    f"REST endpoint failed for rename, falling back to legacy /upd/user/ for {client_mac}: {e}",
+                    exc_info=True,
+                )
                 api_request = ApiRequest(method="put", path=f"/upd/user/{client_id}", data={"name": name})
                 await self._connection.request(api_request)
             logger.info(f"Rename command sent for client {client_mac} to '{name}'")


### PR DESCRIPTION
## Summary

`rename_client()` in `client_manager.py` uses `PUT /upd/user/{client_id}` which returns "Permission denied" on at least UDM Pro Max (UniFi OS 5.0.12, Network App 10.1.85) with a Super Admin local account. 

Updated to use `PUT /rest/user/{client_id}` — the same REST endpoint already used by `set_client_ip_settings()` in the same file — with a fallback to the legacy `/upd/user/` endpoint for older standalone controllers.

## Problem

- `rename_client()` uses `PUT /upd/user/{client_id}` (line 145)
- `set_client_ip_settings()` uses `PUT /rest/user/{client_id}` (lines 294, 332)
- The legacy endpoint fails on the test environment below; the REST endpoint works with the same credentials

## Fix

Try `/rest/user/` first, fall back to `/upd/user/` if it fails. One file changed, ~5 lines modified. No new dependencies, no config changes.

## Live testing

All tests performed via MCP tool execution against a live controller.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.12 |
| **Firmware** | 5.0.12.30269 |
| **Network Application** | 10.1.85 |
| **MCP Client** | Claude Code 2.1.76 |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Test | Result |
|---|---|
| Rename client via MCP tool (previously failed with "Permission denied") | ✅ Pass |
| Rename back to original name | ✅ Pass |

> **Note:** Reproducing requires `UNIFI_PERMISSIONS_CLIENTS_UPDATE=true` (client update operations are disabled by default). Without this, the tool-level permission check blocks the request before the API endpoint is reached.

## Unit tests

```
Full suite — 217 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)