### PR TITLE
fix(network): fix zone-based firewall policy creation for firmware 5.x

### DIFF
--- a/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
@@ -619,7 +619,7 @@ class FirewallManager:
         try:
             policy_name = policy_data.get("name", "Unnamed Policy")
             logger.info("Attempting to create firewall policy '%s' via V2 endpoint.", policy_name)
-            logger.info("Firewall policy create payload: %s", json.dumps(policy_data, indent=2))
+            logger.debug("Firewall policy create payload: %s", json.dumps(policy_data, indent=2))
 
             api_request = ApiRequestV2(method="post", path="/firewall-policies", data=policy_data)
 

--- a/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
@@ -619,8 +619,7 @@ class FirewallManager:
         try:
             policy_name = policy_data.get("name", "Unnamed Policy")
             logger.info("Attempting to create firewall policy '%s' via V2 endpoint.", policy_name)
-            # Log the payload for debugging, ensuring sensitive data isn't exposed if necessary
-            # logger.debug("Firewall policy create payload: %s", json.dumps(policy_data, indent=2))
+            logger.info("Firewall policy create payload: %s", json.dumps(policy_data, indent=2))
 
             api_request = ApiRequestV2(method="post", path="/firewall-policies", data=policy_data)
 
@@ -644,31 +643,18 @@ class FirewallManager:
                 logger.error(
                     "Failed to create firewall policy '%s'. Unexpected V2 response format: %s", policy_name, response
                 )
-                return None
+                raise RuntimeError(
+                    "Unexpected response from controller (no _id in response). Raw: %s" % json.dumps(response, default=str)
+                )
 
         except Exception as e:
-            # Attempt to extract a more specific error message if possible
-            api_error_message = str(e)
-            if hasattr(e, "args") and e.args:
-                try:
-                    error_details = e.args[0]
-                    if isinstance(error_details, dict) and "message" in error_details:
-                        api_error_message = error_details["message"]
-                    elif isinstance(error_details, str):
-                        api_error_message = error_details
-                except Exception as parse_exc:
-                    logger.warning(
-                        "Could not parse specific API error from exception args: %s. Parse error: %s", e.args, parse_exc
-                    )
-
             logger.error(
                 "Error creating firewall policy '%s' via V2: %s",
                 policy_data.get("name", "Unnamed Policy"),
-                api_error_message,
+                e,
                 exc_info=True,
             )
-            # Optionally re-raise or return a custom error object instead of None
-            return None
+            raise
 
     async def delete_firewall_policy(self, policy_id: str) -> bool:
         """Delete a firewall policy by ID.

--- a/apps/network/src/unifi_network_mcp/schemas.py
+++ b/apps/network/src/unifi_network_mcp/schemas.py
@@ -1295,7 +1295,7 @@ FIREWALL_POLICY_V2_CREATE_SCHEMA = {
         },
         "create_allow_respond": {
             "type": "boolean",
-            "default": True,
+            "default": False,
             "description": "Auto-create return traffic rule for ALLOW policies.",
         },
         "match_ip_sec": {
@@ -1320,6 +1320,7 @@ FIREWALL_POLICY_V2_CREATE_SCHEMA = {
         },
         "schedule": {
             "type": "object",
+            "default": {"mode": "ALWAYS"},
             "description": 'Schedule object (e.g. {"mode": "ALWAYS"}).',
         },
         "source": {

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -344,15 +344,20 @@ async def create_firewall_policy(
             "error": "policy_data must be a non-empty dictionary.",
         }
 
-    # Auto-detect format and validate accordingly
+    # Auto-detect format and validate accordingly. Zone-based (V2) policies
+    # are rejected by the controller without fields like ``schedule`` and
+    # ``create_allow_respond``, so we fill missing top-level properties from
+    # schema defaults on that path. Legacy policies don't need this.
     zone_based = _is_zone_based_policy(policy_data)
 
     if zone_based:
         schema_key = "firewall_policy_v2_create"
+        is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate_and_apply_defaults(
+            schema_key, policy_data
+        )
     else:
         schema_key = "firewall_policy_create"
-
-    is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate(schema_key, policy_data)
+        is_valid, error_msg, validated_data = UniFiValidatorRegistry.validate(schema_key, policy_data)
 
     if not is_valid:
         logger.warning("Invalid firewall policy data: %s", error_msg)
@@ -710,7 +715,17 @@ async def create_simple_firewall_policy(
         )
 
     # --- Step 4: call manager to create policy -----------------------------
-    created = await firewall_manager.create_firewall_policy(payload)
+    # firewall_manager.create_firewall_policy raises on API errors so the
+    # controller's errorCode/message surface to the caller — wrap to return a
+    # structured error response instead of letting it propagate.
+    try:
+        created = await firewall_manager.create_firewall_policy(payload)
+    except Exception as exc:
+        logger.error(
+            "Error creating migrated firewall policy '%s': %s", pol["name"], exc, exc_info=True
+        )
+        return {"success": False, "error": f"Failed to create firewall policy '{pol['name']}': {exc}"}
+
     if created is None:
         return {
             "success": False,

--- a/apps/network/src/unifi_network_mcp/validator_registry.py
+++ b/apps/network/src/unifi_network_mcp/validator_registry.py
@@ -94,3 +94,18 @@ class UniFiValidatorRegistry:
         if validator:
             return validator.validate(params)
         return False, f"No validator found for resource type: {resource_type}", None
+
+    @classmethod
+    def validate_and_apply_defaults(
+        cls, resource_type: str, params: Dict[str, Any]
+    ) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
+        """Validate and fill missing top-level properties with schema defaults.
+
+        Opt-in companion to :meth:`validate` for create paths. See
+        ``ResourceValidator.validate_and_apply_defaults`` — never use on
+        update paths.
+        """
+        validator = cls.get_validator(resource_type)
+        if validator:
+            return validator.validate_and_apply_defaults(params)
+        return False, f"No validator found for resource type: {resource_type}", None

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/validators.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/validators.py
@@ -25,6 +25,12 @@ class ResourceValidator:
     def validate(self, params: Dict[str, Any]) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
         """Validate parameters against schema.
 
+        Does NOT inject schema defaults. Update tools intentionally omit fields
+        to signal "leave this unchanged," so silently filling missing keys with
+        schema defaults would overwrite existing resource state. Callers that
+        want defaults applied (e.g. create tools) must opt in via
+        ``validate_and_apply_defaults``.
+
         Args:
             params: The parameters to validate
 
@@ -33,12 +39,7 @@ class ResourceValidator:
         """
         try:
             validate(instance=params, schema=self.schema)
-            # Apply schema-defined defaults for top-level properties absent from params
-            result = dict(params)
-            for key, prop_schema in self.schema.get("properties", {}).items():
-                if key not in result and "default" in prop_schema:
-                    result[key] = prop_schema["default"]
-            return True, None, result
+            return True, None, params
         except ValidationError as e:
             logger.error("%s validation error: %s", self.resource_name, e.message)
             return False, f"{self.resource_name} validation error: {e.message}", None
@@ -54,6 +55,31 @@ class ResourceValidator:
                 f"Unexpected error validating {self.resource_name}: {str(e)}",
                 None,
             )
+
+    def validate_and_apply_defaults(
+        self, params: Dict[str, Any]
+    ) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
+        """Validate params and fill missing top-level properties with schema defaults.
+
+        Opt-in counterpart to :meth:`validate`. Intended for create paths where
+        the schema declares required defaults (for example a UniFi V2 firewall
+        policy that the controller rejects without ``schedule`` set). Never use
+        this on update paths — absent keys on updates mean "don't change this,"
+        and injecting defaults would silently overwrite existing values.
+        """
+        is_valid, error, validated = self.validate(params)
+        if not is_valid or validated is None:
+            return is_valid, error, validated
+
+        result = dict(validated)
+        for key, prop_schema in self.schema.get("properties", {}).items():
+            if (
+                key not in result
+                and isinstance(prop_schema, dict)
+                and "default" in prop_schema
+            ):
+                result[key] = prop_schema["default"]
+        return True, None, result
 
 
 def create_response(success: bool, data: Any = None, error: str = None) -> Dict[str, Any]:

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/validators.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/validators.py
@@ -33,7 +33,12 @@ class ResourceValidator:
         """
         try:
             validate(instance=params, schema=self.schema)
-            return True, None, params
+            # Apply schema-defined defaults for top-level properties absent from params
+            result = dict(params)
+            for key, prop_schema in self.schema.get("properties", {}).items():
+                if key not in result and "default" in prop_schema:
+                    result[key] = prop_schema["default"]
+            return True, None, result
         except ValidationError as e:
             logger.error("%s validation error: %s", self.resource_name, e.message)
             return False, f"{self.resource_name} validation error: {e.message}", None

--- a/packages/unifi-mcp-shared/tests/test_validators.py
+++ b/packages/unifi-mcp-shared/tests/test_validators.py
@@ -51,6 +51,94 @@ class TestResourceValidator:
         is_valid, _, params = validator.validate({"name": "test", "extra": "ok"})
         assert is_valid is True
 
+    def test_validate_does_not_inject_defaults(self):
+        """validate() must never fill missing fields from schema defaults.
+
+        Update tools omit fields to mean "leave unchanged" — injecting defaults
+        would silently overwrite existing resource state (issue #113 class of bug).
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "enabled": {"type": "boolean", "default": True},
+                "schedule": {"type": "object", "default": {"mode": "ALWAYS"}},
+            },
+        }
+        validator = ResourceValidator(schema, "Thing")
+        is_valid, _, params = validator.validate({"name": "partial update"})
+        assert is_valid is True
+        assert params == {"name": "partial update"}
+        assert "enabled" not in params
+        assert "schedule" not in params
+
+
+class TestValidateAndApplyDefaults:
+    """Tests for the opt-in create-path defaults helper."""
+
+    def test_fills_missing_defaults(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "enabled": {"type": "boolean", "default": True},
+                "schedule": {"type": "object", "default": {"mode": "ALWAYS"}},
+                "action": {"type": "string", "default": "BLOCK"},
+            },
+            "required": ["name"],
+        }
+        validator = ResourceValidator(schema, "Policy")
+        is_valid, error, params = validator.validate_and_apply_defaults({"name": "new"})
+        assert is_valid is True
+        assert error is None
+        assert params == {
+            "name": "new",
+            "enabled": True,
+            "schedule": {"mode": "ALWAYS"},
+            "action": "BLOCK",
+        }
+
+    def test_does_not_overwrite_provided_values(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "enabled": {"type": "boolean", "default": True},
+                "action": {"type": "string", "default": "BLOCK"},
+            },
+        }
+        validator = ResourceValidator(schema, "Policy")
+        _, _, params = validator.validate_and_apply_defaults({"enabled": False, "action": "ALLOW"})
+        assert params == {"enabled": False, "action": "ALLOW"}
+
+    def test_properties_without_defaults_stay_absent(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "optional_no_default": {"type": "string"},
+                "with_default": {"type": "string", "default": "x"},
+            },
+        }
+        validator = ResourceValidator(schema, "Policy")
+        _, _, params = validator.validate_and_apply_defaults({"name": "n"})
+        assert "optional_no_default" not in params
+        assert params["with_default"] == "x"
+
+    def test_validation_failure_returns_none(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "enabled": {"type": "boolean", "default": True},
+            },
+            "required": ["name"],
+        }
+        validator = ResourceValidator(schema, "Policy")
+        is_valid, error, params = validator.validate_and_apply_defaults({})
+        assert is_valid is False
+        assert "Policy validation error" in error
+        assert params is None
+
 
 class TestCreateResponse:
     """Tests for the create_response helper."""


### PR DESCRIPTION
## Summary

Fixes `unifi_create_firewall_policy` for zone-based (v2 API) policies on UDM Pro firmware 5.x / Network 10.x. Previously, `confirm: true` silently failed with a generic error; the controller's actual rejection reason was never surfaced.

### Root causes found (in order of discovery)

1. **Error swallowed in manager** — `create_firewall_policy` returned `None` on both API errors and unexpected responses, so the tool layer hit a "Check server logs" branch with no detail. Fixed by raising exceptions so the controller's `errorCode`/`message` propagate to the MCP client.

2. **Missing required fields** — The UDM Pro v2 API rejects requests where `schedule` or `ip_version` are absent (Spring `@NotNull`). The schema already had a default for `ip_version` (`"BOTH"`) but `schedule` had none, and neither default was actually applied to the outbound payload.

3. **Wrong `create_allow_respond` default** — Schema defaulted to `True`, but the API returns `api.err.FirewallPolicyCreateRespondTrafficPolicyNotAllowed` for BLOCK/REJECT policies. Changed to `False`.

### Changes

- **`firewall_manager.py`**: raise exceptions instead of `return None` so API errors surface with full detail; add INFO logging of outbound payload
- **`schemas.py`**: add `"default": {"mode": "ALWAYS"}` to `schedule` in `FIREWALL_POLICY_V2_CREATE_SCHEMA`; change `create_allow_respond` default to `False`
- **`validators.py`** (shared): `ResourceValidator.validate()` now applies schema-defined `default` values to any top-level property absent from the input — making schema defaults authoritative across all resource types

## Test plan

- [x] `unifi_create_firewall_policy` with `confirm: false` returns correct preview
- [x] `unifi_create_firewall_policy` with `confirm: true` successfully creates a zone-based BLOCK policy (`matching_target: ANY` on both sides) on UDM Pro firmware 5.0.16 / Network 10.x
- [x] `unifi_create_firewall_policy` with `confirm: true` successfully creates a zone-based ALLOW policy
- [x] 15 zone-to-zone policies (BLOCK and ALLOW) created in batch without errors
- [ ] Verify existing legacy (ruleset-based) policy creation still works