### PR TITLE
fix(transport): add support for running HTTP transport only in Docker PID 1

### DIFF
--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
@@ -133,6 +133,20 @@ async def run_transports(
         except Exception as http_e:
             logger.error("FastMCP %s server failed to start: %s", transport_label, http_e, exc_info=True)
 
+    # When running as PID 1 (Docker container main process), stdin has no
+    # client — stdio would exit immediately via EOF and cancel the HTTP
+    # transport.  Run HTTP-only in this case.
+    is_main_container_process = os.getpid() == 1
+    if is_main_container_process:
+        logger.info("Container main process (PID 1): running %s transport only.", transport_label)
+        try:
+            await run_http()
+            logger.info("FastMCP %s server exited.", transport_label)
+        except Exception as e:
+            logger.error("Error running FastMCP %s server: %s", transport_label, e, exc_info=True)
+            raise
+        return
+
     # Use asyncio tasks so we can cancel HTTP when stdio exits (or vice versa).
     # Without this, the HTTP server keeps the process alive as an orphan after
     # the stdio client disconnects.

--- a/packages/unifi-mcp-shared/tests/test_transport.py
+++ b/packages/unifi-mcp-shared/tests/test_transport.py
@@ -1,0 +1,129 @@
+"""Tests for shared transport lifecycle management."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from unifi_mcp_shared.transport import resolve_http_config, run_transports
+
+
+class TestResolveHttpConfig:
+    """Tests for resolve_http_config utility."""
+
+    def _make_server_cfg(self, **overrides):
+        cfg = {
+            "host": "0.0.0.0",
+            "port": 3000,
+            "http": {"enabled": False, "force": False, "transport": "streamable-http"},
+        }
+        cfg.update(overrides)
+        return MagicMock(**{"get.side_effect": cfg.get})
+
+    def test_http_disabled_by_default(self):
+        cfg = self._make_server_cfg()
+        enabled, transport, host, port = resolve_http_config(
+            cfg, default_port=3000, logger=logging.getLogger("test")
+        )
+        assert enabled is False
+
+    def test_invalid_transport_falls_back(self):
+        cfg = self._make_server_cfg(http={"enabled": True, "force": True, "transport": "bogus"})
+        enabled, transport, host, port = resolve_http_config(
+            cfg, default_port=3000, logger=logging.getLogger("test")
+        )
+        assert transport == "streamable-http"
+
+
+class TestRunTransports:
+    """Tests for transport lifecycle coupling."""
+
+    @pytest.fixture()
+    def mock_server(self):
+        server = MagicMock()
+        server.run_stdio_async = AsyncMock()
+        server.run_streamable_http_async = AsyncMock()
+        server.run_sse_async = AsyncMock()
+        server.settings = MagicMock()
+        return server
+
+    @pytest.mark.asyncio
+    async def test_stdio_only_when_http_disabled(self, mock_server):
+        """When HTTP is disabled, only stdio runs."""
+        await run_transports(
+            server=mock_server,
+            http_enabled=False,
+            host="0.0.0.0",
+            port=3000,
+            http_transport="streamable-http",
+            logger=logging.getLogger("test"),
+        )
+        mock_server.run_stdio_async.assert_awaited_once()
+        mock_server.run_streamable_http_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pid1_skips_stdio_runs_http_only(self, mock_server):
+        """When PID is 1 (Docker container), skip stdio and run HTTP only."""
+        with patch("unifi_mcp_shared.transport.os.getpid", return_value=1):
+            await run_transports(
+                server=mock_server,
+                http_enabled=True,
+                host="0.0.0.0",
+                port=3000,
+                http_transport="streamable-http",
+                logger=logging.getLogger("test"),
+            )
+        mock_server.run_stdio_async.assert_not_awaited()
+        mock_server.run_streamable_http_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pid1_runs_sse_transport(self, mock_server):
+        """PID 1 with SSE transport runs SSE, not streamable-http."""
+        with patch("unifi_mcp_shared.transport.os.getpid", return_value=1):
+            await run_transports(
+                server=mock_server,
+                http_enabled=True,
+                host="0.0.0.0",
+                port=3000,
+                http_transport="sse",
+                logger=logging.getLogger("test"),
+            )
+        mock_server.run_sse_async.assert_awaited_once()
+        mock_server.run_streamable_http_async.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_pid1_runs_both_transports(self, mock_server):
+        """When not PID 1 (local dev with force), both transports start."""
+        # Make both return immediately to avoid hanging
+        mock_server.run_stdio_async.return_value = None
+        mock_server.run_streamable_http_async.return_value = None
+
+        with patch("unifi_mcp_shared.transport.os.getpid", return_value=12345):
+            await run_transports(
+                server=mock_server,
+                http_enabled=True,
+                host="0.0.0.0",
+                port=3000,
+                http_transport="streamable-http",
+                logger=logging.getLogger("test"),
+            )
+        mock_server.run_stdio_async.assert_awaited_once()
+        mock_server.run_streamable_http_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pid1_http_error_logged_not_raised(self, mock_server, caplog):
+        """HTTP errors are logged but don't crash in PID 1 mode (matches dual-transport behaviour)."""
+        mock_server.run_streamable_http_async.side_effect = RuntimeError("bind failed")
+
+        with patch("unifi_mcp_shared.transport.os.getpid", return_value=1):
+            # Should not raise — run_http catches the exception internally
+            await run_transports(
+                server=mock_server,
+                http_enabled=True,
+                host="0.0.0.0",
+                port=3000,
+                http_transport="streamable-http",
+                logger=logging.getLogger("test"),
+            )
+        assert "bind failed" in caplog.text


### PR DESCRIPTION
This pull request improves the lifecycle management of the shared transport layer, especially for containerized deployments, and introduces comprehensive tests for these behaviors. The main focus is to ensure correct handling when running as the main process in a Docker container (PID 1), and to add robust test coverage for various transport startup scenarios.

Key changes include:

**Container lifecycle handling:**

* Updated the transport startup logic to detect when the process is running as PID 1 (the main process in a Docker container) and, in that case, to run only the HTTP transport and skip stdio, preventing premature exit due to lack of a stdio client.

**Testing improvements:**

* Added a new test suite `test_transport.py` that covers:
  - HTTP configuration resolution, including fallback for invalid transports.
  - Correct startup behavior for stdio and HTTP transports depending on configuration and process PID.
  - Ensuring that in PID 1 mode, only the appropriate transport is started and errors are logged instead of crashing the process.
  - Coverage for both streamable HTTP and SSE transports, and for error handling in HTTP startup.