### PR TITLE
feat(network): add backup management tools (list, create, delete, auto-backup settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 
 | Server | Status | Tools | Package |
 |--------|--------|-------|---------|
-| [Network](apps/network/) | Stable | 130 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
+| [Network](apps/network/) | Stable | 161 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
 | [Protect](apps/protect/) | Beta | 34 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
 | [Access](apps/access/) | Beta | 29 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
 
@@ -174,7 +174,7 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 130 tools)
+  network/          # UniFi Network MCP server (stable, 161 tools)
   protect/          # UniFi Protect MCP server (beta, 34 tools)
   access/           # UniFi Access MCP server (beta, 29 tools)
 packages/

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -5,7 +5,7 @@
   <img src="../../assets/hero-network.svg" alt="UniFi Network MCP Server" width="720">
 </p>
 
-MCP server exposing 130 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
+MCP server exposing 161 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
 
 ## Install
 
@@ -204,7 +204,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 130 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 161 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 130 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 161 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 For machine-readable tool metadata, call the `unifi_tool_index` meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`.
 
@@ -208,13 +208,18 @@ These are always registered regardless of mode:
 - `unifi_get_dpi_stats` — Deep Packet Inspection statistics
 - `unifi_get_alerts` — Recent alerts
 
-## System (5 tools)
+## System (10 tools)
 
 - `unifi_get_system_info` — Controller version, uptime, resource usage
 - `unifi_get_network_health` — Per-subsystem health (WAN, LAN, WLAN, VPN)
 - `unifi_get_site_settings` — Current site settings
 - `unifi_get_snmp_settings` — SNMP configuration
 - `unifi_update_snmp_settings` — Update SNMP settings
+- `unifi_list_backups` — List available backups on the controller
+- `unifi_create_backup` — Create a new backup of the controller configuration
+- `unifi_delete_backup` — Delete a backup file from the controller
+- `unifi_get_autobackup_settings` — Get auto-backup settings
+- `unifi_update_autobackup_settings` — Update auto-backup settings
 
 ## Tool Registration Modes
 

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -48,6 +48,7 @@ NETWORK_CATEGORY_MAP = {
     "oon_policy": "oon_policies",
     "dpi": "dpi",
     "switch": "switch",
+    "system": "system",
 }
 
 # Backward-compatible alias

--- a/apps/network/src/unifi_network_mcp/managers/system_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/system_manager.py
@@ -63,22 +63,25 @@ class SystemManager:
             logger.error("Error getting controller status: %s", e)
             return {}
 
-    async def create_backup(self, filename: Optional[str] = None) -> Optional[bytes]:
+    async def create_backup(self) -> Optional[Dict[str, Any]]:
         """Create a backup of the controller configuration.
 
-        Args:
-            filename: Optional filename for the backup (currently unused by API call)
-
         Returns:
-            Backup data as bytes if successful, None otherwise
+            Dict with backup metadata including download URL, or None on failure.
         """
         try:
             api_request = ApiRequest(method="post", path="/cmd/backup", data={"cmd": "backup"})
-            response = await self._connection.request(api_request, return_raw=True)
-            logger.info("Backup creation requested successfully.")
-            return response if isinstance(response, bytes) else None
+            response = await self._connection.request(api_request)
+            if isinstance(response, list) and response:
+                logger.info("Backup creation requested successfully.")
+                return response[0]
+            if isinstance(response, dict) and response.get("url"):
+                logger.info("Backup creation requested successfully.")
+                return response
+            logger.error("Unexpected backup response: %s", response)
+            return None
         except Exception as e:
-            logger.error("Error creating backup: %s", e)
+            logger.error("Error creating backup: %s", e, exc_info=True)
             return None
 
     async def restore_backup(self, backup_data: bytes) -> bool:
@@ -118,6 +121,87 @@ class SystemManager:
                     return False
         except Exception as e:
             logger.error("Exception during backup restore: %s", e)
+            return False
+
+    async def list_backups(self) -> List[Dict[str, Any]]:
+        """List available backups on the controller.
+
+        Returns:
+            List of backup dicts with filename, datetime, size, etc.
+        """
+        try:
+            api_request = ApiRequest(
+                method="post", path="/cmd/backup", data={"cmd": "list-backups"}
+            )
+            response = await self._connection.request(api_request)
+            if isinstance(response, list):
+                return response
+            if isinstance(response, dict):
+                return response.get("data", [])
+            return []
+        except Exception as e:
+            logger.error("Error listing backups: %s", e, exc_info=True)
+            return []
+
+    async def delete_backup(self, filename: str) -> bool:
+        """Delete a backup file from the controller.
+
+        Args:
+            filename: Backup filename (from list_backups).
+
+        Returns:
+            True on success, False on failure.
+        """
+        try:
+            api_request = ApiRequest(
+                method="post",
+                path="/cmd/backup",
+                data={"cmd": "delete-backup", "filename": filename},
+            )
+            await self._connection.request(api_request)
+            logger.info("Backup '%s' deleted successfully.", filename)
+            return True
+        except Exception as e:
+            logger.error("Error deleting backup '%s': %s", filename, e, exc_info=True)
+            return False
+
+    async def get_autobackup_settings(self) -> Dict[str, Any]:
+        """Get auto-backup settings from the controller.
+
+        Returns:
+            Dict with autobackup_enabled, cron schedule, retention, cloud settings.
+        """
+        try:
+            settings_list = await self.get_settings("super_mgmt")
+            if not settings_list:
+                return {}
+            settings = settings_list[0]
+            return {
+                "autobackup_enabled": settings.get("autobackup_enabled", False),
+                "autobackup_cron_expr": settings.get("autobackup_cron_expr"),
+                "autobackup_days": settings.get("autobackup_days"),
+                "autobackup_max_files": settings.get("autobackup_max_files"),
+                "autobackup_timezone": settings.get("autobackup_timezone"),
+                "autobackup_cloud_enabled": settings.get("autobackup_cloud_enabled", False),
+            }
+        except Exception as e:
+            logger.error("Error getting auto-backup settings: %s", e, exc_info=True)
+            return {}
+
+    async def update_autobackup_settings(self, settings: Dict[str, Any]) -> bool:
+        """Update auto-backup settings on the controller.
+
+        Args:
+            settings: Dict of auto-backup fields to update.
+
+        Returns:
+            True on success, False on failure.
+        """
+        try:
+            # update_settings handles cache invalidation with correct site-qualified key
+            return await self.update_settings("super_mgmt", settings)
+        except Exception as e:
+            logger.error("Error updating auto-backup settings: %s", e, exc_info=True)
             return False
 
     async def check_firmware_updates(self) -> Dict[str, Any]:

--- a/apps/network/src/unifi_network_mcp/schemas.py
+++ b/apps/network/src/unifi_network_mcp/schemas.py
@@ -1306,6 +1306,55 @@ DEVICE_RADIO_UPDATE_SCHEMA = {
 }
 
 
+SNMP_SETTINGS_UPDATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable SNMP on the site",
+        },
+        "community": {
+            "type": "string",
+            "description": "SNMP community string (e.g., 'public')",
+        },
+    },
+    "additionalProperties": False,
+}
+
+AUTOBACKUP_SETTINGS_UPDATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "autobackup_enabled": {
+            "type": "boolean",
+            "description": "Enable or disable automatic backups",
+        },
+        "autobackup_cron_expr": {
+            "type": "string",
+            "description": "Cron expression for backup schedule (e.g., '30 2 * * *' for daily at 2:30 AM)",
+        },
+        "autobackup_days": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Backup retention in days (0 = use max_files instead)",
+        },
+        "autobackup_max_files": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of backup files to keep",
+        },
+        "autobackup_timezone": {
+            "type": "string",
+            "description": "Timezone for backup schedule (e.g., 'America/Denver')",
+        },
+        "autobackup_cloud_enabled": {
+            "type": "boolean",
+            "description": "Enable cloud backup storage",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
 class UniFiResourceRegistry:
     """Registry for UniFi Network resource schemas and validators."""
 
@@ -1329,6 +1378,7 @@ class UniFiResourceRegistry:
         "qos_rule_simple": QOS_RULE_SIMPLE_SCHEMA,
         "port_forward_simple": PORT_FORWARD_SIMPLE_SCHEMA,
         "device_radio_update": DEVICE_RADIO_UPDATE_SCHEMA,
+        "autobackup_settings_update": AUTOBACKUP_SETTINGS_UPDATE_SCHEMA,
         "firewall_policy_v2_create": FIREWALL_POLICY_V2_CREATE_SCHEMA,
     }
 

--- a/apps/network/src/unifi_network_mcp/schemas.py
+++ b/apps/network/src/unifi_network_mcp/schemas.py
@@ -1378,6 +1378,7 @@ class UniFiResourceRegistry:
         "qos_rule_simple": QOS_RULE_SIMPLE_SCHEMA,
         "port_forward_simple": PORT_FORWARD_SIMPLE_SCHEMA,
         "device_radio_update": DEVICE_RADIO_UPDATE_SCHEMA,
+        "snmp_settings_update": SNMP_SETTINGS_UPDATE_SCHEMA,
         "autobackup_settings_update": AUTOBACKUP_SETTINGS_UPDATE_SCHEMA,
         "firewall_policy_v2_create": FIREWALL_POLICY_V2_CREATE_SCHEMA,
     }

--- a/apps/network/src/unifi_network_mcp/tools/system.py
+++ b/apps/network/src/unifi_network_mcp/tools/system.py
@@ -176,7 +176,7 @@ async def update_snmp_settings(
         success = await system_manager.update_settings("snmp", validated_data)
         if success:
             refreshed = await system_manager.get_settings("snmp")
-            new_settings = refreshed[0] if refreshed else payload
+            new_settings = refreshed[0] if refreshed else validated_data
             return {
                 "success": True,
                 "site": system_manager._connection.site,

--- a/apps/network/src/unifi_network_mcp/tools/system.py
+++ b/apps/network/src/unifi_network_mcp/tools/system.py
@@ -10,8 +10,9 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_mcp_shared.confirmation import update_preview
+from unifi_mcp_shared.confirmation import create_preview, update_preview
 from unifi_network_mcp.runtime import server, system_manager
+from unifi_network_mcp.validator_registry import UniFiValidatorRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -144,13 +145,21 @@ async def update_snmp_settings(
     """
     logger.info("unifi_update_snmp_settings tool called (enabled=%s, confirm=%s)", enabled, confirm)
 
+    updates: Dict[str, Any] = {"enabled": enabled}
+    if community is not None:
+        updates["community"] = community
+
+    is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate(
+        "snmp_settings_update", updates
+    )
+    if not is_valid:
+        return {"success": False, "error": f"Validation error: {error_msg}"}
+    if not validated_data:
+        return {"success": False, "error": "No valid fields to update after validation."}
+
     try:
         settings_list = await system_manager.get_settings("snmp")
         current = settings_list[0] if settings_list else {}
-
-        updates: Dict[str, Any] = {"enabled": enabled}
-        if community is not None:
-            updates["community"] = community
 
         if not confirm:
             return update_preview(
@@ -161,14 +170,10 @@ async def update_snmp_settings(
                     "enabled": current.get("enabled", False),
                     "community": current.get("community", ""),
                 },
-                updates=updates,
+                updates=validated_data,
             )
 
-        payload: Dict[str, Any] = {"enabled": enabled}
-        if community is not None:
-            payload["community"] = community
-
-        success = await system_manager.update_settings("snmp", payload)
+        success = await system_manager.update_settings("snmp", validated_data)
         if success:
             refreshed = await system_manager.get_settings("snmp")
             new_settings = refreshed[0] if refreshed else payload
@@ -186,8 +191,178 @@ async def update_snmp_settings(
         return {"success": False, "error": f"Failed to update SNMP settings: {e}"}
 
 
-# Print confirmation that all tools have been registered
-logger.info(
-    "System tools registered: unifi_get_system_info, unifi_get_network_health, "
-    "unifi_get_site_settings, unifi_get_snmp_settings, unifi_update_snmp_settings"
+# ---- Backup Management ----
+
+
+@server.tool(
+    name="unifi_list_backups",
+    description="List available backups on the controller. Returns filename, datetime, size, and version for each backup.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
+async def list_backups() -> Dict[str, Any]:
+    """List available backups."""
+    logger.info("unifi_list_backups tool called")
+    try:
+        backups = await system_manager.list_backups()
+        return {
+            "success": True,
+            "site": system_manager._connection.site,
+            "count": len(backups),
+            "backups": backups,
+        }
+    except Exception as e:
+        logger.error("Error listing backups: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list backups: {e}"}
+
+
+@server.tool(
+    name="unifi_create_backup",
+    description="Create a new backup of the controller configuration. "
+    "Returns the backup metadata on success. Requires confirmation.",
+    permission_category="system",
+    permission_action="create",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def create_backup(
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the backup. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Create a controller backup."""
+    logger.info("unifi_create_backup tool called (confirm=%s)", confirm)
+    if not confirm:
+        return create_preview(
+            resource_type="backup",
+            resource_data={"action": "create_backup"},
+            resource_name="controller_backup",
+        )
+
+    try:
+        result = await system_manager.create_backup()
+        if result is not None:
+            return {
+                "success": True,
+                "message": "Backup created successfully.",
+                "details": result,
+            }
+        return {"success": False, "error": "Failed to create backup."}
+    except Exception as e:
+        logger.error("Error creating backup: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to create backup: {e}"}
+
+
+@server.tool(
+    name="unifi_delete_backup",
+    description="Delete a backup file from the controller. Use unifi_list_backups to find filenames. "
+    "Requires confirmation.",
+    permission_category="system",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_backup(
+    filename: Annotated[str, Field(description="Backup filename to delete (from unifi_list_backups)")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the backup. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Delete a backup file."""
+    logger.info("unifi_delete_backup tool called (filename=%s, confirm=%s)", filename, confirm)
+    if not confirm:
+        return create_preview(
+            resource_type="backup",
+            resource_data={"filename": filename},
+            resource_name=filename,
+            warnings=["This will permanently delete the backup file."],
+        )
+
+    try:
+        success = await system_manager.delete_backup(filename)
+        if success:
+            return {"success": True, "message": f"Backup '{filename}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete backup '{filename}'."}
+    except Exception as e:
+        logger.error("Error deleting backup '%s': %s", filename, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete backup '{filename}': {e}"}
+
+
+@server.tool(
+    name="unifi_get_autobackup_settings",
+    description="Get auto-backup settings (enabled state, schedule, retention count, cloud backup).",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_autobackup_settings() -> Dict[str, Any]:
+    """Get auto-backup configuration."""
+    logger.info("unifi_get_autobackup_settings tool called")
+    try:
+        settings = await system_manager.get_autobackup_settings()
+        return {
+            "success": True,
+            "site": system_manager._connection.site,
+            "autobackup_settings": settings,
+        }
+    except Exception as e:
+        logger.error("Error getting auto-backup settings: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to get auto-backup settings: {e}"}
+
+
+@server.tool(
+    name="unifi_update_autobackup_settings",
+    description="Update auto-backup settings. Pass only the fields you want to change — "
+    "current values are automatically preserved. "
+    "Fields: autobackup_enabled (bool), autobackup_cron_expr (str, cron format), "
+    "autobackup_days (int, retention days), autobackup_max_files (int, max backup files to keep), "
+    "autobackup_timezone (str), autobackup_cloud_enabled (bool). "
+    "Requires confirmation.",
+    permission_category="system",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_autobackup_settings(
+    update_data: Annotated[
+        Dict[str, Any],
+        Field(description="Dictionary of auto-backup fields to update. See tool description for supported fields."),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, applies the update. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Update auto-backup settings."""
+    logger.info("unifi_update_autobackup_settings tool called (confirm=%s)", confirm)
+    if not update_data:
+        return {"success": False, "error": "No settings provided to update."}
+
+    is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate(
+        "autobackup_settings_update", update_data
+    )
+    if not is_valid:
+        return {"success": False, "error": f"Validation error: {error_msg}"}
+    if not validated_data:
+        return {"success": False, "error": "No valid fields to update after validation."}
+
+    try:
+        current = await system_manager.get_autobackup_settings()
+
+        if not confirm:
+            return update_preview(
+                resource_type="autobackup_settings",
+                resource_id="super_mgmt",
+                resource_name="Auto-Backup Settings",
+                current_state=current,
+                updates=validated_data,
+            )
+
+        success = await system_manager.update_autobackup_settings(validated_data)
+        if success:
+            updated = await system_manager.get_autobackup_settings()
+            return {
+                "success": True,
+                "message": "Auto-backup settings updated successfully.",
+                "autobackup_settings": updated,
+            }
+        return {"success": False, "error": "Failed to update auto-backup settings."}
+    except Exception as e:
+        logger.error("Error updating auto-backup settings: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to update auto-backup settings: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 156,
+  "count": 161,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -11,6 +11,7 @@
     "unifi_configure_port_mirror": "unifi_network_mcp.tools.switch",
     "unifi_create_acl_rule": "unifi_network_mcp.tools.acl",
     "unifi_create_ap_group": "unifi_network_mcp.tools.network",
+    "unifi_create_backup": "unifi_network_mcp.tools.system",
     "unifi_create_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_create_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_create_firewall_policy": "unifi_network_mcp.tools.firewall",
@@ -28,6 +29,7 @@
     "unifi_create_wlan": "unifi_network_mcp.tools.network",
     "unifi_delete_acl_rule": "unifi_network_mcp.tools.acl",
     "unifi_delete_ap_group": "unifi_network_mcp.tools.network",
+    "unifi_delete_backup": "unifi_network_mcp.tools.system",
     "unifi_delete_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_delete_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_delete_firewall_group": "unifi_network_mcp.tools.firewall",
@@ -41,6 +43,7 @@
     "unifi_get_alerts": "unifi_network_mcp.tools.stats",
     "unifi_get_anomalies": "unifi_network_mcp.tools.stats",
     "unifi_get_ap_group_details": "unifi_network_mcp.tools.network",
+    "unifi_get_autobackup_settings": "unifi_network_mcp.tools.system",
     "unifi_get_client_details": "unifi_network_mcp.tools.clients",
     "unifi_get_client_dpi_traffic": "unifi_network_mcp.tools.stats",
     "unifi_get_client_group_details": "unifi_network_mcp.tools.client_groups",
@@ -89,6 +92,7 @@
     "unifi_list_alarms": "unifi_network_mcp.tools.events",
     "unifi_list_ap_groups": "unifi_network_mcp.tools.network",
     "unifi_list_available_channels": "unifi_network_mcp.tools.devices",
+    "unifi_list_backups": "unifi_network_mcp.tools.system",
     "unifi_list_blocked_clients": "unifi_network_mcp.tools.clients",
     "unifi_list_client_groups": "unifi_network_mcp.tools.client_groups",
     "unifi_list_clients": "unifi_network_mcp.tools.clients",
@@ -139,6 +143,7 @@
     "unifi_unblock_client": "unifi_network_mcp.tools.clients",
     "unifi_update_acl_rule": "unifi_network_mcp.tools.acl",
     "unifi_update_ap_group": "unifi_network_mcp.tools.network",
+    "unifi_update_autobackup_settings": "unifi_network_mcp.tools.system",
     "unifi_update_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_update_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_update_device_radio": "unifi_network_mcp.tools.devices",
@@ -469,6 +474,29 @@
           "required": [
             "group_data"
           ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a new backup of the controller configuration. Returns the backup metadata on success. Requires confirmation.",
+      "name": "unifi_create_backup",
+      "permission_action": "create",
+      "permission_category": "system",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, creates the backup. When false (default), returns a preview",
+              "type": "boolean"
+            }
+          },
           "type": "object"
         }
       }
@@ -1103,6 +1131,36 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
+      "description": "Delete a backup file from the controller. Use unifi_list_backups to find filenames. Requires confirmation.",
+      "name": "unifi_delete_backup",
+      "permission_action": "delete",
+      "permission_category": "system",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the backup. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "filename": {
+              "description": "Backup filename to delete (from unifi_list_backups)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "filename"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete a client group. Requires confirmation. WARNING: Deleting a group may affect OON policies and firewall rules that reference it.",
       "name": "unifi_delete_client_group",
       "permission_action": "delete",
@@ -1448,6 +1506,20 @@
           "required": [
             "group_id"
           ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get auto-backup settings (enabled state, schedule, retention count, cloud backup).",
+      "name": "unifi_get_autobackup_settings",
+      "schema": {
+        "input": {
+          "properties": {},
           "type": "object"
         }
       }
@@ -2442,6 +2514,20 @@
       },
       "description": "List allowed RF channels for the site's regulatory domain. Returns per-band channel lists with DFS status and max power. Useful for planning channel assignments.",
       "name": "unifi_list_available_channels",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List available backups on the controller. Returns filename, datetime, size, and version for each backup.",
+      "name": "unifi_list_backups",
       "schema": {
         "input": {
           "properties": {},
@@ -3684,6 +3770,36 @@
           },
           "required": [
             "group_id",
+            "update_data"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Update auto-backup settings. Pass only the fields you want to change \u2014 current values are automatically preserved. Fields: autobackup_enabled (bool), autobackup_cron_expr (str, cron format), autobackup_days (int, retention days), autobackup_max_files (int, max backup files to keep), autobackup_timezone (str), autobackup_cloud_enabled (bool). Requires confirmation.",
+      "name": "unifi_update_autobackup_settings",
+      "permission_action": "update",
+      "permission_category": "system",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, applies the update. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "update_data": {
+              "description": "Dictionary of auto-backup fields to update. See tool description for supported fields.",
+              "type": "object"
+            }
+          },
+          "required": [
             "update_data"
           ],
           "type": "object"

--- a/apps/network/src/unifi_network_mcp/validator_registry.py
+++ b/apps/network/src/unifi_network_mcp/validator_registry.py
@@ -4,7 +4,9 @@ from .schemas import (
     ACL_RULE_UPDATE_SCHEMA,
     AP_GROUP_SCHEMA,
     AP_GROUP_UPDATE_SCHEMA,
+    AUTOBACKUP_SETTINGS_UPDATE_SCHEMA,
     CLIENT_GROUP_UPDATE_SCHEMA,
+    SNMP_SETTINGS_UPDATE_SCHEMA,
     CONTENT_FILTER_UPDATE_SCHEMA,
     DEVICE_RADIO_UPDATE_SCHEMA,
     FIREWALL_POLICY_CREATE_SCHEMA,
@@ -61,6 +63,10 @@ class UniFiValidatorRegistry:
         "ap_group": ResourceValidator(AP_GROUP_SCHEMA, "AP Group"),
         "ap_group_update": ResourceValidator(AP_GROUP_UPDATE_SCHEMA, "AP Group Update"),
         "device_radio_update": ResourceValidator(DEVICE_RADIO_UPDATE_SCHEMA, "Device Radio Update"),
+        "snmp_settings_update": ResourceValidator(SNMP_SETTINGS_UPDATE_SCHEMA, "SNMP Settings Update"),
+        "autobackup_settings_update": ResourceValidator(
+            AUTOBACKUP_SETTINGS_UPDATE_SCHEMA, "Auto-Backup Settings Update"
+        ),
     }
 
     @classmethod

--- a/apps/network/tests/unit/test_backup_tools.py
+++ b/apps/network/tests/unit/test_backup_tools.py
@@ -1,0 +1,208 @@
+"""Tests for backup management tools in SystemManager.
+
+Tests list, create, delete backups and auto-backup settings.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestBackupTools:
+    """Tests for backup-related SystemManager methods."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def system_manager(self, mock_connection):
+        """Create a SystemManager with mocked connection."""
+        from unifi_network_mcp.managers.system_manager import SystemManager
+
+        mgr = SystemManager(mock_connection)
+        return mgr
+
+    # ---- Create Backup ----
+
+    @pytest.mark.asyncio
+    async def test_create_backup_list_response(self, system_manager, mock_connection):
+        """Test create_backup handles list response with URL."""
+        mock_connection.request.return_value = [{"url": "/dl/backup/10.1.89.unf"}]
+
+        result = await system_manager.create_backup()
+
+        assert result is not None
+        assert result["url"] == "/dl/backup/10.1.89.unf"
+
+    @pytest.mark.asyncio
+    async def test_create_backup_dict_response(self, system_manager, mock_connection):
+        """Test create_backup handles dict response with URL."""
+        mock_connection.request.return_value = {"url": "/dl/backup/10.1.89.unf"}
+
+        result = await system_manager.create_backup()
+
+        assert result is not None
+        assert result["url"] == "/dl/backup/10.1.89.unf"
+
+    @pytest.mark.asyncio
+    async def test_create_backup_unexpected_response(self, system_manager, mock_connection):
+        """Test create_backup returns None on unexpected response."""
+        mock_connection.request.return_value = {"no_url": True}
+
+        result = await system_manager.create_backup()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_create_backup_handles_error(self, system_manager, mock_connection):
+        """Test create_backup returns None on error."""
+        mock_connection.request.side_effect = Exception("Connection failed")
+
+        result = await system_manager.create_backup()
+
+        assert result is None
+
+    # ---- List Backups ----
+
+    @pytest.mark.asyncio
+    async def test_list_backups_returns_list(self, system_manager, mock_connection):
+        """Test list_backups returns list of backup dicts."""
+        backups = [
+            {"filename": "autobackup_1.unf", "datetime": "2026-03-28", "size": 28000000},
+            {"filename": "autobackup_2.unf", "datetime": "2026-03-27", "size": 27500000},
+        ]
+        mock_connection.request.return_value = backups
+
+        result = await system_manager.list_backups()
+
+        assert len(result) == 2
+        assert result[0]["filename"] == "autobackup_1.unf"
+
+    @pytest.mark.asyncio
+    async def test_list_backups_handles_dict_response(self, system_manager, mock_connection):
+        """Test list_backups handles dict with data key."""
+        mock_connection.request.return_value = {"data": [{"filename": "backup.unf"}]}
+
+        result = await system_manager.list_backups()
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_backups_handles_error(self, system_manager, mock_connection):
+        """Test list_backups returns empty list on error."""
+        mock_connection.request.side_effect = Exception("Connection failed")
+
+        result = await system_manager.list_backups()
+
+        assert result == []
+
+    # ---- Delete Backup ----
+
+    @pytest.mark.asyncio
+    async def test_delete_backup_success(self, system_manager, mock_connection):
+        """Test delete_backup sends correct command."""
+        mock_connection.request.return_value = {}
+
+        result = await system_manager.delete_backup("autobackup_1.unf")
+
+        assert result is True
+        call_args = mock_connection.request.call_args
+        api_req = call_args[0][0]
+        assert api_req.path == "/cmd/backup"
+        assert api_req.data["cmd"] == "delete-backup"
+        assert api_req.data["filename"] == "autobackup_1.unf"
+
+    @pytest.mark.asyncio
+    async def test_delete_backup_handles_error(self, system_manager, mock_connection):
+        """Test delete_backup returns False on error."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        result = await system_manager.delete_backup("nonexistent.unf")
+
+        assert result is False
+
+    # ---- Auto-Backup Settings ----
+
+    @pytest.mark.asyncio
+    async def test_get_autobackup_settings(self, system_manager, mock_connection):
+        """Test get_autobackup_settings returns filtered settings."""
+        mock_connection.request.return_value = [
+            {
+                "_id": "abc123",
+                "autobackup_enabled": True,
+                "autobackup_cron_expr": "0 2 * * *",
+                "autobackup_days": 30,
+                "autobackup_max_files": 10,
+                "autobackup_timezone": "America/Denver",
+                "autobackup_cloud_enabled": True,
+                "other_field": "ignored",
+            }
+        ]
+
+        result = await system_manager.get_autobackup_settings()
+
+        assert result["autobackup_enabled"] is True
+        assert result["autobackup_cron_expr"] == "0 2 * * *"
+        assert result["autobackup_max_files"] == 10
+        assert result["autobackup_cloud_enabled"] is True
+        assert "other_field" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_autobackup_settings_empty(self, system_manager, mock_connection):
+        """Test get_autobackup_settings returns empty dict when no settings."""
+        mock_connection.request.return_value = []
+
+        result = await system_manager.get_autobackup_settings()
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_update_autobackup_settings_success(self, system_manager, mock_connection):
+        """Test update_autobackup_settings calls update_settings."""
+        # First call: get_settings (for update_settings internal fetch-merge)
+        # Second call: the actual PUT (returns list = success)
+        mock_connection.request.side_effect = [
+            [{"_id": "abc123", "autobackup_enabled": False}],
+            [{"_id": "abc123", "autobackup_enabled": True}],
+        ]
+
+        result = await system_manager.update_autobackup_settings(
+            {"autobackup_enabled": True}
+        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_update_autobackup_settings_error(self, system_manager, mock_connection):
+        """Test update_autobackup_settings returns False on error."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        result = await system_manager.update_autobackup_settings(
+            {"autobackup_enabled": True}
+        )
+
+        assert result is False
+
+    # ---- API Path Verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_backups_uses_correct_path(self, system_manager, mock_connection):
+        """Test list_backups uses POST /cmd/backup with list-backups command."""
+        mock_connection.request.return_value = []
+
+        await system_manager.list_backups()
+
+        call_args = mock_connection.request.call_args
+        api_req = call_args[0][0]
+        assert api_req.path == "/cmd/backup"
+        assert api_req.method == "post"
+        assert api_req.data["cmd"] == "list-backups"

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (156 tools)
+# Network Server Tool Reference (161 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -468,14 +468,19 @@ Always available, regardless of registration mode.
 ## System
 
 <!-- AUTO:tools:system,config -->
-5 tools.
+10 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
+| `unifi_get_autobackup_settings` | Read | Get auto-backup settings (enabled state, schedule, retention count, cloud backup). |
 | `unifi_get_network_health` | Read | Returns per-subsystem health status for WAN, LAN, WLAN, and VPN — each with status, number of gateways/switches/APs, and active user counts. |
 | `unifi_get_site_settings` | Read | Get current site settings (e.g., country code, timezone, connectivity monitoring). |
 | `unifi_get_snmp_settings` | Read | Get current SNMP settings for the site (enabled state, community string). |
 | `unifi_get_system_info` | Read | Returns controller version, uptime, hostname, memory/CPU usage, and update availability. |
+| `unifi_list_backups` | Read | List available backups on the controller. |
+| `unifi_create_backup` | Mutate | Create a new backup of the controller configuration. |
+| `unifi_delete_backup` | Mutate | Delete a backup file from the controller. |
+| `unifi_update_autobackup_settings` | Mutate | Update auto-backup settings. |
 | `unifi_update_snmp_settings` | Mutate | Update SNMP settings for the site (enable/disable, set community string). |
 <!-- /AUTO:tools:system,config -->
 


### PR DESCRIPTION
## Summary

Adds 5 tools for managing controller backups via the existing `system_manager` and `tools/system.py`. Exposes backup lifecycle management and auto-backup configuration that were previously only accessible through the UI.

**Backup tools (5):**
- `unifi_list_backups` — List available backups with filename, datetime, size, version
- `unifi_create_backup` — Create a new backup (returns download URL)
- `unifi_delete_backup` — Delete a backup file by filename
- `unifi_get_autobackup_settings` — Get auto-backup config (schedule, retention, cloud)
- `unifi_update_autobackup_settings` — Update auto-backup settings (enabled, cron, max_files, timezone, cloud)

**API endpoints:** `POST /proxy/network/api/s/{site}/cmd/backup` (list-backups, backup, delete-backup), `GET /proxy/network/api/s/{site}/get/setting/super_mgmt`, `PUT /proxy/network/api/s/{site}/set/setting/super_mgmt`

### Design decisions

- **Tools extend existing `system_manager` and `tools/system.py`** — backup commands use `/cmd/backup` (same pattern as existing `create_backup` and `restore_backup` manager methods). Auto-backup settings use `get_settings`/`update_settings` (same pattern as SNMP settings in the same file).
- **`permission_category="system"`** added to `NETWORK_CATEGORY_MAP` — backup operations are system-level, not SNMP-specific.
- **Schema validation on both update tools** — added `AUTOBACKUP_SETTINGS_UPDATE_SCHEMA` and `SNMP_SETTINGS_UPDATE_SCHEMA` with `additionalProperties: false`. Both registered in `UniFiValidatorRegistry` and validated before execution.

### Bug fixes

**`create_backup` manager method was broken (pre-existing).** The original method used `return_raw=True` expecting bytes, but the API returns JSON: `{"meta":{"rc":"ok"},"data":[{"url":"/dl/backup/10.1.89.unf"}]}`. Fixed to parse JSON normally and return the metadata dict with the download URL.

**`update_snmp_settings` lacked schema validation (pre-existing).** Added `SNMP_SETTINGS_UPDATE_SCHEMA` and wired up `UniFiValidatorRegistry.validate()` — aligns with AGENTS.md golden path for update tools and matches the pattern applied to `update_device_radio` in PR #123.

## Files changed

| File | Change |
|---|---|
| `managers/system_manager.py` | **Modified** — fixed `create_backup` return type, added `list_backups`, `delete_backup`, `get_autobackup_settings`, `update_autobackup_settings` |
| `tools/system.py` | **Modified** — 5 new tool functions, added schema validation to `update_snmp_settings` |
| `schemas.py` | **Modified** — added `SNMP_SETTINGS_UPDATE_SCHEMA` and `AUTOBACKUP_SETTINGS_UPDATE_SCHEMA` |
| `validator_registry.py` | **Modified** — registered both new schemas |
| `categories.py` | **Modified** — added `"system": "system"` to `NETWORK_CATEGORY_MAP` |
| `tests/unit/test_backup_tools.py` | **New** — 14 tests |
| `tools_manifest.json` | Regenerated (161 tools) |

## Live testing

All 5 tools tested end-to-end against a live controller.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.16 |
| **Network Application** | 10.1.89 |
| **MCP Client** | Claude Code |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Tool | Test | Result |
|---|---|---|
| `unifi_list_backups` | List 12 backups, verified count drop to 11 after delete | ✅ Pass |
| `unifi_create_backup` | Create backup, got download URL | ✅ Pass |
| `unifi_delete_backup` | Preview + confirm delete oldest backup | ✅ Pass |
| `unifi_get_autobackup_settings` | Read current auto-backup settings | ✅ Pass |
| `unifi_update_autobackup_settings` | Changed max_files, reverted; validated type rejection and unknown field rejection | ✅ Pass |
| `unifi_update_snmp_settings` | Preview with schema validation | ✅ Pass |

## Unit tests

14 tests covering: create_backup (list response, dict response, unexpected response, error), list_backups (success, dict response, error), delete_backup (success, error), get_autobackup_settings (success, empty), update_autobackup_settings (success, error), API path verification.

```
tests/unit/test_backup_tools.py — 14 passed
Full suite — 521 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)