### PR TITLE
fix(stats): filter /stat/sta by MAC in get_client_wifi_details (#148)

### DIFF
--- a/apps/network/src/unifi_network_mcp/managers/stats_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/stats_manager.py
@@ -573,20 +573,25 @@ class StatsManager:
             return cached_data
 
         try:
-            endpoint = "/stat/sta"
-            payload = {"mac": client_mac}
-            api_request = ApiRequest(method="post", path=endpoint, data=payload)
+            # /stat/sta is a collection endpoint: it returns all currently-
+            # connected wireless clients and ignores any MAC filter in the body.
+            # Fetch the full list, then filter for the requested MAC ourselves.
+            api_request = ApiRequest(method="get", path="/stat/sta")
             response = await self._connection.request(api_request)
 
-            # Response is typically a list; find the matching client
             clients = response if isinstance(response, list) else []
-            if not clients:
+            target = client_mac.lower()
+            raw = next(
+                (
+                    c
+                    for c in clients
+                    if isinstance(c, dict) and str(c.get("mac", "")).lower() == target
+                ),
+                None,
+            )
+            if raw is None:
                 return None
 
-            # Use the first matching entry
-            raw = clients[0] if isinstance(clients[0], dict) else {}
-
-            # Extract WiFi-specific fields
             wifi_fields = [
                 "signal",
                 "noise",
@@ -607,7 +612,7 @@ class StatsManager:
                 "nss",
                 "is_11r",
             ]
-            result: Dict[str, Any] = {"mac": client_mac}
+            result: Dict[str, Any] = {"mac": raw.get("mac", client_mac)}
             for field in wifi_fields:
                 if field in raw:
                     result[field] = raw[field]

--- a/apps/network/tests/unit/test_stats_enhanced.py
+++ b/apps/network/tests/unit/test_stats_enhanced.py
@@ -358,6 +358,58 @@ class TestStatsManagerEnhanced:
         assert result["channel"] == 100
 
     @pytest.mark.asyncio
+    async def test_get_client_wifi_details_uses_get_stat_sta(self, stats_manager, mock_connection):
+        """Regression for #148: /stat/sta ignores MAC in POST body — must use GET."""
+        mock_connection.request.return_value = []
+
+        await stats_manager.get_client_wifi_details("aa:bb:cc:dd:ee:ff")
+
+        api_request = mock_connection.request.call_args[0][0]
+        assert api_request.method == "get"
+        assert api_request.path == "/stat/sta"
+
+    @pytest.mark.asyncio
+    async def test_get_client_wifi_details_filters_by_mac(self, stats_manager, mock_connection):
+        """Regression for #148: must filter list by MAC, not return clients[0]."""
+        mock_connection.request.return_value = [
+            {"mac": "11:11:11:11:11:11", "signal": -57, "channel": 132, "radio": "na"},
+            {"mac": "aa:bb:cc:dd:ee:ff", "signal": -34, "channel": 1, "radio": "ng"},
+            {"mac": "22:22:22:22:22:22", "signal": -79, "channel": 11, "radio": "ng"},
+        ]
+
+        result = await stats_manager.get_client_wifi_details("aa:bb:cc:dd:ee:ff")
+
+        assert result is not None
+        assert result["mac"] == "aa:bb:cc:dd:ee:ff"
+        assert result["signal"] == -34
+        assert result["channel"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_client_wifi_details_no_match_returns_none(self, stats_manager, mock_connection):
+        """Regression for #148: unknown MAC must return None, not clients[0]."""
+        mock_connection.request.return_value = [
+            {"mac": "11:11:11:11:11:11", "signal": -57, "channel": 132},
+            {"mac": "22:22:22:22:22:22", "signal": -60, "channel": 36},
+        ]
+
+        result = await stats_manager.get_client_wifi_details("00:00:00:00:00:00")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_client_wifi_details_mac_case_insensitive(self, stats_manager, mock_connection):
+        """MAC matching must ignore case so callers aren't forced to normalize."""
+        mock_connection.request.return_value = [
+            {"mac": "AA:BB:CC:DD:EE:FF", "signal": -50, "channel": 36},
+        ]
+
+        result = await stats_manager.get_client_wifi_details("aa:bb:cc:dd:ee:ff")
+
+        assert result is not None
+        assert result["mac"] == "AA:BB:CC:DD:EE:FF"
+        assert result["signal"] == -50
+
+    @pytest.mark.asyncio
     async def test_get_client_wifi_details_not_found(self, stats_manager, mock_connection):
         """Test get_client_wifi_details returns None for unknown client."""
         mock_connection.request.return_value = []


### PR DESCRIPTION
## Summary

Fixes #148. `unifi_get_client_wifi_details` was returning the same payload for every call regardless of `client_mac` — including an invalid `00:00:00:00:00:00` — because the handler:

- POSTed to `/stat/sta` with `{\"mac\": client_mac}`, but `/stat/sta` is the collection endpoint and ignores that body (it returns all currently-connected wireless clients).
- Took `clients[0]` instead of filtering the list (despite a comment claiming otherwise).
- Seeded `result = {\"mac\": client_mac}`, so the echoed MAC masked the mismatch from callers.

Switched to `GET /stat/sta` (matching `client_manager`'s convention), filter the returned list for the requested MAC case-insensitively, return `None` on no match, and source the `mac` field from the matched record so the response reflects the controller's truth.

## Verification

Reproduced the bug via code inspection and verified the fix on a live UDM Pro running UniFi Network 10.2.105:

- Two distinct wireless clients now return **distinct** payloads with different signal, channel, and BSSID values — pre-fix they returned identical data.
- Each response's `mac` field now matches the matched record's MAC (not just the caller's input).
- An invalid MAC (`00:00:00:00:00:00`) now returns `None`, which the tool layer surfaces as `success: false` with a not-found error instead of the prior `success: true` with spoofed data.

## Test plan

- [x] New regression tests in `test_stats_enhanced.py` covering the four failure modes exposed by the issue: GET method + `/stat/sta` path, multi-client list where target isn't first, non-matching MAC returns `None`, case-insensitive MAC matching.
- [x] `uv run pytest apps/network/tests/unit/test_stats_enhanced.py` — 41/41 pass.
- [x] Smoke test against live UniFi Network 10.2.105 on a UDM Pro (see Verification above).