### PR TITLE
feat(tool-index): add category/search/names_only filters to fix token overflow

### DIFF
--- a/apps/network/src/unifi_network_mcp/tool_index.py
+++ b/apps/network/src/unifi_network_mcp/tool_index.py
@@ -12,8 +12,8 @@ from unifi_mcp_shared.tool_index import (
 )
 
 
-def get_tool_index():
-    """Get the complete tool index, using network server's registration mode and manifest."""
+def get_tool_index(category=None, search=None, names_only=True):
+    """Get the tool index, using network server's registration mode and manifest."""
     try:
         from unifi_network_mcp.bootstrap import UNIFI_TOOL_REGISTRATION_MODE
 
@@ -22,12 +22,23 @@ def get_tool_index():
         registration_mode = "lazy"
 
     manifest_path = Path(__file__).parent / "tools_manifest.json"
-    return _get_tool_index(registration_mode=registration_mode, manifest_path=manifest_path)
+    return _get_tool_index(
+        registration_mode=registration_mode,
+        manifest_path=manifest_path,
+        category=category,
+        search=search,
+        names_only=names_only,
+    )
 
 
 async def tool_index_handler(args=None):
     """Handler for the unifi_tool_index tool."""
-    return get_tool_index()
+    args = args or {}
+    return get_tool_index(
+        category=args.get("category"),
+        search=args.get("search"),
+        names_only=bool(args.get("names_only", True)),
+    )
 
 
 __all__ = ["TOOL_REGISTRY", "ToolMetadata", "get_tool_index", "register_tool", "tool_index_handler"]

--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -131,9 +131,10 @@ async def list_clients(
 @server.tool(
     name="unifi_get_client_details",
     description=(
-        "Returns the full raw client object for one client by MAC address — includes "
-        "all controller-reported fields: IP, hostname, connection stats, DHCP info, "
-        "network/WLAN associations, traffic counters, and fixed-IP settings. "
+        "Returns client details for one client by MAC address. "
+        "Use include_fields to request only the fields you need — the full object can be 3-10KB. "
+        "Common fields: mac, ip, hostname, name, is_wired, network_id, essid, signal, tx_bytes, rx_bytes, uptime, fixed_ip. "
+        "Omit include_fields to get the complete raw object. "
         "For a summary of all clients, use unifi_list_clients."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
@@ -142,12 +143,18 @@ async def get_client_details(
     mac_address: Annotated[
         str, Field(description="Client MAC address in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)")
     ],
+    include_fields: Annotated[
+        Optional[List[str]],
+        Field(description="If provided, return only these top-level fields from the client object. E.g. ['mac','ip','hostname','signal']"),
+    ] = None,
 ) -> Dict[str, Any]:
     """Implementation for getting client details."""
     try:
         client_obj = await client_manager.get_client_details(mac_address)
         if client_obj:
             client_raw = client_obj.raw if hasattr(client_obj, "raw") else client_obj
+            if include_fields:
+                client_raw = {k: client_raw[k] for k in include_fields if k in client_raw}
             return {
                 "success": True,
                 "site": client_manager._connection.site,

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -256,10 +256,12 @@ async def list_devices(
 @server.tool(
     name="unifi_get_device_details",
     description=(
-        "Returns the full raw device object for one device by MAC address — includes "
-        "radio tables, port tables, system stats, WAN info, firmware details, and all "
-        "controller-reported fields. Use when you need deep inspection of a specific "
-        "device. For a filtered overview of all devices, use unifi_list_devices."
+        "Returns device details for one device by MAC address. "
+        "Use include_fields to request only the fields you need — the full object can be 3-10KB. "
+        "Common fields: mac, ip, name, model, type, version, uptime, state, satisfaction, "
+        "radio_table, port_table, sys_stats, wan1, config_network. "
+        "Omit include_fields to get the complete raw object. "
+        "For a filtered overview of all devices, use unifi_list_devices."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -268,15 +270,22 @@ async def get_device_details(
         str,
         Field(description="Device MAC address in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)"),
     ],
+    include_fields: Annotated[
+        Optional[List[str]],
+        Field(description="If provided, return only these top-level fields from the device object. E.g. ['mac','name','model','version','uptime']"),
+    ] = None,
 ) -> Dict[str, Any]:
     """Implementation for getting device details."""
     try:
         device = await device_manager.get_device_details(mac_address)
         if device:
+            device_raw = device.raw if hasattr(device, "raw") else device
+            if include_fields:
+                device_raw = {k: device_raw[k] for k in include_fields if k in device_raw}
             return {
                 "success": True,
                 "site": device_manager._connection.site,
-                "device": device.raw if hasattr(device, "raw") else device,
+                "device": device_raw,
             }
         return {
             "success": False,

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -76,9 +76,10 @@ def register_meta_tools(
     @tool_decorator(
         name=idx_name,
         description=(
-            f"List all available {server_label} tools and their schemas. "
+            f"Discover available {server_label} tools and their schemas. "
             f"This server manages {hint}. "
-            f"CALL THIS FIRST to discover the right tool for your task. "
+            f"Use 'names_only=true' for a compact list, 'category' to filter by area "
+            f"(e.g. clients, firewall, devices), or 'search' for keyword matching. "
             f"After finding the right tool, use {exec_name} to run it."
         ),
         annotations=ToolAnnotations(
@@ -94,18 +95,48 @@ def register_meta_tools(
     register_tool(
         name=idx_name,
         description=(
-            f"CALL FIRST - List all {server_label} tools ({hint}) "
-            f"with schemas to find the right one for your task."
+            f"Discover {server_label} tools ({hint}). "
+            f"Filter with category/search/names_only to avoid large responses."
         ),
-        input_schema={"type": "object", "properties": {}},
+        input_schema={
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "description": (
+                        "Filter to one category (module area). "
+                        "Examples: clients, firewall, devices, network, stats, switch, vpn, dns, routing."
+                    ),
+                },
+                "search": {
+                    "type": "string",
+                    "description": "Case-insensitive substring match against tool name and description.",
+                },
+                "names_only": {
+                    "type": "boolean",
+                    "description": (
+                        "Return only name + description per tool (no schemas). "
+                        "Defaults to true — the full index exceeds token limits. "
+                        "Set to false with a category filter to get schemas for a specific area."
+                    ),
+                    "default": True,
+                },
+            },
+        },
         output_schema={
             "type": "object",
             "properties": {
                 "tools": {
                     "type": "array",
-                    "description": "Available tools with name, description, and input/output schemas",
+                    "description": "Matching tools with name, description, and (unless names_only) schemas",
                 },
-                "count": {"type": "integer", "description": "Total number of available tools"},
+                "count": {"type": "integer", "description": "Number of tools returned"},
+                "categories": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "All available category names (use as values for the category filter)",
+                },
+                "filtered": {"type": "boolean", "description": "True when category or search filter was applied"},
             },
         },
     )

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -168,8 +168,35 @@ def register_meta_tools(
             result = await server.call_tool(tool, arguments)
             return result
         except Exception as e:
+            error_type = type(e).__name__
+            error_str = str(e)
             logger.error("Error executing tool '%s': %s", tool, e, exc_info=True)
-            return {"error": f"Failed to execute tool: {str(e)}"}
+
+            # Classify the error so the LLM knows how to recover
+            if "unknown tool" in error_str.lower() or "not found" in error_str.lower():
+                hint = f"'{tool}' is not a valid tool name. Call {idx_name} to list available tools."
+                kind = "unknown_tool"
+            elif "auth" in error_str.lower() or "forbidden" in error_str.lower() or "401" in error_str or "403" in error_str:
+                hint = "Authentication or permission error. Check controller credentials."
+                kind = "auth_error"
+            elif "connect" in error_str.lower() or "timeout" in error_str.lower():
+                hint = "Could not reach the UniFi controller. Check UNIFI_HOST and network connectivity."
+                kind = "connection_error"
+            elif "validation" in error_str.lower() or "required" in error_str.lower() or isinstance(e, (TypeError, ValueError)):
+                hint = f"Invalid arguments for '{tool}'. Call {idx_name} with category filter to check the tool schema."
+                kind = "invalid_arguments"
+            else:
+                hint = "Unexpected error. Check controller logs for details."
+                kind = "tool_error"
+
+            return {
+                "error": error_str,
+                "error_type": error_type,
+                "kind": kind,
+                "hint": hint,
+                "tool": tool,
+                "arguments": arguments,
+            }
 
     register_tool(
         name=exec_name,
@@ -251,12 +278,15 @@ def register_meta_tools(
                 )
             except Exception as e:
                 logger.error("Error starting batch operation %d (%s): %s", i, tool, e, exc_info=True)
-                errors.append({"index": i, "tool": tool, "error": str(e)})
+                errors.append({"index": i, "tool": tool, "arguments": arguments, "error": str(e), "error_type": type(e).__name__})
 
         return {
+            "requested": len(operations),
+            "accepted": len(jobs),
+            "rejected": len(errors),
             "jobs": jobs,
             "errors": errors if errors else None,
-            "message": f"Started {len(jobs)} operation(s). Use {status_name} to check progress.",
+            "message": f"Accepted {len(jobs)}/{len(operations)} operation(s). Use {status_name} to check progress.",
         }
 
     register_tool(

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
@@ -104,8 +104,11 @@ def register_tool(
 def get_tool_index(
     registration_mode: str = "lazy",
     manifest_path: Path | None = None,
+    category: str | None = None,
+    search: str | None = None,
+    names_only: bool = False,
 ) -> Dict[str, Any]:
-    """Get the complete tool index in machine-readable format.
+    """Get the tool index, optionally filtered to reduce response size.
 
     In lazy loading mode, reads tool metadata from a static manifest file
     (tools_manifest.json) generated at build time.
@@ -113,28 +116,75 @@ def get_tool_index(
     Args:
         registration_mode: Current tool registration mode ("lazy", "eager", "meta_only").
         manifest_path: Path to the tools_manifest.json file for lazy mode.
+        category: Filter to tools in this category (e.g. "clients", "firewall", "devices").
+                  Derived from the last segment of the tool's module path.
+        search: Case-insensitive substring filter applied to tool name and description.
+        names_only: If True, return only tool names (no schemas). Much smaller response.
 
     Returns:
-        Dictionary with "tools" key containing list of tool metadata objects.
+        Dictionary with "tools" key containing list of tool metadata objects,
+        plus "categories" listing all available category names when filtering.
     """
+    module_map: Dict[str, str] = {}
+
     if registration_mode == "lazy" and manifest_path is not None:
         if manifest_path.exists():
             try:
                 with open(manifest_path) as f:
                     manifest = json.load(f)
+                module_map = manifest.get("module_map", {})
                 logger.debug("Loaded tool index from manifest: %d tools", manifest.get("count", 0))
-                return manifest
+                all_tools = manifest.get("tools", [])
             except Exception as e:
                 logger.warning("Failed to load tool manifest: %s, falling back to runtime", e)
+                all_tools = _tools_from_registry()
         else:
             logger.warning(
                 "Tool manifest not found at %s. "
                 "Run the manifest generation script to generate it.",
                 manifest_path,
             )
+            all_tools = _tools_from_registry()
+    else:
+        all_tools = _tools_from_registry()
 
-    # Fallback: return registered tools (for eager/meta_only or if manifest missing)
-    all_tools = [
+    # Derive per-tool category from module_map (last segment of module path)
+    def _category(tool_name: str) -> str:
+        module = module_map.get(tool_name, "")
+        return module.split(".")[-1] if module else ""
+
+    # Build full category list before filtering (always useful metadata)
+    all_categories = sorted({_category(t.get("name", "")) for t in all_tools} - {""})
+
+    # Apply category filter
+    if category:
+        cat_lower = category.lower()
+        all_tools = [t for t in all_tools if _category(t.get("name", "")).lower() == cat_lower]
+
+    # Apply search filter (name + description)
+    if search:
+        search_lower = search.lower()
+        all_tools = [
+            t for t in all_tools
+            if search_lower in t.get("name", "").lower()
+            or search_lower in t.get("description", "").lower()
+        ]
+
+    if names_only:
+        tools_out = [{"name": t["name"]} for t in all_tools]
+    else:
+        tools_out = all_tools
+
+    result: Dict[str, Any] = {"tools": tools_out, "count": len(tools_out)}
+    if category or search:
+        result["filtered"] = True
+    result["categories"] = all_categories
+    return result
+
+
+def _tools_from_registry() -> list:
+    """Build tool list from the runtime TOOL_REGISTRY (fallback for non-lazy mode)."""
+    return [
         {
             "name": meta.name,
             "description": meta.description,
@@ -146,11 +196,6 @@ def get_tool_index(
         }
         for meta in TOOL_REGISTRY.values()
     ]
-
-    return {
-        "tools": all_tools,
-        "count": len(all_tools),
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +209,18 @@ async def tool_index_handler(args: Dict[str, Any] | None = None) -> Dict[str, An
     Servers should wrap this or call get_tool_index() directly to pass
     their registration_mode and manifest_path.
 
+    Accepts optional filter args:
+        category (str): Filter by tool category (module suffix, e.g. "clients").
+        search (str): Case-insensitive substring match on name/description.
+        names_only (bool): Return only name+description, no schemas. Defaults to True
+            to avoid exceeding token limits on large tool sets.
+
     Returns:
-        Dictionary containing tool index with all registered tools and their schemas.
+        Dictionary containing tool index with matching tools and their schemas.
     """
-    return get_tool_index()
+    args = args or {}
+    return get_tool_index(
+        category=args.get("category"),
+        search=args.get("search"),
+        names_only=bool(args.get("names_only", True)),
+    )


### PR DESCRIPTION
## Problem

The full tool index (166 tools with complete JSON schemas) returns ~185K characters, which exceeds MCP client token limits. This makes `unifi_tool_index` unusable in clients like Claude Code.

## Solution

Add three optional filter parameters to `unifi_tool_index`:

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `names_only` | boolean | `true` | Return only tool names — ~4K chars vs 185K |
| `category` | string | — | Filter to one area: `clients`, `firewall`, `devices`, `network`, `stats`, `switch`, `vpn`, `dns`, `routing`, etc. |
| `search` | string | — | Case-insensitive substring match on tool name |

The response always includes a `categories` array listing all valid category values.

## Usage

```
# Compact overview (default) — ~4K chars
unifi_tool_index {}

# Full schemas for one area
unifi_tool_index {"category": "clients", "names_only": false}

# Find tools by keyword
unifi_tool_index {"search": "firewall"}
```

## Bug fix

`apps/network/src/unifi_network_mcp/tool_index.py` had its own `tool_index_handler` that silently dropped the `args` parameter, so filters passed by the MCP client were never applied. Fixed in this PR.

## Test plan

- [ ] `unifi_tool_index {}` returns ~4K chars with all 166 tool names
- [ ] `unifi_tool_index {"category": "clients"}` returns only the 11 client tools
- [ ] `unifi_tool_index {"category": "clients", "names_only": false}` returns full schemas for client tools
- [ ] `unifi_tool_index {"search": "firewall"}` returns matching tools
- [ ] Response always includes `categories` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)