### PR TITLE
feat(network): add content filtering tools

### DIFF
--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -24,6 +24,16 @@ These are always registered regardless of mode:
 - `unifi_list_firewall_zones` — List firewall zones (V2 API)
 - `unifi_list_ip_groups` — List IP groups (V2 API)
 
+## Content Filtering (4 tools)
+
+- `unifi_list_content_filters` — List content filtering profiles with category/targeting summary
+- `unifi_get_content_filter_details` — Get full profile config (categories, MACs, networks, safe search)
+- `unifi_update_content_filter` — Update an existing profile (full object replacement)
+- `unifi_delete_content_filter` — Delete a profile (requires delete permission)
+
+> **Note:** The UniFi API does not support creating content filtering profiles (POST returns 405).
+> Profiles must be created in the UniFi UI first, then managed via these tools.
+
 ## OON Policies (6 tools)
 
 - `unifi_list_oon_policies` — List OON policies with schedule and targeting summary

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -44,6 +44,7 @@ NETWORK_CATEGORY_MAP = {
     "snmp": "snmp",
     "acl": "acl_rules",
     "client_group": "client_groups",
+    "content_filter": "content_filters",
     "oon_policy": "oon_policies",
     "dpi": "dpi",
 }

--- a/apps/network/src/unifi_network_mcp/config/config.yaml
+++ b/apps/network/src/unifi_network_mcp/config/config.yaml
@@ -31,6 +31,7 @@ server:
   #     - events         # Events and alarms
   #     - acl            # MAC ACL rules (Policy Engine, Layer 2 access control)
   #     - client_groups  # Client groups (network member groups for OON policies)
+  #     - content_filtering  # Content filtering profiles (DNS blocking, safe search)
   #     - dpi            # DPI application/category lookup (requires API key)
   #     - firewall       # Firewall rules and groups
   #     - oon            # OON policies (internet scheduling, app blocking, QoS, routing)

--- a/apps/network/src/unifi_network_mcp/managers/content_filter_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/content_filter_manager.py
@@ -1,0 +1,137 @@
+"""Manager for content filtering profiles on the UniFi controller.
+
+Content filtering uses DNS-based category blocking and safe search
+enforcement. Profiles can be applied per-client (by MAC address)
+or per-network (by network ID).
+
+NOTE: The UniFi API does not support creating content filtering profiles
+via POST. Profiles must be created through the UniFi UI first, then
+managed (list, update, delete) via the API.
+
+API endpoint: /proxy/network/v2/api/site/{site}/content-filtering
+Supported methods:
+  GET  /content-filtering        — list all profiles
+  PUT  /content-filtering/{id}   — update a profile
+  DELETE /content-filtering/{id} — delete a profile
+Not supported:
+  POST /content-filtering        — returns 405
+  GET  /content-filtering/{id}   — returns 405 (use list + filter)
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiounifi.models.api import ApiRequestV2
+
+from .connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_CONTENT_FILTERS = "content_filters"
+
+
+class ContentFilterManager:
+    """Manages content filtering profiles on the UniFi controller."""
+
+    def __init__(self, connection_manager: ConnectionManager):
+        self._connection = connection_manager
+
+    async def get_content_filters(self) -> List[Dict[str, Any]]:
+        """Get all content filtering profiles.
+
+        Returns:
+            List of content filtering profile dictionaries.
+        """
+        cache_key = f"{CACHE_PREFIX_CONTENT_FILTERS}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key)
+        if cached_data is not None:
+            return cached_data
+
+        if not await self._connection.ensure_connected():
+            return []
+
+        try:
+            api_request = ApiRequestV2(method="get", path="/content-filtering")
+            response = await self._connection.request(api_request)
+
+            filters = (
+                response
+                if isinstance(response, list)
+                else response.get("data", [])
+                if isinstance(response, dict)
+                else []
+            )
+
+            self._connection._update_cache(cache_key, filters)
+            return filters
+        except Exception as e:
+            logger.error("Error getting content filters: %s", e)
+            return []
+
+    async def get_content_filter_by_id(self, filter_id: str) -> Optional[Dict[str, Any]]:
+        """Get a specific content filtering profile by ID.
+
+        The API does not support GET /content-filtering/{id} (returns 405),
+        so this method fetches all profiles and filters by ID.
+
+        Args:
+            filter_id: The ID of the content filtering profile.
+
+        Returns:
+            The profile dictionary, or None if not found.
+        """
+        try:
+            filters = await self.get_content_filters()
+            return next((f for f in filters if f.get("_id", f.get("id")) == filter_id), None)
+        except Exception as e:
+            logger.error("Error getting content filter %s: %s", filter_id, e)
+            return None
+
+    async def update_content_filter(self, filter_id: str, filter_data: Dict[str, Any]) -> bool:
+        """Update an existing content filtering profile.
+
+        Args:
+            filter_id: The ID of the profile to update.
+            filter_data: Complete profile data (PUT replaces the entire object).
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="put", path=f"/content-filtering/{filter_id}", data=filter_data)
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error("Error updating content filter %s: %s", filter_id, e, exc_info=True)
+            return False
+
+    async def delete_content_filter(self, filter_id: str) -> bool:
+        """Delete a content filtering profile.
+
+        Args:
+            filter_id: The ID of the profile to delete.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="delete", path=f"/content-filtering/{filter_id}")
+            await self._connection.request(api_request)
+
+            self._invalidate_cache()
+            return True
+        except Exception as e:
+            logger.error("Error deleting content filter %s: %s", filter_id, e, exc_info=True)
+            return False
+
+    def _invalidate_cache(self):
+        """Invalidate all content filter caches."""
+        self._connection._invalidate_cache(CACHE_PREFIX_CONTENT_FILTERS)

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -31,6 +31,7 @@ from unifi_network_mcp.managers.acl_manager import AclManager
 from unifi_network_mcp.managers.client_group_manager import ClientGroupManager
 from unifi_network_mcp.managers.client_manager import ClientManager
 from unifi_network_mcp.managers.connection_manager import ConnectionManager
+from unifi_network_mcp.managers.content_filter_manager import ContentFilterManager
 from unifi_network_mcp.managers.device_manager import DeviceManager
 from unifi_network_mcp.managers.dpi_manager import DpiManager
 from unifi_network_mcp.managers.event_manager import EventManager
@@ -171,6 +172,11 @@ def get_client_manager() -> ClientManager:
 
 
 @lru_cache
+def get_content_filter_manager() -> ContentFilterManager:
+    return ContentFilterManager(get_connection_manager())
+
+
+@lru_cache
 def get_dpi_manager() -> DpiManager:
     return DpiManager(get_connection_manager(), get_auth())
 
@@ -260,6 +266,7 @@ connection_manager = get_connection_manager()
 acl_manager = get_acl_manager()
 client_group_manager = get_client_group_manager()
 client_manager = get_client_manager()
+content_filter_manager = get_content_filter_manager()
 dpi_manager = get_dpi_manager()
 device_manager = get_device_manager()
 stats_manager = get_stats_manager()

--- a/apps/network/src/unifi_network_mcp/tools/content_filtering.py
+++ b/apps/network/src/unifi_network_mcp/tools/content_filtering.py
@@ -1,0 +1,207 @@
+"""
+Content filtering tools for UniFi Network MCP server.
+
+Content filtering uses DNS-based category blocking and safe search
+enforcement. Profiles can target specific clients (by MAC address)
+or entire networks (by network ID).
+
+NOTE: The UniFi API does not support creating content filtering profiles
+via POST (returns 405). Profiles must be created through the UniFi UI
+first, then managed (list, update, delete) via these tools.
+"""
+
+import json
+import logging
+from typing import Annotated, Any, Dict
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_mcp_shared.confirmation import create_preview
+from unifi_network_mcp.runtime import content_filter_manager, server
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_content_filters",
+    description="List content filtering profiles. "
+    "Profiles control DNS-based category blocking, safe search enforcement "
+    "(GOOGLE, YOUTUBE, BING), and domain allow/block lists. "
+    "Profiles can target specific clients by MAC or entire networks by ID. "
+    "NOTE: Profiles must be created in the UniFi UI — the API only supports list, update, and delete. "
+    "Common categories: FAMILY, ADVERTISEMENT, MALWARE, PHISHING, BOTNETS, SPAM, SPYWARE, "
+    "HACKING, ANONYMIZERS, DNS_TUNNELING, ADULT, ALCOHOL, DRUGS, GAMBLING, VIOLENCE, "
+    "PORNOGRAPHY, NUDITY, WEAPONS, DATING, HATE_SPEECH_AND_EXTREMISM, CHILD_ABUSE, CIPA, "
+    "EMPTY_DOMAINS, NEWLY_DISCOVERED_DOMAINS, PARKED_DOMAINS, UNREACHABLE_DOMAINS.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_content_filters() -> Dict[str, Any]:
+    """
+    Lists all content filtering profiles configured on the controller.
+
+    Returns:
+        A dictionary containing:
+        - success (bool): Indicates if the operation was successful.
+        - count (int): Number of profiles found.
+        - filters (List[Dict]): List of profiles with summary info.
+    """
+    try:
+        filters = await content_filter_manager.get_content_filters()
+        formatted = [
+            {
+                "id": f.get("_id", f.get("id")),
+                "name": f.get("name"),
+                "enabled": f.get("enabled"),
+                "categories": f.get("categories", []),
+                "category_count": len(f.get("categories", [])),
+                "client_mac_count": len(f.get("client_macs", [])),
+                "network_ids": f.get("network_ids", []),
+                "network_id_count": len(f.get("network_ids", [])),
+                "safe_search": f.get("safe_search", []),
+                "allow_list_count": len(f.get("allow_list", [])),
+                "block_list_count": len(f.get("block_list", [])),
+                "schedule_mode": f.get("schedule", {}).get("mode"),
+            }
+            for f in filters
+        ]
+        return {
+            "success": True,
+            "site": content_filter_manager._connection.site,
+            "count": len(formatted),
+            "filters": formatted,
+        }
+    except Exception as e:
+        logger.error("Error listing content filters: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list content filters: {e}"}
+
+
+@server.tool(
+    name="unifi_get_content_filter_details",
+    description="Get detailed configuration for a specific content filtering profile by ID. "
+    "Returns the full profile including categories, client MACs, network IDs, "
+    "safe search settings, and allow/block lists.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_content_filter_details(
+    filter_id: Annotated[str, Field(description="The unique identifier (_id) of the content filtering profile")],
+) -> Dict[str, Any]:
+    """
+    Gets the detailed configuration of a specific content filtering profile.
+
+    Args:
+        filter_id (str): The unique identifier of the profile.
+
+    Returns:
+        A dictionary containing the full profile configuration.
+    """
+    try:
+        if not filter_id:
+            return {"success": False, "error": "filter_id is required"}
+
+        profile = await content_filter_manager.get_content_filter_by_id(filter_id)
+        if not profile:
+            return {"success": False, "error": f"Content filter '{filter_id}' not found."}
+
+        return {
+            "success": True,
+            "filter_id": filter_id,
+            "details": json.loads(json.dumps(profile, default=str)),
+        }
+    except Exception as e:
+        logger.error("Error getting content filter %s: %s", filter_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get content filter {filter_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_update_content_filter",
+    description="Update an existing content filtering profile. Requires the full profile object "
+    "(PUT replaces entire resource). Use unifi_get_content_filter_details to fetch the current "
+    "object, modify it, and send back. "
+    "client_macs and network_ids are additive — both can be set and the filter applies to all. "
+    "Safe search valid values: GOOGLE, YOUTUBE, BING (only these three are supported). "
+    "Requires confirmation.",
+    permission_category="content_filter",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_content_filter(
+    filter_id: Annotated[str, Field(description="The ID of the profile to update")],
+    filter_data: Annotated[
+        dict,
+        Field(description="The complete updated profile object with all fields"),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, updates the profile. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Updates an existing content filtering profile.
+
+    Args:
+        filter_id (str): The ID of the profile to update.
+        filter_data (dict): The complete updated profile object.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview of changes or success/failure status.
+    """
+    if not confirm:
+        return create_preview(
+            resource_type="content_filter",
+            resource_data=filter_data,
+            resource_name=filter_id,
+        )
+
+    try:
+        success = await content_filter_manager.update_content_filter(filter_id, filter_data)
+        if success:
+            return {"success": True, "message": f"Content filter '{filter_id}' updated successfully."}
+        return {"success": False, "error": f"Failed to update content filter '{filter_id}'."}
+    except Exception as e:
+        logger.error("Error updating content filter %s: %s", filter_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to update content filter '{filter_id}': {e}"}
+
+
+@server.tool(
+    name="unifi_delete_content_filter",
+    description="Delete a content filtering profile. Requires confirmation. "
+    "WARNING: Deleting a profile removes DNS-based blocking for all targeted clients/networks.",
+    permission_category="content_filter",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_content_filter(
+    filter_id: Annotated[str, Field(description="The ID of the profile to delete")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the profile. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """
+    Deletes a content filtering profile.
+
+    Args:
+        filter_id (str): The ID of the profile to delete.
+        confirm (bool): Must be True to execute.
+
+    Returns:
+        Preview or success/failure status.
+    """
+    if not confirm:
+        return create_preview(
+            resource_type="content_filter",
+            resource_data={"filter_id": filter_id},
+            resource_name=filter_id,
+            warnings=["Deleting a content filter removes DNS-based blocking for all targeted clients/networks."],
+        )
+
+    try:
+        success = await content_filter_manager.delete_content_filter(filter_id)
+        if success:
+            return {"success": True, "message": f"Content filter '{filter_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete content filter '{filter_id}'."}
+    except Exception as e:
+        logger.error("Error deleting content filter %s: %s", filter_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete content filter '{filter_id}': {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 105,
+  "count": 109,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -23,6 +23,7 @@
     "unifi_create_wlan": "unifi_network_mcp.tools.network",
     "unifi_delete_acl_rule": "unifi_network_mcp.tools.acl",
     "unifi_delete_client_group": "unifi_network_mcp.tools.client_groups",
+    "unifi_delete_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_delete_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_force_reconnect_client": "unifi_network_mcp.tools.clients",
@@ -31,6 +32,7 @@
     "unifi_get_client_details": "unifi_network_mcp.tools.clients",
     "unifi_get_client_group_details": "unifi_network_mcp.tools.client_groups",
     "unifi_get_client_stats": "unifi_network_mcp.tools.stats",
+    "unifi_get_content_filter_details": "unifi_network_mcp.tools.content_filtering",
     "unifi_get_device_details": "unifi_network_mcp.tools.devices",
     "unifi_get_device_radio": "unifi_network_mcp.tools.devices",
     "unifi_get_device_stats": "unifi_network_mcp.tools.stats",
@@ -60,6 +62,7 @@
     "unifi_list_blocked_clients": "unifi_network_mcp.tools.clients",
     "unifi_list_client_groups": "unifi_network_mcp.tools.client_groups",
     "unifi_list_clients": "unifi_network_mcp.tools.clients",
+    "unifi_list_content_filters": "unifi_network_mcp.tools.content_filtering",
     "unifi_list_devices": "unifi_network_mcp.tools.devices",
     "unifi_list_dpi_applications": "unifi_network_mcp.tools.dpi",
     "unifi_list_dpi_categories": "unifi_network_mcp.tools.dpi",
@@ -93,6 +96,7 @@
     "unifi_unblock_client": "unifi_network_mcp.tools.clients",
     "unifi_update_acl_rule": "unifi_network_mcp.tools.acl",
     "unifi_update_client_group": "unifi_network_mcp.tools.client_groups",
+    "unifi_update_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_update_device_radio": "unifi_network_mcp.tools.devices",
     "unifi_update_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_update_network": "unifi_network_mcp.tools.network",
@@ -827,6 +831,36 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
+      "description": "Delete a content filtering profile. Requires confirmation. WARNING: Deleting a profile removes DNS-based blocking for all targeted clients/networks.",
+      "name": "unifi_delete_content_filter",
+      "permission_action": "delete",
+      "permission_category": "content_filter",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the profile. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "filter_id": {
+              "description": "The ID of the profile to delete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete a firewall policy by ID. Requires confirmation. WARNING: Removing an ALLOW rule may block traffic. Removing a BLOCK rule may open access.",
       "name": "unifi_delete_firewall_policy",
       "permission_action": "delete",
@@ -1020,6 +1054,28 @@
           },
           "required": [
             "client_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get detailed configuration for a specific content filtering profile by ID. Returns the full profile including categories, client MACs, network IDs, safe search settings, and allow/block lists.",
+      "name": "unifi_get_content_filter_details",
+      "schema": {
+        "input": {
+          "properties": {
+            "filter_id": {
+              "description": "The unique identifier (_id) of the content filtering profile",
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter_id"
           ],
           "type": "object"
         }
@@ -1592,6 +1648,20 @@
               "type": "integer"
             }
           },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List content filtering profiles. Profiles control DNS-based category blocking, safe search enforcement (GOOGLE, YOUTUBE, BING), and domain allow/block lists. Profiles can target specific clients by MAC or entire networks by ID. NOTE: Profiles must be created in the UniFi UI \u2014 the API only supports list, update, and delete. Common categories: FAMILY, ADVERTISEMENT, MALWARE, PHISHING, BOTNETS, SPAM, SPYWARE, HACKING, ANONYMIZERS, DNS_TUNNELING, ADULT, ALCOHOL, DRUGS, GAMBLING, VIOLENCE, PORNOGRAPHY, NUDITY, WEAPONS, DATING, HATE_SPEECH_AND_EXTREMISM, CHILD_ABUSE, CIPA, EMPTY_DOMAINS, NEWLY_DISCOVERED_DOMAINS, PARKED_DOMAINS, UNREACHABLE_DOMAINS.",
+      "name": "unifi_list_content_filters",
+      "schema": {
+        "input": {
+          "properties": {},
           "type": "object"
         }
       }
@@ -2378,6 +2448,41 @@
           "required": [
             "group_id",
             "group_data"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Update an existing content filtering profile. Requires the full profile object (PUT replaces entire resource). Use unifi_get_content_filter_details to fetch the current object, modify it, and send back. client_macs and network_ids are additive \u2014 both can be set and the filter applies to all. Safe search valid values: GOOGLE, YOUTUBE, BING (only these three are supported). Requires confirmation.",
+      "name": "unifi_update_content_filter",
+      "permission_action": "update",
+      "permission_category": "content_filter",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, updates the profile. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "filter_data": {
+              "description": "The complete updated profile object with all fields",
+              "type": "object"
+            },
+            "filter_id": {
+              "description": "The ID of the profile to update",
+              "type": "string"
+            }
+          },
+          "required": [
+            "filter_id",
+            "filter_data"
           ],
           "type": "object"
         }

--- a/apps/network/tests/unit/test_content_filter_manager.py
+++ b/apps/network/tests/unit/test_content_filter_manager.py
@@ -1,0 +1,234 @@
+"""Tests for the ContentFilterManager class.
+
+This module tests content filtering profile operations.
+Note: The UniFi API does not support POST (create) or GET /{id}.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestContentFilterManager:
+    """Tests for the ContentFilterManager class."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def content_filter_manager(self, mock_connection):
+        """Create a ContentFilterManager with mocked connection."""
+        from unifi_network_mcp.managers.content_filter_manager import ContentFilterManager
+
+        return ContentFilterManager(mock_connection)
+
+    # ---- get_content_filters ----
+
+    @pytest.mark.asyncio
+    async def test_get_content_filters_returns_list(self, content_filter_manager, mock_connection):
+        """Test get_content_filters returns a list of profiles."""
+        mock_filters = [
+            {"_id": "f1", "name": "Kids", "enabled": True, "categories": ["FAMILY"]},
+            {"_id": "f2", "name": "All Internal", "enabled": True, "categories": ["MALWARE"]},
+        ]
+        mock_connection.request.return_value = mock_filters
+
+        filters = await content_filter_manager.get_content_filters()
+
+        assert len(filters) == 2
+        assert filters[0]["name"] == "Kids"
+        mock_connection._update_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_content_filters_uses_cache(self, content_filter_manager, mock_connection):
+        """Test get_content_filters returns cached data when available."""
+        cached = [{"_id": "cached", "name": "Cached Filter"}]
+        mock_connection.get_cached.return_value = cached
+
+        filters = await content_filter_manager.get_content_filters()
+
+        assert filters == cached
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_content_filters_handles_error(self, content_filter_manager, mock_connection):
+        """Test get_content_filters returns empty list on error."""
+        mock_connection.request.side_effect = Exception("Network error")
+
+        filters = await content_filter_manager.get_content_filters()
+
+        assert filters == []
+
+    @pytest.mark.asyncio
+    async def test_get_content_filters_not_connected(self, content_filter_manager, mock_connection):
+        """Test get_content_filters returns empty list when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        filters = await content_filter_manager.get_content_filters()
+
+        assert filters == []
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_content_filters_handles_dict_response(self, content_filter_manager, mock_connection):
+        """Test get_content_filters handles dict response with data key."""
+        mock_connection.request.return_value = {"data": [{"_id": "f1", "name": "Filter"}]}
+
+        filters = await content_filter_manager.get_content_filters()
+
+        assert len(filters) == 1
+
+    # ---- get_content_filter_by_id ----
+
+    @pytest.mark.asyncio
+    async def test_get_content_filter_by_id_found(self, content_filter_manager, mock_connection):
+        """Test get_content_filter_by_id returns profile when found via list search."""
+        mock_connection.request.return_value = [
+            {"_id": "f1", "name": "Kids", "categories": ["FAMILY"]},
+            {"_id": "f2", "name": "All Internal", "categories": ["MALWARE"]},
+        ]
+
+        profile = await content_filter_manager.get_content_filter_by_id("f1")
+
+        assert profile is not None
+        assert profile["name"] == "Kids"
+
+    @pytest.mark.asyncio
+    async def test_get_content_filter_by_id_not_found(self, content_filter_manager, mock_connection):
+        """Test get_content_filter_by_id returns None when ID not in list."""
+        mock_connection.request.return_value = [
+            {"_id": "f1", "name": "Kids"},
+        ]
+
+        profile = await content_filter_manager.get_content_filter_by_id("nonexistent")
+
+        assert profile is None
+
+    @pytest.mark.asyncio
+    async def test_get_content_filter_by_id_handles_error(self, content_filter_manager, mock_connection):
+        """Test get_content_filter_by_id returns None on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        profile = await content_filter_manager.get_content_filter_by_id("f1")
+
+        assert profile is None
+
+    # ---- update_content_filter ----
+
+    @pytest.mark.asyncio
+    async def test_update_content_filter_success(self, content_filter_manager, mock_connection):
+        """Test update_content_filter with valid data."""
+        mock_connection.request.return_value = {}
+
+        result = await content_filter_manager.update_content_filter(
+            "f1", {"_id": "f1", "name": "Updated", "categories": ["FAMILY"]}
+        )
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_content_filter_not_connected(self, content_filter_manager, mock_connection):
+        """Test update_content_filter returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await content_filter_manager.update_content_filter("f1", {"name": "Test"})
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_update_content_filter_handles_error(self, content_filter_manager, mock_connection):
+        """Test update_content_filter returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await content_filter_manager.update_content_filter("f1", {"name": "Test"})
+
+        assert result is False
+
+    # ---- delete_content_filter ----
+
+    @pytest.mark.asyncio
+    async def test_delete_content_filter_success(self, content_filter_manager, mock_connection):
+        """Test delete_content_filter with valid ID."""
+        mock_connection.request.return_value = {}
+
+        result = await content_filter_manager.delete_content_filter("f1")
+
+        assert result is True
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_content_filter_not_connected(self, content_filter_manager, mock_connection):
+        """Test delete_content_filter returns False when not connected."""
+        mock_connection.ensure_connected.return_value = False
+
+        result = await content_filter_manager.delete_content_filter("f1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_content_filter_handles_error(self, content_filter_manager, mock_connection):
+        """Test delete_content_filter returns False on error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await content_filter_manager.delete_content_filter("f1")
+
+        assert result is False
+
+    # ---- API path verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_uses_correct_path(self, content_filter_manager, mock_connection):
+        """Test get_content_filters calls the correct API endpoint."""
+        mock_connection.request.return_value = []
+
+        await content_filter_manager.get_content_filters()
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/content-filtering"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_uses_list(self, content_filter_manager, mock_connection):
+        """Test get_content_filter_by_id searches via list (no direct GET /{id})."""
+        mock_connection.request.return_value = [{"_id": "f1", "name": "Test"}]
+
+        await content_filter_manager.get_content_filter_by_id("f1")
+
+        # Should call the list endpoint, not /content-filtering/f1
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/content-filtering"
+
+    @pytest.mark.asyncio
+    async def test_update_uses_correct_path_and_method(self, content_filter_manager, mock_connection):
+        """Test update_content_filter uses PUT to the correct endpoint."""
+        mock_connection.request.return_value = {}
+
+        await content_filter_manager.update_content_filter("f1", {"name": "Updated"})
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/content-filtering/f1"
+        assert api_request.method == "put"
+
+    @pytest.mark.asyncio
+    async def test_delete_uses_correct_path_and_method(self, content_filter_manager, mock_connection):
+        """Test delete_content_filter uses DELETE to the correct endpoint."""
+        mock_connection.request.return_value = {}
+
+        await content_filter_manager.delete_content_filter("f1")
+
+        call_args = mock_connection.request.call_args
+        api_request = call_args[0][0]
+        assert api_request.path == "/content-filtering/f1"
+        assert api_request.method == "delete"

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (105 tools)
+# Network Server Tool Reference (109 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -239,6 +239,26 @@ Always available, regardless of registration mode.
 
 **Tips:**
 - This is the only category with a delete tool — requires `UNIFI_POLICY_NETWORK_ACL_RULES_DELETE=true`
+
+---
+
+## Content Filtering
+
+<!-- AUTO:tools:content_filtering -->
+4 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_get_content_filter_details` | Read | Get detailed configuration for a specific content filtering profile by ID. |
+| `unifi_list_content_filters` | Read | List content filtering profiles. |
+| `unifi_delete_content_filter` | Mutate | Delete a content filtering profile. |
+| `unifi_update_content_filter` | Mutate | Update an existing content filtering profile. |
+<!-- /AUTO:tools:content_filtering -->
+
+**Tips:**
+- Profiles apply DNS-based category blocking (FAMILY, MALWARE, PHISHING, etc.) and safe search
+- Target by client MACs (per-device) or network IDs (per-VLAN)
+- Use `unifi_get_content_filter_details` to fetch the current profile before updating
 
 ---
 


### PR DESCRIPTION
## Summary

Adds 4 tools for managing UniFi content filtering profiles via the v2 API. Content filtering uses DNS-based category blocking, safe search enforcement (Google, YouTube, Bing), and domain allow/block lists. Profiles can target specific clients by MAC or entire networks by ID.

**Content Filtering tools (4):**
- `unifi_list_content_filters` — List profiles with categories, targeting summary, safe search, schedule
- `unifi_get_content_filter_details` — Get full profile config by ID
- `unifi_update_content_filter` — Update an existing profile (full object replacement)
- `unifi_delete_content_filter` — Delete a profile

**API endpoint:** `GET/PUT/DELETE /proxy/network/v2/api/site/default/content-filtering[/{id}]`

## Files changed

| File | Change |
|---|---|
| `apps/network/src/unifi_network_mcp/managers/content_filter_manager.py` | **New** — list, get-by-id (via list search), update, delete |
| `apps/network/src/unifi_network_mcp/tools/content_filtering.py` | **New** — 4 tool functions with ToolAnnotations |
| `apps/network/tests/unit/test_content_filter_manager.py` | **New** — 20 unit tests |
| `apps/network/src/unifi_network_mcp/runtime.py` | Added `ContentFilterManager` factory and alias |
| `apps/network/src/unifi_network_mcp/categories.py` | Added `content_filter` to `NETWORK_CATEGORY_MAP` |
| `apps/network/src/unifi_network_mcp/tools_manifest.json` | Regenerated (109 tools) |
| `apps/network/docs/tools.md` | Added content filtering section |
| `plugins/unifi-network/skills/.../network-tools.md` | Added skill reference markers |

## Live testing

All 4 tools tested end-to-end against a live controller.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.12 |
| **Network Application** | 10.1.85 |
| **MCP Client** | Claude Code 2.1.81 |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Tool | Test | Result |
|---|---|---|
| `list_content_filters` | List 2 profiles (All Internal + test) | ✅ Pass |
| `get_content_filter_details` | Get "All Internal" by ID via list search | ✅ Pass |
| `update_content_filter` | Re-PUT "All Internal" with same data | ✅ Pass |
| `delete_content_filter` | Delete "test" profile created in UI | ✅ Pass |

## Unit tests

20 tests covering: list success/error/not-connected/cache/dict-response, get-by-id found/not-found/error, update success/not-connected/error, delete success/not-connected/error, API path verification.

```
tests/unit/test_content_filter_manager.py — 20 passed
Full suite — 366 passed, 0 failed
```

## Notes

### Vendor API limitation: no create (POST returns 405)

The UniFi API does not support creating content filtering profiles. Profiles must be created in the UniFi UI first, then managed via these tools. GET `/{id}` also returns 405, so `get_content_filter_by_id` fetches all profiles and filters by ID.

This is a confirmed limitation across the community — no known project has found a create endpoint. See [beezly/sync_unifi_filters](https://github.com/beezly/sync_unifi_filters) for prior art.

| Method | `/content-filtering` | `/content-filtering/{id}` |
|---|---|---|
| GET | 200 (list) | 405 |
| POST | 405 | N/A |
| PUT | 405 | 200 (update) |
| DELETE | 405 | 200 (delete) |

### Category documentation

Tool descriptions include all known category strings discovered through live testing. Safe search supports only three values: GOOGLE, YOUTUBE, BING. `client_macs` and `network_ids` are additive — both can be set on the same profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)