### PR TITLE
feat(network): add OON policy tools and DPI application lookup

### DIFF
--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -24,6 +24,24 @@ These are always registered regardless of mode:
 - `unifi_list_firewall_zones` — List firewall zones (V2 API)
 - `unifi_list_ip_groups` — List IP groups (V2 API)
 
+## OON Policies (6 tools)
+
+- `unifi_list_oon_policies` — List OON policies with schedule and targeting summary
+- `unifi_get_oon_policy_details` — Get full policy config (secure, qos, route, targets)
+- `unifi_create_oon_policy` — Create a new OON policy
+- `unifi_update_oon_policy` — Update an existing policy (full object replacement)
+- `unifi_toggle_oon_policy` — Toggle a policy on/off
+- `unifi_delete_oon_policy` — Delete a policy (requires delete permission)
+
+## DPI Application Lookup (2 tools)
+
+- `unifi_list_dpi_applications` — List/search DPI applications by name (requires API key)
+- `unifi_list_dpi_categories` — List DPI application categories (requires API key)
+
+> **Note:** DPI lookup requires `UNIFI_API_KEY` or `UNIFI_NETWORK_API_KEY`. As of Network App 10.1.85,
+> the official API only returns categories 0-1 (~2,100 apps). Categories 4+ (streaming, social media)
+> are not yet populated by Ubiquiti.
+
 ## Client Groups (5 tools)
 
 - `unifi_list_client_groups` — List all client groups (network member groups)

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -44,6 +44,8 @@ NETWORK_CATEGORY_MAP = {
     "snmp": "snmp",
     "acl": "acl_rules",
     "client_group": "client_groups",
+    "oon_policy": "oon_policies",
+    "dpi": "dpi",
 }
 
 # Backward-compatible alias

--- a/apps/network/src/unifi_network_mcp/config/config.yaml
+++ b/apps/network/src/unifi_network_mcp/config/config.yaml
@@ -31,7 +31,9 @@ server:
   #     - events         # Events and alarms
   #     - acl            # MAC ACL rules (Policy Engine, Layer 2 access control)
   #     - client_groups  # Client groups (network member groups for OON policies)
+  #     - dpi            # DPI application/category lookup (requires API key)
   #     - firewall       # Firewall rules and groups
+  #     - oon            # OON policies (internet scheduling, app blocking, QoS, routing)
   #     - hotspot        # Vouchers for guest network
   #     - network        # Network/VLAN management
   #     - port_forwards  # Port forwarding rules

--- a/apps/network/src/unifi_network_mcp/managers/dpi_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/dpi_manager.py
@@ -69,12 +69,12 @@ class DpiManager:
                     if resp.status == 200:
                         return await resp.json()
                     else:
-                        logger.error(f"Integration API returned {resp.status} for {path}")
+                        logger.error("Integration API returned %s for %s", resp.status, path)
                         return None
             finally:
                 await session.close()
         except Exception as e:
-            logger.error(f"Error calling integration API {path}: {e}")
+            logger.error("Error calling integration API %s: %s", path, e)
             return None
 
     async def get_dpi_applications(

--- a/apps/network/src/unifi_network_mcp/managers/dpi_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/dpi_manager.py
@@ -1,0 +1,160 @@
+"""Manager for DPI (Deep Packet Inspection) application lookups on the UniFi controller.
+
+Provides read-only access to the DPI application and category database
+via the official UniFi integration API. Applications are identified by
+compound IDs: (category_id << 16) | app_id.
+
+Requires an API key (UNIFI_API_KEY or UNIFI_NETWORK_API_KEY).
+
+API endpoints (official integration API):
+  GET /proxy/network/integration/v1/dpi/applications  (paginated)
+  GET /proxy/network/integration/v1/dpi/categories    (paginated)
+
+TODO: As of Network App 10.1.85, the official integration API only
+returns categories 0-1 (IM, P2P — ~2,100 apps). Categories 4+ (streaming,
+social media) are not yet populated by Ubiquiti. A v2 endpoint
+(/v2/api/site/{site}/dpi) exists as a stub but returns 405.
+Revisit when Ubiquiti expands the official API coverage.
+Ref: https://github.com/sirkirby/unifi-network-mcp/issues/20
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+from unifi_core.auth import UniFiAuth
+
+from .connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_DPI_APPS = "dpi_apps"
+CACHE_PREFIX_DPI_CATEGORIES = "dpi_categories"
+
+
+class DpiManager:
+    """Manages DPI application and category lookups via the official UniFi API."""
+
+    def __init__(self, connection_manager: ConnectionManager, auth: UniFiAuth):
+        self._connection = connection_manager
+        self._auth = auth
+
+    async def _request_integration_api(self, path: str, params: Optional[Dict] = None) -> Optional[Dict]:
+        """Make a request to the official integration API using the shared auth module.
+
+        Args:
+            path: API path (e.g., '/v1/dpi/applications')
+            params: Optional query parameters
+
+        Returns:
+            Response dict, or None on failure.
+        """
+        if not self._auth.has_api_key:
+            logger.error("No API key configured. Set UNIFI_API_KEY or UNIFI_NETWORK_API_KEY.")
+            return None
+
+        base_url = f"https://{self._connection.host}:{self._connection.port}"
+        url = f"{base_url}/proxy/network/integration{path}"
+
+        try:
+            session = await self._auth.get_api_key_session()
+            try:
+                async with session.get(
+                    url,
+                    params=params,
+                    ssl=False,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 200:
+                        return await resp.json()
+                    else:
+                        logger.error(f"Integration API returned {resp.status} for {path}")
+                        return None
+            finally:
+                await session.close()
+        except Exception as e:
+            logger.error(f"Error calling integration API {path}: {e}")
+            return None
+
+    async def get_dpi_applications(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get DPI applications from the official API.
+
+        Args:
+            limit: Max results per page (default 100).
+            offset: Pagination offset.
+            search: Optional name search (client-side filtering — the API
+                    does not support server-side text search).
+
+        Returns:
+            Dict with 'data', 'totalCount', 'offset', 'limit' keys.
+        """
+        # When searching, fetch all apps so client-side filter works correctly.
+        # Otherwise use the requested limit/offset for pagination.
+        if search:
+            fetch_limit = 2500
+            fetch_offset = 0
+        else:
+            fetch_limit = limit
+            fetch_offset = offset
+
+        cache_key = f"{CACHE_PREFIX_DPI_APPS}_{fetch_limit}_{fetch_offset}_{self._connection.site}"
+        if not search:
+            cached_data = self._connection.get_cached(cache_key)
+            if cached_data is not None:
+                return cached_data
+
+        params = {"limit": str(fetch_limit), "offset": str(fetch_offset)}
+        result = await self._request_integration_api("/v1/dpi/applications", params)
+
+        if result is None:
+            return {"data": [], "totalCount": 0, "offset": offset, "limit": limit}
+
+        # Client-side search filtering (API doesn't support text search)
+        if search and result.get("data"):
+            search_lower = search.lower()
+            filtered = [a for a in result["data"] if search_lower in a.get("name", "").lower()]
+            result = {
+                "data": filtered,
+                "totalCount": len(filtered),
+                "offset": 0,
+                "limit": len(filtered),
+                "filtered_from": result.get("totalCount", 0),
+            }
+        elif not search:
+            self._connection._update_cache(cache_key, result)
+
+        return result
+
+    async def get_dpi_categories(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """Get DPI categories from the official API.
+
+        Args:
+            limit: Max results per page.
+            offset: Pagination offset.
+
+        Returns:
+            Dict with 'data', 'totalCount', 'offset', 'limit' keys.
+        """
+        cache_key = f"{CACHE_PREFIX_DPI_CATEGORIES}_{limit}_{offset}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key)
+        if cached_data is not None:
+            return cached_data
+
+        params = {"limit": str(limit), "offset": str(offset)}
+        result = await self._request_integration_api("/v1/dpi/categories", params)
+
+        if result is None:
+            return {"data": [], "totalCount": 0, "offset": offset, "limit": limit}
+
+        self._connection._update_cache(cache_key, result)
+        return result

--- a/apps/network/src/unifi_network_mcp/managers/oon_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/oon_manager.py
@@ -71,9 +71,9 @@ class OonManager:
         except Exception as e:
             error_str = str(e).lower()
             if "404" in error_str or "not found" in error_str:
-                logger.debug(f"OON policies not available (controller may not support them): {e}")
+                logger.debug("OON policies not available (controller may not support them): %s", e)
                 return []
-            logger.error(f"Error getting OON policies: {e}")
+            logger.error("Error getting OON policies: %s", e)
             return []
 
     async def get_oon_policy_by_id(self, policy_id: str) -> Optional[Dict[str, Any]]:
@@ -101,7 +101,7 @@ class OonManager:
             policies = await self.get_oon_policies()
             return next((p for p in policies if p.get("id", p.get("_id")) == policy_id), None)
         except Exception as e:
-            logger.error(f"Error getting OON policy {policy_id}: {e}")
+            logger.error("Error getting OON policy %s: %s", policy_id, e)
             return None
 
     async def create_oon_policy(self, policy_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -156,10 +156,10 @@ class OonManager:
                 )
                 return created
             else:
-                logger.error(f"Unexpected response creating OON policy: {type(response)} {response}")
+                logger.error("Unexpected response creating OON policy: %s %s", type(response), response)
                 return None
         except Exception as e:
-            logger.error(f"Error creating OON policy: {e}", exc_info=True)
+            logger.error("Error creating OON policy: %s", e, exc_info=True)
             return None
 
     async def update_oon_policy(self, policy_id: str, policy_data: Dict[str, Any]) -> bool:
@@ -182,7 +182,7 @@ class OonManager:
             self._invalidate_cache()
             return True
         except Exception as e:
-            logger.error(f"Error updating OON policy {policy_id}: {e}", exc_info=True)
+            logger.error("Error updating OON policy %s: %s", policy_id, e, exc_info=True)
             return False
 
     async def toggle_oon_policy(self, policy_id: str) -> Optional[bool]:
@@ -203,7 +203,7 @@ class OonManager:
         try:
             policy = await self.get_oon_policy_by_id(policy_id)
             if not policy:
-                logger.error(f"OON policy {policy_id} not found for toggle")
+                logger.error("OON policy %s not found for toggle", policy_id)
                 return None
 
             new_state = not policy.get("enabled", False)
@@ -215,7 +215,7 @@ class OonManager:
             self._invalidate_cache()
             return new_state
         except Exception as e:
-            logger.error(f"Error toggling OON policy {policy_id}: {e}", exc_info=True)
+            logger.error("Error toggling OON policy %s: %s", policy_id, e, exc_info=True)
             return None
 
     async def delete_oon_policy(self, policy_id: str) -> bool:
@@ -238,7 +238,7 @@ class OonManager:
             self._invalidate_cache()
             return True
         except Exception as e:
-            logger.error(f"Error deleting OON policy {policy_id}: {e}", exc_info=True)
+            logger.error("Error deleting OON policy %s: %s", policy_id, e, exc_info=True)
             return False
 
     def _invalidate_cache(self):

--- a/apps/network/src/unifi_network_mcp/managers/oon_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/oon_manager.py
@@ -1,0 +1,246 @@
+"""Manager for OON (Object-Oriented Network) policies on the UniFi controller.
+
+OON policies provide high-level network access control including:
+- Internet access scheduling (bedtime blackouts)
+- Application blocking (social media, streaming)
+- QoS/bandwidth limiting
+- Policy-based routing (VPN steering)
+
+Policies can target specific client MACs or client groups.
+
+API endpoints:
+  LIST:   GET  /proxy/network/v2/api/site/{site}/object-oriented-network-configs  (plural)
+  GET:    GET  /proxy/network/v2/api/site/{site}/object-oriented-network-config/{id}  (singular)
+  CREATE: POST /proxy/network/v2/api/site/{site}/object-oriented-network-config  (singular)
+  UPDATE: PUT  /proxy/network/v2/api/site/{site}/object-oriented-network-config/{id}  (singular)
+  DELETE: DELETE /proxy/network/v2/api/site/{site}/object-oriented-network-config/{id}  (singular)
+
+Note: The list endpoint uses the PLURAL form, while all other operations use SINGULAR.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiounifi.models.api import ApiRequestV2
+
+from .connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_OON_POLICIES = "oon_policies"
+
+# Asymmetric paths: list uses plural, CRUD uses singular
+OON_PATH_LIST = "/object-oriented-network-configs"
+OON_PATH_SINGLE = "/object-oriented-network-config"
+
+
+class OonManager:
+    """Manages OON (Object-Oriented Network) policies on the UniFi controller."""
+
+    def __init__(self, connection_manager: ConnectionManager):
+        self._connection = connection_manager
+
+    async def get_oon_policies(self) -> List[Dict[str, Any]]:
+        """Get all OON policies.
+
+        Returns:
+            List of OON policy dictionaries.
+        """
+        cache_key = f"{CACHE_PREFIX_OON_POLICIES}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key)
+        if cached_data is not None:
+            return cached_data
+
+        if not await self._connection.ensure_connected():
+            return []
+
+        try:
+            api_request = ApiRequestV2(method="get", path=OON_PATH_LIST)
+            response = await self._connection.request(api_request)
+
+            policies = (
+                response
+                if isinstance(response, list)
+                else response.get("data", [])
+                if isinstance(response, dict)
+                else []
+            )
+
+            self._connection._update_cache(cache_key, policies)
+            return policies
+        except Exception as e:
+            error_str = str(e).lower()
+            if "404" in error_str or "not found" in error_str:
+                logger.debug(f"OON policies not available (controller may not support them): {e}")
+                return []
+            logger.error(f"Error getting OON policies: {e}")
+            return []
+
+    async def get_oon_policy_by_id(self, policy_id: str) -> Optional[Dict[str, Any]]:
+        """Get a specific OON policy by ID.
+
+        Args:
+            policy_id: The ID of the OON policy.
+
+        Returns:
+            The OON policy dictionary, or None if not found.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        try:
+            api_request = ApiRequestV2(method="get", path=f"{OON_PATH_SINGLE}/{policy_id}")
+            response = await self._connection.request(api_request)
+
+            if isinstance(response, dict):
+                result = response if ("id" in response or "_id" in response) else response.get("data", None)
+                if result:
+                    return result
+
+            # Fallback: search in list
+            policies = await self.get_oon_policies()
+            return next((p for p in policies if p.get("id", p.get("_id")) == policy_id), None)
+        except Exception as e:
+            logger.error(f"Error getting OON policy {policy_id}: {e}")
+            return None
+
+    async def create_oon_policy(self, policy_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Create a new OON policy.
+
+        Args:
+            policy_data: Dictionary containing the policy configuration.
+                Required fields:
+                - name (str): Policy name
+                - enabled (bool): Whether the policy is active
+                - target_type (str): "CLIENTS" or "GROUPS"
+                - targets (list): MAC addresses or group IDs
+                At least one of secure, qos, or route must be configured.
+
+        Returns:
+            The created OON policy dictionary, or None on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        if not policy_data.get("name"):
+            logger.error("Missing required field 'name' for OON policy")
+            return None
+
+        # Strip _id/id if present — let the API assign a new one
+        create_data = policy_data.copy()
+        create_data.pop("_id", None)
+        create_data.pop("id", None)
+
+        try:
+            # POST uses singular path, may return 201
+            api_request = ApiRequestV2(method="post", path=OON_PATH_SINGLE, data=create_data)
+            response = await self._connection.request(api_request)
+
+            self._invalidate_cache()
+
+            if isinstance(response, dict) and ("id" in response or "_id" in response):
+                return response
+            elif isinstance(response, dict) and "data" in response:
+                data = response["data"]
+                if isinstance(data, list) and len(data) > 0:
+                    return data[0]
+                return data
+            elif isinstance(response, list) and len(response) > 0:
+                return response[0] if isinstance(response[0], dict) else {"id": str(response[0])}
+            elif response is None or response == "":
+                logger.info("Create returned empty response, verifying via list")
+                policies = await self.get_oon_policies()
+                created = next(
+                    (p for p in policies if p.get("name") == policy_data.get("name")),
+                    None,
+                )
+                return created
+            else:
+                logger.error(f"Unexpected response creating OON policy: {type(response)} {response}")
+                return None
+        except Exception as e:
+            logger.error(f"Error creating OON policy: {e}", exc_info=True)
+            return None
+
+    async def update_oon_policy(self, policy_id: str, policy_data: Dict[str, Any]) -> bool:
+        """Update an existing OON policy.
+
+        Args:
+            policy_id: The ID of the OON policy to update.
+            policy_data: Complete policy data (PUT replaces the entire object).
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="put", path=f"{OON_PATH_SINGLE}/{policy_id}", data=policy_data)
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error(f"Error updating OON policy {policy_id}: {e}", exc_info=True)
+            return False
+
+    async def toggle_oon_policy(self, policy_id: str) -> Optional[bool]:
+        """Toggle an OON policy's enabled state.
+
+        Fetches the current policy, flips the enabled flag, and sends
+        the full object back via PUT.
+
+        Args:
+            policy_id: The ID of the OON policy to toggle.
+
+        Returns:
+            The new enabled state (True/False), or None on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        try:
+            policy = await self.get_oon_policy_by_id(policy_id)
+            if not policy:
+                logger.error(f"OON policy {policy_id} not found for toggle")
+                return None
+
+            new_state = not policy.get("enabled", False)
+            policy["enabled"] = new_state
+
+            api_request = ApiRequestV2(method="put", path=f"{OON_PATH_SINGLE}/{policy_id}", data=policy)
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return new_state
+        except Exception as e:
+            logger.error(f"Error toggling OON policy {policy_id}: {e}", exc_info=True)
+            return None
+
+    async def delete_oon_policy(self, policy_id: str) -> bool:
+        """Delete an OON policy.
+
+        Args:
+            policy_id: The ID of the OON policy to delete.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            # DELETE may return 204 No Content
+            api_request = ApiRequestV2(method="delete", path=f"{OON_PATH_SINGLE}/{policy_id}")
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting OON policy {policy_id}: {e}", exc_info=True)
+            return False
+
+    def _invalidate_cache(self):
+        """Invalidate all OON policy caches."""
+        self._connection._invalidate_cache(CACHE_PREFIX_OON_POLICIES)

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -31,11 +31,13 @@ from unifi_network_mcp.managers.acl_manager import AclManager
 from unifi_network_mcp.managers.client_group_manager import ClientGroupManager
 from unifi_network_mcp.managers.client_manager import ClientManager
 from unifi_network_mcp.managers.connection_manager import ConnectionManager
+from unifi_network_mcp.managers.dpi_manager import DpiManager
 from unifi_network_mcp.managers.device_manager import DeviceManager
 from unifi_network_mcp.managers.event_manager import EventManager
 from unifi_network_mcp.managers.firewall_manager import FirewallManager
 from unifi_network_mcp.managers.hotspot_manager import HotspotManager
 from unifi_network_mcp.managers.network_manager import NetworkManager
+from unifi_network_mcp.managers.oon_manager import OonManager
 from unifi_network_mcp.managers.qos_manager import QosManager
 from unifi_network_mcp.managers.routing_manager import RoutingManager
 from unifi_network_mcp.managers.stats_manager import StatsManager
@@ -169,6 +171,11 @@ def get_client_manager() -> ClientManager:
 
 
 @lru_cache
+def get_dpi_manager() -> DpiManager:
+    return DpiManager(get_connection_manager(), get_auth())
+
+
+@lru_cache
 def get_device_manager() -> DeviceManager:
     return DeviceManager(get_connection_manager())
 
@@ -191,6 +198,11 @@ def get_vpn_manager() -> VpnManager:
 @lru_cache
 def get_network_manager() -> NetworkManager:
     return NetworkManager(get_connection_manager())
+
+
+@lru_cache
+def get_oon_manager() -> OonManager:
+    return OonManager(get_connection_manager())
 
 
 @lru_cache
@@ -248,11 +260,13 @@ connection_manager = get_connection_manager()
 acl_manager = get_acl_manager()
 client_group_manager = get_client_group_manager()
 client_manager = get_client_manager()
+dpi_manager = get_dpi_manager()
 device_manager = get_device_manager()
 stats_manager = get_stats_manager()
 qos_manager = get_qos_manager()
 vpn_manager = get_vpn_manager()
 network_manager = get_network_manager()
+oon_manager = get_oon_manager()
 system_manager = get_system_manager()
 firewall_manager = get_firewall_manager()
 event_manager = get_event_manager()

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -31,8 +31,8 @@ from unifi_network_mcp.managers.acl_manager import AclManager
 from unifi_network_mcp.managers.client_group_manager import ClientGroupManager
 from unifi_network_mcp.managers.client_manager import ClientManager
 from unifi_network_mcp.managers.connection_manager import ConnectionManager
-from unifi_network_mcp.managers.dpi_manager import DpiManager
 from unifi_network_mcp.managers.device_manager import DeviceManager
+from unifi_network_mcp.managers.dpi_manager import DpiManager
 from unifi_network_mcp.managers.event_manager import EventManager
 from unifi_network_mcp.managers.firewall_manager import FirewallManager
 from unifi_network_mcp.managers.hotspot_manager import HotspotManager

--- a/apps/network/src/unifi_network_mcp/tools/dpi.py
+++ b/apps/network/src/unifi_network_mcp/tools/dpi.py
@@ -84,7 +84,7 @@ async def list_dpi_applications(
 
         return response
     except Exception as e:
-        logger.error(f"Error listing DPI applications: {e}", exc_info=True)
+        logger.error("Error listing DPI applications: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list DPI applications: {e}"}
 
 
@@ -128,5 +128,5 @@ async def list_dpi_categories(
             "categories": formatted,
         }
     except Exception as e:
-        logger.error(f"Error listing DPI categories: {e}", exc_info=True)
+        logger.error("Error listing DPI categories: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list DPI categories: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/dpi.py
+++ b/apps/network/src/unifi_network_mcp/tools/dpi.py
@@ -1,0 +1,132 @@
+"""
+DPI (Deep Packet Inspection) application lookup tools for UniFi Network MCP server.
+
+Provides read-only access to the UniFi DPI application and category database
+via the official integration API. Use these to find application IDs for use
+in OON policies and firewall rules.
+
+Requires an API key (UNIFI_API_KEY or UNIFI_NETWORK_API_KEY).
+
+NOTE: As of Network App 10.1.85, the official API only returns categories 0-1
+(instant messengers, P2P — ~2,100 apps). Categories 4+ (streaming, social
+media, gaming) are not yet populated by Ubiquiti. For apps not found here,
+add via the UniFi UI and read back the IDs from the policy.
+"""
+
+import logging
+from typing import Annotated, Any, Dict, Optional
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_network_mcp.runtime import dpi_manager, server
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_dpi_applications",
+    description="List DPI applications available for use in firewall rules and OON policies. "
+    "Returns application names and their compound IDs. Supports name-based search. "
+    "NOTE: The official API currently only returns categories 0-1 (IM, P2P). "
+    "Streaming, social media, and other categories are not yet populated by Ubiquiti. "
+    "For apps not found here, add via the UniFi UI and read back the IDs from the policy. "
+    "Requires UNIFI_API_KEY or UNIFI_NETWORK_API_KEY.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_dpi_applications(
+    search: Annotated[
+        Optional[str],
+        Field(description="Search for apps by name (case-insensitive, client-side filter). E.g., 'slack', 'telegram'"),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(description="Max results per page (default 100, max 2500)"),
+    ] = 100,
+    offset: Annotated[
+        int,
+        Field(description="Pagination offset (default 0)"),
+    ] = 0,
+) -> Dict[str, Any]:
+    """
+    Lists DPI applications from the official UniFi API.
+
+    Args:
+        search: Optional name search filter.
+        limit: Max results per page.
+        offset: Pagination offset.
+
+    Returns:
+        A dictionary with applications, count, and pagination info.
+    """
+    try:
+        result = await dpi_manager.get_dpi_applications(
+            limit=min(limit, 2500),
+            offset=offset,
+            search=search,
+        )
+
+        apps = result.get("data", [])
+        formatted = [{"id": a.get("id"), "name": a.get("name")} for a in apps]
+
+        response = {
+            "success": True,
+            "count": len(formatted),
+            "total_count": result.get("totalCount", len(formatted)),
+            "offset": result.get("offset", offset),
+            "limit": result.get("limit", limit),
+            "applications": formatted,
+        }
+
+        if result.get("filtered_from"):
+            response["filtered_from"] = result["filtered_from"]
+            response["note"] = f"Filtered {result['filtered_from']} total apps by search term '{search}'"
+
+        return response
+    except Exception as e:
+        logger.error(f"Error listing DPI applications: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to list DPI applications: {e}"}
+
+
+@server.tool(
+    name="unifi_list_dpi_categories",
+    description="List DPI application categories (e.g., 'Instant messengers', 'Peer-to-peer networks', "
+    "'Media streaming services'). Categories group applications for DPI classification. "
+    "Requires UNIFI_API_KEY or UNIFI_NETWORK_API_KEY.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_dpi_categories(
+    limit: Annotated[
+        int,
+        Field(description="Max results per page (default 100)"),
+    ] = 100,
+    offset: Annotated[
+        int,
+        Field(description="Pagination offset (default 0)"),
+    ] = 0,
+) -> Dict[str, Any]:
+    """
+    Lists DPI application categories from the official UniFi API.
+
+    Args:
+        limit: Max results per page.
+        offset: Pagination offset.
+
+    Returns:
+        A dictionary with categories, count, and pagination info.
+    """
+    try:
+        result = await dpi_manager.get_dpi_categories(limit=limit, offset=offset)
+
+        categories = result.get("data", [])
+        formatted = [{"id": c.get("id"), "name": c.get("name")} for c in categories]
+
+        return {
+            "success": True,
+            "count": len(formatted),
+            "total_count": result.get("totalCount", len(formatted)),
+            "categories": formatted,
+        }
+    except Exception as e:
+        logger.error(f"Error listing DPI categories: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to list DPI categories: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/oon.py
+++ b/apps/network/src/unifi_network_mcp/tools/oon.py
@@ -70,7 +70,7 @@ async def list_oon_policies() -> Dict[str, Any]:
             "policies": formatted,
         }
     except Exception as e:
-        logger.error(f"Error listing OON policies: {e}", exc_info=True)
+        logger.error("Error listing OON policies: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list OON policies: {e}"}
 
 
@@ -98,11 +98,6 @@ async def get_oon_policy_details(
 
         policy = await oon_manager.get_oon_policy_by_id(policy_id)
         if not policy:
-            # Fallback: search in list
-            policies = await oon_manager.get_oon_policies()
-            policy = next((p for p in policies if p.get("id", p.get("_id")) == policy_id), None)
-
-        if not policy:
             return {"success": False, "error": f"OON policy '{policy_id}' not found."}
 
         return {
@@ -111,7 +106,7 @@ async def get_oon_policy_details(
             "details": json.loads(json.dumps(policy, default=str)),
         }
     except Exception as e:
-        logger.error(f"Error getting OON policy {policy_id}: {e}", exc_info=True)
+        logger.error("Error getting OON policy %s: %s", policy_id, e, exc_info=True)
         return {"success": False, "error": f"Failed to get OON policy {policy_id}: {e}"}
 
 
@@ -172,7 +167,7 @@ async def create_oon_policy(
             }
         return {"success": False, "error": f"Failed to create OON policy '{policy_data.get('name', '')}'."}
     except Exception as e:
-        logger.error(f"Error creating OON policy: {e}", exc_info=True)
+        logger.error("Error creating OON policy: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to create OON policy: {e}"}
 
 
@@ -220,7 +215,7 @@ async def update_oon_policy(
             return {"success": True, "message": f"OON policy '{policy_id}' updated successfully."}
         return {"success": False, "error": f"Failed to update OON policy '{policy_id}'."}
     except Exception as e:
-        logger.error(f"Error updating OON policy {policy_id}: {e}", exc_info=True)
+        logger.error("Error updating OON policy %s: %s", policy_id, e, exc_info=True)
         return {"success": False, "error": f"Failed to update OON policy '{policy_id}': {e}"}
 
 
@@ -264,8 +259,8 @@ async def toggle_oon_policy(
                     "proposed_changes": {"enabled": not current},
                     "message": f"Will {'disable' if current else 'enable'} OON policy '{policy.get('name', policy_id)}'. Set confirm=true to execute.",
                 }
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Could not fetch policy %s for toggle preview: %s", policy_id, e)
         return create_preview(
             resource_type="oon_policy",
             resource_data={"policy_id": policy_id, "action": "toggle"},
@@ -283,7 +278,7 @@ async def toggle_oon_policy(
             }
         return {"success": False, "error": f"Failed to toggle OON policy '{policy_id}'."}
     except Exception as e:
-        logger.error(f"Error toggling OON policy {policy_id}: {e}", exc_info=True)
+        logger.error("Error toggling OON policy %s: %s", policy_id, e, exc_info=True)
         return {"success": False, "error": f"Failed to toggle OON policy '{policy_id}': {e}"}
 
 
@@ -327,5 +322,5 @@ async def delete_oon_policy(
             return {"success": True, "message": f"OON policy '{policy_id}' deleted successfully."}
         return {"success": False, "error": f"Failed to delete OON policy '{policy_id}'."}
     except Exception as e:
-        logger.error(f"Error deleting OON policy {policy_id}: {e}", exc_info=True)
+        logger.error("Error deleting OON policy %s: %s", policy_id, e, exc_info=True)
         return {"success": False, "error": f"Failed to delete OON policy '{policy_id}': {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/oon.py
+++ b/apps/network/src/unifi_network_mcp/tools/oon.py
@@ -92,9 +92,6 @@ async def get_oon_policy_details(
     Returns:
         A dictionary containing the full policy configuration.
     """
-    if not parse_permission(config.permissions, "oon_policy", "read"):
-        return {"success": False, "error": "Permission denied to get OON policy details."}
-
     try:
         if not policy_id:
             return {"success": False, "error": "policy_id is required"}

--- a/apps/network/src/unifi_network_mcp/tools/oon.py
+++ b/apps/network/src/unifi_network_mcp/tools/oon.py
@@ -1,0 +1,334 @@
+"""
+OON (Object-Oriented Network) policy tools for UniFi Network MCP server.
+
+OON policies provide high-level network access control including internet
+scheduling, application blocking, QoS, and policy-based routing. Policies
+can target specific client MACs or client groups.
+"""
+
+import json
+import logging
+from typing import Annotated, Any, Dict
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_mcp_shared.confirmation import create_preview
+from unifi_network_mcp.runtime import oon_manager, server
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_oon_policies",
+    description="List OON (Object-Oriented Network) policies. "
+    "These policies control internet access schedules (bedtime blackouts), "
+    "application blocking (social media, streaming), QoS, and policy-based routing.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_oon_policies() -> Dict[str, Any]:
+    """
+    Lists all OON policies configured on the controller.
+
+    Returns:
+        A dictionary containing:
+        - success (bool): Indicates if the operation was successful.
+        - count (int): Number of policies found.
+        - policies (List[Dict]): List of policies with summary info.
+    """
+    try:
+        policies = await oon_manager.get_oon_policies()
+        formatted = []
+        for p in policies:
+            secure = p.get("secure", {})
+            internet = secure.get("internet", {}) if secure.get("enabled") else {}
+            schedule = internet.get("schedule", {})
+
+            summary = {
+                "id": p.get("id", p.get("_id")),
+                "name": p.get("name"),
+                "enabled": p.get("enabled"),
+                "target_type": p.get("target_type"),
+                "target_count": len(p.get("targets", [])),
+                "secure_enabled": secure.get("enabled", False),
+                "secure_mode": internet.get("mode") if secure.get("enabled") else None,
+                "schedule_mode": schedule.get("mode") if schedule else None,
+                "qos_enabled": p.get("qos", {}).get("enabled", False),
+                "route_enabled": p.get("route", {}).get("enabled", False),
+            }
+
+            if schedule.get("mode") in ("EVERY_DAY", "EVERY_WEEK"):
+                summary["schedule_start"] = schedule.get("time_range_start")
+                summary["schedule_end"] = schedule.get("time_range_end")
+
+            formatted.append(summary)
+
+        return {
+            "success": True,
+            "site": oon_manager._connection.site,
+            "count": len(formatted),
+            "policies": formatted,
+        }
+    except Exception as e:
+        logger.error(f"Error listing OON policies: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to list OON policies: {e}"}
+
+
+@server.tool(
+    name="unifi_get_oon_policy_details",
+    description="Get detailed configuration for a specific OON policy by ID. "
+    "Returns the full policy object including secure, qos, route sections and targets.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_oon_policy_details(
+    policy_id: Annotated[str, Field(description="The unique identifier of the OON policy")],
+) -> Dict[str, Any]:
+    """
+    Gets the detailed configuration of a specific OON policy.
+
+    Args:
+        policy_id (str): The unique identifier of the OON policy.
+
+    Returns:
+        A dictionary containing the full policy configuration.
+    """
+    if not parse_permission(config.permissions, "oon_policy", "read"):
+        return {"success": False, "error": "Permission denied to get OON policy details."}
+
+    try:
+        if not policy_id:
+            return {"success": False, "error": "policy_id is required"}
+
+        policy = await oon_manager.get_oon_policy_by_id(policy_id)
+        if not policy:
+            # Fallback: search in list
+            policies = await oon_manager.get_oon_policies()
+            policy = next((p for p in policies if p.get("id", p.get("_id")) == policy_id), None)
+
+        if not policy:
+            return {"success": False, "error": f"OON policy '{policy_id}' not found."}
+
+        return {
+            "success": True,
+            "policy_id": policy_id,
+            "details": json.loads(json.dumps(policy, default=str)),
+        }
+    except Exception as e:
+        logger.error(f"Error getting OON policy {policy_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to get OON policy {policy_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_create_oon_policy",
+    description="Create a new OON (Object-Oriented Network) policy. "
+    "Policies can block internet access on a schedule, block specific apps, "
+    "apply QoS limits, or route traffic via VPN. "
+    "Targets can be specific client MACs (target_type='CLIENTS') or "
+    "client group IDs (target_type='GROUPS'). "
+    "IMPORTANT: The policy_data must include complete qos and route objects "
+    "(including mode, apps, domains, ip_addresses, regions fields) even if disabled. "
+    "Use unifi_get_oon_policy_details on an existing policy as a template. "
+    "Requires confirmation.",
+    permission_category="oon_policy",
+    permission_action="create",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def create_oon_policy(
+    policy_data: Annotated[
+        dict,
+        Field(
+            description="Complete OON policy object. Required fields: name (str), enabled (bool), "
+            "target_type ('CLIENTS' or 'GROUPS'), targets (list of MACs or group IDs). "
+            "Configure at least one of: secure (internet access/app blocking), "
+            "qos (bandwidth limits), route (VPN routing)"
+        ),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the policy. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Creates a new OON policy.
+
+    Args:
+        policy_data (dict): Complete policy configuration.
+        confirm (bool): Must be True to execute. False returns a preview.
+
+    Returns:
+        Preview of changes or the created policy.
+    """
+    if not confirm:
+        return create_preview(
+            resource_type="oon_policy",
+            resource_data=policy_data,
+            resource_name=policy_data.get("name", "unnamed"),
+        )
+
+    try:
+        result = await oon_manager.create_oon_policy(policy_data)
+        if result:
+            return {
+                "success": True,
+                "message": f"OON policy '{policy_data.get('name', '')}' created successfully.",
+                "policy": json.loads(json.dumps(result, default=str)),
+            }
+        return {"success": False, "error": f"Failed to create OON policy '{policy_data.get('name', '')}'."}
+    except Exception as e:
+        logger.error(f"Error creating OON policy: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to create OON policy: {e}"}
+
+
+@server.tool(
+    name="unifi_update_oon_policy",
+    description="Update an existing OON policy. Requires the full policy object "
+    "(PUT replaces entire resource). Use unifi_get_oon_policy_details to fetch "
+    "the current object, modify it, and send back. Requires confirmation.",
+    permission_category="oon_policy",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_oon_policy(
+    policy_id: Annotated[str, Field(description="The ID of the policy to update")],
+    policy_data: Annotated[
+        dict,
+        Field(description="The complete updated policy object with all fields"),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, updates the policy. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Updates an existing OON policy.
+
+    Args:
+        policy_id (str): The ID of the policy to update.
+        policy_data (dict): The complete updated policy object.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview of changes or success/failure status.
+    """
+    if not confirm:
+        return create_preview(
+            resource_type="oon_policy",
+            resource_data=policy_data,
+            resource_name=policy_id,
+        )
+
+    try:
+        success = await oon_manager.update_oon_policy(policy_id, policy_data)
+        if success:
+            return {"success": True, "message": f"OON policy '{policy_id}' updated successfully."}
+        return {"success": False, "error": f"Failed to update OON policy '{policy_id}'."}
+    except Exception as e:
+        logger.error(f"Error updating OON policy {policy_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to update OON policy '{policy_id}': {e}"}
+
+
+@server.tool(
+    name="unifi_toggle_oon_policy",
+    description="Toggle an OON policy on or off. Fetches the current state, "
+    "flips the enabled flag, and sends the update. Requires confirmation.",
+    permission_category="oon_policy",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def toggle_oon_policy(
+    policy_id: Annotated[str, Field(description="The ID of the policy to toggle")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, toggles the policy. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Toggles an OON policy's enabled state.
+
+    Args:
+        policy_id (str): The ID of the policy to toggle.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview or the new enabled state.
+    """
+    if not confirm:
+        # Fetch current state for preview
+        try:
+            policy = await oon_manager.get_oon_policy_by_id(policy_id)
+            if policy:
+                current = policy.get("enabled", False)
+                return {
+                    "success": True,
+                    "requires_confirmation": True,
+                    "action": "toggle",
+                    "resource_type": "oon_policy",
+                    "current_state": {"enabled": current},
+                    "proposed_changes": {"enabled": not current},
+                    "message": f"Will {'disable' if current else 'enable'} OON policy '{policy.get('name', policy_id)}'. Set confirm=true to execute.",
+                }
+        except Exception:
+            pass
+        return create_preview(
+            resource_type="oon_policy",
+            resource_data={"policy_id": policy_id, "action": "toggle"},
+            resource_name=policy_id,
+        )
+
+    try:
+        new_state = await oon_manager.toggle_oon_policy(policy_id)
+        if new_state is not None:
+            state_str = "enabled" if new_state else "disabled"
+            return {
+                "success": True,
+                "message": f"OON policy '{policy_id}' is now {state_str}.",
+                "enabled": new_state,
+            }
+        return {"success": False, "error": f"Failed to toggle OON policy '{policy_id}'."}
+    except Exception as e:
+        logger.error(f"Error toggling OON policy {policy_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to toggle OON policy '{policy_id}': {e}"}
+
+
+@server.tool(
+    name="unifi_delete_oon_policy",
+    description="Delete an OON policy. Requires confirmation. "
+    "WARNING: This will remove the policy and all associated firewall rules "
+    "that were auto-generated from it.",
+    permission_category="oon_policy",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_oon_policy(
+    policy_id: Annotated[str, Field(description="The ID of the policy to delete")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the policy. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Deletes an OON policy.
+
+    Args:
+        policy_id (str): The ID of the policy to delete.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview or success/failure status.
+    """
+    if not confirm:
+        return create_preview(
+            resource_type="oon_policy",
+            resource_data={"policy_id": policy_id},
+            resource_name=policy_id,
+            warnings=["Deleting an OON policy removes all auto-generated firewall rules associated with it."],
+        )
+
+    try:
+        success = await oon_manager.delete_oon_policy(policy_id)
+        if success:
+            return {"success": True, "message": f"OON policy '{policy_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete OON policy '{policy_id}'."}
+    except Exception as e:
+        logger.error(f"Error deleting OON policy {policy_id}: {e}", exc_info=True)
+        return {"success": False, "error": f"Failed to delete OON policy '{policy_id}': {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -111,8 +111,16 @@
   "note": "Auto-generated with full schemas from tool decorators. Do not edit manually.",
   "tools": [
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Adopt a pending device into the Unifi Network by MAC address",
       "name": "unifi_adopt_device",
+      "permission_action": "create",
+      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -141,6 +149,8 @@
       },
       "description": "Archive (resolve/dismiss) a specific alarm by its ID",
       "name": "unifi_archive_alarm",
+      "permission_action": "update",
+      "permission_category": "events",
       "schema": {
         "input": {
           "properties": {
@@ -169,6 +179,8 @@
       },
       "description": "Archive (resolve/dismiss) all active alarms",
       "name": "unifi_archive_all_alarms",
+      "permission_action": "update",
+      "permission_category": "events",
       "schema": {
         "input": {
           "properties": {
@@ -182,8 +194,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Authorize a guest client to access the guest network by MAC address",
       "name": "unifi_authorize_guest",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -220,8 +240,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Block a client/device from the network by MAC address",
       "name": "unifi_block_client",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -250,6 +278,8 @@
       },
       "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Requires confirmation. IMPORTANT: traffic_source and traffic_destination type MUST be 'CLIENT_MAC' (not 'ANY'). Use an empty specific_mac_addresses list to match any device.",
       "name": "unifi_create_acl_rule",
+      "permission_action": "create",
+      "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
@@ -301,6 +331,8 @@
       },
       "description": "Create a new client group (network member group). Groups organize devices by MAC address for use in OON policies and firewall rules. Requires confirmation.",
       "name": "unifi_create_client_group",
+      "permission_action": "create",
+      "permission_category": "client_group",
       "schema": {
         "input": {
           "properties": {
@@ -334,6 +366,8 @@
       },
       "description": "Create a new firewall policy with schema validation. Supports both legacy ruleset-based policies (action: accept/drop/reject) and zone-based policies (action: ALLOW/BLOCK/REJECT with source/destination zone_id targeting). Format is auto-detected from the policy_data structure.",
       "name": "unifi_create_firewall_policy",
+      "permission_action": "create",
+      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -354,8 +388,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Create a new network (LAN/VLAN) with schema validation. Requires confirmation.",
       "name": "unifi_create_network",
+      "permission_action": "create",
+      "permission_category": "networks",
       "schema": {
         "input": {
           "properties": {
@@ -384,6 +426,8 @@
       },
       "description": "Create a new OON (Object-Oriented Network) policy. Policies can block internet access on a schedule, block specific apps, apply QoS limits, or route traffic via VPN. Targets can be specific client MACs (target_type='CLIENTS') or client group IDs (target_type='GROUPS'). IMPORTANT: The policy_data must include complete qos and route objects (including mode, apps, domains, ip_addresses, regions fields) even if disabled. Use unifi_get_oon_policy_details on an existing policy as a template. Requires confirmation.",
       "name": "unifi_create_oon_policy",
+      "permission_action": "create",
+      "permission_category": "oon_policy",
       "schema": {
         "input": {
           "properties": {
@@ -412,6 +456,8 @@
       },
       "description": "Create a new port forwarding rule on your Unifi Network controller using schema validation.",
       "name": "unifi_create_port_forward",
+      "permission_action": "create",
+      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -436,6 +482,8 @@
       },
       "description": "Create a new QoS rule on the Unifi Network controller. Requires confirmation.",
       "name": "unifi_create_qos_rule",
+      "permission_action": "create",
+      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -456,8 +504,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Create a new static route for advanced routing configuration.\n\nSpecify destination network in CIDR format (e.g., \"10.0.0.0/24\") and\nnext-hop IP address (e.g., \"192.168.1.1\").",
       "name": "unifi_create_route",
+      "permission_action": "create",
+      "permission_category": "routes",
       "schema": {
         "input": {
           "properties": {
@@ -504,6 +560,8 @@
       },
       "description": "Create a firewall policy using a simplified high-level schema. Accepts friendly src/dst selectors and returns a preview unless confirm=true.",
       "name": "unifi_create_simple_firewall_policy",
+      "permission_action": "create",
+      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -532,6 +590,8 @@
       },
       "description": "Create a port forward using a simplified schema. Returns a preview unless confirm=true.",
       "name": "unifi_create_simple_port_forward",
+      "permission_action": "create",
+      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -560,6 +620,8 @@
       },
       "description": "Create a QoS rule using a simplified high-level schema. Returns a preview unless confirm=true.",
       "name": "unifi_create_simple_qos_rule",
+      "permission_action": "create",
+      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -588,6 +650,8 @@
       },
       "description": "Create a new user group (bandwidth profile) with optional speed limits.\n\nBandwidth limits are specified in Kbps. Use -1 for unlimited.\nUser groups can be assigned to clients to enforce bandwidth policies.",
       "name": "unifi_create_usergroup",
+      "permission_action": "create",
+      "permission_category": "usergroups",
       "schema": {
         "input": {
           "properties": {
@@ -624,6 +688,8 @@
       },
       "description": "Create hotspot voucher(s) for guest network access.\n\nVouchers can have:\n- Time limits: How long the voucher is valid after activation\n- Usage quota: Single-use (1), multi-use (0), or n-times usable\n- Bandwidth limits: Upload/download speed caps in Kbps\n- Data caps: Total data transfer limit in MB",
       "name": "unifi_create_voucher",
+      "permission_action": "create",
+      "permission_category": "vouchers",
       "schema": {
         "input": {
           "properties": {
@@ -665,8 +731,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Create a new Wireless LAN (WLAN/SSID) with schema validation. Requires confirmation.",
       "name": "unifi_create_wlan",
+      "permission_action": "create",
+      "permission_category": "wlans",
       "schema": {
         "input": {
           "properties": {
@@ -687,8 +761,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete a MAC ACL rule. Requires confirmation. WARNING: Removing an ALLOW rule may block device communication. Removing a BLOCK rule may open access.",
       "name": "unifi_delete_acl_rule",
+      "permission_action": "delete",
+      "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
@@ -709,8 +791,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete a client group. Requires confirmation. WARNING: Deleting a group may affect OON policies and firewall rules that reference it.",
       "name": "unifi_delete_client_group",
+      "permission_action": "delete",
+      "permission_category": "client_group",
       "schema": {
         "input": {
           "properties": {
@@ -731,8 +821,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete a firewall policy by ID. Requires confirmation. WARNING: Removing an ALLOW rule may block traffic. Removing a BLOCK rule may open access.",
       "name": "unifi_delete_firewall_policy",
+      "permission_action": "delete",
+      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -753,8 +851,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete an OON policy. Requires confirmation. WARNING: This will remove the policy and all associated firewall rules that were auto-generated from it.",
       "name": "unifi_delete_oon_policy",
+      "permission_action": "delete",
+      "permission_category": "oon_policy",
       "schema": {
         "input": {
           "properties": {
@@ -775,8 +881,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Force a client to reconnect to the network (kick) by MAC address",
       "name": "unifi_force_reconnect_client",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -1814,8 +1928,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Reboot a specific device by MAC address",
       "name": "unifi_reboot_device",
+      "permission_action": "update",
+      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -1844,6 +1966,8 @@
       },
       "description": "Rename a client/device in the Unifi Network controller by MAC address",
       "name": "unifi_rename_client",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -1869,8 +1993,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Rename a device in the Unifi Network controller by MAC address",
       "name": "unifi_rename_device",
+      "permission_action": "update",
+      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -1896,8 +2028,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Revoke/delete a hotspot voucher by its ID, preventing further use",
       "name": "unifi_revoke_voucher",
+      "permission_action": "delete",
+      "permission_category": "vouchers",
       "schema": {
         "input": {
           "properties": {
@@ -1918,8 +2058,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Set fixed IP address and/or local DNS record for a client device.\n\nAllows configuring:\n- Fixed IP: Assign a static IP address to a client (DHCP reservation)\n- Local DNS: Create a local DNS hostname for the client (UniFi Network 7.2+)\n\nEither setting can be enabled/disabled independently.",
       "name": "unifi_set_client_ip_settings",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -1964,6 +2112,8 @@
       },
       "description": "Enable or disable a specific firewall policy by ID.",
       "name": "unifi_toggle_firewall_policy",
+      "permission_action": "update",
+      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -1992,6 +2142,8 @@
       },
       "description": "Toggle an OON policy on or off. Fetches the current state, flips the enabled flag, and sends the update. Requires confirmation.",
       "name": "unifi_toggle_oon_policy",
+      "permission_action": "update",
+      "permission_category": "oon_policy",
       "schema": {
         "input": {
           "properties": {
@@ -2020,6 +2172,8 @@
       },
       "description": "Toggle a port forwarding rule on or off on your Unifi Network controller.",
       "name": "unifi_toggle_port_forward",
+      "permission_action": "update",
+      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -2048,6 +2202,8 @@
       },
       "description": "Enable or disable a specific QoS rule by ID. Requires confirmation.",
       "name": "unifi_toggle_qos_rule_enabled",
+      "permission_action": "update",
+      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -2076,6 +2232,8 @@
       },
       "description": "Toggle a traffic route on/off by ID.",
       "name": "unifi_toggle_traffic_route",
+      "permission_action": "update",
+      "permission_category": "traffic_routes",
       "schema": {
         "input": {
           "properties": {
@@ -2096,8 +2254,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Revoke authorization for a guest client by MAC address",
       "name": "unifi_unauthorize_guest",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -2118,8 +2284,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Unblock a previously blocked client/device by MAC address",
       "name": "unifi_unblock_client",
+      "permission_action": "update",
+      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -2148,6 +2322,8 @@
       },
       "description": "Update an existing MAC ACL rule. Requires the full rule object (PUT replaces entire resource). Requires confirmation. IMPORTANT: traffic source/destination type MUST be 'CLIENT_MAC' (not 'ANY').",
       "name": "unifi_update_acl_rule",
+      "permission_action": "update",
+      "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
@@ -2181,6 +2357,8 @@
       },
       "description": "Update an existing client group. Requires the full group object (PUT replaces entire resource). Requires confirmation.",
       "name": "unifi_update_client_group",
+      "permission_action": "update",
+      "permission_category": "client_group",
       "schema": {
         "input": {
           "properties": {
@@ -2206,8 +2384,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Update radio settings for a specific band on an access point. Supports tx_power_mode, tx_power (custom dBm), channel, ht (channel width), min_rssi_enabled, and min_rssi. Use unifi_get_device_radio first to see current settings.",
       "name": "unifi_update_device_radio",
+      "permission_action": "update",
+      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -2265,6 +2451,8 @@
       },
       "description": "Update specific fields of an existing firewall policy by ID. Supports both legacy fields (ruleset, action as accept/drop/reject) and zone-based fields (source, destination, action as ALLOW/BLOCK/REJECT, ip_version, etc.).",
       "name": "unifi_update_firewall_policy",
+      "permission_action": "update",
+      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -2290,8 +2478,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Update specific fields of an existing network (LAN/VLAN). Requires confirmation. Note: Network isolation is only supported on 'corporate' networks, not 'guest' networks.",
       "name": "unifi_update_network",
+      "permission_action": "update",
+      "permission_category": "networks",
       "schema": {
         "input": {
           "properties": {
@@ -2325,6 +2521,8 @@
       },
       "description": "Update an existing OON policy. Requires the full policy object (PUT replaces entire resource). Use unifi_get_oon_policy_details to fetch the current object, modify it, and send back. Requires confirmation.",
       "name": "unifi_update_oon_policy",
+      "permission_action": "update",
+      "permission_category": "oon_policy",
       "schema": {
         "input": {
           "properties": {
@@ -2358,6 +2556,8 @@
       },
       "description": "Update specific fields of an existing port forwarding rule using schema validation. Requires confirmation.",
       "name": "unifi_update_port_forward",
+      "permission_action": "update",
+      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -2391,6 +2591,8 @@
       },
       "description": "Update specific fields of an existing QoS rule. Requires confirmation.",
       "name": "unifi_update_qos_rule",
+      "permission_action": "update",
+      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -2416,8 +2618,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Update an existing static route's properties.\n\nCan modify name, destination network, next-hop, distance, or enabled status.",
       "name": "unifi_update_route",
+      "permission_action": "update",
+      "permission_category": "routes",
       "schema": {
         "input": {
           "properties": {
@@ -2466,6 +2676,8 @@
       },
       "description": "Update SNMP settings for the site (enable/disable, set community string). Requires confirm=true to apply changes.",
       "name": "unifi_update_snmp_settings",
+      "permission_action": "update",
+      "permission_category": "snmp",
       "schema": {
         "input": {
           "properties": {
@@ -2498,6 +2710,8 @@
       },
       "description": "Update a traffic route's settings.\n\nCan update:\n- enabled: Enable or disable the traffic route\n- kill_switch_enabled: Enable/disable the kill switch (blocks traffic if VPN is down)\n\nAt least one parameter must be provided.",
       "name": "unifi_update_traffic_route",
+      "permission_action": "update",
+      "permission_category": "traffic_routes",
       "schema": {
         "input": {
           "properties": {
@@ -2534,6 +2748,8 @@
       },
       "description": "Update an existing user group's name or bandwidth limits.\n\nUse -1 for unlimited bandwidth. Changes affect all clients assigned to this group.",
       "name": "unifi_update_usergroup",
+      "permission_action": "update",
+      "permission_category": "usergroups",
       "schema": {
         "input": {
           "properties": {
@@ -2574,6 +2790,8 @@
       },
       "description": "Enable or disable a specific VPN client by ID.",
       "name": "unifi_update_vpn_client_state",
+      "permission_action": "update",
+      "permission_category": "vpn_clients",
       "schema": {
         "input": {
           "properties": {
@@ -2603,6 +2821,8 @@
       },
       "description": "Enable or disable a specific VPN server by ID.",
       "name": "unifi_update_vpn_server_state",
+      "permission_action": "update",
+      "permission_category": "vpn_servers",
       "schema": {
         "input": {
           "properties": {
@@ -2624,8 +2844,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Update specific fields of an existing WLAN (SSID). Requires confirmation.",
       "name": "unifi_update_wlan",
+      "permission_action": "update",
+      "permission_category": "wlans",
       "schema": {
         "input": {
           "properties": {
@@ -2651,8 +2879,16 @@
       }
     },
     {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Initiate a firmware upgrade for a device by MAC address (uses cached firmware by default)",
       "name": "unifi_upgrade_device",
+      "permission_action": "update",
+      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 97,
+  "count": 105,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -11,6 +11,7 @@
     "unifi_create_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_create_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_create_network": "unifi_network_mcp.tools.network",
+    "unifi_create_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_create_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_create_qos_rule": "unifi_network_mcp.tools.qos",
     "unifi_create_route": "unifi_network_mcp.tools.routing",
@@ -23,6 +24,7 @@
     "unifi_delete_acl_rule": "unifi_network_mcp.tools.acl",
     "unifi_delete_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
+    "unifi_delete_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_force_reconnect_client": "unifi_network_mcp.tools.clients",
     "unifi_get_acl_rule_details": "unifi_network_mcp.tools.acl",
     "unifi_get_alerts": "unifi_network_mcp.tools.stats",
@@ -38,10 +40,11 @@
     "unifi_get_network_details": "unifi_network_mcp.tools.network",
     "unifi_get_network_health": "unifi_network_mcp.tools.system",
     "unifi_get_network_stats": "unifi_network_mcp.tools.stats",
+    "unifi_get_oon_policy_details": "unifi_network_mcp.tools.oon",
     "unifi_get_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_get_qos_rule_details": "unifi_network_mcp.tools.qos",
     "unifi_get_route_details": "unifi_network_mcp.tools.routing",
-    "unifi_get_site_settings": "unifi_network_mcp.tools.config",
+    "unifi_get_site_settings": "unifi_network_mcp.tools.system",
     "unifi_get_snmp_settings": "unifi_network_mcp.tools.system",
     "unifi_get_system_info": "unifi_network_mcp.tools.system",
     "unifi_get_top_clients": "unifi_network_mcp.tools.stats",
@@ -58,11 +61,14 @@
     "unifi_list_client_groups": "unifi_network_mcp.tools.client_groups",
     "unifi_list_clients": "unifi_network_mcp.tools.clients",
     "unifi_list_devices": "unifi_network_mcp.tools.devices",
+    "unifi_list_dpi_applications": "unifi_network_mcp.tools.dpi",
+    "unifi_list_dpi_categories": "unifi_network_mcp.tools.dpi",
     "unifi_list_events": "unifi_network_mcp.tools.events",
     "unifi_list_firewall_policies": "unifi_network_mcp.tools.firewall",
     "unifi_list_firewall_zones": "unifi_network_mcp.tools.firewall",
     "unifi_list_ip_groups": "unifi_network_mcp.tools.firewall",
     "unifi_list_networks": "unifi_network_mcp.tools.network",
+    "unifi_list_oon_policies": "unifi_network_mcp.tools.oon",
     "unifi_list_port_forwards": "unifi_network_mcp.tools.port_forwards",
     "unifi_list_qos_rules": "unifi_network_mcp.tools.qos",
     "unifi_list_routes": "unifi_network_mcp.tools.routing",
@@ -79,6 +85,7 @@
     "unifi_revoke_voucher": "unifi_network_mcp.tools.hotspot",
     "unifi_set_client_ip_settings": "unifi_network_mcp.tools.clients",
     "unifi_toggle_firewall_policy": "unifi_network_mcp.tools.firewall",
+    "unifi_toggle_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_toggle_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_toggle_qos_rule_enabled": "unifi_network_mcp.tools.qos",
     "unifi_toggle_traffic_route": "unifi_network_mcp.tools.traffic_routes",
@@ -89,6 +96,7 @@
     "unifi_update_device_radio": "unifi_network_mcp.tools.devices",
     "unifi_update_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_update_network": "unifi_network_mcp.tools.network",
+    "unifi_update_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_update_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_update_qos_rule": "unifi_network_mcp.tools.qos",
     "unifi_update_route": "unifi_network_mcp.tools.routing",
@@ -103,16 +111,8 @@
   "note": "Auto-generated with full schemas from tool decorators. Do not edit manually.",
   "tools": [
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Adopt a pending device into the Unifi Network by MAC address",
       "name": "unifi_adopt_device",
-      "permission_action": "create",
-      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -141,8 +141,6 @@
       },
       "description": "Archive (resolve/dismiss) a specific alarm by its ID",
       "name": "unifi_archive_alarm",
-      "permission_action": "update",
-      "permission_category": "events",
       "schema": {
         "input": {
           "properties": {
@@ -171,8 +169,6 @@
       },
       "description": "Archive (resolve/dismiss) all active alarms",
       "name": "unifi_archive_all_alarms",
-      "permission_action": "update",
-      "permission_category": "events",
       "schema": {
         "input": {
           "properties": {
@@ -186,16 +182,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Authorize a guest client to access the guest network by MAC address",
       "name": "unifi_authorize_guest",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -232,16 +220,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Block a client/device from the network by MAC address",
       "name": "unifi_block_client",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -270,8 +250,6 @@
       },
       "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Requires confirmation. IMPORTANT: traffic_source and traffic_destination type MUST be 'CLIENT_MAC' (not 'ANY'). Use an empty specific_mac_addresses list to match any device.",
       "name": "unifi_create_acl_rule",
-      "permission_action": "create",
-      "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
@@ -323,8 +301,6 @@
       },
       "description": "Create a new client group (network member group). Groups organize devices by MAC address for use in OON policies and firewall rules. Requires confirmation.",
       "name": "unifi_create_client_group",
-      "permission_action": "create",
-      "permission_category": "client_group",
       "schema": {
         "input": {
           "properties": {
@@ -358,8 +334,6 @@
       },
       "description": "Create a new firewall policy with schema validation. Supports both legacy ruleset-based policies (action: accept/drop/reject) and zone-based policies (action: ALLOW/BLOCK/REJECT with source/destination zone_id targeting). Format is auto-detected from the policy_data structure.",
       "name": "unifi_create_firewall_policy",
-      "permission_action": "create",
-      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -380,16 +354,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": false,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Create a new network (LAN/VLAN) with schema validation. Requires confirmation.",
       "name": "unifi_create_network",
-      "permission_action": "create",
-      "permission_category": "networks",
       "schema": {
         "input": {
           "properties": {
@@ -416,10 +382,36 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
+      "description": "Create a new OON (Object-Oriented Network) policy. Policies can block internet access on a schedule, block specific apps, apply QoS limits, or route traffic via VPN. Targets can be specific client MACs (target_type='CLIENTS') or client group IDs (target_type='GROUPS'). IMPORTANT: The policy_data must include complete qos and route objects (including mode, apps, domains, ip_addresses, regions fields) even if disabled. Use unifi_get_oon_policy_details on an existing policy as a template. Requires confirmation.",
+      "name": "unifi_create_oon_policy",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, creates the policy. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "policy_data": {
+              "description": "Complete OON policy object. Required fields: name (str), enabled (bool), target_type ('CLIENTS' or 'GROUPS'), targets (list of MACs or group IDs). Configure at least one of: secure (internet access/app blocking), qos (bandwidth limits), route (VPN routing)",
+              "type": "object"
+            }
+          },
+          "required": [
+            "policy_data"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Create a new port forwarding rule on your Unifi Network controller using schema validation.",
       "name": "unifi_create_port_forward",
-      "permission_action": "create",
-      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -444,8 +436,6 @@
       },
       "description": "Create a new QoS rule on the Unifi Network controller. Requires confirmation.",
       "name": "unifi_create_qos_rule",
-      "permission_action": "create",
-      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -466,16 +456,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": false,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Create a new static route for advanced routing configuration.\n\nSpecify destination network in CIDR format (e.g., \"10.0.0.0/24\") and\nnext-hop IP address (e.g., \"192.168.1.1\").",
       "name": "unifi_create_route",
-      "permission_action": "create",
-      "permission_category": "routes",
       "schema": {
         "input": {
           "properties": {
@@ -522,8 +504,6 @@
       },
       "description": "Create a firewall policy using a simplified high-level schema. Accepts friendly src/dst selectors and returns a preview unless confirm=true.",
       "name": "unifi_create_simple_firewall_policy",
-      "permission_action": "create",
-      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -552,8 +532,6 @@
       },
       "description": "Create a port forward using a simplified schema. Returns a preview unless confirm=true.",
       "name": "unifi_create_simple_port_forward",
-      "permission_action": "create",
-      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -582,8 +560,6 @@
       },
       "description": "Create a QoS rule using a simplified high-level schema. Returns a preview unless confirm=true.",
       "name": "unifi_create_simple_qos_rule",
-      "permission_action": "create",
-      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -612,8 +588,6 @@
       },
       "description": "Create a new user group (bandwidth profile) with optional speed limits.\n\nBandwidth limits are specified in Kbps. Use -1 for unlimited.\nUser groups can be assigned to clients to enforce bandwidth policies.",
       "name": "unifi_create_usergroup",
-      "permission_action": "create",
-      "permission_category": "usergroups",
       "schema": {
         "input": {
           "properties": {
@@ -650,8 +624,6 @@
       },
       "description": "Create hotspot voucher(s) for guest network access.\n\nVouchers can have:\n- Time limits: How long the voucher is valid after activation\n- Usage quota: Single-use (1), multi-use (0), or n-times usable\n- Bandwidth limits: Upload/download speed caps in Kbps\n- Data caps: Total data transfer limit in MB",
       "name": "unifi_create_voucher",
-      "permission_action": "create",
-      "permission_category": "vouchers",
       "schema": {
         "input": {
           "properties": {
@@ -693,16 +665,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": false,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Create a new Wireless LAN (WLAN/SSID) with schema validation. Requires confirmation.",
       "name": "unifi_create_wlan",
-      "permission_action": "create",
-      "permission_category": "wlans",
       "schema": {
         "input": {
           "properties": {
@@ -723,16 +687,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Delete a MAC ACL rule. Requires confirmation. WARNING: Removing an ALLOW rule may block device communication. Removing a BLOCK rule may open access.",
       "name": "unifi_delete_acl_rule",
-      "permission_action": "delete",
-      "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
@@ -753,16 +709,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Delete a client group. Requires confirmation. WARNING: Deleting a group may affect OON policies and firewall rules that reference it.",
       "name": "unifi_delete_client_group",
-      "permission_action": "delete",
-      "permission_category": "client_group",
       "schema": {
         "input": {
           "properties": {
@@ -783,16 +731,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Delete a firewall policy by ID. Requires confirmation. WARNING: Removing an ALLOW rule may block traffic. Removing a BLOCK rule may open access.",
       "name": "unifi_delete_firewall_policy",
-      "permission_action": "delete",
-      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -813,16 +753,30 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
+      "description": "Delete an OON policy. Requires confirmation. WARNING: This will remove the policy and all associated firewall rules that were auto-generated from it.",
+      "name": "unifi_delete_oon_policy",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the policy. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "policy_id": {
+              "description": "The ID of the policy to delete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "policy_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
       "description": "Force a client to reconnect to the network (kick) by MAC address",
       "name": "unifi_force_reconnect_client",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -1128,6 +1082,28 @@
               "type": "string"
             }
           },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get detailed configuration for a specific OON policy by ID. Returns the full policy object including secure, qos, route sections and targets.",
+      "name": "unifi_get_oon_policy_details",
+      "schema": {
+        "input": {
+          "properties": {
+            "policy_id": {
+              "description": "The unique identifier of the OON policy",
+              "type": "string"
+            }
+          },
+          "required": [
+            "policy_id"
+          ],
           "type": "object"
         }
       }
@@ -1538,6 +1514,56 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
+      "description": "List DPI applications available for use in firewall rules and OON policies. Returns application names and their compound IDs. Supports name-based search. NOTE: The official API currently only returns categories 0-1 (IM, P2P). Streaming, social media, and other categories are not yet populated by Ubiquiti. For apps not found here, add via the UniFi UI and read back the IDs from the policy. Requires UNIFI_API_KEY or UNIFI_NETWORK_API_KEY.",
+      "name": "unifi_list_dpi_applications",
+      "schema": {
+        "input": {
+          "properties": {
+            "limit": {
+              "description": "Max results per page (default 100, max 2500)",
+              "type": "integer"
+            },
+            "offset": {
+              "description": "Pagination offset (default 0)",
+              "type": "integer"
+            },
+            "search": {
+              "description": "Search for apps by name (case-insensitive, client-side filter). E.g., 'slack', 'telegram'",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List DPI application categories (e.g., 'Instant messengers', 'Peer-to-peer networks', 'Media streaming services'). Categories group applications for DPI classification. Requires UNIFI_API_KEY or UNIFI_NETWORK_API_KEY.",
+      "name": "unifi_list_dpi_categories",
+      "schema": {
+        "input": {
+          "properties": {
+            "limit": {
+              "description": "Max results per page (default 100)",
+              "type": "integer"
+            },
+            "offset": {
+              "description": "Pagination offset (default 0)",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
       "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), event_type prefix (use unifi_get_event_types for valid prefixes), and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
       "name": "unifi_list_events",
       "schema": {
@@ -1618,6 +1644,20 @@
       },
       "description": "Returns all configured networks (LAN, WAN, VLAN-only) with name, purpose, IP subnet, VLAN ID, DHCP settings, and enabled state. Use to understand network topology and VLAN layout. For a single network's full config, use unifi_get_network_details. For wireless SSIDs, use unifi_list_wlans.",
       "name": "unifi_list_networks",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List OON (Object-Oriented Network) policies. These policies control internet access schedules (bedtime blackouts), application blocking (social media, streaming), QoS, and policy-based routing.",
+      "name": "unifi_list_oon_policies",
       "schema": {
         "input": {
           "properties": {},
@@ -1774,16 +1814,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Reboot a specific device by MAC address",
       "name": "unifi_reboot_device",
-      "permission_action": "update",
-      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -1812,8 +1844,6 @@
       },
       "description": "Rename a client/device in the Unifi Network controller by MAC address",
       "name": "unifi_rename_client",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -1839,16 +1869,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Rename a device in the Unifi Network controller by MAC address",
       "name": "unifi_rename_device",
-      "permission_action": "update",
-      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -1874,16 +1896,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Revoke/delete a hotspot voucher by its ID, preventing further use",
       "name": "unifi_revoke_voucher",
-      "permission_action": "delete",
-      "permission_category": "vouchers",
       "schema": {
         "input": {
           "properties": {
@@ -1904,16 +1918,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Set fixed IP address and/or local DNS record for a client device.\n\nAllows configuring:\n- Fixed IP: Assign a static IP address to a client (DHCP reservation)\n- Local DNS: Create a local DNS hostname for the client (UniFi Network 7.2+)\n\nEither setting can be enabled/disabled independently.",
       "name": "unifi_set_client_ip_settings",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -1958,8 +1964,6 @@
       },
       "description": "Enable or disable a specific firewall policy by ID.",
       "name": "unifi_toggle_firewall_policy",
-      "permission_action": "update",
-      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -1986,10 +1990,36 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
+      "description": "Toggle an OON policy on or off. Fetches the current state, flips the enabled flag, and sends the update. Requires confirmation.",
+      "name": "unifi_toggle_oon_policy",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, toggles the policy. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "policy_id": {
+              "description": "The ID of the policy to toggle",
+              "type": "string"
+            }
+          },
+          "required": [
+            "policy_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Toggle a port forwarding rule on or off on your Unifi Network controller.",
       "name": "unifi_toggle_port_forward",
-      "permission_action": "update",
-      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -2018,8 +2048,6 @@
       },
       "description": "Enable or disable a specific QoS rule by ID. Requires confirmation.",
       "name": "unifi_toggle_qos_rule_enabled",
-      "permission_action": "update",
-      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -2048,8 +2076,6 @@
       },
       "description": "Toggle a traffic route on/off by ID.",
       "name": "unifi_toggle_traffic_route",
-      "permission_action": "update",
-      "permission_category": "traffic_routes",
       "schema": {
         "input": {
           "properties": {
@@ -2070,16 +2096,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Revoke authorization for a guest client by MAC address",
       "name": "unifi_unauthorize_guest",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -2100,16 +2118,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Unblock a previously blocked client/device by MAC address",
       "name": "unifi_unblock_client",
-      "permission_action": "update",
-      "permission_category": "clients",
       "schema": {
         "input": {
           "properties": {
@@ -2138,8 +2148,6 @@
       },
       "description": "Update an existing MAC ACL rule. Requires the full rule object (PUT replaces entire resource). Requires confirmation. IMPORTANT: traffic source/destination type MUST be 'CLIENT_MAC' (not 'ANY').",
       "name": "unifi_update_acl_rule",
-      "permission_action": "update",
-      "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
@@ -2173,8 +2181,6 @@
       },
       "description": "Update an existing client group. Requires the full group object (PUT replaces entire resource). Requires confirmation.",
       "name": "unifi_update_client_group",
-      "permission_action": "update",
-      "permission_category": "client_group",
       "schema": {
         "input": {
           "properties": {
@@ -2200,16 +2206,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Update radio settings for a specific band on an access point. Supports tx_power_mode, tx_power (custom dBm), channel, ht (channel width), min_rssi_enabled, and min_rssi. Use unifi_get_device_radio first to see current settings.",
       "name": "unifi_update_device_radio",
-      "permission_action": "update",
-      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {
@@ -2267,8 +2265,6 @@
       },
       "description": "Update specific fields of an existing firewall policy by ID. Supports both legacy fields (ruleset, action as accept/drop/reject) and zone-based fields (source, destination, action as ALLOW/BLOCK/REJECT, ip_version, etc.).",
       "name": "unifi_update_firewall_policy",
-      "permission_action": "update",
-      "permission_category": "firewall_policies",
       "schema": {
         "input": {
           "properties": {
@@ -2294,16 +2290,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Update specific fields of an existing network (LAN/VLAN). Requires confirmation. Note: Network isolation is only supported on 'corporate' networks, not 'guest' networks.",
       "name": "unifi_update_network",
-      "permission_action": "update",
-      "permission_category": "networks",
       "schema": {
         "input": {
           "properties": {
@@ -2335,10 +2323,41 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
+      "description": "Update an existing OON policy. Requires the full policy object (PUT replaces entire resource). Use unifi_get_oon_policy_details to fetch the current object, modify it, and send back. Requires confirmation.",
+      "name": "unifi_update_oon_policy",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, updates the policy. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "policy_data": {
+              "description": "The complete updated policy object with all fields",
+              "type": "object"
+            },
+            "policy_id": {
+              "description": "The ID of the policy to update",
+              "type": "string"
+            }
+          },
+          "required": [
+            "policy_id",
+            "policy_data"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Update specific fields of an existing port forwarding rule using schema validation. Requires confirmation.",
       "name": "unifi_update_port_forward",
-      "permission_action": "update",
-      "permission_category": "port_forwards",
       "schema": {
         "input": {
           "properties": {
@@ -2372,8 +2391,6 @@
       },
       "description": "Update specific fields of an existing QoS rule. Requires confirmation.",
       "name": "unifi_update_qos_rule",
-      "permission_action": "update",
-      "permission_category": "qos_rules",
       "schema": {
         "input": {
           "properties": {
@@ -2399,16 +2416,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Update an existing static route's properties.\n\nCan modify name, destination network, next-hop, distance, or enabled status.",
       "name": "unifi_update_route",
-      "permission_action": "update",
-      "permission_category": "routes",
       "schema": {
         "input": {
           "properties": {
@@ -2457,8 +2466,6 @@
       },
       "description": "Update SNMP settings for the site (enable/disable, set community string). Requires confirm=true to apply changes.",
       "name": "unifi_update_snmp_settings",
-      "permission_action": "update",
-      "permission_category": "snmp",
       "schema": {
         "input": {
           "properties": {
@@ -2491,8 +2498,6 @@
       },
       "description": "Update a traffic route's settings.\n\nCan update:\n- enabled: Enable or disable the traffic route\n- kill_switch_enabled: Enable/disable the kill switch (blocks traffic if VPN is down)\n\nAt least one parameter must be provided.",
       "name": "unifi_update_traffic_route",
-      "permission_action": "update",
-      "permission_category": "traffic_routes",
       "schema": {
         "input": {
           "properties": {
@@ -2529,8 +2534,6 @@
       },
       "description": "Update an existing user group's name or bandwidth limits.\n\nUse -1 for unlimited bandwidth. Changes affect all clients assigned to this group.",
       "name": "unifi_update_usergroup",
-      "permission_action": "update",
-      "permission_category": "usergroups",
       "schema": {
         "input": {
           "properties": {
@@ -2571,8 +2574,6 @@
       },
       "description": "Enable or disable a specific VPN client by ID.",
       "name": "unifi_update_vpn_client_state",
-      "permission_action": "update",
-      "permission_category": "vpn_clients",
       "schema": {
         "input": {
           "properties": {
@@ -2602,8 +2603,6 @@
       },
       "description": "Enable or disable a specific VPN server by ID.",
       "name": "unifi_update_vpn_server_state",
-      "permission_action": "update",
-      "permission_category": "vpn_servers",
       "schema": {
         "input": {
           "properties": {
@@ -2625,16 +2624,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Update specific fields of an existing WLAN (SSID). Requires confirmation.",
       "name": "unifi_update_wlan",
-      "permission_action": "update",
-      "permission_category": "wlans",
       "schema": {
         "input": {
           "properties": {
@@ -2660,16 +2651,8 @@
       }
     },
     {
-      "annotations": {
-        "destructiveHint": true,
-        "idempotentHint": false,
-        "openWorldHint": false,
-        "readOnlyHint": false
-      },
       "description": "Initiate a firmware upgrade for a device by MAC address (uses cached firmware by default)",
       "name": "unifi_upgrade_device",
-      "permission_action": "update",
-      "permission_category": "devices",
       "schema": {
         "input": {
           "properties": {

--- a/apps/network/tests/unit/test_dpi_manager.py
+++ b/apps/network/tests/unit/test_dpi_manager.py
@@ -1,0 +1,186 @@
+"""Tests for the DpiManager class.
+
+This module tests DPI application and category lookup operations.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestDpiManager:
+    """Tests for the DpiManager class."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.host = "192.168.1.1"
+        conn.port = 443
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        return conn
+
+    @pytest.fixture
+    def mock_auth(self):
+        """Create a mock UniFiAuth."""
+        auth = MagicMock()
+        auth.has_api_key = True
+        auth.get_api_key_session = AsyncMock()
+        return auth
+
+    @pytest.fixture
+    def mock_auth_no_key(self):
+        """Create a mock UniFiAuth without API key."""
+        auth = MagicMock()
+        auth.has_api_key = False
+        return auth
+
+    @pytest.fixture
+    def dpi_manager(self, mock_connection, mock_auth):
+        """Create a DpiManager with mocked connection and auth."""
+        from unifi_network_mcp.managers.dpi_manager import DpiManager
+
+        return DpiManager(mock_connection, mock_auth)
+
+    @pytest.fixture
+    def dpi_manager_no_key(self, mock_connection, mock_auth_no_key):
+        """Create a DpiManager without API key."""
+        from unifi_network_mcp.managers.dpi_manager import DpiManager
+
+        return DpiManager(mock_connection, mock_auth_no_key)
+
+    # ---- get_dpi_applications ----
+
+    @pytest.mark.asyncio
+    async def test_get_dpi_applications_no_api_key(self, dpi_manager_no_key):
+        """Test get_dpi_applications returns empty when no API key."""
+        result = await dpi_manager_no_key.get_dpi_applications()
+
+        assert result["data"] == []
+        assert result["totalCount"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_dpi_applications_uses_cache(self, dpi_manager, mock_connection):
+        """Test get_dpi_applications returns cached data."""
+        cached = {"data": [{"id": 1, "name": "Cached"}], "totalCount": 1}
+        mock_connection.get_cached.return_value = cached
+
+        result = await dpi_manager.get_dpi_applications()
+
+        assert result == cached
+
+    @pytest.mark.asyncio
+    async def test_get_dpi_applications_search_filters_client_side(self, dpi_manager, mock_connection):
+        """Test search filtering happens client-side."""
+        # Mock the integration API response
+        api_response = {
+            "data": [
+                {"id": 1, "name": "Slack"},
+                {"id": 2, "name": "Telegram"},
+                {"id": 3, "name": "WhatsApp"},
+            ],
+            "totalCount": 3,
+            "offset": 0,
+            "limit": 100,
+        }
+
+        with patch.object(dpi_manager, "_request_integration_api", new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = api_response
+
+            result = await dpi_manager.get_dpi_applications(search="slack")
+
+        assert len(result["data"]) == 1
+        assert result["data"][0]["name"] == "Slack"
+        assert result.get("filtered_from") == 3
+
+    @pytest.mark.asyncio
+    async def test_get_dpi_applications_search_case_insensitive(self, dpi_manager):
+        """Test search is case-insensitive."""
+        api_response = {
+            "data": [{"id": 1, "name": "Telegram"}],
+            "totalCount": 1,
+            "offset": 0,
+            "limit": 100,
+        }
+
+        with patch.object(dpi_manager, "_request_integration_api", new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = api_response
+
+            result = await dpi_manager.get_dpi_applications(search="TELEGRAM")
+
+        assert len(result["data"]) == 1
+
+    # ---- get_dpi_categories ----
+
+    @pytest.mark.asyncio
+    async def test_get_dpi_categories_no_api_key(self, dpi_manager_no_key):
+        """Test get_dpi_categories returns empty when no API key."""
+        result = await dpi_manager_no_key.get_dpi_categories()
+
+        assert result["data"] == []
+        assert result["totalCount"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_dpi_categories_uses_cache(self, dpi_manager, mock_connection):
+        """Test get_dpi_categories returns cached data."""
+        cached = {"data": [{"id": 0, "name": "IM"}], "totalCount": 1}
+        mock_connection.get_cached.return_value = cached
+
+        result = await dpi_manager.get_dpi_categories()
+
+        assert result == cached
+
+    # ---- _request_integration_api ----
+
+    @pytest.mark.asyncio
+    async def test_request_integration_api_builds_correct_url(self, dpi_manager, mock_auth):
+        """Test _request_integration_api builds the correct URL."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"data": []})
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        mock_session.close = AsyncMock()
+
+        mock_auth.get_api_key_session.return_value = mock_session
+
+        await dpi_manager._request_integration_api("/v1/dpi/applications")
+
+        mock_session.get.assert_called_once()
+        call_args = mock_session.get.call_args
+        assert "/proxy/network/integration/v1/dpi/applications" in call_args[0][0]
+        mock_session.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_request_integration_api_non_200_returns_none(self, dpi_manager, mock_auth):
+        """Test _request_integration_api returns None on non-200 response."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 401
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        mock_session.close = AsyncMock()
+
+        mock_auth.get_api_key_session.return_value = mock_session
+
+        result = await dpi_manager._request_integration_api("/v1/dpi/applications")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_request_integration_api_no_key_returns_none(self, dpi_manager_no_key):
+        """Test _request_integration_api returns None when no API key configured."""
+        result = await dpi_manager_no_key._request_integration_api("/v1/dpi/applications")
+
+        assert result is None

--- a/apps/network/tests/unit/test_oon_manager.py
+++ b/apps/network/tests/unit/test_oon_manager.py
@@ -1,0 +1,361 @@
+"""Tests for the OonManager class.
+
+This module tests OON (Object-Oriented Network) policy operations.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestOonManager:
+    """Tests for the OonManager class."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def oon_manager(self, mock_connection):
+        """Create an OonManager with mocked connection."""
+        from unifi_network_mcp.managers.oon_manager import OonManager
+
+        return OonManager(mock_connection)
+
+    # ---- get_oon_policies ----
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policies_returns_list(self, oon_manager, mock_connection):
+        """Test get_oon_policies returns a list of policies."""
+        mock_policies = [
+            {"id": "p1", "name": "Bedtime", "enabled": True},
+            {"id": "p2", "name": "App Block", "enabled": True},
+        ]
+        mock_connection.request.return_value = mock_policies
+
+        policies = await oon_manager.get_oon_policies()
+
+        assert len(policies) == 2
+        assert policies[0]["name"] == "Bedtime"
+        mock_connection._update_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policies_uses_cache(self, oon_manager, mock_connection):
+        """Test get_oon_policies returns cached data when available."""
+        cached = [{"id": "cached", "name": "Cached Policy"}]
+        mock_connection.get_cached.return_value = cached
+
+        policies = await oon_manager.get_oon_policies()
+
+        assert policies == cached
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policies_handles_error(self, oon_manager, mock_connection):
+        """Test get_oon_policies returns empty list on error."""
+        mock_connection.request.side_effect = Exception("Network error")
+
+        policies = await oon_manager.get_oon_policies()
+
+        assert policies == []
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policies_handles_404(self, oon_manager, mock_connection):
+        """Test get_oon_policies returns empty list on 404 (unsupported controller)."""
+        mock_connection.request.side_effect = Exception("404 Not Found")
+
+        policies = await oon_manager.get_oon_policies()
+
+        assert policies == []
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policies_not_connected(self, oon_manager, mock_connection):
+        """Test get_oon_policies returns empty list when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        policies = await oon_manager.get_oon_policies()
+
+        assert policies == []
+        mock_connection.request.assert_not_called()
+
+    # ---- get_oon_policy_by_id ----
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policy_by_id_found(self, oon_manager, mock_connection):
+        """Test get_oon_policy_by_id returns policy when found."""
+        mock_connection.request.return_value = {"id": "p1", "name": "Test Policy"}
+
+        policy = await oon_manager.get_oon_policy_by_id("p1")
+
+        assert policy is not None
+        assert policy["name"] == "Test Policy"
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policy_by_id_not_connected(self, oon_manager, mock_connection):
+        """Test get_oon_policy_by_id returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        policy = await oon_manager.get_oon_policy_by_id("p1")
+
+        assert policy is None
+
+    @pytest.mark.asyncio
+    async def test_get_oon_policy_by_id_handles_error(self, oon_manager, mock_connection):
+        """Test get_oon_policy_by_id returns None on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        policy = await oon_manager.get_oon_policy_by_id("p1")
+
+        assert policy is None
+
+    # ---- create_oon_policy ----
+
+    @pytest.mark.asyncio
+    async def test_create_oon_policy_success(self, oon_manager, mock_connection):
+        """Test create_oon_policy with valid data."""
+        policy_data = {
+            "name": "New Policy",
+            "enabled": True,
+            "target_type": "CLIENTS",
+            "targets": ["aa:bb:cc:dd:ee:ff"],
+        }
+        mock_connection.request.return_value = {"id": "new1", **policy_data}
+
+        result = await oon_manager.create_oon_policy(policy_data)
+
+        assert result is not None
+        assert result["id"] == "new1"
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_create_oon_policy_strips_id(self, oon_manager, mock_connection):
+        """Test create_oon_policy strips _id and id from data."""
+        policy_data = {"_id": "old1", "id": "old1", "name": "Test", "enabled": True}
+        mock_connection.request.return_value = {"id": "new1", "name": "Test"}
+
+        await oon_manager.create_oon_policy(policy_data)
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert "_id" not in api_request.data
+        assert "id" not in api_request.data
+
+    @pytest.mark.asyncio
+    async def test_create_oon_policy_missing_name(self, oon_manager, mock_connection):
+        """Test create_oon_policy returns None when name is missing."""
+        result = await oon_manager.create_oon_policy({"enabled": True})
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_oon_policy_not_connected(self, oon_manager, mock_connection):
+        """Test create_oon_policy returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await oon_manager.create_oon_policy({"name": "Test"})
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_oon_policy_handles_data_wrapper(self, oon_manager, mock_connection):
+        """Test create_oon_policy handles response with data key."""
+        mock_connection.request.return_value = {"data": {"id": "new1", "name": "Test"}}
+
+        result = await oon_manager.create_oon_policy({"name": "Test"})
+
+        assert result == {"id": "new1", "name": "Test"}
+
+    @pytest.mark.asyncio
+    async def test_create_oon_policy_handles_error(self, oon_manager, mock_connection):
+        """Test create_oon_policy returns None on API error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await oon_manager.create_oon_policy({"name": "Test"})
+
+        assert result is None
+
+    # ---- update_oon_policy ----
+
+    @pytest.mark.asyncio
+    async def test_update_oon_policy_success(self, oon_manager, mock_connection):
+        """Test update_oon_policy with valid data."""
+        mock_connection.request.return_value = {}
+
+        result = await oon_manager.update_oon_policy("p1", {"id": "p1", "name": "Updated"})
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_oon_policy_not_connected(self, oon_manager, mock_connection):
+        """Test update_oon_policy returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await oon_manager.update_oon_policy("p1", {"name": "Test"})
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_update_oon_policy_handles_error(self, oon_manager, mock_connection):
+        """Test update_oon_policy returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await oon_manager.update_oon_policy("p1", {"name": "Test"})
+
+        assert result is False
+
+    # ---- toggle_oon_policy ----
+
+    @pytest.mark.asyncio
+    async def test_toggle_oon_policy_enables(self, oon_manager, mock_connection):
+        """Test toggle_oon_policy enables a disabled policy."""
+        mock_connection.request.side_effect = [
+            {"id": "p1", "name": "Test", "enabled": False},  # get
+            {},  # put
+        ]
+
+        result = await oon_manager.toggle_oon_policy("p1")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_toggle_oon_policy_disables(self, oon_manager, mock_connection):
+        """Test toggle_oon_policy disables an enabled policy."""
+        mock_connection.request.side_effect = [
+            {"id": "p1", "name": "Test", "enabled": True},  # get
+            {},  # put
+        ]
+
+        result = await oon_manager.toggle_oon_policy("p1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_toggle_oon_policy_not_connected(self, oon_manager, mock_connection):
+        """Test toggle_oon_policy returns None when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await oon_manager.toggle_oon_policy("p1")
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_toggle_oon_policy_not_found(self, oon_manager, mock_connection):
+        """Test toggle_oon_policy returns None when policy not found."""
+        mock_connection.request.return_value = None
+
+        result = await oon_manager.toggle_oon_policy("nonexistent")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_toggle_oon_policy_invalidates_cache(self, oon_manager, mock_connection):
+        """Test toggle_oon_policy invalidates cache."""
+        mock_connection.request.side_effect = [
+            {"id": "p1", "enabled": True},
+            {},
+        ]
+
+        await oon_manager.toggle_oon_policy("p1")
+
+        mock_connection._invalidate_cache.assert_called()
+
+    # ---- delete_oon_policy ----
+
+    @pytest.mark.asyncio
+    async def test_delete_oon_policy_success(self, oon_manager, mock_connection):
+        """Test delete_oon_policy with valid ID."""
+        mock_connection.request.return_value = {}
+
+        result = await oon_manager.delete_oon_policy("p1")
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_oon_policy_not_connected(self, oon_manager, mock_connection):
+        """Test delete_oon_policy returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await oon_manager.delete_oon_policy("p1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_oon_policy_handles_error(self, oon_manager, mock_connection):
+        """Test delete_oon_policy returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await oon_manager.delete_oon_policy("p1")
+
+        assert result is False
+
+    # ---- API path verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_uses_plural_path(self, oon_manager, mock_connection):
+        """Test get_oon_policies uses plural path."""
+        mock_connection.request.return_value = []
+
+        await oon_manager.get_oon_policies()
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/object-oriented-network-configs"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_uses_singular_path(self, oon_manager, mock_connection):
+        """Test get_oon_policy_by_id uses singular path."""
+        mock_connection.request.return_value = {"id": "p1"}
+
+        await oon_manager.get_oon_policy_by_id("p1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/object-oriented-network-config/p1"
+
+    @pytest.mark.asyncio
+    async def test_create_uses_singular_path(self, oon_manager, mock_connection):
+        """Test create_oon_policy uses singular POST path."""
+        mock_connection.request.return_value = {"id": "new1"}
+
+        await oon_manager.create_oon_policy({"name": "Test"})
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/object-oriented-network-config"
+        assert api_request.method == "post"
+
+    @pytest.mark.asyncio
+    async def test_update_uses_singular_path(self, oon_manager, mock_connection):
+        """Test update_oon_policy uses singular PUT path."""
+        mock_connection.request.return_value = {}
+
+        await oon_manager.update_oon_policy("p1", {"name": "Updated"})
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/object-oriented-network-config/p1"
+        assert api_request.method == "put"
+
+    @pytest.mark.asyncio
+    async def test_delete_uses_singular_path(self, oon_manager, mock_connection):
+        """Test delete_oon_policy uses singular DELETE path."""
+        mock_connection.request.return_value = {}
+
+        await oon_manager.delete_oon_policy("p1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/object-oriented-network-config/p1"
+        assert api_request.method == "delete"

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (97 tools)
+# Network Server Tool Reference (105 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -43,7 +43,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address â€” includes all controller-reported fields: IP, hostname, connection stat... |
+| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address — includes all controller-reported fields: IP, hostname, connection stat... |
 | `unifi_list_blocked_clients` | Read | List clients/devices that are currently blocked from the network |
 | `unifi_list_clients` | Read | Returns connected clients with MAC, name, hostname, IP, connection type (wired/wireless), and for wireless clients: SSID, signal dBm, cha... |
 | `unifi_lookup_by_ip` | Read | Quick IP-to-hostname lookup. |
@@ -70,7 +70,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address â€” includes radio tables, port tables, system stats, WAN info, firmware d... |
+| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address — includes radio tables, port tables, system stats, WAN info, firmware d... |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
 | `unifi_list_devices` | Read | Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_categ... |
 | `unifi_adopt_device` | Mutate | Adopt a pending device into the Unifi Network by MAC address |
@@ -262,6 +262,48 @@ Always available, regardless of registration mode.
 
 ---
 
+## OON Policies
+
+<!-- AUTO:tools:oon -->
+6 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_get_oon_policy_details` | Read | Get detailed configuration for a specific OON policy by ID. |
+| `unifi_list_oon_policies` | Read | List OON (Object-Oriented Network) policies. |
+| `unifi_create_oon_policy` | Mutate | Create a new OON (Object-Oriented Network) policy. |
+| `unifi_delete_oon_policy` | Mutate | Delete an OON policy. |
+| `unifi_toggle_oon_policy` | Mutate | Toggle an OON policy on or off. |
+| `unifi_update_oon_policy` | Mutate | Update an existing OON policy. |
+<!-- /AUTO:tools:oon -->
+
+**Tips:**
+- OON policies control internet scheduling (bedtime blackouts), app blocking, QoS, and VPN routing
+- Policies can target specific MACs (target_type=CLIENTS) or client groups (target_type=GROUPS)
+- Use `unifi_toggle_oon_policy` for quick enable/disable without sending the full object
+- Delete requires `UNIFI_PERMISSIONS_OON_POLICIES_DELETE=true`
+
+---
+
+## DPI Application Lookup
+
+<!-- AUTO:tools:dpi -->
+2 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_list_dpi_applications` | Read | List DPI applications available for use in firewall rules and OON policies. |
+| `unifi_list_dpi_categories` | Read | List DPI application categories (e.g., 'Instant messengers', 'Peer-to-peer networks', 'Media streaming services'). |
+<!-- /AUTO:tools:dpi -->
+
+**Tips:**
+- Requires `UNIFI_API_KEY` or `UNIFI_NETWORK_API_KEY` (official integration API)
+- As of Network App 10.1.85, only categories 0-1 (IM, P2P) are populated (~2,100 apps)
+- Categories 4+ (streaming, social media) are not yet available â€” add via UI and read back IDs
+- Use `search` parameter on `unifi_list_dpi_applications` for name-based lookup
+
+---
+
 ## Events & Alarms
 
 <!-- AUTO:tools:events -->
@@ -345,7 +387,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN â€” each with status, number of gateways/switches/APs, and active user counts. |
+| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN — each with status, number of gateways/switches/APs, and active user counts. |
 | `unifi_get_site_settings` | Read | Get current site settings (e.g., country code, timezone, connectivity monitoring). |
 | `unifi_get_snmp_settings` | Read | Get current SNMP settings for the site (enabled state, community string). |
 | `unifi_get_system_info` | Read | Returns controller version, uptime, hostname, memory/CPU usage, and update availability. |

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -281,7 +281,7 @@ Always available, regardless of registration mode.
 - OON policies control internet scheduling (bedtime blackouts), app blocking, QoS, and VPN routing
 - Policies can target specific MACs (target_type=CLIENTS) or client groups (target_type=GROUPS)
 - Use `unifi_toggle_oon_policy` for quick enable/disable without sending the full object
-- Delete requires `UNIFI_PERMISSIONS_OON_POLICIES_DELETE=true`
+- Delete requires `UNIFI_POLICY_NETWORK_OON_POLICIES_DELETE=true`
 
 ---
 

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -43,7 +43,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address — includes all controller-reported fields: IP, hostname, connection stat... |
+| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address â€” includes all controller-reported fields: IP, hostname, connection stat... |
 | `unifi_list_blocked_clients` | Read | List clients/devices that are currently blocked from the network |
 | `unifi_list_clients` | Read | Returns connected clients with MAC, name, hostname, IP, connection type (wired/wireless), and for wireless clients: SSID, signal dBm, cha... |
 | `unifi_lookup_by_ip` | Read | Quick IP-to-hostname lookup. |
@@ -70,7 +70,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address — includes radio tables, port tables, system stats, WAN info, firmware d... |
+| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address â€” includes radio tables, port tables, system stats, WAN info, firmware d... |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
 | `unifi_list_devices` | Read | Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_categ... |
 | `unifi_adopt_device` | Mutate | Adopt a pending device into the Unifi Network by MAC address |
@@ -387,7 +387,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN — each with status, number of gateways/switches/APs, and active user counts. |
+| `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN â€” each with status, number of gateways/switches/APs, and active user counts. |
 | `unifi_get_site_settings` | Read | Get current site settings (e.g., country code, timezone, connectivity monitoring). |
 | `unifi_get_snmp_settings` | Read | Get current SNMP settings for the site (enabled state, community string). |
 | `unifi_get_system_info` | Read | Returns controller version, uptime, hostname, memory/CPU usage, and update availability. |


### PR DESCRIPTION
## Summary

Adds 8 new tools: 6 for managing OON (Object-Oriented Network) policies and 2 for DPI application/category lookup via the official integration API.

**OON Policy tools (6):**
- `unifi_list_oon_policies` — List policies with schedule, targeting, and feature summary
- `unifi_get_oon_policy_details` — Get full policy config (secure, qos, route, targets)
- `unifi_create_oon_policy` — Create a new policy (preview-then-confirm)
- `unifi_update_oon_policy` — Update an existing policy (full object replacement)
- `unifi_toggle_oon_policy` — Toggle a policy on/off without sending the full object
- `unifi_delete_oon_policy` — Delete a policy (requires delete permission)

**DPI Application Lookup tools (2):**
- `unifi_list_dpi_applications` — List/search DPI applications by name (requires API key)
- `unifi_list_dpi_categories` — List all 35 DPI categories (requires API key)

**API endpoints:**
- OON: `GET/POST/PUT/DELETE /proxy/network/v2/api/site/default/object-oriented-network-config[/{id}]`
- DPI: `GET /proxy/network/integration/v1/dpi/applications` and `/dpi/categories`

## Files changed

| File | Change |
|---|---|
| `apps/network/src/unifi_network_mcp/managers/oon_manager.py` | **New** — OON CRUD + toggle, caching, 404 graceful degradation |
| `apps/network/src/unifi_network_mcp/managers/dpi_manager.py` | **New** — DPI lookup via official integration API using shared `UniFiAuth` |
| `apps/network/src/unifi_network_mcp/tools/oon.py` | **New** — 6 tool functions with ToolAnnotations |
| `apps/network/src/unifi_network_mcp/tools/dpi.py` | **New** — 2 read-only tool functions |
| `apps/network/tests/unit/test_oon_manager.py` | **New** — 30 unit tests |
| `apps/network/tests/unit/test_dpi_manager.py` | **New** — 9 unit tests |
| `apps/network/src/unifi_network_mcp/runtime.py` | Added `OonManager` + `DpiManager` factories and aliases |
| `apps/network/src/unifi_network_mcp/categories.py` | Added `oon_policy` and `dpi` to `NETWORK_CATEGORY_MAP` |
| `apps/network/src/unifi_network_mcp/config/config.yaml` | Added `oon_policies` + `dpi` permission blocks and category comments |
| `apps/network/src/unifi_network_mcp/tools_manifest.json` | Regenerated (97 → 105 tools) |
| `apps/network/docs/tools.md` | Added OON and DPI sections |
| `plugins/unifi-network/skills/.../network-tools.md` | Added skill reference markers for both categories |

## Live testing

All 8 tools tested end-to-end against a live controller.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.12 |
| **Firmware** | 5.0.12.30269 |
| **Network Application** | 10.1.85 |
| **MCP Client** | Claude Code 2.1.81 |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Tool | Test | Result |
|---|---|---|
| `list_oon_policies` | List 3 policies with summaries | ✅ Pass |
| `get_oon_policy_details` | Fetch bedtime blackout by ID | ✅ Pass |
| `create_oon_policy` | Create with full object, verify returned policy | ✅ Pass |
| `update_oon_policy` | Update policy, verify change | ✅ Pass |
| `toggle_oon_policy` | Toggle off → verify → toggle on → verify | ✅ Pass |
| `delete_oon_policy` | Delete test policy | ✅ Pass |
| `list_dpi_applications` | Search "slack" with small limit (fetches all before filtering) | ✅ Pass |
| `list_dpi_categories` | List all 35 categories | ✅ Pass |

> **Note:** OON delete testing requires `UNIFI_PERMISSIONS_OON_POLICIES_DELETE=true`. DPI tools require `UNIFI_API_KEY` or `UNIFI_NETWORK_API_KEY`.

## Unit tests

39 tests covering: CRUD + toggle success/error/not-connected paths, API path verification (plural vs singular), cache behavior, 404 graceful degradation, DPI search filtering, API key auth.

```
tests/unit/test_oon_manager.py — 30 passed
tests/unit/test_dpi_manager.py — 9 passed
Full suite (excluding pre-existing test_tool_map_sync path issue) — 366 passed, 0 failed
```

## Notes

### OON policies
- List endpoint uses **plural** path (`/object-oriented-network-configs`), all other operations use **singular** (`/object-oriented-network-config[/{id}]`)
- Create requires complete `qos` and `route` objects (including `mode`, `apps`, `domains`, etc.) even when disabled — the API rejects minimal objects. Tool description advises using `unifi_get_oon_policy_details` on an existing policy as a template.
- Toggle fetches current state via list fallback, flips `enabled`, and PUTs the full object back
- 404 errors are handled gracefully for controllers that don't support OON policies

### DPI application lookup
- Uses the **official integration API** with API key auth (`X-API-KEY` header) via the existing `UniFiAuth.get_api_key_session()` — not a custom HTTP client
- As of Network App 10.1.85, the official API only returns categories 0-1 (~2,100 apps). Categories 4+ (streaming, social media) are not yet populated by Ubiquiti. A v2 endpoint (`/v2/api/site/{site}/dpi`) exists as a stub but returns 405. This is documented in the manager, tool descriptions, and docs. Ref: #20
- Client-side search filtering: when `search` is provided, all apps are fetched before filtering to ensure correct results regardless of `limit` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)