### PR TITLE
fix(acl): add source_macs/destination_macs params to prevent silent ANY→ANY rule creation

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/acl.py
+++ b/apps/network/src/unifi_network_mcp/tools/acl.py
@@ -8,7 +8,7 @@ Application with Policy Engine support.
 
 import json
 import logging
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -115,8 +115,8 @@ async def get_acl_rule_details(
 @server.tool(
     name="unifi_create_acl_rule",
     description="Create a new MAC ACL rule for Layer 2 access control within a VLAN. "
-    "Requires confirmation. IMPORTANT: traffic_source and traffic_destination type MUST be 'CLIENT_MAC' "
-    "(not 'ANY'). Use an empty specific_mac_addresses list to match any device.",
+    "Use source_macs/destination_macs to specify MAC addresses (same field names as unifi_list_acl_rules output). "
+    "Empty list = match any device. Requires confirmation.",
     permission_category="acl_rules",
     permission_action="create",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
@@ -129,17 +129,21 @@ async def create_acl_rule(
         str,
         Field(description="Network/VLAN ID this rule applies to (from unifi_list_networks)"),
     ],
+    source_macs: Annotated[
+        Optional[List[str]],
+        Field(description="List of source MAC addresses to match (empty list = any source). Uses same field name as unifi_list_acl_rules output"),
+    ] = None,
+    destination_macs: Annotated[
+        Optional[List[str]],
+        Field(description="List of destination MAC addresses to match (empty list = any destination). Uses same field name as unifi_list_acl_rules output"),
+    ] = None,
     traffic_source: Annotated[
         Optional[dict],
-        Field(
-            description="Source config dict with keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs, empty list = any). Defaults to matching any source"
-        ),
+        Field(description="(Advanced) Full source config dict. Ignored if source_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)"),
     ] = None,
     traffic_destination: Annotated[
         Optional[dict],
-        Field(
-            description="Destination config dict with same structure as traffic_source. Defaults to matching any destination"
-        ),
+        Field(description="(Advanced) Full destination config dict. Ignored if destination_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)"),
     ] = None,
     confirm: Annotated[
         bool,
@@ -154,16 +158,26 @@ async def create_acl_rule(
         acl_index (int): Position in the rule chain (lower = evaluated first).
         action (str): "ALLOW" or "BLOCK".
         mac_acl_network_id (str): Network ID of the VLAN this rule applies to.
-        traffic_source (dict): Source config with keys:
-            - type (str): "CLIENT_MAC"
-            - specific_mac_addresses (list): List of source MAC addresses. Empty list = any.
-        traffic_destination (dict): Destination config with same structure as source.
+        source_macs (list): List of source MAC addresses. Empty list or None = any.
+        destination_macs (list): List of destination MAC addresses. Empty list or None = any.
+        traffic_source (dict): Advanced — full source config dict. Ignored if source_macs is provided.
+        traffic_destination (dict): Advanced — full destination config dict. Ignored if destination_macs is provided.
         confirm (bool): Must be True to execute. False returns a preview.
 
     Returns:
         Preview of changes or the created rule.
     """
-    if traffic_source is None:
+    logger.info("unifi_create_acl_rule called (name=%s, action=%s, confirm=%s)", name, action, confirm)
+    # Build traffic_source: convenience params take precedence over raw dicts
+    if source_macs is not None:
+        traffic_source = {
+            "ips_or_subnets": [],
+            "network_ids": [],
+            "ports": [],
+            "specific_mac_addresses": source_macs,
+            "type": "CLIENT_MAC",
+        }
+    elif traffic_source is None:
         traffic_source = {
             "ips_or_subnets": [],
             "network_ids": [],
@@ -171,7 +185,16 @@ async def create_acl_rule(
             "specific_mac_addresses": [],
             "type": "CLIENT_MAC",
         }
-    if traffic_destination is None:
+    # Build traffic_destination: same precedence
+    if destination_macs is not None:
+        traffic_destination = {
+            "ips_or_subnets": [],
+            "network_ids": [],
+            "ports": [],
+            "specific_mac_addresses": destination_macs,
+            "type": "CLIENT_MAC",
+        }
+    elif traffic_destination is None:
         traffic_destination = {
             "ips_or_subnets": [],
             "network_ids": [],
@@ -217,7 +240,8 @@ async def create_acl_rule(
     name="unifi_update_acl_rule",
     description="Update an existing MAC ACL rule. Pass only the fields you want to change — "
     "current values are automatically preserved. "
-    "Requires confirmation. IMPORTANT: traffic source/destination type MUST be 'CLIENT_MAC' (not 'ANY').",
+    "Requires confirmation. Use source_macs/destination_macs for MAC lists (same field names as list output). "
+    "If using advanced traffic_source/traffic_destination dicts instead, type MUST be 'CLIENT_MAC'.",
     permission_category="acl_rules",
     permission_action="update",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
@@ -232,7 +256,8 @@ async def update_acl_rule(
             description="Dictionary of fields to update. Pass only the fields you want to change — "
             "current values are automatically preserved. "
             "Allowed keys: name, acl_index, action ('ALLOW'/'BLOCK'), enabled (bool), "
-            "mac_acl_network_id, traffic_source (dict), traffic_destination (dict)"
+            "mac_acl_network_id, source_macs (list of MACs), destination_macs (list of MACs), "
+            "traffic_source (dict, advanced), traffic_destination (dict, advanced)"
         ),
     ],
     confirm: Annotated[
@@ -241,10 +266,29 @@ async def update_acl_rule(
     ] = False,
 ) -> Dict[str, Any]:
     """Updates an existing MAC ACL rule with partial data."""
+    logger.info("unifi_update_acl_rule called (rule_id=%s, confirm=%s)", rule_id, confirm)
     if not rule_id:
         return {"success": False, "error": "rule_id is required"}
     if not rule_data:
         return {"success": False, "error": "rule_data cannot be empty"}
+
+    # Translate flattened field names (from list output) to nested structure
+    if "source_macs" in rule_data:
+        rule_data["traffic_source"] = {
+            "ips_or_subnets": [],
+            "network_ids": [],
+            "ports": [],
+            "specific_mac_addresses": rule_data.pop("source_macs"),
+            "type": "CLIENT_MAC",
+        }
+    if "destination_macs" in rule_data:
+        rule_data["traffic_destination"] = {
+            "ips_or_subnets": [],
+            "network_ids": [],
+            "ports": [],
+            "specific_mac_addresses": rule_data.pop("destination_macs"),
+            "type": "CLIENT_MAC",
+        }
 
     is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate("acl_rule_update", rule_data)
     if not is_valid:

--- a/apps/network/src/unifi_network_mcp/tools/acl.py
+++ b/apps/network/src/unifi_network_mcp/tools/acl.py
@@ -131,19 +131,27 @@ async def create_acl_rule(
     ],
     source_macs: Annotated[
         Optional[List[str]],
-        Field(description="List of source MAC addresses to match (empty list = any source). Uses same field name as unifi_list_acl_rules output"),
+        Field(
+            description="List of source MAC addresses to match (empty list = any source). Uses same field name as unifi_list_acl_rules output"
+        ),
     ] = None,
     destination_macs: Annotated[
         Optional[List[str]],
-        Field(description="List of destination MAC addresses to match (empty list = any destination). Uses same field name as unifi_list_acl_rules output"),
+        Field(
+            description="List of destination MAC addresses to match (empty list = any destination). Uses same field name as unifi_list_acl_rules output"
+        ),
     ] = None,
     traffic_source: Annotated[
         Optional[dict],
-        Field(description="(Advanced) Full source config dict. Ignored if source_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)"),
+        Field(
+            description="(Advanced) Full source config dict. Ignored if source_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)"
+        ),
     ] = None,
     traffic_destination: Annotated[
         Optional[dict],
-        Field(description="(Advanced) Full destination config dict. Ignored if destination_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)"),
+        Field(
+            description="(Advanced) Full destination config dict. Ignored if destination_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)"
+        ),
     ] = None,
     confirm: Annotated[
         bool,
@@ -271,6 +279,21 @@ async def update_acl_rule(
         return {"success": False, "error": "rule_id is required"}
     if not rule_data:
         return {"success": False, "error": "rule_data cannot be empty"}
+
+    # Convenience params and advanced dicts are mutually exclusive — reject
+    # the collision up front rather than silently picking a winner (which
+    # would be the same class of silent-drop bug this tool's create path
+    # exists to prevent).
+    if "source_macs" in rule_data and "traffic_source" in rule_data:
+        return {
+            "success": False,
+            "error": "Pass either source_macs or traffic_source, not both.",
+        }
+    if "destination_macs" in rule_data and "traffic_destination" in rule_data:
+        return {
+            "success": False,
+            "error": "Pass either destination_macs or traffic_destination, not both.",
+        }
 
     # Translate flattened field names (from list output) to nested structure
     if "source_macs" in rule_data:

--- a/apps/network/src/unifi_network_mcp/tools/content_filtering.py
+++ b/apps/network/src/unifi_network_mcp/tools/content_filtering.py
@@ -62,7 +62,7 @@ async def list_content_filters() -> Dict[str, Any]:
                 "safe_search": f.get("safe_search", []),
                 "allow_list_count": len(f.get("allow_list", [])),
                 "block_list_count": len(f.get("block_list", [])),
-                "schedule_mode": f.get("schedule", {}).get("mode"),
+                "schedule_mode": f.get("schedule", {}).get("mode"),  # read-only summary, not updateable via API
             }
             for f in filters
         ]

--- a/apps/network/src/unifi_network_mcp/tools/oon.py
+++ b/apps/network/src/unifi_network_mcp/tools/oon.py
@@ -115,8 +115,8 @@ async def get_oon_policy_details(
     name="unifi_create_oon_policy",
     description="Create a new OON (Object-Oriented Network) policy for internet access scheduling, "
     "app blocking, bandwidth limiting, or VPN routing. "
-    "IMPORTANT: qos and route objects (including mode, apps, domains, ip_addresses, regions fields) "
-    "must be complete even if disabled — use unifi_get_oon_policy_details on an existing policy as a template. "
+    "IMPORTANT: qos and route must be full nested dicts (not the flattened qos_enabled/route_enabled booleans from list output). "
+    "Use unifi_get_oon_policy_details on an existing policy as a template for the nested structure. "
     "Requires confirmation.",
     permission_category="oon_policy",
     permission_action="create",

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -407,7 +407,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Requires confirmation. IMPORTANT: traffic_source and traffic_destination type MUST be 'CLIENT_MAC' (not 'ANY'). Use an empty specific_mac_addresses list to match any device.",
+      "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Use source_macs/destination_macs to specify MAC addresses (same field names as unifi_list_acl_rules output). Empty list = match any device. Requires confirmation.",
       "name": "unifi_create_acl_rule",
       "permission_action": "create",
       "permission_category": "acl_rules",
@@ -426,6 +426,10 @@
               "description": "When true, creates the rule. When false (default), returns a preview of the changes",
               "type": "boolean"
             },
+            "destination_macs": {
+              "description": "List of destination MAC addresses to match (empty list = any destination). Uses same field name as unifi_list_acl_rules output",
+              "type": "array"
+            },
             "mac_acl_network_id": {
               "description": "Network/VLAN ID this rule applies to (from unifi_list_networks)",
               "type": "string"
@@ -434,12 +438,16 @@
               "description": "Descriptive name for the ACL rule",
               "type": "string"
             },
+            "source_macs": {
+              "description": "List of source MAC addresses to match (empty list = any source). Uses same field name as unifi_list_acl_rules output",
+              "type": "array"
+            },
             "traffic_destination": {
-              "description": "Destination config dict with same structure as traffic_source. Defaults to matching any destination",
+              "description": "(Advanced) Full destination config dict. Ignored if destination_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)",
               "type": "object"
             },
             "traffic_source": {
-              "description": "Source config dict with keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs, empty list = any). Defaults to matching any source",
+              "description": "(Advanced) Full source config dict. Ignored if source_macs is provided. Keys: type ('CLIENT_MAC'), specific_mac_addresses (list of MACs)",
               "type": "object"
             }
           },
@@ -678,7 +686,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a new OON (Object-Oriented Network) policy for internet access scheduling, app blocking, bandwidth limiting, or VPN routing. IMPORTANT: qos and route objects (including mode, apps, domains, ip_addresses, regions fields) must be complete even if disabled \u2014 use unifi_get_oon_policy_details on an existing policy as a template. Requires confirmation.",
+      "description": "Create a new OON (Object-Oriented Network) policy for internet access scheduling, app blocking, bandwidth limiting, or VPN routing. IMPORTANT: qos and route must be full nested dicts (not the flattened qos_enabled/route_enabled booleans from list output). Use unifi_get_oon_policy_details on an existing policy as a template for the nested structure. Requires confirmation.",
       "name": "unifi_create_oon_policy",
       "permission_action": "create",
       "permission_category": "oon_policy",
@@ -3814,7 +3822,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Update an existing MAC ACL rule. Pass only the fields you want to change \u2014 current values are automatically preserved. Requires confirmation. IMPORTANT: traffic source/destination type MUST be 'CLIENT_MAC' (not 'ANY').",
+      "description": "Update an existing MAC ACL rule. Pass only the fields you want to change \u2014 current values are automatically preserved. Requires confirmation. Use source_macs/destination_macs for MAC lists (same field names as list output). If using advanced traffic_source/traffic_destination dicts instead, type MUST be 'CLIENT_MAC'.",
       "name": "unifi_update_acl_rule",
       "permission_action": "update",
       "permission_category": "acl_rules",
@@ -3826,7 +3834,7 @@
               "type": "boolean"
             },
             "rule_data": {
-              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, acl_index, action ('ALLOW'/'BLOCK'), enabled (bool), mac_acl_network_id, traffic_source (dict), traffic_destination (dict)",
+              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, acl_index, action ('ALLOW'/'BLOCK'), enabled (bool), mac_acl_network_id, source_macs (list of MACs), destination_macs (list of MACs), traffic_source (dict, advanced), traffic_destination (dict, advanced)",
               "type": "object"
             },
             "rule_id": {

--- a/apps/network/tests/unit/test_acl_tools.py
+++ b/apps/network/tests/unit/test_acl_tools.py
@@ -205,3 +205,96 @@ class TestUpdateAclRule:
         assert "traffic_destination" in update_data
         assert update_data["traffic_destination"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
         assert "destination_macs" not in update_data
+
+    @pytest.mark.asyncio
+    async def test_source_macs_with_traffic_source_returns_error(self):
+        """Passing both source_macs and traffic_source in rule_data is rejected."""
+        from unifi_network_mcp.tools.acl import update_acl_rule
+
+        result = await update_acl_rule(
+            rule_id="rule001",
+            rule_data={
+                "source_macs": ["11:22:33:44:55:66"],
+                "traffic_source": {
+                    "type": "CLIENT_MAC",
+                    "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                },
+            },
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "source_macs" in result["error"]
+        assert "traffic_source" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_destination_macs_with_traffic_destination_returns_error(self):
+        """Passing both destination_macs and traffic_destination in rule_data is rejected."""
+        from unifi_network_mcp.tools.acl import update_acl_rule
+
+        result = await update_acl_rule(
+            rule_id="rule001",
+            rule_data={
+                "destination_macs": ["11:22:33:44:55:66"],
+                "traffic_destination": {
+                    "type": "CLIENT_MAC",
+                    "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                },
+            },
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "destination_macs" in result["error"]
+        assert "traffic_destination" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_source_macs_clears_mac_list(self):
+        """source_macs=[] in rule_data clears specific_mac_addresses (not a no-op).
+
+        Mirror image of the original silent-drop bug: a caller clearing MAC
+        restrictions must actually clear them, not silently keep the old list.
+        """
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.get_acl_rule_by_id = AsyncMock(return_value=SAMPLE_RULE)
+            mock_mgr.update_acl_rule = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.acl import update_acl_rule
+
+            result = await update_acl_rule(
+                rule_id="rule001",
+                rule_data={"source_macs": []},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.update_acl_rule.call_args[0]
+        update_data = call_args[1]
+        assert update_data["traffic_source"]["specific_mac_addresses"] == []
+        assert "source_macs" not in update_data
+
+    @pytest.mark.asyncio
+    async def test_source_macs_preserves_sibling_fields(self):
+        """source_macs translation does not drop other fields in rule_data."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.get_acl_rule_by_id = AsyncMock(return_value=SAMPLE_RULE)
+            mock_mgr.update_acl_rule = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.acl import update_acl_rule
+
+            result = await update_acl_rule(
+                rule_id="rule001",
+                rule_data={
+                    "source_macs": ["11:22:33:44:55:66"],
+                    "name": "Renamed Rule",
+                    "action": "BLOCK",
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.update_acl_rule.call_args[0]
+        update_data = call_args[1]
+        assert update_data["traffic_source"]["specific_mac_addresses"] == ["11:22:33:44:55:66"]
+        assert update_data["name"] == "Renamed Rule"
+        assert update_data["action"] == "BLOCK"

--- a/apps/network/tests/unit/test_acl_tools.py
+++ b/apps/network/tests/unit/test_acl_tools.py
@@ -1,0 +1,207 @@
+"""Tests for ACL rule tool functions.
+
+Tests the source_macs/destination_macs convenience params and the
+flattened-to-nested translation in create and update paths.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+SAMPLE_RULE = {
+    "_id": "rule001",
+    "name": "Test Rule",
+    "acl_index": 5,
+    "action": "ALLOW",
+    "enabled": True,
+    "mac_acl_network_id": "net001",
+    "traffic_source": {
+        "type": "CLIENT_MAC",
+        "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+        "ips_or_subnets": [],
+        "network_ids": [],
+        "ports": [],
+    },
+    "traffic_destination": {
+        "type": "CLIENT_MAC",
+        "specific_mac_addresses": [],
+        "ips_or_subnets": [],
+        "network_ids": [],
+        "ports": [],
+    },
+}
+
+
+class TestCreateAclRule:
+    """Test create_acl_rule with convenience MAC params."""
+
+    @pytest.mark.asyncio
+    async def test_source_macs_builds_traffic_source(self):
+        """source_macs param builds the nested traffic_source dict correctly."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.create_acl_rule = AsyncMock(return_value=SAMPLE_RULE)
+
+            from unifi_network_mcp.tools.acl import create_acl_rule
+
+            result = await create_acl_rule(
+                name="Test",
+                acl_index=5,
+                action="ALLOW",
+                mac_acl_network_id="net001",
+                source_macs=["aa:bb:cc:dd:ee:ff"],
+                destination_macs=[],
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        # Verify the manager received the nested structure
+        call_args = mock_mgr.create_acl_rule.call_args[0][0]
+        assert call_args["traffic_source"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+        assert call_args["traffic_destination"]["specific_mac_addresses"] == []
+
+    @pytest.mark.asyncio
+    async def test_source_macs_overrides_traffic_source_dict(self):
+        """source_macs takes precedence over traffic_source dict when both provided."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.create_acl_rule = AsyncMock(return_value=SAMPLE_RULE)
+
+            from unifi_network_mcp.tools.acl import create_acl_rule
+
+            result = await create_acl_rule(
+                name="Test",
+                acl_index=5,
+                action="ALLOW",
+                mac_acl_network_id="net001",
+                source_macs=["11:22:33:44:55:66"],
+                traffic_source={
+                    "type": "CLIENT_MAC",
+                    "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.create_acl_rule.call_args[0][0]
+        # source_macs wins over traffic_source
+        assert call_args["traffic_source"]["specific_mac_addresses"] == ["11:22:33:44:55:66"]
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_traffic_source_dict(self):
+        """traffic_source dict still works when source_macs is not provided."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.create_acl_rule = AsyncMock(return_value=SAMPLE_RULE)
+
+            from unifi_network_mcp.tools.acl import create_acl_rule
+
+            result = await create_acl_rule(
+                name="Test",
+                acl_index=5,
+                action="ALLOW",
+                mac_acl_network_id="net001",
+                traffic_source={
+                    "type": "CLIENT_MAC",
+                    "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                    "ips_or_subnets": [],
+                    "network_ids": [],
+                    "ports": [],
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.create_acl_rule.call_args[0][0]
+        assert call_args["traffic_source"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+
+    @pytest.mark.asyncio
+    async def test_no_macs_defaults_to_any(self):
+        """Omitting both source_macs and traffic_source defaults to ANY (empty list)."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.create_acl_rule = AsyncMock(return_value=SAMPLE_RULE)
+
+            from unifi_network_mcp.tools.acl import create_acl_rule
+
+            result = await create_acl_rule(
+                name="Block All",
+                acl_index=99,
+                action="BLOCK",
+                mac_acl_network_id="net001",
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.create_acl_rule.call_args[0][0]
+        assert call_args["traffic_source"]["specific_mac_addresses"] == []
+        assert call_args["traffic_destination"]["specific_mac_addresses"] == []
+
+    @pytest.mark.asyncio
+    async def test_preview_includes_macs(self):
+        """Preview mode shows the resolved MAC addresses in the rule data."""
+        from unifi_network_mcp.tools.acl import create_acl_rule
+
+        result = await create_acl_rule(
+            name="Test Preview",
+            acl_index=5,
+            action="ALLOW",
+            mac_acl_network_id="net001",
+            source_macs=["aa:bb:cc:dd:ee:ff"],
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+        preview_data = result.get("preview", {}).get("will_create", {})
+        assert preview_data["traffic_source"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+
+
+class TestUpdateAclRule:
+    """Test update_acl_rule flattened field translation."""
+
+    @pytest.mark.asyncio
+    async def test_source_macs_translated_to_traffic_source(self):
+        """source_macs in rule_data is translated to nested traffic_source before validation."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.get_acl_rule_by_id = AsyncMock(return_value=SAMPLE_RULE)
+            mock_mgr.update_acl_rule = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.acl import update_acl_rule
+
+            result = await update_acl_rule(
+                rule_id="rule001",
+                rule_data={"source_macs": ["11:22:33:44:55:66"]},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.update_acl_rule.call_args[0]
+        update_data = call_args[1]
+        assert "traffic_source" in update_data
+        assert update_data["traffic_source"]["specific_mac_addresses"] == ["11:22:33:44:55:66"]
+        assert "source_macs" not in update_data
+
+    @pytest.mark.asyncio
+    async def test_destination_macs_translated_to_traffic_destination(self):
+        """destination_macs in rule_data is translated to nested traffic_destination."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.get_acl_rule_by_id = AsyncMock(return_value=SAMPLE_RULE)
+            mock_mgr.update_acl_rule = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.acl import update_acl_rule
+
+            result = await update_acl_rule(
+                rule_id="rule001",
+                rule_data={"destination_macs": ["aa:bb:cc:dd:ee:ff"]},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        call_args = mock_mgr.update_acl_rule.call_args[0]
+        update_data = call_args[1]
+        assert "traffic_destination" in update_data
+        assert update_data["traffic_destination"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+        assert "destination_macs" not in update_data


### PR DESCRIPTION
## Summary

Fixes a security bug where `create_acl_rule` silently dropped MAC addresses
passed as `source_macs`/`destination_macs`, creating ANY→ANY ALLOW rules
instead of MAC-specific rules. Also adds flattened-to-nested field translation
in `update_acl_rule` and clarifies the same class of list-vs-create field
shape mismatch in OON and content filtering tools.

### Bug details

`list_acl_rules` outputs flattened fields (`source_macs`, `destination_macs`),
but `create_acl_rule` expected nested dicts (`traffic_source:
{specific_mac_addresses: [...]}`). When an LLM or caller passed the field
names from the list output, they were silently ignored by the MCP framework
(not in the function signature), and the tool defaulted to empty MAC lists =
match any device. An admin intending to allow one specific MAC got an ALLOW
ANY→ANY rule with no error.

Discovered during live use: an attempt to create a single-MAC ALLOW rule on
a default-deny network silently punched a hole allowing all device-to-device
traffic. The rule was caught and deleted within seconds, but only because the
caller knew to verify the created rule's MAC lists.

### Why OON and content filtering are in this PR

After discovering the ACL bug, we audited all tools for the same pattern
(list output uses flattened field names, create/update expects nested dicts,
LLM naturally uses the list field names and they get silently dropped or
ignored). Found two more instances:

- **OON**: `list_oon_policies` outputs `qos_enabled`/`route_enabled`
  (flattened booleans), but `create_oon_policy` expects `qos`/`route`
  (full nested dicts). Lower severity than ACL — an LLM passing
  `qos_enabled=True` would get an error (not a valid param), not a silent
  misconfiguration. Fix: clarified the create description to explicitly
  warn against using the flattened list fields.

- **Content filtering**: `list_content_filters` outputs `schedule_mode`
  (flattened from nested `schedule.mode`), but the update tool doesn't
  accept schedule changes at all. No risk — read-only summary field.
  Fix: added code comment documenting it as read-only.

Bundled here because they're the same class of bug found in the same audit.
The OON and content filtering changes are description/comment-only — no
behavioral changes outside of ACL.

### Fix

- **`create_acl_rule`**: Added `source_macs` and `destination_macs` as
  top-level convenience params (same field names as `list_acl_rules` output).
  These build the nested `traffic_source`/`traffic_destination` dicts
  internally. Original nested dict params retained for backward compatibility
  but marked as "(Advanced)" — convenience params take precedence when both
  are provided.
- **`update_acl_rule`**: Translates `source_macs`/`destination_macs` keys in
  `rule_data` to nested structure before schema validation, so callers can
  use the same field names from list output.

## Files changed

| File | Change |
|---|---|
| `tools/acl.py` | **Modified** — added `source_macs`/`destination_macs` convenience params on create, flattened-to-nested translation on update, entry logging, updated descriptions |
| `tools/oon.py` | **Modified** — clarified create description re: nested vs flattened fields |
| `tools/content_filtering.py` | **Modified** — added read-only comment on `schedule_mode` |
| `tests/unit/test_acl_tools.py` | **New** — 7 tests covering convenience params, precedence, backward compat, defaults, preview, update translation |
| `tools_manifest.json` | Regenerated (166 tools) |

## Live testing

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.16 |
| **Network Application** | 10.1.89 |
| **MCP Client** | Claude Code |
| **MCP Transport** | stdio |
| **Host OS** | Windows 10 Pro 10.0.19045 |
| **Shell** | Git Bash 5.2.37 (MINGW64) |

| Test | Result |
|---|---|
| `create_acl_rule` with `source_macs` + `destination_macs` — MACs persisted in controller response | ✅ Pass |
| Verified `traffic_source.specific_mac_addresses` and `traffic_destination.specific_mac_addresses` populated correctly | ✅ Pass |
| Test rule deleted after verification | ✅ Pass |

## Unit tests

7 new tests in `test_acl_tools.py`:
- `source_macs` builds correct nested dict
- `source_macs` takes precedence over `traffic_source` dict
- Backward compat: `traffic_source` dict still works alone
- Omitting both defaults to ANY (empty list)
- Preview mode shows resolved MACs
- `update_acl_rule` translates `source_macs` in rule_data
- `update_acl_rule` translates `destination_macs` in rule_data

```
Full suite — 578 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)