### PR TITLE
feat(network): add DNS record management tools (CRUD for static DNS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 161 tools)
+  network/          # UniFi Network MCP server (stable, 166 tools)
   protect/          # UniFi Protect MCP server (beta, 34 tools)
   access/           # UniFi Access MCP server (beta, 29 tools)
 packages/

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -204,7 +204,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 161 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 166 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 161 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 166 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 For machine-readable tool metadata, call the `unifi_tool_index` meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`.
 
@@ -207,6 +207,14 @@ These are always registered regardless of mode:
 - `unifi_get_top_clients` — Top clients by bandwidth usage
 - `unifi_get_dpi_stats` — Deep Packet Inspection statistics
 - `unifi_get_alerts` — Recent alerts
+
+## DNS Records (5 tools)
+
+- `unifi_list_dns_records` — List all static DNS records
+- `unifi_get_dns_record_details` — Get full record config by ID
+- `unifi_create_dns_record` — Create a new DNS record (A, AAAA, CNAME, MX, TXT, SRV)
+- `unifi_update_dns_record` — Update a record (partial updates preserved)
+- `unifi_delete_dns_record` — Delete a record
 
 ## System (10 tools)
 

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -49,6 +49,7 @@ NETWORK_CATEGORY_MAP = {
     "dpi": "dpi",
     "switch": "switch",
     "system": "system",
+    "dns": "dns",
 }
 
 # Backward-compatible alias

--- a/apps/network/src/unifi_network_mcp/managers/dns_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/dns_manager.py
@@ -1,0 +1,146 @@
+"""DNS record management for UniFi Network MCP server.
+
+Provides CRUD operations for static DNS records via the v2 API.
+Endpoint: GET/POST/PUT/DELETE /v2/api/site/{site}/static-dns[/{id}]
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiounifi.models.api import ApiRequestV2
+
+from .connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_DNS = "dns_records"
+
+
+class DnsManager:
+    """Manages DNS record operations on the UniFi controller."""
+
+    def __init__(self, connection_manager: ConnectionManager):
+        self._connection = connection_manager
+
+    async def list_dns_records(self) -> List[Dict[str, Any]]:
+        """List all static DNS records.
+
+        Returns:
+            List of DNS record dicts.
+        """
+        if not await self._connection.ensure_connected():
+            return []
+
+        cache_key = f"{CACHE_PREFIX_DNS}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key, timeout=300)
+        if cached_data is not None:
+            return cached_data
+
+        try:
+            api_request = ApiRequestV2(method="get", path="/static-dns")
+            response = await self._connection.request(api_request)
+            result = response if isinstance(response, list) else []
+            self._connection._update_cache(cache_key, result, timeout=300)
+            return result
+        except Exception as e:
+            logger.error("Error listing DNS records: %s", e, exc_info=True)
+            return []
+
+    async def get_dns_record(self, record_id: str) -> Optional[Dict[str, Any]]:
+        """Get a DNS record by ID.
+
+        GET by ID returns 405 on this endpoint, so we list and filter.
+
+        Args:
+            record_id: The _id of the DNS record.
+
+        Returns:
+            DNS record dict, or None if not found.
+        """
+        try:
+            records = await self.list_dns_records()
+            for record in records:
+                if record.get("_id") == record_id:
+                    return record
+            return None
+        except Exception as e:
+            logger.error("Error getting DNS record %s: %s", record_id, e, exc_info=True)
+            return None
+
+    async def create_dns_record(self, record_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Create a new static DNS record.
+
+        Args:
+            record_data: Dict with key (hostname), value (target), record_type, enabled.
+
+        Returns:
+            Created record dict with _id, or None on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return None
+
+        try:
+            api_request = ApiRequestV2(method="post", path="/static-dns", data=record_data)
+            response = await self._connection.request(api_request)
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_DNS}_{self._connection.site}")
+            if isinstance(response, dict) and response.get("_id"):
+                return response
+            if isinstance(response, list) and response:
+                return response[0]
+            return response
+        except Exception as e:
+            logger.error("Error creating DNS record: %s", e, exc_info=True)
+            return None
+
+    async def update_dns_record(self, record_id: str, record_data: Dict[str, Any]) -> bool:
+        """Update an existing DNS record.
+
+        Uses fetch-merge-put: fetches current record, merges updates, PUTs full object.
+
+        Args:
+            record_id: The _id of the record to update.
+            record_data: Dict of fields to update.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            current = await self.get_dns_record(record_id)
+            if not current:
+                logger.error("DNS record %s not found for update.", record_id)
+                return False
+
+            merged = dict(current)
+            merged.update(record_data)
+
+            api_request = ApiRequestV2(method="put", path=f"/static-dns/{record_id}", data=merged)
+            await self._connection.request(api_request)
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_DNS}_{self._connection.site}")
+            return True
+        except Exception as e:
+            logger.error("Error updating DNS record %s: %s", record_id, e, exc_info=True)
+            return False
+
+    async def delete_dns_record(self, record_id: str) -> bool:
+        """Delete a DNS record.
+
+        Args:
+            record_id: The _id of the record to delete.
+
+        Returns:
+            True on success, False on failure.
+        """
+        if not await self._connection.ensure_connected():
+            return False
+
+        try:
+            api_request = ApiRequestV2(method="delete", path=f"/static-dns/{record_id}")
+            await self._connection.request(api_request)
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_DNS}_{self._connection.site}")
+            return True
+        except Exception as e:
+            logger.error("Error deleting DNS record %s: %s", record_id, e, exc_info=True)
+            return False

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -33,6 +33,7 @@ from unifi_network_mcp.managers.client_manager import ClientManager
 from unifi_network_mcp.managers.connection_manager import ConnectionManager
 from unifi_network_mcp.managers.content_filter_manager import ContentFilterManager
 from unifi_network_mcp.managers.device_manager import DeviceManager
+from unifi_network_mcp.managers.dns_manager import DnsManager
 from unifi_network_mcp.managers.dpi_manager import DpiManager
 from unifi_network_mcp.managers.event_manager import EventManager
 from unifi_network_mcp.managers.firewall_manager import FirewallManager
@@ -178,6 +179,11 @@ def get_content_filter_manager() -> ContentFilterManager:
 
 
 @lru_cache
+def get_dns_manager() -> DnsManager:
+    return DnsManager(get_connection_manager())
+
+
+@lru_cache
 def get_dpi_manager() -> DpiManager:
     return DpiManager(get_connection_manager(), get_auth())
 
@@ -273,6 +279,7 @@ acl_manager = get_acl_manager()
 client_group_manager = get_client_group_manager()
 client_manager = get_client_manager()
 content_filter_manager = get_content_filter_manager()
+dns_manager = get_dns_manager()
 dpi_manager = get_dpi_manager()
 device_manager = get_device_manager()
 stats_manager = get_stats_manager()

--- a/apps/network/src/unifi_network_mcp/schemas.py
+++ b/apps/network/src/unifi_network_mcp/schemas.py
@@ -1354,6 +1354,54 @@ AUTOBACKUP_SETTINGS_UPDATE_SCHEMA = {
     "additionalProperties": False,
 }
 
+DNS_RECORD_SCHEMA = {
+    "type": "object",
+    "required": ["key", "value", "record_type"],
+    "properties": {
+        "key": {
+            "type": "string",
+            "description": "Hostname / record name (e.g., 'myhost.example.com')",
+        },
+        "value": {
+            "type": "string",
+            "description": "Record value — IP address for A/AAAA, hostname for CNAME, mail server for MX, text for TXT",
+        },
+        "record_type": {
+            "type": "string",
+            "enum": ["A", "AAAA", "CNAME", "MX", "TXT", "SRV"],
+            "description": "DNS record type",
+        },
+        "enabled": {
+            "type": "boolean",
+            "description": "Whether the record is active",
+        },
+        "ttl": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Time to live in seconds (0 = default 300s)",
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Port number (for SRV records)",
+        },
+        "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Priority (for MX and SRV records, lower = higher priority)",
+        },
+        "weight": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Weight (for SRV records)",
+        },
+    },
+    "additionalProperties": False,
+}
+
+DNS_RECORD_UPDATE_SCHEMA = copy.deepcopy(DNS_RECORD_SCHEMA)
+DNS_RECORD_UPDATE_SCHEMA.pop("required", None)
+
 
 class UniFiResourceRegistry:
     """Registry for UniFi Network resource schemas and validators."""
@@ -1380,6 +1428,8 @@ class UniFiResourceRegistry:
         "device_radio_update": DEVICE_RADIO_UPDATE_SCHEMA,
         "snmp_settings_update": SNMP_SETTINGS_UPDATE_SCHEMA,
         "autobackup_settings_update": AUTOBACKUP_SETTINGS_UPDATE_SCHEMA,
+        "dns_record": DNS_RECORD_SCHEMA,
+        "dns_record_update": DNS_RECORD_UPDATE_SCHEMA,
         "firewall_policy_v2_create": FIREWALL_POLICY_V2_CREATE_SCHEMA,
     }
 

--- a/apps/network/src/unifi_network_mcp/tools/dns.py
+++ b/apps/network/src/unifi_network_mcp/tools/dns.py
@@ -1,0 +1,228 @@
+"""
+DNS record management tools for UniFi Network MCP server.
+
+Provides CRUD for static DNS records (A, AAAA, CNAME, MX, TXT, SRV)
+via the v2 API endpoint /static-dns.
+"""
+
+import json
+import logging
+from typing import Annotated, Any, Dict
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_mcp_shared.confirmation import create_preview, update_preview
+from unifi_network_mcp.runtime import dns_manager, server
+from unifi_network_mcp.validator_registry import UniFiValidatorRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_dns_records",
+    description="List all static DNS records configured on the controller. "
+    "Returns hostname, value, record type, enabled state, and TTL for each record.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_dns_records() -> Dict[str, Any]:
+    """List all static DNS records."""
+    logger.info("unifi_list_dns_records tool called")
+    try:
+        records = await dns_manager.list_dns_records()
+        formatted = [
+            {
+                "id": r.get("_id"),
+                "key": r.get("key"),
+                "value": r.get("value"),
+                "record_type": r.get("record_type"),
+                "enabled": r.get("enabled", True),
+                "ttl": r.get("ttl", 0),
+                "port": r.get("port", 0),
+                "priority": r.get("priority", 0),
+                "weight": r.get("weight", 0),
+            }
+            for r in records
+        ]
+        return {
+            "success": True,
+            "site": dns_manager._connection.site,
+            "count": len(formatted),
+            "records": formatted,
+        }
+    except Exception as e:
+        logger.error("Error listing DNS records: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list DNS records: {e}"}
+
+
+@server.tool(
+    name="unifi_get_dns_record_details",
+    description="Get details for a specific DNS record by ID.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_dns_record_details(
+    record_id: Annotated[str, Field(description="The unique identifier (_id) of the DNS record")],
+) -> Dict[str, Any]:
+    """Get a specific DNS record."""
+    logger.info("unifi_get_dns_record_details tool called (record_id=%s)", record_id)
+    try:
+        record = await dns_manager.get_dns_record(record_id)
+        if not record:
+            return {"success": False, "error": f"DNS record '{record_id}' not found."}
+        return {
+            "success": True,
+            "record_id": record_id,
+            "details": json.loads(json.dumps(record, default=str)),
+        }
+    except Exception as e:
+        logger.error("Error getting DNS record %s: %s", record_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get DNS record {record_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_create_dns_record",
+    description="Create a new static DNS record. "
+    "Required: key (hostname, e.g. 'myhost.example.com'), value (IP or target hostname), "
+    "record_type ('A'/'AAAA'/'CNAME'/'MX'/'TXT'/'SRV'). "
+    "Optional: enabled (bool, default true), ttl (int, 0=default 300s), "
+    "port (int, for SRV), priority (int, for MX/SRV), weight (int, for SRV). "
+    "Requires confirmation.",
+    permission_category="dns",
+    permission_action="create",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def create_dns_record(
+    record_data: Annotated[
+        Dict[str, Any],
+        Field(description="DNS record data. See tool description for required and optional fields."),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the record. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Create a new static DNS record."""
+    logger.info("unifi_create_dns_record tool called (confirm=%s)", confirm)
+
+    is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate("dns_record", record_data)
+    if not is_valid:
+        return {"success": False, "error": f"Validation error: {error_msg}"}
+    if not validated_data:
+        return {"success": False, "error": "No valid fields after validation."}
+
+    if not confirm:
+        return create_preview(
+            resource_type="dns_record",
+            resource_data=validated_data,
+            resource_name=validated_data.get("key", "unnamed"),
+        )
+
+    try:
+        result = await dns_manager.create_dns_record(validated_data)
+        if result:
+            return {
+                "success": True,
+                "message": f"DNS record '{validated_data.get('key', '')}' created successfully.",
+                "details": json.loads(json.dumps(result, default=str)),
+            }
+        return {"success": False, "error": f"Failed to create DNS record '{validated_data.get('key', '')}'."}
+    except Exception as e:
+        logger.error("Error creating DNS record: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to create DNS record: {e}"}
+
+
+@server.tool(
+    name="unifi_update_dns_record",
+    description="Update an existing DNS record. "
+    "Pass only the fields you want to change — current values are automatically preserved. "
+    "Fields: key (str), value (str), record_type ('A'/'AAAA'/'CNAME'/'MX'/'TXT'/'SRV'), "
+    "enabled (bool), ttl (int), port (int), priority (int), weight (int). "
+    "Requires confirmation.",
+    permission_category="dns",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_dns_record(
+    record_id: Annotated[str, Field(description="The ID of the DNS record to update (from unifi_list_dns_records)")],
+    update_data: Annotated[
+        Dict[str, Any],
+        Field(description="Dictionary of fields to update. See tool description for supported fields."),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, applies the update. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Update an existing DNS record."""
+    logger.info("unifi_update_dns_record tool called (record_id=%s, confirm=%s)", record_id, confirm)
+
+    if not update_data:
+        return {"success": False, "error": "No fields provided to update."}
+
+    is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate("dns_record_update", update_data)
+    if not is_valid:
+        return {"success": False, "error": f"Validation error: {error_msg}"}
+    if not validated_data:
+        return {"success": False, "error": "No valid fields to update after validation."}
+
+    try:
+        current = await dns_manager.get_dns_record(record_id)
+        if not current:
+            return {"success": False, "error": f"DNS record '{record_id}' not found."}
+
+        if not confirm:
+            return update_preview(
+                resource_type="dns_record",
+                resource_id=record_id,
+                resource_name=current.get("key", record_id),
+                current_state=current,
+                updates=validated_data,
+            )
+
+        success = await dns_manager.update_dns_record(record_id, validated_data)
+        if success:
+            return {
+                "success": True,
+                "message": f"DNS record '{current.get('key', record_id)}' updated successfully.",
+            }
+        return {"success": False, "error": f"Failed to update DNS record '{record_id}'."}
+    except Exception as e:
+        logger.error("Error updating DNS record %s: %s", record_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to update DNS record {record_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_delete_dns_record",
+    description="Delete a static DNS record. Use unifi_list_dns_records to find record IDs. "
+    "Requires confirmation.",
+    permission_category="dns",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_dns_record(
+    record_id: Annotated[str, Field(description="The ID of the DNS record to delete (from unifi_list_dns_records)")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the record. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Delete a DNS record."""
+    logger.info("unifi_delete_dns_record tool called (record_id=%s, confirm=%s)", record_id, confirm)
+    try:
+        if not confirm:
+            record = await dns_manager.get_dns_record(record_id)
+            name = record.get("key", record_id) if record else record_id
+            return create_preview(
+                resource_type="dns_record",
+                resource_data={"record_id": record_id},
+                resource_name=name,
+                warnings=["This will permanently delete the DNS record."],
+            )
+
+        success = await dns_manager.delete_dns_record(record_id)
+        if success:
+            return {"success": True, "message": f"DNS record '{record_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete DNS record '{record_id}'."}
+    except Exception as e:
+        logger.error("Error deleting DNS record %s: %s", record_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete DNS record '{record_id}': {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 161,
+  "count": 166,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -13,6 +13,7 @@
     "unifi_create_ap_group": "unifi_network_mcp.tools.network",
     "unifi_create_backup": "unifi_network_mcp.tools.system",
     "unifi_create_client_group": "unifi_network_mcp.tools.client_groups",
+    "unifi_create_dns_record": "unifi_network_mcp.tools.dns",
     "unifi_create_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_create_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_create_network": "unifi_network_mcp.tools.network",
@@ -32,6 +33,7 @@
     "unifi_delete_backup": "unifi_network_mcp.tools.system",
     "unifi_delete_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_delete_content_filter": "unifi_network_mcp.tools.content_filtering",
+    "unifi_delete_dns_record": "unifi_network_mcp.tools.dns",
     "unifi_delete_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_delete_oon_policy": "unifi_network_mcp.tools.oon",
@@ -55,6 +57,7 @@
     "unifi_get_device_details": "unifi_network_mcp.tools.devices",
     "unifi_get_device_radio": "unifi_network_mcp.tools.devices",
     "unifi_get_device_stats": "unifi_network_mcp.tools.stats",
+    "unifi_get_dns_record_details": "unifi_network_mcp.tools.dns",
     "unifi_get_dpi_stats": "unifi_network_mcp.tools.stats",
     "unifi_get_event_types": "unifi_network_mcp.tools.events",
     "unifi_get_firewall_group_details": "unifi_network_mcp.tools.firewall",
@@ -98,6 +101,7 @@
     "unifi_list_clients": "unifi_network_mcp.tools.clients",
     "unifi_list_content_filters": "unifi_network_mcp.tools.content_filtering",
     "unifi_list_devices": "unifi_network_mcp.tools.devices",
+    "unifi_list_dns_records": "unifi_network_mcp.tools.dns",
     "unifi_list_dpi_applications": "unifi_network_mcp.tools.dpi",
     "unifi_list_dpi_categories": "unifi_network_mcp.tools.dpi",
     "unifi_list_events": "unifi_network_mcp.tools.events",
@@ -147,6 +151,7 @@
     "unifi_update_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_update_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_update_device_radio": "unifi_network_mcp.tools.devices",
+    "unifi_update_dns_record": "unifi_network_mcp.tools.dns",
     "unifi_update_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_update_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_update_network": "unifi_network_mcp.tools.network",
@@ -531,6 +536,36 @@
           "required": [
             "name",
             "members"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a new static DNS record. Required: key (hostname, e.g. 'myhost.example.com'), value (IP or target hostname), record_type ('A'/'AAAA'/'CNAME'/'MX'/'TXT'/'SRV'). Optional: enabled (bool, default true), ttl (int, 0=default 300s), port (int, for SRV), priority (int, for MX/SRV), weight (int, for SRV). Requires confirmation.",
+      "name": "unifi_create_dns_record",
+      "permission_action": "create",
+      "permission_category": "dns",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, creates the record. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "record_data": {
+              "description": "DNS record data. See tool description for required and optional fields.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "record_data"
           ],
           "type": "object"
         }
@@ -1221,6 +1256,36 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
+      "description": "Delete a static DNS record. Use unifi_list_dns_records to find record IDs. Requires confirmation.",
+      "name": "unifi_delete_dns_record",
+      "permission_action": "delete",
+      "permission_category": "dns",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the record. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "record_id": {
+              "description": "The ID of the DNS record to delete (from unifi_list_dns_records)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
       "description": "Delete a firewall group. Requires confirmation. WARNING: Firewall policies referencing this group via ip_group_id or port_group_id may break.",
       "name": "unifi_delete_firewall_group",
       "permission_action": "delete",
@@ -1778,6 +1843,28 @@
           },
           "required": [
             "device_id"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get details for a specific DNS record by ID.",
+      "name": "unifi_get_dns_record_details",
+      "schema": {
+        "input": {
+          "properties": {
+            "record_id": {
+              "description": "The unique identifier (_id) of the DNS record",
+              "type": "string"
+            }
+          },
+          "required": [
+            "record_id"
           ],
           "type": "object"
         }
@@ -2627,6 +2714,20 @@
               "type": "string"
             }
           },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List all static DNS records configured on the controller. Returns hostname, value, record type, enabled state, and TTL for each record.",
+      "name": "unifi_list_dns_records",
+      "schema": {
+        "input": {
+          "properties": {},
           "type": "object"
         }
       }
@@ -3950,6 +4051,41 @@
           "required": [
             "mac_address",
             "radio"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Update an existing DNS record. Pass only the fields you want to change \u2014 current values are automatically preserved. Fields: key (str), value (str), record_type ('A'/'AAAA'/'CNAME'/'MX'/'TXT'/'SRV'), enabled (bool), ttl (int), port (int), priority (int), weight (int). Requires confirmation.",
+      "name": "unifi_update_dns_record",
+      "permission_action": "update",
+      "permission_category": "dns",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, applies the update. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "record_id": {
+              "description": "The ID of the DNS record to update (from unifi_list_dns_records)",
+              "type": "string"
+            },
+            "update_data": {
+              "description": "Dictionary of fields to update. See tool description for supported fields.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "record_id",
+            "update_data"
           ],
           "type": "object"
         }

--- a/apps/network/src/unifi_network_mcp/validator_registry.py
+++ b/apps/network/src/unifi_network_mcp/validator_registry.py
@@ -6,6 +6,8 @@ from .schemas import (
     AP_GROUP_UPDATE_SCHEMA,
     AUTOBACKUP_SETTINGS_UPDATE_SCHEMA,
     CLIENT_GROUP_UPDATE_SCHEMA,
+    DNS_RECORD_SCHEMA,
+    DNS_RECORD_UPDATE_SCHEMA,
     SNMP_SETTINGS_UPDATE_SCHEMA,
     CONTENT_FILTER_UPDATE_SCHEMA,
     DEVICE_RADIO_UPDATE_SCHEMA,
@@ -67,6 +69,8 @@ class UniFiValidatorRegistry:
         "autobackup_settings_update": ResourceValidator(
             AUTOBACKUP_SETTINGS_UPDATE_SCHEMA, "Auto-Backup Settings Update"
         ),
+        "dns_record": ResourceValidator(DNS_RECORD_SCHEMA, "DNS Record"),
+        "dns_record_update": ResourceValidator(DNS_RECORD_UPDATE_SCHEMA, "DNS Record Update"),
     }
 
     @classmethod

--- a/apps/network/tests/unit/test_dns_manager.py
+++ b/apps/network/tests/unit/test_dns_manager.py
@@ -1,0 +1,203 @@
+"""Tests for DNS record management in DnsManager.
+
+Tests list, get, create, update, delete DNS records.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestDnsManager:
+    """Tests for DnsManager methods."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def dns_manager(self, mock_connection):
+        """Create a DnsManager with mocked connection."""
+        from unifi_network_mcp.managers.dns_manager import DnsManager
+
+        return DnsManager(mock_connection)
+
+    # ---- List DNS Records ----
+
+    @pytest.mark.asyncio
+    async def test_list_dns_records_returns_list(self, dns_manager, mock_connection):
+        """Test list_dns_records returns list of record dicts."""
+        records = [
+            {"_id": "r1", "key": "host.example.com", "value": "10.0.0.1", "record_type": "A"},
+            {"_id": "r2", "key": "alias.example.com", "value": "host.example.com", "record_type": "CNAME"},
+        ]
+        mock_connection.request.return_value = records
+
+        result = await dns_manager.list_dns_records()
+
+        assert len(result) == 2
+        assert result[0]["key"] == "host.example.com"
+
+    @pytest.mark.asyncio
+    async def test_list_dns_records_uses_cache(self, dns_manager, mock_connection):
+        """Test list_dns_records uses cache when available."""
+        cached = [{"_id": "r1", "key": "cached.example.com"}]
+        mock_connection.get_cached.return_value = cached
+
+        result = await dns_manager.list_dns_records()
+
+        assert result == cached
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_dns_records_handles_error(self, dns_manager, mock_connection):
+        """Test list_dns_records returns empty list on error."""
+        mock_connection.request.side_effect = Exception("Connection failed")
+
+        result = await dns_manager.list_dns_records()
+
+        assert result == []
+
+    # ---- Get DNS Record ----
+
+    @pytest.mark.asyncio
+    async def test_get_dns_record_found(self, dns_manager, mock_connection):
+        """Test get_dns_record returns record when found."""
+        records = [
+            {"_id": "r1", "key": "host.example.com", "value": "10.0.0.1"},
+            {"_id": "r2", "key": "other.example.com", "value": "10.0.0.2"},
+        ]
+        mock_connection.request.return_value = records
+
+        result = await dns_manager.get_dns_record("r1")
+
+        assert result is not None
+        assert result["key"] == "host.example.com"
+
+    @pytest.mark.asyncio
+    async def test_get_dns_record_not_found(self, dns_manager, mock_connection):
+        """Test get_dns_record returns None when not found."""
+        mock_connection.request.return_value = [{"_id": "r1"}]
+
+        result = await dns_manager.get_dns_record("nonexistent")
+
+        assert result is None
+
+    # ---- Create DNS Record ----
+
+    @pytest.mark.asyncio
+    async def test_create_dns_record_success(self, dns_manager, mock_connection):
+        """Test create_dns_record returns created record."""
+        created = {"_id": "r_new", "key": "new.example.com", "value": "10.0.0.99", "record_type": "A"}
+        mock_connection.request.return_value = created
+
+        result = await dns_manager.create_dns_record(
+            {"key": "new.example.com", "value": "10.0.0.99", "record_type": "A"}
+        )
+
+        assert result is not None
+        assert result["_id"] == "r_new"
+        mock_connection._invalidate_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_dns_record_handles_error(self, dns_manager, mock_connection):
+        """Test create_dns_record returns None on error."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        result = await dns_manager.create_dns_record({"key": "fail.example.com"})
+
+        assert result is None
+
+    # ---- Update DNS Record ----
+
+    @pytest.mark.asyncio
+    async def test_update_dns_record_success(self, dns_manager, mock_connection):
+        """Test update_dns_record uses fetch-merge-put."""
+        existing = [{"_id": "r1", "key": "host.example.com", "value": "10.0.0.1", "record_type": "A"}]
+        # First call: list (for get_dns_record), second call: PUT
+        mock_connection.request.side_effect = [existing, {}]
+
+        result = await dns_manager.update_dns_record("r1", {"value": "10.0.0.2"})
+
+        assert result is True
+        # Verify PUT was called with merged data
+        put_call = mock_connection.request.call_args_list[1]
+        put_req = put_call[0][0]
+        assert put_req.method == "put"
+        assert "r1" in put_req.path
+
+    @pytest.mark.asyncio
+    async def test_update_dns_record_not_found(self, dns_manager, mock_connection):
+        """Test update_dns_record returns False when not found."""
+        mock_connection.request.return_value = []
+
+        result = await dns_manager.update_dns_record("nonexistent", {"value": "10.0.0.2"})
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_update_dns_record_handles_error(self, dns_manager, mock_connection):
+        """Test update_dns_record returns False on error."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        result = await dns_manager.update_dns_record("r1", {"value": "10.0.0.2"})
+
+        assert result is False
+
+    # ---- Delete DNS Record ----
+
+    @pytest.mark.asyncio
+    async def test_delete_dns_record_success(self, dns_manager, mock_connection):
+        """Test delete_dns_record sends DELETE request."""
+        mock_connection.request.return_value = {}
+
+        result = await dns_manager.delete_dns_record("r1")
+
+        assert result is True
+        call_args = mock_connection.request.call_args
+        api_req = call_args[0][0]
+        assert api_req.method == "delete"
+        assert "r1" in api_req.path
+        mock_connection._invalidate_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_dns_record_handles_error(self, dns_manager, mock_connection):
+        """Test delete_dns_record returns False on error."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        result = await dns_manager.delete_dns_record("r1")
+
+        assert result is False
+
+    # ---- API Path Verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_uses_correct_path(self, dns_manager, mock_connection):
+        """Test list_dns_records uses v2 /static-dns endpoint."""
+        mock_connection.request.return_value = []
+
+        await dns_manager.list_dns_records()
+
+        call_args = mock_connection.request.call_args
+        api_req = call_args[0][0]
+        assert api_req.path == "/static-dns"
+
+    @pytest.mark.asyncio
+    async def test_create_uses_post(self, dns_manager, mock_connection):
+        """Test create_dns_record uses POST."""
+        mock_connection.request.return_value = {"_id": "new"}
+
+        await dns_manager.create_dns_record({"key": "test", "value": "10.0.0.1", "record_type": "A"})
+
+        call_args = mock_connection.request.call_args
+        api_req = call_args[0][0]
+        assert api_req.method == "post"
+        assert api_req.path == "/static-dns"

--- a/apps/network/tests/unit/test_dns_tools.py
+++ b/apps/network/tests/unit/test_dns_tools.py
@@ -1,0 +1,401 @@
+"""Tests for DNS record tool functions.
+
+Tests tool-layer behavior: validation, preview/confirm flow, response format.
+Manager-level tests are in test_dns_manager.py.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+SAMPLE_RECORD = {
+    "_id": "dns001",
+    "key": "host.example.com",
+    "value": "10.0.0.1",
+    "record_type": "A",
+    "enabled": True,
+    "ttl": 300,
+}
+
+
+# ---------------------------------------------------------------------------
+# list_dns_records
+# ---------------------------------------------------------------------------
+
+
+class TestListDnsRecords:
+    """Test the list_dns_records tool."""
+
+    @pytest.mark.asyncio
+    async def test_list_success(self):
+        """List returns formatted records with success."""
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.list_dns_records = AsyncMock(return_value=[SAMPLE_RECORD])
+            mock_mgr._connection = mock_conn
+
+            from unifi_network_mcp.tools.dns import list_dns_records
+
+            result = await list_dns_records()
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["records"][0]["key"] == "host.example.com"
+        assert result["records"][0]["id"] == "dns001"
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self):
+        """List returns zero count when no records exist."""
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.list_dns_records = AsyncMock(return_value=[])
+            mock_mgr._connection = mock_conn
+
+            from unifi_network_mcp.tools.dns import list_dns_records
+
+            result = await list_dns_records()
+
+        assert result["success"] is True
+        assert result["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_exception(self):
+        """List returns error on exception."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.list_dns_records = AsyncMock(side_effect=Exception("Connection lost"))
+
+            from unifi_network_mcp.tools.dns import list_dns_records
+
+            result = await list_dns_records()
+
+        assert result["success"] is False
+        assert "Failed to list" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_dns_record_details
+# ---------------------------------------------------------------------------
+
+
+class TestGetDnsRecordDetails:
+    """Test the get_dns_record_details tool."""
+
+    @pytest.mark.asyncio
+    async def test_get_found(self):
+        """Get returns record details when found."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=SAMPLE_RECORD)
+
+            from unifi_network_mcp.tools.dns import get_dns_record_details
+
+            result = await get_dns_record_details(record_id="dns001")
+
+        assert result["success"] is True
+        assert result["record_id"] == "dns001"
+        assert result["details"]["key"] == "host.example.com"
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self):
+        """Get returns error when record not found."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=None)
+
+            from unifi_network_mcp.tools.dns import get_dns_record_details
+
+            result = await get_dns_record_details(record_id="nonexistent")
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_exception(self):
+        """Get returns error on exception."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(side_effect=Exception("Timeout"))
+
+            from unifi_network_mcp.tools.dns import get_dns_record_details
+
+            result = await get_dns_record_details(record_id="dns001")
+
+        assert result["success"] is False
+        assert "Failed to get" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# create_dns_record
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDnsRecord:
+    """Test the create_dns_record tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_preview(self):
+        """Preview mode returns confirmation prompt without creating."""
+        from unifi_network_mcp.tools.dns import create_dns_record
+
+        result = await create_dns_record(
+            record_data={"key": "new.example.com", "value": "10.0.0.5", "record_type": "A"},
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_create_confirm_success(self):
+        """Confirmed create returns success with details."""
+        created = {"_id": "dns_new", "key": "new.example.com", "value": "10.0.0.5", "record_type": "A"}
+
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.create_dns_record = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.dns import create_dns_record
+
+            result = await create_dns_record(
+                record_data={"key": "new.example.com", "value": "10.0.0.5", "record_type": "A"},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        assert "created successfully" in result["message"]
+        assert result["details"]["_id"] == "dns_new"
+
+    @pytest.mark.asyncio
+    async def test_create_validation_error(self):
+        """Invalid record_type is rejected by schema validation."""
+        from unifi_network_mcp.tools.dns import create_dns_record
+
+        result = await create_dns_record(
+            record_data={"key": "bad.example.com", "value": "10.0.0.1", "record_type": "INVALID"},
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "Validation error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_missing_required_field(self):
+        """Missing required field is rejected by schema validation."""
+        from unifi_network_mcp.tools.dns import create_dns_record
+
+        result = await create_dns_record(
+            record_data={"key": "novalue.example.com", "record_type": "A"},
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "Validation error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_manager_failure(self):
+        """Manager returning None results in error response."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.create_dns_record = AsyncMock(return_value=None)
+
+            from unifi_network_mcp.tools.dns import create_dns_record
+
+            result = await create_dns_record(
+                record_data={"key": "fail.example.com", "value": "10.0.0.1", "record_type": "A"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "Failed to create" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_additional_properties(self):
+        """Schema with additionalProperties: false rejects unknown fields."""
+        from unifi_network_mcp.tools.dns import create_dns_record
+
+        result = await create_dns_record(
+            record_data={
+                "key": "test.example.com",
+                "value": "10.0.0.1",
+                "record_type": "A",
+                "bogus_field": "should fail",
+            },
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "Validation error" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# update_dns_record
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDnsRecord:
+    """Test the update_dns_record tool."""
+
+    @pytest.mark.asyncio
+    async def test_update_preview(self):
+        """Preview mode returns current state and proposed changes."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=SAMPLE_RECORD)
+
+            from unifi_network_mcp.tools.dns import update_dns_record
+
+            result = await update_dns_record(
+                record_id="dns001",
+                update_data={"value": "10.0.0.2"},
+                confirm=False,
+            )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_update_confirm_success(self):
+        """Confirmed update calls manager and returns success."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=SAMPLE_RECORD)
+            mock_mgr.update_dns_record = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.dns import update_dns_record
+
+            result = await update_dns_record(
+                record_id="dns001",
+                update_data={"value": "10.0.0.2"},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        assert "updated successfully" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_update_not_found(self):
+        """Update returns error when record not found."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=None)
+
+            from unifi_network_mcp.tools.dns import update_dns_record
+
+            result = await update_dns_record(
+                record_id="nonexistent",
+                update_data={"value": "10.0.0.2"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_empty_data(self):
+        """Empty update_data returns error."""
+        from unifi_network_mcp.tools.dns import update_dns_record
+
+        result = await update_dns_record(
+            record_id="dns001",
+            update_data={},
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "No fields provided" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_validation_error(self):
+        """Invalid field type is rejected by schema."""
+        from unifi_network_mcp.tools.dns import update_dns_record
+
+        result = await update_dns_record(
+            record_id="dns001",
+            update_data={"record_type": "INVALID"},
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "Validation error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_manager_failure(self):
+        """Manager returning False results in error response."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=SAMPLE_RECORD)
+            mock_mgr.update_dns_record = AsyncMock(return_value=False)
+
+            from unifi_network_mcp.tools.dns import update_dns_record
+
+            result = await update_dns_record(
+                record_id="dns001",
+                update_data={"value": "10.0.0.2"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "Failed to update" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# delete_dns_record
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteDnsRecord:
+    """Test the delete_dns_record tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_preview(self):
+        """Preview mode returns confirmation prompt with warning."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.get_dns_record = AsyncMock(return_value=SAMPLE_RECORD)
+
+            from unifi_network_mcp.tools.dns import delete_dns_record
+
+            result = await delete_dns_record(record_id="dns001", confirm=False)
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_delete_confirm_success(self):
+        """Confirmed delete calls manager and returns success."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.delete_dns_record = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.dns import delete_dns_record
+
+            result = await delete_dns_record(record_id="dns001", confirm=True)
+
+        assert result["success"] is True
+        assert "deleted successfully" in result["message"]
+        mock_mgr.delete_dns_record.assert_called_once_with("dns001")
+
+    @pytest.mark.asyncio
+    async def test_delete_manager_failure(self):
+        """Manager returning False results in error response."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.delete_dns_record = AsyncMock(return_value=False)
+
+            from unifi_network_mcp.tools.dns import delete_dns_record
+
+            result = await delete_dns_record(record_id="dns001", confirm=True)
+
+        assert result["success"] is False
+        assert "Failed to delete" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_exception(self):
+        """Exception returns clean error."""
+        with patch("unifi_network_mcp.tools.dns.dns_manager") as mock_mgr:
+            mock_mgr.delete_dns_record = AsyncMock(side_effect=Exception("Connection refused"))
+
+            from unifi_network_mcp.tools.dns import delete_dns_record
+
+            result = await delete_dns_record(record_id="dns001", confirm=True)
+
+        assert result["success"] is False
+        assert "Connection refused" in result["error"]

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (161 tools)
+# Network Server Tool Reference (166 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 


### PR DESCRIPTION
## Summary

Adds 5 tools for managing static DNS records via the v2 REST API. Supports A, AAAA, CNAME, MX, TXT, and SRV record types with full CRUD operations.

**DNS Record tools (5):**
- `unifi_list_dns_records` — List all static DNS records with hostname, value, type, TTL
- `unifi_get_dns_record_details` — Get full record config by ID
- `unifi_create_dns_record` — Create a new DNS record with schema validation
- `unifi_update_dns_record` — Update a record (fetch-merge-put, partial updates preserved)
- `unifi_delete_dns_record` — Delete a record

**API endpoint:** `GET/POST/PUT/DELETE /proxy/network/v2/api/site/{site}/static-dns[/{id}]`

### Design decisions

- **New tool category** — DNS records are a distinct resource type, not part of network config or system tools. New `dns_manager.py` and `tools/dns.py` following AGENTS.md "Add a new tool category" golden path.
- **v2 API** — uses `ApiRequestV2`. The v1 integration endpoint (`/integration/v1/sites/{siteId}/dns/policies`) requires site UUID (not "default") and is less proven.
- **GET-by-ID returns 405** — `get_dns_record` uses list-then-filter, same pattern as AP groups and content filtering.
- **Schema validation on create and update** — `DNS_RECORD_SCHEMA` with `additionalProperties: false` and required fields (key, value, record_type). Update schema derived via deepcopy with required removed.
- **`ensure_connected()` on all manager methods** — follows anchor pattern from content_filter_manager.

## Files changed

| File | Change |
|---|---|
| `managers/dns_manager.py` | **New** — list, get (list-filter), create, update (fetch-merge-put), delete |
| `tools/dns.py` | **New** — 5 tool functions with ToolAnnotations, schema validation, confirm pattern |
| `tests/unit/test_dns_manager.py` | **New** — 14 tests |
| `runtime.py` | Added `DnsManager` factory and alias |
| `categories.py` | Added `"dns": "dns"` to `NETWORK_CATEGORY_MAP` |
| `schemas.py` | Added `DNS_RECORD_SCHEMA` and `DNS_RECORD_UPDATE_SCHEMA` |
| `validator_registry.py` | Registered both DNS schemas |
| `tools_manifest.json` | Regenerated (166 tools) |
| `network-tools.md` | Skill references regenerated |

## Live testing

All 5 tools tested end-to-end against a live controller.

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.16 |
| **Network Application** | 10.1.89 |
| **MCP Client** | Claude Code |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Tool | Test | Result |
|---|---|---|
| `unifi_list_dns_records` | List 15 records | ✅ Pass |
| `unifi_get_dns_record_details` | Get by ID (list-filter) | ✅ Pass |
| `unifi_create_dns_record` | Create A record | ✅ Pass |
| `unifi_create_dns_record` | Invalid record_type rejected by schema | ✅ Pass |
| `unifi_update_dns_record` | Update value (partial merge) | ✅ Pass |
| `unifi_delete_dns_record` | Delete test record | ✅ Pass |

## Unit tests

14 tests covering: list (success, cache, error), get (found, not found), create (success, error), update (success, not found, error), delete (success, error), API path verification (list endpoint, create method).

```
tests/unit/test_dns_manager.py — 14 passed
Full suite — 535 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)