### PR TITLE
feat(network): add client group (network member group) tools

### DIFF
--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -24,6 +24,14 @@ These are always registered regardless of mode:
 - `unifi_list_firewall_zones` — List firewall zones (V2 API)
 - `unifi_list_ip_groups` — List IP groups (V2 API)
 
+## Client Groups (5 tools)
+
+- `unifi_list_client_groups` — List all client groups (network member groups)
+- `unifi_get_client_group_details` — Get group details by ID
+- `unifi_create_client_group` — Create a new client group with MAC members
+- `unifi_update_client_group` — Update an existing group
+- `unifi_delete_client_group` — Delete a group (requires delete permission)
+
 ## MAC ACL Rules (5 tools)
 
 - `unifi_list_acl_rules` — List MAC ACL rules, optionally filtered by network/VLAN

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -45,6 +45,7 @@ NETWORK_CATEGORY_MAP = {
     "route": "routes",
     "snmp": "snmp",
     "acl": "acl_rules",
+    "client_group": "client_groups",
 }
 
 # Backward-compatible alias used by the old permissions module

--- a/apps/network/src/unifi_network_mcp/config/config.yaml
+++ b/apps/network/src/unifi_network_mcp/config/config.yaml
@@ -30,6 +30,7 @@ server:
   #     - devices        # Device listing, radio config, reboot, locate, upgrade
   #     - events         # Events and alarms
   #     - acl            # MAC ACL rules (Policy Engine, Layer 2 access control)
+  #     - client_groups  # Client groups (network member groups for OON policies)
   #     - firewall       # Firewall rules and groups
   #     - hotspot        # Vouchers for guest network
   #     - network        # Network/VLAN management
@@ -69,6 +70,11 @@ permissions:
     delete: false
 
   acl_rules:
+    create: true
+    update: true
+    delete: false
+
+  client_groups:
     create: true
     update: true
     delete: false

--- a/apps/network/src/unifi_network_mcp/managers/client_group_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/client_group_manager.py
@@ -1,0 +1,179 @@
+"""Manager for client groups (network member groups) on the UniFi controller.
+
+Client groups organize devices by MAC address for use in OON policies,
+firewall rules, and other network configurations. Groups have a name,
+type (CLIENTS), and a list of member MAC addresses.
+
+API endpoint: /proxy/network/v2/api/site/{site}/network-members-group
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiounifi.models.api import ApiRequestV2
+
+from .connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_CLIENT_GROUPS = "client_groups"
+
+
+class ClientGroupManager:
+    """Manages client groups (network member groups) on the UniFi controller."""
+
+    def __init__(self, connection_manager: ConnectionManager):
+        self._connection = connection_manager
+
+    async def get_client_groups(self) -> List[Dict[str, Any]]:
+        """Get all client groups.
+
+        Returns:
+            List of client group dictionaries.
+        """
+        cache_key = f"{CACHE_PREFIX_CLIENT_GROUPS}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key)
+        if cached_data is not None:
+            return cached_data
+
+        if not await self._connection.ensure_connected():
+            return []
+
+        try:
+            api_request = ApiRequestV2(method="get", path="/network-members-groups")
+            response = await self._connection.request(api_request)
+
+            groups = (
+                response
+                if isinstance(response, list)
+                else response.get("data", [])
+                if isinstance(response, dict)
+                else []
+            )
+
+            self._connection._update_cache(cache_key, groups)
+            return groups
+        except Exception as e:
+            logger.error(f"Error getting client groups: {e}")
+            return []
+
+    async def get_client_group_by_id(self, group_id: str) -> Optional[Dict[str, Any]]:
+        """Get a specific client group by ID.
+
+        Args:
+            group_id: The ID of the client group.
+
+        Returns:
+            The client group dictionary, or None if not found.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        try:
+            api_request = ApiRequestV2(method="get", path=f"/network-members-group/{group_id}")
+            response = await self._connection.request(api_request)
+
+            if isinstance(response, dict):
+                return response if "id" in response or "_id" in response else response.get("data", None)
+            return None
+        except Exception as e:
+            logger.error(f"Error getting client group {group_id}: {e}")
+            return None
+
+    async def create_client_group(self, group_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Create a new client group.
+
+        Args:
+            group_data: Dictionary containing the group configuration.
+                Required fields:
+                - name (str): Group name
+                - members (list): List of MAC addresses
+                - type (str): "CLIENTS"
+
+        Returns:
+            The created client group dictionary, or None on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        required_keys = {"name", "members", "type"}
+        missing = required_keys - group_data.keys()
+        if missing:
+            logger.error(f"Missing required keys for client group: {missing}")
+            return None
+
+        try:
+            api_request = ApiRequestV2(method="post", path="/network-members-group", data=group_data)
+            response = await self._connection.request(api_request)
+
+            self._invalidate_cache()
+
+            if isinstance(response, dict) and ("id" in response or "_id" in response):
+                return response
+            elif isinstance(response, dict) and "data" in response:
+                return response["data"]
+            elif isinstance(response, list) and len(response) > 0:
+                return response[0] if isinstance(response[0], dict) else {"id": str(response[0])}
+            elif response is None or response == "":
+                logger.info("Create returned empty response, verifying via list")
+                groups = await self.get_client_groups()
+                created = next(
+                    (g for g in groups if g.get("name") == group_data.get("name")),
+                    None,
+                )
+                return created
+            else:
+                logger.error(f"Unexpected response creating client group: {type(response)} {response}")
+                return None
+        except Exception as e:
+            logger.error(f"Error creating client group: {e}", exc_info=True)
+            return None
+
+    async def update_client_group(self, group_id: str, group_data: Dict[str, Any]) -> bool:
+        """Update an existing client group.
+
+        Args:
+            group_id: The ID of the client group to update.
+            group_data: Complete group data (PUT replaces the entire object).
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="put", path=f"/network-members-group/{group_id}", data=group_data)
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error(f"Error updating client group {group_id}: {e}", exc_info=True)
+            return False
+
+    async def delete_client_group(self, group_id: str) -> bool:
+        """Delete a client group.
+
+        Args:
+            group_id: The ID of the client group to delete.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="delete", path=f"/network-members-group/{group_id}")
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting client group {group_id}: {e}", exc_info=True)
+            return False
+
+    def _invalidate_cache(self):
+        """Invalidate all client group caches."""
+        self._connection._invalidate_cache(CACHE_PREFIX_CLIENT_GROUPS)

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -28,6 +28,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from unifi_core.auth import UniFiAuth
 from unifi_network_mcp.bootstrap import load_config, logger
 from unifi_network_mcp.managers.acl_manager import AclManager
+from unifi_network_mcp.managers.client_group_manager import ClientGroupManager
 from unifi_network_mcp.managers.client_manager import ClientManager
 from unifi_network_mcp.managers.connection_manager import ConnectionManager
 from unifi_network_mcp.managers.device_manager import DeviceManager
@@ -151,6 +152,11 @@ def get_acl_manager() -> AclManager:
 
 
 @lru_cache
+def get_client_group_manager() -> ClientGroupManager:
+    return ClientGroupManager(get_connection_manager())
+
+
+@lru_cache
 def get_client_manager() -> ClientManager:
     return ClientManager(get_connection_manager())
 
@@ -233,6 +239,7 @@ auth = get_auth()
 server = get_server()
 connection_manager = get_connection_manager()
 acl_manager = get_acl_manager()
+client_group_manager = get_client_group_manager()
 client_manager = get_client_manager()
 device_manager = get_device_manager()
 stats_manager = get_stats_manager()

--- a/apps/network/src/unifi_network_mcp/tools/client_groups.py
+++ b/apps/network/src/unifi_network_mcp/tools/client_groups.py
@@ -1,0 +1,254 @@
+"""
+Client group tools for UniFi Network MCP server.
+
+Client groups (network member groups) organize devices by MAC address
+for use in OON policies, firewall rules, and other configurations.
+"""
+
+import json
+import logging
+from typing import Annotated, Any, Dict
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_mcp_shared.confirmation import create_preview, should_auto_confirm
+from unifi_network_mcp.categories import parse_permission
+from unifi_network_mcp.runtime import client_group_manager, config, server
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_client_groups",
+    description="List client groups (network member groups). "
+    "Groups organize devices by MAC address for use in OON policies and firewall rules.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_client_groups() -> Dict[str, Any]:
+    """
+    Lists all client groups configured on the controller.
+
+    Returns:
+        A dictionary containing:
+        - success (bool): Indicates if the operation was successful.
+        - count (int): Number of groups found.
+        - groups (List[Dict]): List of groups with id, name, type, and members.
+    """
+    if not parse_permission(config.permissions, "client_groups", "read"):
+        return {"success": False, "error": "Permission denied to list client groups."}
+
+    try:
+        groups = await client_group_manager.get_client_groups()
+        formatted = [
+            {
+                "id": g.get("id", g.get("_id")),
+                "name": g.get("name"),
+                "type": g.get("type"),
+                "member_count": len(g.get("members", [])),
+                "members": g.get("members", []),
+            }
+            for g in groups
+        ]
+        return {
+            "success": True,
+            "site": client_group_manager._connection.site,
+            "count": len(formatted),
+            "groups": formatted,
+        }
+    except Exception as e:
+        logger.error(f"Error listing client groups: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to list client groups: {e}"}
+
+
+@server.tool(
+    name="unifi_get_client_group_details",
+    description="Get detailed configuration for a specific client group by ID.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_client_group_details(
+    group_id: Annotated[str, Field(description="The unique identifier of the client group")],
+) -> Dict[str, Any]:
+    """
+    Gets the detailed configuration of a specific client group.
+
+    Args:
+        group_id (str): The unique identifier of the client group.
+
+    Returns:
+        A dictionary containing the full group configuration.
+    """
+    if not parse_permission(config.permissions, "client_groups", "read"):
+        return {"success": False, "error": "Permission denied to get client group details."}
+
+    try:
+        if not group_id:
+            return {"success": False, "error": "group_id is required"}
+
+        group = await client_group_manager.get_client_group_by_id(group_id)
+        if not group:
+            # Fallback: search in list
+            groups = await client_group_manager.get_client_groups()
+            group = next((g for g in groups if g.get("id", g.get("_id")) == group_id), None)
+
+        if not group:
+            return {"success": False, "error": f"Client group '{group_id}' not found."}
+
+        return {
+            "success": True,
+            "group_id": group_id,
+            "details": json.loads(json.dumps(group, default=str)),
+        }
+    except Exception as e:
+        logger.error(f"Error getting client group {group_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to get client group {group_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_create_client_group",
+    description="Create a new client group (network member group). "
+    "Groups organize devices by MAC address for use in OON policies and firewall rules. "
+    "Requires confirmation.",
+    permission_category="client_groups",
+    permission_action="create",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def create_client_group(
+    name: Annotated[str, Field(description="Descriptive name for the group (e.g., 'Kids All', 'Work Laptops')")],
+    members: Annotated[
+        list[str],
+        Field(
+            description="List of MAC addresses to include in the group (e.g., ['aa:bb:cc:dd:ee:ff', '11:22:33:44:55:66'])"
+        ),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the group. When false (default), returns a preview of the changes"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Creates a new client group.
+
+    Args:
+        name (str): Name of the group.
+        members (list): List of MAC addresses.
+        confirm (bool): Must be True to execute. False returns a preview.
+
+    Returns:
+        Preview of changes or the created group.
+    """
+    group_data = {
+        "name": name,
+        "members": members,
+        "type": "CLIENTS",
+    }
+
+    if not confirm and not should_auto_confirm():
+        return create_preview(
+            resource_type="client_group",
+            resource_data=group_data,
+            resource_name=name,
+        )
+
+    try:
+        result = await client_group_manager.create_client_group(group_data)
+        if result:
+            return {
+                "success": True,
+                "message": f"Client group '{name}' created successfully.",
+                "group": json.loads(json.dumps(result, default=str)),
+            }
+        return {"success": False, "error": f"Failed to create client group '{name}'."}
+    except Exception as e:
+        logger.error(f"Error creating client group: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to create client group '{name}': {e}"}
+
+
+@server.tool(
+    name="unifi_update_client_group",
+    description="Update an existing client group. Requires the full group object (PUT replaces entire resource). "
+    "Requires confirmation.",
+    permission_category="client_groups",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_client_group(
+    group_id: Annotated[str, Field(description="The ID of the group to update")],
+    group_data: Annotated[
+        dict,
+        Field(description="The complete updated group object with id, name, members, and type fields"),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, updates the group. When false (default), returns a preview of the changes"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Updates an existing client group.
+
+    Args:
+        group_id (str): The ID of the group to update.
+        group_data (dict): The complete updated group object (PUT replaces the entire resource).
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview of changes or success/failure status.
+    """
+    if not confirm and not should_auto_confirm():
+        return create_preview(
+            resource_type="client_group",
+            resource_data=group_data,
+            resource_name=group_id,
+        )
+
+    try:
+        success = await client_group_manager.update_client_group(group_id, group_data)
+        if success:
+            return {"success": True, "message": f"Client group '{group_id}' updated successfully."}
+        return {"success": False, "error": f"Failed to update client group '{group_id}'."}
+    except Exception as e:
+        logger.error(f"Error updating client group {group_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to update client group '{group_id}': {e}"}
+
+
+@server.tool(
+    name="unifi_delete_client_group",
+    description="Delete a client group. Requires confirmation. "
+    "WARNING: Deleting a group may affect OON policies and firewall rules that reference it.",
+    permission_category="client_groups",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_client_group(
+    group_id: Annotated[str, Field(description="The ID of the group to delete")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the group. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Deletes a client group.
+
+    Args:
+        group_id (str): The ID of the group to delete.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview or success/failure status.
+    """
+    if not confirm and not should_auto_confirm():
+        return create_preview(
+            resource_type="client_group",
+            resource_data={"group_id": group_id},
+            resource_name=group_id,
+            warnings=["Deleting a group may affect OON policies and firewall rules that reference it."],
+        )
+
+    try:
+        success = await client_group_manager.delete_client_group(group_id)
+        if success:
+            return {"success": True, "message": f"Client group '{group_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete client group '{group_id}'."}
+    except Exception as e:
+        logger.error(f"Error deleting client group {group_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to delete client group '{group_id}': {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/client_groups.py
+++ b/apps/network/src/unifi_network_mcp/tools/client_groups.py
@@ -109,7 +109,7 @@ async def get_client_group_details(
     description="Create a new client group (network member group). "
     "Groups organize devices by MAC address for use in OON policies and firewall rules. "
     "Requires confirmation.",
-    permission_category="client_groups",
+    permission_category="client_group",
     permission_action="create",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
 )
@@ -168,7 +168,7 @@ async def create_client_group(
     name="unifi_update_client_group",
     description="Update an existing client group. Requires the full group object (PUT replaces entire resource). "
     "Requires confirmation.",
-    permission_category="client_groups",
+    permission_category="client_group",
     permission_action="update",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
 )
@@ -215,7 +215,7 @@ async def update_client_group(
     name="unifi_delete_client_group",
     description="Delete a client group. Requires confirmation. "
     "WARNING: Deleting a group may affect OON policies and firewall rules that reference it.",
-    permission_category="client_groups",
+    permission_category="client_group",
     permission_action="delete",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
 )

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 92,
+  "count": 97,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -8,6 +8,7 @@
     "unifi_authorize_guest": "unifi_network_mcp.tools.clients",
     "unifi_block_client": "unifi_network_mcp.tools.clients",
     "unifi_create_acl_rule": "unifi_network_mcp.tools.acl",
+    "unifi_create_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_create_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_create_network": "unifi_network_mcp.tools.network",
     "unifi_create_port_forward": "unifi_network_mcp.tools.port_forwards",
@@ -20,11 +21,13 @@
     "unifi_create_voucher": "unifi_network_mcp.tools.hotspot",
     "unifi_create_wlan": "unifi_network_mcp.tools.network",
     "unifi_delete_acl_rule": "unifi_network_mcp.tools.acl",
+    "unifi_delete_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_force_reconnect_client": "unifi_network_mcp.tools.clients",
     "unifi_get_acl_rule_details": "unifi_network_mcp.tools.acl",
     "unifi_get_alerts": "unifi_network_mcp.tools.stats",
     "unifi_get_client_details": "unifi_network_mcp.tools.clients",
+    "unifi_get_client_group_details": "unifi_network_mcp.tools.client_groups",
     "unifi_get_client_stats": "unifi_network_mcp.tools.stats",
     "unifi_get_device_details": "unifi_network_mcp.tools.devices",
     "unifi_get_device_radio": "unifi_network_mcp.tools.devices",
@@ -38,7 +41,7 @@
     "unifi_get_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_get_qos_rule_details": "unifi_network_mcp.tools.qos",
     "unifi_get_route_details": "unifi_network_mcp.tools.routing",
-    "unifi_get_site_settings": "unifi_network_mcp.tools.config",
+    "unifi_get_site_settings": "unifi_network_mcp.tools.system",
     "unifi_get_snmp_settings": "unifi_network_mcp.tools.system",
     "unifi_get_system_info": "unifi_network_mcp.tools.system",
     "unifi_get_top_clients": "unifi_network_mcp.tools.stats",
@@ -52,6 +55,7 @@
     "unifi_list_active_routes": "unifi_network_mcp.tools.routing",
     "unifi_list_alarms": "unifi_network_mcp.tools.events",
     "unifi_list_blocked_clients": "unifi_network_mcp.tools.clients",
+    "unifi_list_client_groups": "unifi_network_mcp.tools.client_groups",
     "unifi_list_clients": "unifi_network_mcp.tools.clients",
     "unifi_list_devices": "unifi_network_mcp.tools.devices",
     "unifi_list_events": "unifi_network_mcp.tools.events",
@@ -81,6 +85,7 @@
     "unifi_unauthorize_guest": "unifi_network_mcp.tools.clients",
     "unifi_unblock_client": "unifi_network_mcp.tools.clients",
     "unifi_update_acl_rule": "unifi_network_mcp.tools.acl",
+    "unifi_update_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_update_device_radio": "unifi_network_mcp.tools.devices",
     "unifi_update_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_update_network": "unifi_network_mcp.tools.network",
@@ -274,6 +279,39 @@
             "acl_index",
             "action",
             "mac_acl_network_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a new client group (network member group). Groups organize devices by MAC address for use in OON policies and firewall rules. Requires confirmation.",
+      "name": "unifi_create_client_group",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, creates the group. When false (default), returns a preview of the changes",
+              "type": "boolean"
+            },
+            "members": {
+              "description": "List of MAC addresses to include in the group (e.g., ['aa:bb:cc:dd:ee:ff', '11:22:33:44:55:66'])",
+              "type": "array"
+            },
+            "name": {
+              "description": "Descriptive name for the group (e.g., 'Kids All', 'Work Laptops')",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "members"
           ],
           "type": "object"
         }
@@ -635,6 +673,28 @@
       }
     },
     {
+      "description": "Delete a client group. Requires confirmation. WARNING: Deleting a group may affect OON policies and firewall rules that reference it.",
+      "name": "unifi_delete_client_group",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the group. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "group_id": {
+              "description": "The ID of the group to delete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "group_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
       "description": "Delete a firewall policy by ID. Requires confirmation. WARNING: Removing an ALLOW rule may block traffic. Removing a BLOCK rule may open access.",
       "name": "unifi_delete_firewall_policy",
       "schema": {
@@ -740,6 +800,28 @@
           },
           "required": [
             "mac_address"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get detailed configuration for a specific client group by ID.",
+      "name": "unifi_get_client_group_details",
+      "schema": {
+        "input": {
+          "properties": {
+            "group_id": {
+              "description": "The unique identifier of the client group",
+              "type": "string"
+            }
+          },
+          "required": [
+            "group_id"
           ],
           "type": "object"
         }
@@ -1272,6 +1354,20 @@
       },
       "description": "List clients/devices that are currently blocked from the network",
       "name": "unifi_list_blocked_clients",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List client groups (network member groups). Groups organize devices by MAC address for use in OON policies and firewall rules.",
+      "name": "unifi_list_client_groups",
       "schema": {
         "input": {
           "properties": {},
@@ -1899,6 +1995,39 @@
           "required": [
             "rule_id",
             "rule_data"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Update an existing client group. Requires the full group object (PUT replaces entire resource). Requires confirmation.",
+      "name": "unifi_update_client_group",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, updates the group. When false (default), returns a preview of the changes",
+              "type": "boolean"
+            },
+            "group_data": {
+              "description": "The complete updated group object with id, name, members, and type fields",
+              "type": "object"
+            },
+            "group_id": {
+              "description": "The ID of the group to update",
+              "type": "string"
+            }
+          },
+          "required": [
+            "group_id",
+            "group_data"
           ],
           "type": "object"
         }

--- a/apps/network/tests/unit/test_client_group_manager.py
+++ b/apps/network/tests/unit/test_client_group_manager.py
@@ -1,0 +1,316 @@
+"""Tests for the ClientGroupManager class.
+
+This module tests client group (network member group) operations.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestClientGroupManager:
+    """Tests for the ClientGroupManager class."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def client_group_manager(self, mock_connection):
+        """Create a ClientGroupManager with mocked connection."""
+        from unifi_network_mcp.managers.client_group_manager import ClientGroupManager
+
+        return ClientGroupManager(mock_connection)
+
+    # ---- get_client_groups ----
+
+    @pytest.mark.asyncio
+    async def test_get_client_groups_returns_list(self, client_group_manager, mock_connection):
+        """Test get_client_groups returns a list of groups."""
+        mock_groups = [
+            {"id": "g1", "name": "Kids Everything", "type": "CLIENTS", "members": ["aa:bb:cc:dd:ee:ff"]},
+            {"id": "g2", "name": "Adults", "type": "CLIENTS", "members": ["11:22:33:44:55:66"]},
+        ]
+        mock_connection.request.return_value = mock_groups
+
+        groups = await client_group_manager.get_client_groups()
+
+        assert len(groups) == 2
+        assert groups[0]["name"] == "Kids Everything"
+        mock_connection._update_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_client_groups_uses_cache(self, client_group_manager, mock_connection):
+        """Test get_client_groups returns cached data when available."""
+        cached = [{"id": "cached", "name": "Cached Group"}]
+        mock_connection.get_cached.return_value = cached
+
+        groups = await client_group_manager.get_client_groups()
+
+        assert groups == cached
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_client_groups_handles_error(self, client_group_manager, mock_connection):
+        """Test get_client_groups returns empty list on error."""
+        mock_connection.request.side_effect = Exception("Network error")
+
+        groups = await client_group_manager.get_client_groups()
+
+        assert groups == []
+
+    @pytest.mark.asyncio
+    async def test_get_client_groups_not_connected(self, client_group_manager, mock_connection):
+        """Test get_client_groups returns empty list when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        groups = await client_group_manager.get_client_groups()
+
+        assert groups == []
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_client_groups_handles_dict_response(self, client_group_manager, mock_connection):
+        """Test get_client_groups handles dict response with data key."""
+        mock_connection.request.return_value = {"data": [{"id": "g1", "name": "Group"}]}
+
+        groups = await client_group_manager.get_client_groups()
+
+        assert len(groups) == 1
+
+    # ---- get_client_group_by_id ----
+
+    @pytest.mark.asyncio
+    async def test_get_client_group_by_id_found(self, client_group_manager, mock_connection):
+        """Test get_client_group_by_id returns group when found."""
+        mock_connection.request.return_value = {"id": "g1", "name": "Test Group", "members": []}
+
+        group = await client_group_manager.get_client_group_by_id("g1")
+
+        assert group is not None
+        assert group["name"] == "Test Group"
+
+    @pytest.mark.asyncio
+    async def test_get_client_group_by_id_not_connected(self, client_group_manager, mock_connection):
+        """Test get_client_group_by_id returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        group = await client_group_manager.get_client_group_by_id("g1")
+
+        assert group is None
+
+    @pytest.mark.asyncio
+    async def test_get_client_group_by_id_handles_error(self, client_group_manager, mock_connection):
+        """Test get_client_group_by_id returns None on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        group = await client_group_manager.get_client_group_by_id("g1")
+
+        assert group is None
+
+    # ---- create_client_group ----
+
+    @pytest.mark.asyncio
+    async def test_create_client_group_success(self, client_group_manager, mock_connection):
+        """Test create_client_group with valid data."""
+        group_data = {
+            "name": "New Group",
+            "members": ["aa:bb:cc:dd:ee:ff"],
+            "type": "CLIENTS",
+        }
+        mock_connection.request.return_value = {"id": "new1", **group_data}
+
+        result = await client_group_manager.create_client_group(group_data)
+
+        assert result is not None
+        assert result["id"] == "new1"
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_create_client_group_missing_required_keys(self, client_group_manager, mock_connection):
+        """Test create_client_group returns None when required keys are missing."""
+        result = await client_group_manager.create_client_group({"name": "Incomplete"})
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_client_group_not_connected(self, client_group_manager, mock_connection):
+        """Test create_client_group returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await client_group_manager.create_client_group(
+            {
+                "name": "Test",
+                "members": [],
+                "type": "CLIENTS",
+            }
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_client_group_handles_error(self, client_group_manager, mock_connection):
+        """Test create_client_group returns None on API error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await client_group_manager.create_client_group(
+            {
+                "name": "Test",
+                "members": [],
+                "type": "CLIENTS",
+            }
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_client_group_handles_data_wrapper(self, client_group_manager, mock_connection):
+        """Test create_client_group handles response with data key."""
+        mock_connection.request.return_value = {"data": {"id": "new1", "name": "Test"}}
+
+        result = await client_group_manager.create_client_group(
+            {
+                "name": "Test",
+                "members": [],
+                "type": "CLIENTS",
+            }
+        )
+
+        assert result == {"id": "new1", "name": "Test"}
+
+    # ---- update_client_group ----
+
+    @pytest.mark.asyncio
+    async def test_update_client_group_success(self, client_group_manager, mock_connection):
+        """Test update_client_group with valid data."""
+        mock_connection.request.return_value = {}
+
+        result = await client_group_manager.update_client_group(
+            "g1", {"id": "g1", "name": "Updated", "members": [], "type": "CLIENTS"}
+        )
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_client_group_not_connected(self, client_group_manager, mock_connection):
+        """Test update_client_group returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await client_group_manager.update_client_group("g1", {"name": "Test"})
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_update_client_group_handles_error(self, client_group_manager, mock_connection):
+        """Test update_client_group returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await client_group_manager.update_client_group("g1", {"name": "Test"})
+
+        assert result is False
+
+    # ---- delete_client_group ----
+
+    @pytest.mark.asyncio
+    async def test_delete_client_group_success(self, client_group_manager, mock_connection):
+        """Test delete_client_group with valid ID."""
+        mock_connection.request.return_value = {}
+
+        result = await client_group_manager.delete_client_group("g1")
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_client_group_not_connected(self, client_group_manager, mock_connection):
+        """Test delete_client_group returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await client_group_manager.delete_client_group("g1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_client_group_handles_error(self, client_group_manager, mock_connection):
+        """Test delete_client_group returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await client_group_manager.delete_client_group("g1")
+
+        assert result is False
+
+    # ---- API path verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_uses_correct_path(self, client_group_manager, mock_connection):
+        """Test get_client_groups calls the correct API endpoint."""
+        mock_connection.request.return_value = []
+
+        await client_group_manager.get_client_groups()
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/network-members-groups"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_uses_correct_path(self, client_group_manager, mock_connection):
+        """Test get_client_group_by_id calls the correct API endpoint."""
+        mock_connection.request.return_value = {"id": "g1"}
+
+        await client_group_manager.get_client_group_by_id("g1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/network-members-group/g1"
+
+    @pytest.mark.asyncio
+    async def test_create_uses_correct_path_and_method(self, client_group_manager, mock_connection):
+        """Test create_client_group uses POST to the correct endpoint."""
+        mock_connection.request.return_value = {"id": "new1"}
+
+        await client_group_manager.create_client_group(
+            {
+                "name": "Test",
+                "members": [],
+                "type": "CLIENTS",
+            }
+        )
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/network-members-group"
+        assert api_request.method == "post"
+
+    @pytest.mark.asyncio
+    async def test_update_uses_correct_path_and_method(self, client_group_manager, mock_connection):
+        """Test update_client_group uses PUT to the correct endpoint."""
+        mock_connection.request.return_value = {}
+
+        await client_group_manager.update_client_group("g1", {"name": "Updated"})
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/network-members-group/g1"
+        assert api_request.method == "put"
+
+    @pytest.mark.asyncio
+    async def test_delete_uses_correct_path_and_method(self, client_group_manager, mock_connection):
+        """Test delete_client_group uses DELETE to the correct endpoint."""
+        mock_connection.request.return_value = {}
+
+        await client_group_manager.delete_client_group("g1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/network-members-group/g1"
+        assert api_request.method == "delete"

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -43,7 +43,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address — includes all controller-reported fields: IP, hostname, connection stat... |
+| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address â€” includes all controller-reported fields: IP, hostname, connection stat... |
 | `unifi_list_blocked_clients` | Read | List clients/devices that are currently blocked from the network |
 | `unifi_list_clients` | Read | Returns connected clients with MAC, name, hostname, IP, connection type (wired/wireless), and for wireless clients: SSID, signal dBm, cha... |
 | `unifi_lookup_by_ip` | Read | Quick IP-to-hostname lookup. |
@@ -70,7 +70,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address — includes radio tables, port tables, system stats, WAN info, firmware d... |
+| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address â€” includes radio tables, port tables, system stats, WAN info, firmware d... |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
 | `unifi_list_devices` | Read | Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_categ... |
 | `unifi_adopt_device` | Mutate | Adopt a pending device into the Unifi Network by MAC address |
@@ -345,7 +345,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN — each with status, number of gateways/switches/APs, and active user counts. |
+| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN â€” each with status, number of gateways/switches/APs, and active user counts. |
 | `unifi_get_site_settings` | Read | Get current site settings (e.g., country code, timezone, connectivity monitoring). |
 | `unifi_get_snmp_settings` | Read | Get current SNMP settings for the site (enabled state, community string). |
 | `unifi_get_system_info` | Read | Returns controller version, uptime, hostname, memory/CPU usage, and update availability. |

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (92 tools)
+# Network Server Tool Reference (97 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -43,7 +43,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address â€” includes all controller-reported fields: IP, hostname, connection stat... |
+| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address — includes all controller-reported fields: IP, hostname, connection stat... |
 | `unifi_list_blocked_clients` | Read | List clients/devices that are currently blocked from the network |
 | `unifi_list_clients` | Read | Returns connected clients with MAC, name, hostname, IP, connection type (wired/wireless), and for wireless clients: SSID, signal dBm, cha... |
 | `unifi_lookup_by_ip` | Read | Quick IP-to-hostname lookup. |
@@ -70,7 +70,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address â€” includes radio tables, port tables, system stats, WAN info, firmware d... |
+| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address — includes radio tables, port tables, system stats, WAN info, firmware d... |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
 | `unifi_list_devices` | Read | Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_categ... |
 | `unifi_adopt_device` | Mutate | Adopt a pending device into the Unifi Network by MAC address |
@@ -242,6 +242,26 @@ Always available, regardless of registration mode.
 
 ---
 
+## Client Groups
+
+<!-- AUTO:tools:client_groups -->
+5 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_get_client_group_details` | Read | Get detailed configuration for a specific client group by ID. |
+| `unifi_list_client_groups` | Read | List client groups (network member groups). |
+| `unifi_create_client_group` | Mutate | Create a new client group (network member group). |
+| `unifi_delete_client_group` | Mutate | Delete a client group. |
+| `unifi_update_client_group` | Mutate | Update an existing client group. |
+<!-- /AUTO:tools:client_groups -->
+
+**Tips:**
+- Client groups organize devices by MAC address for use in OON policies and firewall rules
+- Delete requires `UNIFI_PERMISSIONS_CLIENT_GROUPS_DELETE=true`
+
+---
+
 ## Events & Alarms
 
 <!-- AUTO:tools:events -->
@@ -325,7 +345,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN â€” each with status, number of gateways/switches/APs, and active user counts. |
+| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN — each with status, number of gateways/switches/APs, and active user counts. |
 | `unifi_get_site_settings` | Read | Get current site settings (e.g., country code, timezone, connectivity monitoring). |
 | `unifi_get_snmp_settings` | Read | Get current SNMP settings for the site (enabled state, community string). |
 | `unifi_get_system_info` | Read | Returns controller version, uptime, hostname, memory/CPU usage, and update availability. |


### PR DESCRIPTION
## Summary

Adds 5 new tools for managing client groups (network member groups) via the v2 API. Client groups organize devices by MAC address and are used by OON policies, firewall rules, and other network configurations.

**New tools:**
- `unifi_list_client_groups` — List all client groups with member counts
- `unifi_get_client_group_details` — Get group details by ID
- `unifi_create_client_group` — Create a new group with MAC members (preview-then-confirm)
- `unifi_update_client_group` — Update an existing group (full object replacement)
- `unifi_delete_client_group` — Delete a group (with OON/firewall impact warning)

**API endpoint:** `GET/POST/PUT/DELETE /proxy/network/v2/api/site/default/network-members-group[/{id}]`

## Files changed

| File | Change |
|---|---|
| `apps/network/src/unifi_network_mcp/managers/client_group_manager.py` | **New** — Manager with CRUD operations, caching, error handling |
| `apps/network/src/unifi_network_mcp/tools/client_groups.py` | **New** — 5 tool functions with ToolAnnotations and Annotated parameters |
| `apps/network/tests/unit/test_client_group_manager.py` | **New** — 24 unit tests |
| `apps/network/src/unifi_network_mcp/runtime.py` | Added `ClientGroupManager` factory + alias |
| `apps/network/src/unifi_network_mcp/categories.py` | Added `"client_group": "client_groups"` to `NETWORK_CATEGORY_MAP` |
| `apps/network/src/unifi_network_mcp/config/config.yaml` | Added `client_groups` category + permissions |
| `apps/network/src/unifi_network_mcp/tools_manifest.json` | Regenerated (91 → 97 tools) |
| `apps/network/docs/tools.md` | Added Client Groups section |

## Live testing

All 5 tools tested end-to-end against a live controller, including create → update → verify → delete round-trip.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.12 |
| **Firmware** | 5.0.12.30269 |
| **Network Application** | 10.1.85 |
| **MCP Client** | Claude Code 2.1.81 |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Tool | Test | Result |
|---|---|---|
| `list_client_groups` | List all 16 groups | ✅ Pass |
| `get_client_group_details` | Fetch "Kids Everything" by ID | ✅ Pass |
| `create_client_group` | Create with MAC members, verify returned object | ✅ Pass |
| `update_client_group` | Update name + add member, verified via get | ✅ Pass |
| `delete_client_group` | Delete + verify removed | ✅ Pass |

> **Note:** Delete testing requires `UNIFI_PERMISSIONS_CLIENT_GROUPS_DELETE=true` (delete operations are disabled by default per #83).

## Unit tests

24 tests covering: CRUD success paths, cache behavior, error handling, not-connected states, API path verification, response format handling (including data-wrapper).

```
tests/unit/test_client_group_manager.py — 24 passed
Full suite (excluding pre-existing test_tool_map_sync path issue) — 319 passed, 0 failed
```

## Notes

- Uses `permission_action="delete"` (not the old "update" workaround) per #83
- API uses `id` field (not `_id`) consistent with v2 API convention — code handles both defensively
- List endpoint uses plural path (`/network-members-groups`), CRUD uses singular (`/network-members-group/{id}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)