### PR TITLE
fix(network): tolerate malformed entries in manager ID lookups (#151, #152)

### DIFF
--- a/.agents/myco-run.cjs
+++ b/.agents/myco-run.cjs
@@ -19,16 +19,25 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
-// Resolve the myco command name.
+// Defensively pin cwd to the project root. Cursor's hook spawn drops stdin
+// when the command uses shell operators, so our installed hook commands
+// invoke this guard directly (no `cd "$(...)" &&` prefix). The chdir keeps
+// vault resolution working even when the spawning agent's cwd isn't set.
+try { process.chdir(path.resolve(__dirname, '..')); } catch { /* best effort */ }
+
+// Resolve which myco binary to invoke.
 //
-// Source of truth is `.myco/runtime.command` — a one-line plain-text file
-// containing the command to invoke (e.g. `myco`, `myco-dev`, or a user's
-// own alias). When absent or empty, the default is `myco`.
+// `.myco/runtime.command` is the source of truth — a one-line plain-text
+// file holding either a PATH-resolvable name (`myco`, the default for
+// globally-installed users) or an absolute path (`/Users/chris/.local/
+// bin/myco-dev`, what `make dev-link` writes). Absolute paths bypass
+// PATH entirely, which matters because GUI-launched agents (Cursor,
+// Claude Code desktop, etc.) run under macOS launchd and inherit a
+// minimal PATH that typically doesn't include `~/.local/bin`.
 //
-// We resolve the file path via __dirname so the guard doesn't depend on
-// the agent's current working directory. Lifecycle hook wrappers `cd` to
-// project root before invoking us, but not every agent keeps that contract
-// reliably under every shell — __dirname removes the dependency entirely.
+// We locate the alias file via __dirname so the guard doesn't depend on
+// cwd. Hook wrappers `cd` to the project root before invoking us, but
+// not every agent keeps that contract across every shell.
 let bin = 'myco';
 try {
   const aliasPath = path.resolve(__dirname, '..', '.myco', 'runtime.command');

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-run.cjs hook session-start --symbiont codex",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook session-start --symbiont codex",
             "timeout": 10
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-run.cjs hook user-prompt-submit --symbiont codex",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook user-prompt-submit --symbiont codex",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-run.cjs hook post-tool-use --symbiont codex",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook post-tool-use --symbiont codex",
             "timeout": 5
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-run.cjs hook stop --symbiont codex",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook stop --symbiont codex",
             "timeout": 30
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook session-start --symbiont codex",
+            "command": "node .agents/myco-run.cjs hook session-start --symbiont codex",
             "timeout": 10
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook user-prompt-submit --symbiont codex",
+            "command": "node .agents/myco-run.cjs hook user-prompt-submit --symbiont codex",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook post-tool-use --symbiont codex",
+            "command": "node .agents/myco-run.cjs hook post-tool-use --symbiont codex",
             "timeout": 5
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo ${CURSOR_PROJECT_DIR:-.})\" && node .agents/myco-run.cjs hook stop --symbiont codex",
+            "command": "node .agents/myco-run.cjs hook stop --symbiont codex",
             "timeout": 30
           }
         ]

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -2,66 +2,67 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook session-start --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook session-start --symbiont cursor",
         "type": "command",
         "timeout": 10
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook user-prompt-submit --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook user-prompt-submit --symbiont cursor",
         "type": "command",
         "timeout": 5
       }
     ],
     "postToolUse": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook post-tool-use --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook post-tool-use --symbiont cursor",
         "type": "command",
         "timeout": 5
       }
     ],
     "postToolUseFailure": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook post-tool-use-failure --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook post-tool-use-failure --symbiont cursor",
         "type": "command",
         "timeout": 5
       }
     ],
     "stop": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook stop --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook stop --symbiont cursor",
         "type": "command",
         "timeout": 30
       }
     ],
     "sessionEnd": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook session-end --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook session-end --symbiont cursor",
         "type": "command",
         "timeout": 10
       }
     ],
     "subagentStart": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook subagent-start --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook subagent-start --symbiont cursor",
         "type": "command",
         "timeout": 5
       }
     ],
     "subagentStop": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook subagent-stop --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook subagent-stop --symbiont cursor",
         "type": "command",
         "timeout": 10
       }
     ],
     "preCompact": [
       {
-        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-run.cjs hook pre-compact --symbiont cursor",
+        "command": "node .agents/myco-run.cjs hook pre-compact --symbiont cursor",
         "type": "command",
         "timeout": 5
       }
     ]
-  }
+  },
+  "version": 1
 }

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,6 @@ docs/specs/
 .mcpregistry_*
 
 # Myco managed (machine-specific)
-.agents/skills/myco
 .agents/skills/myco-rules
+.agents/skills/myco
 .wrangler/

--- a/.myco/.gitignore
+++ b/.myco/.gitignore
@@ -32,5 +32,9 @@ staging/
 # Never committed — different contributors use different aliases.
 runtime.command
 
+# Project-local managed runtime used for beta isolation
+runtime/
+runtime.tmp/
+
 # Per-user appearance and settings overrides
 local.yaml

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -23,26 +23,6 @@ agent:
   event_tasks_enabled: true
   provider:
     type: anthropic
-  tasks:
-    skill-generate:
-      provider:
-        type: anthropic
-      phases:
-        draft:
-          maxTurns: 20
-        validate:
-          maxTurns: 30
-      schedule:
-        enabled: false
-    skill-evolve:
-      provider:
-        type: anthropic
-      schedule:
-        enabled: true
-    skill-survey:
-      provider:
-        type: anthropic
-    vault-evolve: {}
 context:
   digest_tier: 5000
   session_start_digest_enabled: false
@@ -54,6 +34,8 @@ backup:
 maintenance:
   auto_optimize: true
   auto_optimize_interval_hours: 24
+update:
+  channel: stable
 team:
   enabled: false
   interval_minutes: 15
@@ -77,12 +59,3 @@ appearance:
   mode: dark
   font: default
   density: normal
-symbionts:
-  claude-code:
-    enabled: true
-  codex:
-    enabled: true
-  gemini:
-    enabled: true
-  opencode:
-    enabled: true

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -43,6 +43,14 @@ const MYCO_FETCH_TIMEOUT_MS = 3000;
 /** Tail window read from opencode when building the end-of-turn assistant summary. */
 const SESSION_IDLE_TAIL_LIMIT = 12;
 
+/**
+ * Widened retry window when the initial tail returns no assistant text.
+ * Happens when the last 12 events are all tool calls, or compaction just
+ * rewrote history. A NULL response_summary is worse than spending one
+ * extra round-trip to recover a real one.
+ */
+const SESSION_IDLE_TAIL_LIMIT_RETRY = 60;
+
 /** Max size of resume context injection to keep resumed sessions lean. */
 const RESUME_CONTEXT_MAX_CHARS = 4000;
 
@@ -156,6 +164,9 @@ const activeOpencodeSessions = new Set<string>();
 /** Resume injections are process-local and should run at most once per session. */
 const resumeInjectedSessions = new Set<string>();
 
+/** Parent batch of the current turn, or null between turns. Non-null => a turn is in progress. */
+let currentParentBatchId: number | null = null;
+
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
 function readDaemonPortFromDisk(directory: string): number | null {
   try {
@@ -238,22 +249,50 @@ async function postJson(
   }
 }
 
+// <myco:shared-helpers>
+// ---------------------------------------------------------------------------
+// Shared plugin helpers — single source of truth for buffer/POST + batch kinds.
+//
+// This block is maintained in
+//   src/symbionts/templates/_shared/plugin-helpers.ts.snippet
+// and injected into each plugin file at install time by SymbiontInstaller.
+// The plugin files on disk also carry an inline copy between the
+// `// <myco:shared-helpers>` markers so they stay valid TypeScript for
+// Vitest imports; a unit test enforces the inline copy matches the snippet.
+//
+// Contract: the snippet assumes the containing file has already defined
+//   - `postJson(directory: string, path: string, body): Promise<{ok, data?}>`
+//   - no other imports from the outer file
+// and exposes
+//   - `BATCH_KIND` constants + `BatchKind` type
+//   - `bufferEvent(dir, sessionId, event)` — best-effort JSONL append
+//   - `isIgnoredResponse(data)` — true when daemon returned an "ignored" drop
+//   - `postEventWithBuffer(dir, sessionId, event)` — live POST with buffer fallback
+//
+// DO NOT edit this block inside a plugin file directly — edit the snippet
+// and run the installer (or rerun the template-sync test to update the
+// inlined copy). Changes here apply to every plugin the next time it
+// installs/updates.
+// ---------------------------------------------------------------------------
+
 /**
- * Append an event to the local buffer at .myco/buffer/<session-id>.jsonl.
- *
- * Used as a fallback when the daemon HTTP POST fails (daemon down, network
- * error, timeout). The daemon replays buffered events via reconcileBufferBatches
- * at startup, so events captured here are NOT lost — they land in the vault
- * the next time the daemon comes back up. Mirrors the fallback pattern in
- * src/hooks/send-event.ts + src/capture/buffer.ts that every other symbiont
- * uses (claude-code, cursor, codex, etc.) via the hook CLI path.
- *
- * Without this fallback, opencode would have a significant parity gap — all
- * other symbionts preserve events across daemon downtime, but opencode events
- * would be silently dropped the moment the daemon was unreachable.
- *
- * The entry shape matches EventBuffer.append(): event payload with session_id
- * stripped (it's in the filename) and an auto-injected ISO timestamp.
+ * Discriminated vocabulary for `prompt_batches.kind`. Mirrors
+ * `BATCH_KIND` in src/db/queries/batches.ts — plugins can't import daemon
+ * code, so the constants are inlined here and kept in sync via the shared
+ * snippet + its sync test.
+ */
+const BATCH_KIND = {
+  INITIAL: "initial",
+  STEERING: "steering",
+  INTERRUPT: "interrupt",
+} as const;
+type BatchKind = typeof BATCH_KIND[keyof typeof BATCH_KIND];
+
+/**
+ * Append an event to `.myco/buffer/<session-id>.jsonl` for replay by the
+ * daemon's startup reconciler. On-disk shape intentionally matches
+ * `src/capture/buffer.ts`'s EventBuffer — the plugin can't import it because
+ * of the zero-runtime-dep constraint, so the protocol is the contract.
  */
 function bufferEvent(
   directory: string,
@@ -272,44 +311,37 @@ function bufferEvent(
       timestamp: payload.timestamp ?? new Date().toISOString(),
     });
     appendFileSync(filePath, line + "\n");
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error("[myco] Failed to buffer event:", err);
-  }
-}
-
-/**
- * POST a capture event to the daemon with buffer fallback on failure.
- * Used for user_prompt and tool_use events — both are replayed from the
- * buffer by reconcileBufferBatches when the daemon restarts.
- *
- * Two failure modes route to the buffer:
- *   1. Transport failure — HTTP non-200, timeout, network error. `result.ok`
- *      is false and we buffer exactly as you'd expect.
- *   2. Server-side drop — HTTP 200 with body `{ ok: true, ignored: reason }`.
- *      The daemon chose not to persist the event (capture rules, phantom
- *      detection, etc.), but we've seen rule bugs silently discard entire
- *      live sessions this way. Treat "ignored" as a drop and buffer it so
- *      `reconcileBufferBatches` can recover on the next restart once the
- *      underlying cause is fixed.
- */
-async function postEventWithBuffer(
-  directory: string,
-  sessionId: string,
-  event: Record<string, unknown>,
-): Promise<void> {
-  const result = await postJson(directory, "/events", event);
-  if (!result.ok || isIgnoredResponse(result.data)) {
-    bufferEvent(directory, sessionId, event);
+  } catch {
+    // Best-effort — never crash the host agent.
   }
 }
 
 /** True when the daemon returned 200 but signalled it dropped the event. */
 function isIgnoredResponse(data: unknown): boolean {
-  if (!isRecord(data)) return false;
-  const ignored = data.ignored;
+  if (data === null || typeof data !== "object") return false;
+  const ignored = (data as { ignored?: unknown }).ignored;
   return typeof ignored === "string" && ignored.length > 0;
 }
+
+/**
+ * POST a capture event to the daemon, buffering to disk on failure. Both
+ * transport failures and server-side "ignored" responses route to the
+ * buffer — rule bugs have silently dropped whole live sessions before, and
+ * the buffer is the recovery path once the cause is fixed.
+ */
+async function postEventWithBuffer(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): Promise<unknown> {
+  const result = await postJson(directory, "/events", event);
+  if (!result.ok || isIgnoredResponse(result.data)) {
+    bufferEvent(directory, sessionId, event);
+    return undefined;
+  }
+  return result.data;
+}
+// </myco:shared-helpers>
 
 /** Register an opencode session with the daemon. */
 async function mycoRegisterSession(
@@ -337,24 +369,31 @@ async function mycoUnregisterSession(directory: string, sessionId: string): Prom
  * Opencode has no on-disk transcript for Myco to mine, so images attached by
  * the user in the TUI must travel with the prompt event itself. Other symbionts
  * (claude-code, cursor) extract images from their JSONL transcripts at stop time.
- *
- * Falls back to the local buffer if the daemon is unreachable so events are
- * replayed on daemon restart (same resilience the other symbionts get via
- * src/hooks/send-event.ts).
  */
 async function mycoPostUserPrompt(
   directory: string,
   sessionId: string,
   prompt: string,
   images: Array<{ data: string; mediaType: string }>,
-): Promise<void> {
-  await postEventWithBuffer(directory, sessionId, {
+): Promise<{ batchId?: number }> {
+  const kind: BatchKind = currentParentBatchId !== null ? BATCH_KIND.STEERING : BATCH_KIND.INITIAL;
+  const parentPromptBatchId = kind === BATCH_KIND.INITIAL ? null : currentParentBatchId;
+
+  const result = await postEventWithBuffer(directory, sessionId, {
     type: "user_prompt",
     session_id: sessionId,
     agent: "opencode",
     prompt,
+    kind,
+    parent_prompt_batch_id: parentPromptBatchId,
     ...(images.length > 0 ? { images } : {}),
   });
+
+  const batchId = (result as { batchId?: number } | undefined)?.batchId;
+  if (kind === BATCH_KIND.INITIAL && batchId != null) {
+    currentParentBatchId = batchId;
+  }
+  return { batchId };
 }
 
 /** Post a tool use event. Falls back to the local buffer on failure. */
@@ -375,17 +414,65 @@ async function mycoPostToolUse(
   });
 }
 
-/** Post a stop event with the last assistant message as the response summary. */
+/**
+ * Fetch the last assistant text from an opencode session for use as the
+ * response summary on the next Stop.
+ *
+ * Starts with a small tail window (SESSION_IDLE_TAIL_LIMIT) because most
+ * idle events have recent assistant text within a dozen messages. When that
+ * window contains no assistant text — the turn ended with a tool call,
+ * compaction just rewrote history, etc. — retries once with a wider window
+ * rather than giving up and persisting a NULL response_summary.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function fetchResponseSummary(client: any, directory: string, sessionId: string): Promise<string> {
+  const fetchAt = async (limit: number): Promise<string> => {
+    try {
+      const result = await client.session.messages({
+        path: { id: sessionId },
+        query: { directory, limit },
+      });
+      const messages = ((result as { data?: SessionMessage[] } | undefined)?.data ?? []) as SessionMessage[];
+      return collectAssistantSummaryFromMessages(messages);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[myco] Failed to fetch messages for summary:", err);
+      return "";
+    }
+  };
+
+  let summary = await fetchAt(SESSION_IDLE_TAIL_LIMIT);
+  if (!summary) summary = await fetchAt(SESSION_IDLE_TAIL_LIMIT_RETRY);
+  return summary;
+}
+
+/**
+ * Post a stop event, synchronously buffering to disk before the async POST.
+ *
+ * Covers two failure modes:
+ *   1. Daemon unreachable — the buffered entry is replayed at the daemon's
+ *      next startup reconcile.
+ *   2. Bun process exits before the POST settles — `server.instance.disposed`
+ *      fires on TUI close, and the runtime can tear down before awaited
+ *      fetches complete. The synchronous buffer write survives regardless.
+ *
+ * Duplicate work is harmless: the reconciler's setResponseSummary is
+ * idempotent, so even if both the live POST and the buffered replay land,
+ * the summary is written exactly once.
+ */
 async function mycoPostStop(
   directory: string,
   sessionId: string,
   lastAssistantMessage: string | undefined,
 ): Promise<void> {
-  await postJson(directory, "/events/stop", {
+  const payload = {
+    type: "stop" as const,
     session_id: sessionId,
     agent: "opencode",
     last_assistant_message: lastAssistantMessage,
-  });
+  };
+  bufferEvent(directory, sessionId, payload);
+  await postJson(directory, "/events/stop", payload);
 }
 
 /**
@@ -598,15 +685,28 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         // daemon can mark them completed immediately rather than waiting for
         // the stale-session maintenance sweep (1-hour threshold).
         //
-        // Fire-and-forget-parallel: the Bun process is about to exit, so we
-        // can't rely on awaited fetches completing. Promise.all gives the
-        // unregister calls their best shot at landing before teardown; any
-        // that don't make it fall back to the session-maintenance job.
+        // Two things happen per session: (1) a Stop so the latest batch gets
+        // a response_summary from whatever assistant text exists, and
+        // (2) Unregister so the session row closes. Stop runs first — if it
+        // lands, processStopEvent closes batches correctly; if it misses
+        // (daemon down), the buffer fallback replays on next startup.
+        //
+        // The Bun process is about to exit, so we can't rely on awaited
+        // fetches completing. Promise.all gives both calls their best shot
+        // at landing before teardown.
         if (activeOpencodeSessions.size === 0) return;
         const toClose = Array.from(activeOpencodeSessions);
         activeOpencodeSessions.clear();
         for (const id of toClose) resumeInjectedSessions.delete(id);
-        await Promise.all(toClose.map((id) => mycoUnregisterSession(directory, id)));
+        await Promise.all(
+          toClose.flatMap((id) => [
+            (async () => {
+              const summary = await fetchResponseSummary(client, directory, id);
+              await mycoPostStop(directory, id, summary || undefined);
+            })(),
+            mycoUnregisterSession(directory, id),
+          ]),
+        );
         return;
       }
 
@@ -614,27 +714,9 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const sessionId = event.properties?.sessionID;
         if (!sessionId) return;
 
-        // Fetch the last assistant message for a response summary.
-        let responseSummary = "";
-        try {
-          // `limit` is a tail-limit in opencode's server (returns the last N
-          // messages in chronological order — verified empirically against
-          // opencode v1.4.1 via `opencode serve`). The tail window is large
-          // enough to capture a multi-message assistant block at end-of-turn
-          // without reading the full session history on every idle event.
-          const result = await client.session.messages({
-            path: { id: sessionId },
-            query: { directory, limit: SESSION_IDLE_TAIL_LIMIT },
-          });
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const messages = ((result as any)?.data ?? []) as SessionMessage[];
-          responseSummary = collectAssistantSummaryFromMessages(messages);
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.error("[myco] Failed to fetch messages for summary:", err);
-        }
-
+        const responseSummary = await fetchResponseSummary(client, directory, sessionId);
         await mycoPostStop(directory, sessionId, responseSummary || undefined);
+        currentParentBatchId = null;
         return;
       }
 

--- a/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
@@ -86,7 +86,10 @@ class FirewallManager:
         """
         try:
             policies = await self.get_firewall_policies(include_predefined=True)
-            policy: Optional[FirewallPolicy] = next((p for p in policies if p.id == policy_id), None)
+            policy: Optional[FirewallPolicy] = next(
+                (p for p in policies if isinstance(p.raw, dict) and p.raw.get("_id") == policy_id),
+                None,
+            )
 
             if not policy:
                 logger.error("Firewall policy %s not found.", policy_id)
@@ -131,7 +134,10 @@ class FirewallManager:
 
         try:
             all_policies = await self.get_firewall_policies(include_predefined=True)
-            policy_to_update: Optional[FirewallPolicy] = next((p for p in all_policies if p.id == policy_id), None)
+            policy_to_update: Optional[FirewallPolicy] = next(
+                (p for p in all_policies if isinstance(p.raw, dict) and p.raw.get("_id") == policy_id),
+                None,
+            )
 
             if not policy_to_update:
                 logger.error("Firewall policy %s not found for update.", policy_id)
@@ -218,7 +224,10 @@ class FirewallManager:
         try:
             # Fetch existing route data using the V2-based method
             routes = await self.get_traffic_routes()
-            route_to_update_obj: Optional[TrafficRoute] = next((r for r in routes if r.id == route_id), None)
+            route_to_update_obj: Optional[TrafficRoute] = next(
+                (r for r in routes if isinstance(r.raw, dict) and r.raw.get("_id") == route_id),
+                None,
+            )
 
             if not route_to_update_obj:
                 logger.error("Traffic route %s not found for update.", route_id)
@@ -270,7 +279,10 @@ class FirewallManager:
         """
         try:
             routes = await self.get_traffic_routes()
-            route: Optional[TrafficRoute] = next((r for r in routes if r.id == route_id), None)
+            route: Optional[TrafficRoute] = next(
+                (r for r in routes if isinstance(r.raw, dict) and r.raw.get("_id") == route_id),
+                None,
+            )
 
             if not route:
                 logger.error("Traffic route %s not found.", route_id)
@@ -433,7 +445,10 @@ class FirewallManager:
         """
         try:
             rules = await self.get_port_forwards()
-            return next((rule for rule in rules if rule.id == rule_id), None)
+            return next(
+                (r for r in rules if isinstance(r.raw, dict) and r.raw.get("_id") == rule_id),
+                None,
+            )
         except Exception as e:
             logger.error("Error getting port forward by ID %s: %s", rule_id, e)
             return None

--- a/apps/network/src/unifi_network_mcp/managers/network_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/network_manager.py
@@ -201,7 +201,10 @@ class NetworkManager:
     async def get_wlan_details(self, wlan_id: str) -> Optional[Dict[str, Any]]:
         """Get detailed information for a specific wireless network as a dictionary."""
         wlans = await self.get_wlans()
-        wlan_obj: Optional[Wlan] = next((w for w in wlans if w.id == wlan_id), None)
+        wlan_obj: Optional[Wlan] = next(
+            (w for w in wlans if isinstance(w.raw, dict) and w.raw.get("_id") == wlan_id),
+            None,
+        )
         if not wlan_obj:
             logger.warning("WLAN %s not found in cached/fetched list.", wlan_id)
             return None

--- a/apps/network/src/unifi_network_mcp/tools/port_forwards.py
+++ b/apps/network/src/unifi_network_mcp/tools/port_forwards.py
@@ -67,8 +67,8 @@ async def list_port_forwards() -> Dict[str, Any]:  # Removed context, adjusted r
                 "enabled": r.get("enabled"),
                 "src_port": r.get("dst_port"),  # Note: UniFi uses dst_port for external
                 "dst_port": r.get("fwd_port"),  # Note: UniFi uses fwd_port for internal
-                "protocol": r.get("protocol"),
-                "dest_ip": r.get("fwd_ip"),
+                "protocol": r.get("proto"),
+                "dest_ip": r.get("fwd"),
             }
             for r in rules_raw
         ]

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -206,3 +206,64 @@ class TestUpdateFirewallPolicyEndpoint:
             await firewall_manager.update_firewall_policy("pol001", {"logging": True})
 
         assert policy.raw == original_raw
+
+
+# ---------------------------------------------------------------------------
+# ID-lookup iteration robustness — issue #151
+#
+# `next((x for x in items if x.id == target), None)` over aiounifi item
+# objects raises KeyError when any item in the list has a `raw` dict missing
+# `_id` (the property does `self.raw["_id"]` directly). Lazy iteration meant
+# one malformed item poisoned lookups for every item positioned at-or-after
+# it — earlier matches still resolved, later matches returned "not found".
+# Lookup paths now use `r.raw.get("_id")` so iteration tolerates malformed
+# entries.
+# ---------------------------------------------------------------------------
+
+from aiounifi.models.port_forward import PortForward  # noqa: E402
+from aiounifi.models.traffic_route import TrafficRoute  # noqa: E402
+
+
+class TestPortForwardLookupRobustness:
+    """get_port_forward_by_id must not be poisoned by a malformed sibling rule."""
+
+    @pytest.mark.asyncio
+    async def test_finds_rule_after_malformed_entry(self, firewall_manager):
+        """A rule positioned after a malformed (no `_id`) entry must still resolve."""
+        good_pre = PortForward({"_id": "pf-pre", "name": "pre"})
+        malformed = PortForward({"name": "broken-no-id", "fwd_port": "1", "dst_port": "1"})
+        good_post = PortForward({"_id": "pf-post", "name": "post"})
+
+        with patch.object(
+            firewall_manager,
+            "get_port_forwards",
+            new_callable=AsyncMock,
+            return_value=[good_pre, malformed, good_post],
+        ):
+            pre = await firewall_manager.get_port_forward_by_id("pf-pre")
+            post = await firewall_manager.get_port_forward_by_id("pf-post")
+            missing = await firewall_manager.get_port_forward_by_id("pf-does-not-exist")
+
+        assert pre is good_pre
+        assert post is good_post  # would be None before the fix
+        assert missing is None
+
+
+class TestTrafficRouteLookupRobustness:
+    """update_/toggle_ traffic_route must not be poisoned by a malformed sibling route."""
+
+    @pytest.mark.asyncio
+    async def test_update_finds_route_after_malformed_entry(self, firewall_manager, mock_connection):
+        good_target = TrafficRoute(copy.deepcopy(SAMPLE_ROUTE_RAW))
+        malformed = TrafficRoute({"description": "broken-no-id", "enabled": True})
+
+        with patch.object(
+            firewall_manager,
+            "get_traffic_routes",
+            new_callable=AsyncMock,
+            return_value=[malformed, good_target],
+        ):
+            result = await firewall_manager.update_traffic_route("route001", {"description": "Updated"})
+
+        assert result is True
+        mock_connection.request.assert_called_once()


### PR DESCRIPTION
## Summary
- Six manager methods used `next((x for x in items if x.id == target), None)`. The aiounifi `.id` property does `self.raw["_id"]` directly and raises `KeyError` on missing `_id`. With lazy generator iteration plus a swallowing `try/except`, a single malformed item silently poisoned lookups for every item positioned at-or-after it — earlier matches still resolved, later matches returned "not found".
- Replace `.id` with a guarded `.raw.get("_id")` so iteration tolerates malformed entries.
- Also fix the secondary `protocol`/`dest_ip`-always-null bug in `unifi_list_port_forwards` (wrong source keys: `protocol` → `proto`, `fwd_ip` → `fwd`).

## Why one PR
The same pattern appeared in 6 places (port forwards, traffic routes x2, firewall policies x2, wlan details). All identical class, identical fix shape — bundled so they ship and get tested together.

## What's covered
- `firewall_manager.toggle_firewall_policy`
- `firewall_manager.update_firewall_policy`
- `firewall_manager.update_traffic_route`
- `firewall_manager.toggle_traffic_route`
- `firewall_manager.get_port_forward_by_id` *(directly fixes #151)*
- `network_manager.get_wlan_details`
- `tools/port_forwards.list_port_forwards` — `proto`/`fwd` key fix

## Issue #151 context
Reporter saw 23 of 25 port forwards resolve via `unifi_get_port_forward`, while `unifi_list_port_forwards` returned all 25 with valid IDs. The two failures (Tailscale STUN + DERP — the **newest** ObjectIds, listed later) and the success (Tailscale Peer Relay — older ID, listed earlier) match the positional-failure signature exactly. Reporter should see `ERROR Error getting port forward by ID …: '_id'` in their server logs at the moment of failure — that's the smoking gun for this code path.

I couldn't reproduce against my own controller (all rules well-formed locally), but synthetic injection of one `_id`-less rule between two well-formed rules reproduces the symptom with the exact same KeyError. The new tests use real aiounifi `PortForward` / `TrafficRoute` types so the malformed entry actually raises during iteration if regressed.

## Test plan
- [x] `pytest apps/network/tests/unit` — 606 passed, including 2 new regression tests
- [x] Verified commits land cleanly on top of `main`
- [x] Reporter on #151 confirms `unifi_get_port_forward` resolves the previously failing IDs
- [ ] Reporter confirms `unifi_list_port_forwards` now populates `protocol` and `dest_ip` (no longer always `null`)

Closes #151
Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)