### PR TITLE
feat(clients): add unifi_forget_client tool

### DIFF
--- a/apps/network/src/unifi_network_mcp/managers/client_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/client_manager.py
@@ -179,6 +179,22 @@ class ClientManager:
             logger.error("Error forcing reconnect for client %s: %s", client_mac, e)
             return False
 
+    async def forget_client(self, client_mac: str) -> bool:
+        """Forget/remove a client from the controller's known client history."""
+        try:
+            api_request = ApiRequest(
+                method="post",
+                path="/cmd/stamgr",
+                data={"macs": [client_mac], "cmd": "forget-sta"},
+            )
+            await self._connection.request(api_request)
+            logger.info("Forget command sent for client %s", client_mac)
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
+            return True
+        except Exception as e:
+            logger.error("Error forgetting client %s: %s", client_mac, e)
+            return False
+
     async def get_blocked_clients(self) -> List[Client]:
         """Get a list of currently blocked clients."""
         all_clients = await self.get_all_clients()

--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -447,15 +447,11 @@ async def force_reconnect_client(
 async def forget_client(
     mac_address: Annotated[
         str,
-        Field(
-            description="MAC address of the client to forget, in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)"
-        ),
+        Field(description="MAC address of the client to forget, in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)"),
     ],
     confirm: Annotated[
         bool,
-        Field(
-            description="When true, executes the forget. When false (default), returns a preview of the changes"
-        ),
+        Field(description="When true, executes the forget. When false (default), returns a preview of the changes"),
     ] = False,
 ) -> Dict[str, Any]:
     """Implementation for forgetting/removing a client from the controller."""

--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -438,6 +438,72 @@ async def force_reconnect_client(
 
 
 @server.tool(
+    name="unifi_forget_client",
+    description="Remove/forget a client from the controller's known client history by MAC address. This permanently deletes the client record including its name, notes, fixed IP settings, and historical stats. The client will reappear as a new unknown device if it reconnects.",
+    permission_category="clients",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def forget_client(
+    mac_address: Annotated[
+        str,
+        Field(
+            description="MAC address of the client to forget, in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)"
+        ),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(
+            description="When true, executes the forget. When false (default), returns a preview of the changes"
+        ),
+    ] = False,
+) -> Dict[str, Any]:
+    """Implementation for forgetting/removing a client from the controller."""
+    try:
+        # Fetch client details first
+        client_obj = await client_manager.get_client_details(mac_address)
+        if not client_obj:
+            return {
+                "success": False,
+                "error": f"Client not found with MAC address: {mac_address}",
+            }
+
+        client = client_obj.raw if hasattr(client_obj, "raw") else client_obj
+        client_name = client.get("name") or client.get("hostname", "Unknown")
+
+        # Return preview when confirm=false
+        if not confirm:
+            return {
+                "success": True,
+                "requires_confirmation": True,
+                "action": "forget_client",
+                "resource_type": "client",
+                "resource_id": mac_address,
+                "resource_name": client_name,
+                "preview": {
+                    "current": {
+                        "ip": client.get("ip"),
+                        "hostname": client.get("hostname"),
+                        "connection_type": "Wired" if client.get("is_wired") else "Wireless",
+                    },
+                    "action": "Client will be permanently removed from controller history. Name, notes, fixed IP settings, and historical stats will be deleted.",
+                },
+                "message": f"Will forget client '{client_name}' ({mac_address}). Set confirm=true to execute.",
+            }
+
+        success = await client_manager.forget_client(mac_address)
+        if success:
+            return {
+                "success": True,
+                "message": f"Client {mac_address} ('{client_name}') forgotten successfully.",
+            }
+        return {"success": False, "error": f"Failed to forget client {mac_address}."}
+    except Exception as e:
+        logger.error("Error forgetting client %s: %s", mac_address, e, exc_info=True)
+        return {"success": False, "error": f"Failed to forget client {mac_address}: {e}"}
+
+
+@server.tool(
     name="unifi_authorize_guest",
     description="Authorize a guest client to access the guest network by MAC address",
     permission_category="clients",

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 166,
+  "count": 167,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -41,6 +41,7 @@
     "unifi_delete_wlan": "unifi_network_mcp.tools.network",
     "unifi_force_provision_device": "unifi_network_mcp.tools.devices",
     "unifi_force_reconnect_client": "unifi_network_mcp.tools.clients",
+    "unifi_forget_client": "unifi_network_mcp.tools.clients",
     "unifi_get_acl_rule_details": "unifi_network_mcp.tools.acl",
     "unifi_get_alerts": "unifi_network_mcp.tools.stats",
     "unifi_get_anomalies": "unifi_network_mcp.tools.stats",
@@ -1483,6 +1484,36 @@
             },
             "mac_address": {
               "description": "MAC address of the client to force reconnect, in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "mac_address"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Remove/forget a client from the controller's known client history by MAC address. This permanently deletes the client record including its name, notes, fixed IP settings, and historical stats. The client will reappear as a new unknown device if it reconnects.",
+      "name": "unifi_forget_client",
+      "permission_action": "update",
+      "permission_category": "clients",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, executes the forget. When false (default), returns a preview of the changes",
+              "type": "boolean"
+            },
+            "mac_address": {
+              "description": "MAC address of the client to forget, in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)",
               "type": "string"
             }
           },

--- a/apps/network/tests/unit/test_forget_client.py
+++ b/apps/network/tests/unit/test_forget_client.py
@@ -1,0 +1,64 @@
+"""Tests for the forget client functionality."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestForgetClient:
+    """Tests for ClientManager.forget_client."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.controller = MagicMock()
+        conn.controller.clients = MagicMock()
+        conn.controller.clients.update = AsyncMock()
+        conn.controller.clients.values = MagicMock(return_value=[])
+        conn.controller.clients_all = MagicMock()
+        conn.controller.clients_all.update = AsyncMock()
+        conn.controller.clients_all.values = MagicMock(return_value=[])
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def client_manager(self, mock_connection):
+        """Create a ClientManager with mocked connection."""
+        from unifi_network_mcp.managers.client_manager import ClientManager
+
+        return ClientManager(mock_connection)
+
+    @pytest.mark.asyncio
+    async def test_forget_client_success(self, client_manager, mock_connection):
+        """Test successful forget client call."""
+        result = await client_manager.forget_client("AA:BB:CC:DD:EE:FF")
+
+        assert result is True
+        mock_connection.request.assert_called_once()
+        call_args = mock_connection.request.call_args[0][0]
+        assert call_args.method == "post"
+        assert call_args.path == "/cmd/stamgr"
+        assert call_args.data == {"macs": ["AA:BB:CC:DD:EE:FF"], "cmd": "forget-sta"}
+        mock_connection._invalidate_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_forget_client_api_error(self, client_manager, mock_connection):
+        """Test forget client returns False on API error."""
+        mock_connection.request.side_effect = Exception("API error")
+
+        result = await client_manager.forget_client("AA:BB:CC:DD:EE:FF")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_forget_client_invalidates_cache(self, client_manager, mock_connection):
+        """Test that cache is invalidated after forgetting a client."""
+        await client_manager.forget_client("AA:BB:CC:DD:EE:FF")
+
+        mock_connection._invalidate_cache.assert_called_once_with("clients")

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (166 tools)
+# Network Server Tool Reference (167 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -39,7 +39,7 @@ Always available, regardless of registration mode.
 ## Clients
 
 <!-- AUTO:tools:clients -->
-11 tools.
+12 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -50,6 +50,7 @@ Always available, regardless of registration mode.
 | `unifi_authorize_guest` | Mutate | Authorize a guest client to access the guest network by MAC address |
 | `unifi_block_client` | Mutate | Block a client/device from the network by MAC address |
 | `unifi_force_reconnect_client` | Mutate | Force a client to reconnect to the network (kick) by MAC address |
+| `unifi_forget_client` | Mutate | Remove/forget a client from the controller's known client history by MAC address. |
 | `unifi_rename_client` | Mutate | Rename a client/device in the Unifi Network controller by MAC address |
 | `unifi_set_client_ip_settings` | Mutate | Set fixed IP address and/or local DNS record for a client device. |
 | `unifi_unauthorize_guest` | Mutate | Revoke authorization for a guest client by MAC address |


### PR DESCRIPTION
## Summary
- Adds `unifi_forget_client` tool to remove a client from the controller's known client history via the `forget-sta` stamgr command
- Includes preview/confirm flow consistent with other destructive client tools
- Regenerated manifest (166 → 167 tools) and skill reference
- Unit tests for manager method (success, API error, cache invalidation)

## Test plan
- [ ] Call `unifi_forget_client` with `confirm=false` — verify preview response includes client name, IP, and warning
- [ ] Call `unifi_forget_client` with `confirm=true` — verify client is removed from controller history
- [ ] Verify forgotten client reappears as unknown when it reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)