### PR TITLE
fix(network): surface controller errors instead of swallowing them

### DIFF
--- a/apps/network/src/unifi_network_mcp/managers/acl_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/acl_manager.py
@@ -43,8 +43,7 @@ class AclManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path="/acl-rules")
             response = await self._connection.request(api_request)
@@ -64,7 +63,7 @@ class AclManager:
             return rules
         except Exception as e:
             logger.error("Error getting ACL rules: %s", e)
-            return []
+            raise
 
     async def get_acl_rule_by_id(self, rule_id: str) -> Optional[Dict[str, Any]]:
         """Get a specific ACL rule by ID.
@@ -82,7 +81,7 @@ class AclManager:
             return next((r for r in rules if r.get("_id") == rule_id), None)
         except Exception as e:
             logger.error("Error getting ACL rule %s: %s", rule_id, e)
-            return None
+            raise
 
     async def create_acl_rule(self, rule_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new MAC ACL rule.
@@ -102,7 +101,7 @@ class AclManager:
             The created ACL rule dictionary, or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         required_keys = {"name", "acl_index", "action", "mac_acl_network_id", "type"}
         missing = required_keys - rule_data.keys()
@@ -136,7 +135,7 @@ class AclManager:
                 return None
         except Exception as e:
             logger.error("Error creating ACL rule: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_acl_rule(self, rule_id: str, update_data: Dict[str, Any]) -> bool:
         """Update an existing MAC ACL rule by merging updates with current state.
@@ -152,7 +151,7 @@ class AclManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             return True  # No action needed
 
@@ -171,7 +170,7 @@ class AclManager:
             return True
         except Exception as e:
             logger.error("Error updating ACL rule %s: %s", rule_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_acl_rule(self, rule_id: str) -> bool:
         """Delete a MAC ACL rule.
@@ -183,7 +182,7 @@ class AclManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="delete", path=f"/acl-rules/{rule_id}")
@@ -193,7 +192,7 @@ class AclManager:
             return True
         except Exception as e:
             logger.error("Error deleting ACL rule %s: %s", rule_id, e, exc_info=True)
-            return False
+            raise
 
     def _invalidate_cache(self):
         """Invalidate all ACL rule caches."""

--- a/apps/network/src/unifi_network_mcp/managers/client_group_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/client_group_manager.py
@@ -39,8 +39,7 @@ class ClientGroupManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path="/network-members-groups")
             response = await self._connection.request(api_request)
@@ -57,7 +56,7 @@ class ClientGroupManager:
             return groups
         except Exception as e:
             logger.error("Error getting client groups: %s", e)
-            return []
+            raise
 
     async def get_client_group_by_id(self, group_id: str) -> Optional[Dict[str, Any]]:
         """Get a specific client group by ID.
@@ -69,7 +68,7 @@ class ClientGroupManager:
             The client group dictionary, or None if not found.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="get", path=f"/network-members-group/{group_id}")
@@ -82,7 +81,7 @@ class ClientGroupManager:
             return None
         except Exception as e:
             logger.error("Error getting client group %s: %s", group_id, e)
-            return None
+            raise
 
     async def create_client_group(self, group_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new client group.
@@ -98,7 +97,7 @@ class ClientGroupManager:
             The created client group dictionary, or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         required_keys = {"name", "members", "type"}
         missing = required_keys - group_data.keys()
@@ -131,7 +130,7 @@ class ClientGroupManager:
                 return None
         except Exception as e:
             logger.error("Error creating client group: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_client_group(self, group_id: str, update_data: Dict[str, Any]) -> bool:
         """Update an existing client group by merging updates with current state.
@@ -144,7 +143,7 @@ class ClientGroupManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             return True
 
@@ -163,7 +162,7 @@ class ClientGroupManager:
             return True
         except Exception as e:
             logger.error("Error updating client group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_client_group(self, group_id: str) -> bool:
         """Delete a client group.
@@ -175,7 +174,7 @@ class ClientGroupManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="delete", path=f"/network-members-group/{group_id}")
@@ -185,7 +184,7 @@ class ClientGroupManager:
             return True
         except Exception as e:
             logger.error("Error deleting client group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise
 
     def _invalidate_cache(self):
         """Invalidate all client group caches."""

--- a/apps/network/src/unifi_network_mcp/managers/client_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/client_manager.py
@@ -25,8 +25,7 @@ class ClientManager:
     async def get_clients(self) -> List[Client]:
         """Get list of currently online clients for the current site."""
         if not await self._connection.ensure_connected() or not self._connection.controller:
-            return []
-
+            raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_CLIENTS}_online_{self._connection.site}"
         cached_data: Optional[List[Client]] = self._connection.get_cached(cache_key)
         if cached_data is not None:
@@ -54,13 +53,12 @@ class ClientManager:
             return clients
         except Exception as e:
             logger.error("Error getting online clients: %s", e)
-            return []
+            raise
 
     async def get_all_clients(self) -> List[Client]:
         """Get list of all clients (including offline/historical) for the current site."""
         if not await self._connection.ensure_connected() or not self._connection.controller:
-            return []
-
+            raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_CLIENTS}_all_{self._connection.site}"
         cached_data: Optional[List[Client]] = self._connection.get_cached(cache_key)
         if cached_data is not None:
@@ -87,7 +85,7 @@ class ClientManager:
             return all_clients
         except Exception as e:
             logger.error("Error getting all clients: %s", e)
-            return []
+            raise
 
     async def get_client_details(self, client_mac: str) -> Optional[Client]:
         """Get detailed information for a specific client by MAC address."""
@@ -113,7 +111,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error blocking client %s: %s", client_mac, e)
-            return False
+            raise
 
     async def unblock_client(self, client_mac: str) -> bool:
         """Unblock a client by MAC address."""
@@ -131,7 +129,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error unblocking client %s: %s", client_mac, e)
-            return False
+            raise
 
     async def rename_client(self, client_mac: str, name: str) -> bool:
         """Rename a client device."""
@@ -161,7 +159,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error renaming client %s to '%s': %s", client_mac, name, e)
-            return False
+            raise
 
     async def force_reconnect_client(self, client_mac: str) -> bool:
         """Force a client to reconnect (kick)."""
@@ -177,7 +175,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error forcing reconnect for client %s: %s", client_mac, e)
-            return False
+            raise
 
     async def forget_client(self, client_mac: str) -> bool:
         """Forget/remove a client from the controller's known client history."""
@@ -193,7 +191,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error forgetting client %s: %s", client_mac, e)
-            return False
+            raise
 
     async def get_blocked_clients(self) -> List[Client]:
         """Get a list of currently blocked clients."""
@@ -228,7 +226,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error authorizing guest %s: %s", client_mac, e)
-            return False
+            raise
 
     async def unauthorize_guest(self, client_mac: str) -> bool:
         """Unauthorize (de-authorize) a guest client."""
@@ -244,7 +242,7 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error unauthorizing guest %s: %s", client_mac, e)
-            return False
+            raise
 
     async def get_client_by_ip(self, ip_address: str) -> Optional[Client]:
         """Get client information by IP address.
@@ -366,4 +364,4 @@ class ClientManager:
             return True
         except Exception as e:
             logger.error("Error setting IP settings for %s: %s", client_mac, e)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/connection_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/connection_manager.py
@@ -432,7 +432,7 @@ class ConnectionManager:
     async def request(self, api_request: ApiRequest | ApiRequestV2, return_raw: bool = False) -> Any:
         """Make a request to the controller API, handling raw responses."""
         if not await self.ensure_connected() or not self.controller:
-            raise ConnectionError("Unifi Controller is not connected.")
+            raise ConnectionError("Not connected to controller")
 
         # Apply override if we have better detection (FR-003: use cached detection)
         original_is_unifi_os = None

--- a/apps/network/src/unifi_network_mcp/managers/content_filter_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/content_filter_manager.py
@@ -50,8 +50,7 @@ class ContentFilterManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path="/content-filtering")
             response = await self._connection.request(api_request)
@@ -68,7 +67,7 @@ class ContentFilterManager:
             return filters
         except Exception as e:
             logger.error("Error getting content filters: %s", e)
-            return []
+            raise
 
     async def get_content_filter_by_id(self, filter_id: str) -> Optional[Dict[str, Any]]:
         """Get a specific content filtering profile by ID.
@@ -96,7 +95,7 @@ class ContentFilterManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             return True
 
@@ -115,7 +114,7 @@ class ContentFilterManager:
             return True
         except Exception as e:
             logger.error("Error updating content filter %s: %s", filter_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_content_filter(self, filter_id: str) -> bool:
         """Delete a content filtering profile.
@@ -127,7 +126,7 @@ class ContentFilterManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="delete", path=f"/content-filtering/{filter_id}")
@@ -137,7 +136,7 @@ class ContentFilterManager:
             return True
         except Exception as e:
             logger.error("Error deleting content filter %s: %s", filter_id, e, exc_info=True)
-            return False
+            raise
 
     def _invalidate_cache(self):
         """Invalidate all content filter caches."""

--- a/apps/network/src/unifi_network_mcp/managers/device_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/device_manager.py
@@ -30,8 +30,7 @@ class DeviceManager:
     async def get_devices(self) -> List[Device]:
         """Get list of devices for the current site."""
         if not await self._connection.ensure_connected() or not self._connection.controller:
-            return []
-
+            raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_DEVICES}_{self._connection.site}"
         cached_data: Optional[List[Device]] = self._connection.get_cached(cache_key)
         if cached_data is not None:
@@ -44,7 +43,7 @@ class DeviceManager:
             return devices
         except Exception as e:
             logger.error("Error getting devices: %s", e)
-            return []
+            raise
 
     async def get_device_details(self, device_mac: str) -> Optional[Device]:
         """Get detailed information for a specific device by MAC address."""
@@ -68,7 +67,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error rebooting device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def rename_device(self, device_mac: str, name: str) -> bool:
         """Rename a device."""
@@ -86,7 +85,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error renaming device %s to '%s': %s", device_mac, name, e)
-            return False
+            raise
 
     async def adopt_device(self, device_mac: str) -> bool:
         """Adopt a device by MAC address."""
@@ -102,7 +101,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error adopting device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def upgrade_device(self, device_mac: str) -> bool:
         """Start firmware upgrade for a device by MAC address."""
@@ -118,7 +117,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error upgrading device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def locate_device(self, device_mac: str, enabled: bool = True) -> bool:
         """Enable or disable device locate (LED blinking).
@@ -142,7 +141,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error setting locate mode on device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def force_provision(self, device_mac: str) -> bool:
         """Force re-provision a device.
@@ -164,7 +163,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error force provisioning device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def get_device_radio(self, device_mac: str) -> Optional[Dict[str, Any]]:
         """Get focused radio configuration and live stats for an AP.
@@ -258,7 +257,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error updating radio '%s' on device %s: %s", radio_id, device_mac, e)
-            return False
+            raise
 
     async def trigger_speedtest(self, gateway_mac: str) -> bool:
         """Trigger a speed test on the gateway.
@@ -280,7 +279,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error triggering speedtest on %s: %s", gateway_mac, e)
-            return False
+            raise
 
     async def get_speedtest_status(self, gateway_mac: str) -> Dict[str, Any]:
         """Get the status of a running speed test.
@@ -301,7 +300,7 @@ class DeviceManager:
             return response if isinstance(response, dict) else {}
         except Exception as e:
             logger.error("Error getting speedtest status for %s: %s", gateway_mac, e)
-            return {}
+            raise
 
     async def list_rogue_aps(self, within_hours: int = 24) -> List[Dict[str, Any]]:
         """List detected rogue access points.
@@ -329,7 +328,7 @@ class DeviceManager:
             return result
         except Exception as e:
             logger.error("Error listing rogue APs: %s", e)
-            return []
+            raise
 
     async def trigger_rf_scan(self, ap_mac: str) -> bool:
         """Trigger an RF spectrum scan on an access point.
@@ -351,7 +350,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error triggering RF scan on %s: %s", ap_mac, e)
-            return False
+            raise
 
     async def get_rf_scan_results(self, ap_mac: str) -> List[Dict[str, Any]]:
         """Get RF spectrum scan results for an access point.
@@ -378,7 +377,7 @@ class DeviceManager:
             return result
         except Exception as e:
             logger.error("Error getting RF scan results for %s: %s", ap_mac, e)
-            return []
+            raise
 
     async def list_available_channels(self) -> List[Dict[str, Any]]:
         """List available wireless channels for the current site.
@@ -402,7 +401,7 @@ class DeviceManager:
             return result
         except Exception as e:
             logger.error("Error listing available channels: %s", e)
-            return []
+            raise
 
     async def list_known_rogue_aps(self) -> List[Dict[str, Any]]:
         """List APs previously classified as known/acknowledged.
@@ -426,7 +425,7 @@ class DeviceManager:
             return result
         except Exception as e:
             logger.error("Error listing known rogue APs: %s", e)
-            return []
+            raise
 
     async def set_device_led_override(self, device_mac: str, led_override: str) -> bool:
         """Set LED override state on a device.
@@ -456,7 +455,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error setting LED override on device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def set_device_disabled(self, device_mac: str, disabled: bool) -> bool:
         """Enable or disable a device without unadopting it.
@@ -486,7 +485,7 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error setting disabled state on device %s: %s", device_mac, e)
-            return False
+            raise
 
     async def set_site_led_enabled(self, enabled: bool) -> bool:
         """Toggle all device LEDs site-wide.
@@ -508,4 +507,4 @@ class DeviceManager:
             return True
         except Exception as e:
             logger.error("Error setting site LED state: %s", e)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/dns_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/dns_manager.py
@@ -29,8 +29,7 @@ class DnsManager:
             List of DNS record dicts.
         """
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_DNS}_{self._connection.site}"
         cached_data = self._connection.get_cached(cache_key, timeout=300)
         if cached_data is not None:
@@ -44,7 +43,7 @@ class DnsManager:
             return result
         except Exception as e:
             logger.error("Error listing DNS records: %s", e, exc_info=True)
-            return []
+            raise
 
     async def get_dns_record(self, record_id: str) -> Optional[Dict[str, Any]]:
         """Get a DNS record by ID.
@@ -65,7 +64,7 @@ class DnsManager:
             return None
         except Exception as e:
             logger.error("Error getting DNS record %s: %s", record_id, e, exc_info=True)
-            return None
+            raise
 
     async def create_dns_record(self, record_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new static DNS record.
@@ -77,7 +76,7 @@ class DnsManager:
             Created record dict with _id, or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="post", path="/static-dns", data=record_data)
@@ -90,7 +89,7 @@ class DnsManager:
             return response
         except Exception as e:
             logger.error("Error creating DNS record: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_dns_record(self, record_id: str, record_data: Dict[str, Any]) -> bool:
         """Update an existing DNS record.
@@ -105,7 +104,7 @@ class DnsManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             current = await self.get_dns_record(record_id)
@@ -122,7 +121,7 @@ class DnsManager:
             return True
         except Exception as e:
             logger.error("Error updating DNS record %s: %s", record_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_dns_record(self, record_id: str) -> bool:
         """Delete a DNS record.
@@ -134,7 +133,7 @@ class DnsManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="delete", path=f"/static-dns/{record_id}")
@@ -143,4 +142,4 @@ class DnsManager:
             return True
         except Exception as e:
             logger.error("Error deleting DNS record %s: %s", record_id, e, exc_info=True)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/dpi_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/dpi_manager.py
@@ -75,7 +75,7 @@ class DpiManager:
                 await session.close()
         except Exception as e:
             logger.error("Error calling integration API %s: %s", path, e)
-            return None
+            raise
 
     async def get_dpi_applications(
         self,

--- a/apps/network/src/unifi_network_mcp/managers/event_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/event_manager.py
@@ -145,7 +145,7 @@ class EventManager:
             return []
         except Exception as e:
             logger.error("Error getting events (v2): %s", e)
-            return []
+            raise
 
     async def _get_events_legacy(
         self,
@@ -174,7 +174,7 @@ class EventManager:
             return []
         except Exception as e:
             logger.error("Error getting events (legacy): %s", e)
-            return []
+            raise
 
     async def get_alarms(
         self,
@@ -227,7 +227,7 @@ class EventManager:
             return []
         except Exception as e:
             logger.error("Error getting alarms (v2): %s", e)
-            return []
+            raise
 
     async def _get_alarms_legacy(self, archived: bool, limit: int) -> List[Dict[str, Any]]:
         """Get alarms using the legacy /stat/alarm API."""
@@ -249,7 +249,7 @@ class EventManager:
             return alarms[:limit]
         except Exception as e:
             logger.error("Error getting alarms (legacy): %s", e)
-            return []
+            raise
 
     def get_event_type_prefixes(self) -> List[Dict[str, str]]:
         """Get a list of known event type prefixes for filtering."""
@@ -291,7 +291,7 @@ class EventManager:
             return True
         except Exception as e:
             logger.error("Error archiving alarm %s: %s", alarm_id, e)
-            return False
+            raise
 
     async def archive_all_alarms(self) -> bool:
         """Archive all active alarms."""
@@ -306,4 +306,4 @@ class EventManager:
             return True
         except Exception as e:
             logger.error("Error archiving all alarms: %s", e)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/firewall_manager.py
@@ -47,8 +47,7 @@ class FirewallManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path="/firewall-policies")
 
@@ -73,7 +72,7 @@ class FirewallManager:
             return result
         except Exception as e:
             logger.error("Error getting firewall policies: %s", e)
-            return []
+            raise
 
     async def toggle_firewall_policy(self, policy_id: str) -> bool:
         """Toggle a firewall policy on/off.
@@ -113,7 +112,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error toggling firewall policy %s: %s", policy_id, e)
-            return False
+            raise
 
     async def update_firewall_policy(self, policy_id: str, updates: Dict[str, Any]) -> bool:
         """Update specific fields of a firewall policy.
@@ -126,7 +125,7 @@ class FirewallManager:
             bool: True if successful, False otherwise.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         if not updates:
             logger.warning("No updates provided for firewall policy %s.", policy_id)
@@ -166,7 +165,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error updating firewall policy %s: %s", policy_id, e, exc_info=True)
-            return False
+            raise
 
     async def get_traffic_routes(self) -> List[TrafficRoute]:
         """Get all traffic routes.
@@ -180,8 +179,7 @@ class FirewallManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path="/trafficroutes")
 
@@ -203,7 +201,7 @@ class FirewallManager:
             return result
         except Exception as e:
             logger.error("Error getting traffic routes: %s", e)
-            return []
+            raise
 
     async def update_traffic_route(self, route_id: str, updates: Dict[str, Any]) -> bool:
         """Update specific fields of a traffic route using the V2 API.
@@ -216,7 +214,7 @@ class FirewallManager:
             bool: True if successful, False otherwise.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not updates:
             logger.warning("No updates provided for traffic route %s.", route_id)
             return True  # No action needed, considered success
@@ -266,7 +264,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error updating traffic route %s via V2: %s", route_id, e, exc_info=True)
-            return False
+            raise
 
     async def toggle_traffic_route(self, route_id: str) -> bool:
         """Toggle a traffic route on/off.
@@ -301,7 +299,7 @@ class FirewallManager:
 
         except Exception as e:
             logger.error("Error toggling traffic route %s: %s", route_id, e, exc_info=True)
-            return False
+            raise
 
     async def create_traffic_route(self, route_data: Dict[str, Any]) -> Optional[Dict]:
         """Create a new traffic route. Returns the created route data dict or None.
@@ -386,7 +384,7 @@ class FirewallManager:
             bool: True if successful, False otherwise.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         try:
             # Use V2 endpoint for deletion
             api_request = ApiRequestV2(method="delete", path=f"/trafficroutes/{route_id}")
@@ -399,7 +397,7 @@ class FirewallManager:
         except Exception as e:
             # Handle specific "not found" errors if possible?
             logger.error("Error deleting traffic route %s: %s", route_id, e, exc_info=True)
-            return False
+            raise
 
     async def get_port_forwards(self) -> List[PortForward]:
         """Get all port forwarding rules.
@@ -412,8 +410,7 @@ class FirewallManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequest(method="get", path="/rest/portforward")
             response = await self._connection.request(api_request)
@@ -432,7 +429,7 @@ class FirewallManager:
             return result
         except Exception as e:
             logger.error("Error getting port forwards: %s", e)
-            return []
+            raise
 
     async def get_port_forward_by_id(self, rule_id: str) -> Optional[PortForward]:
         """Get a specific port forwarding rule by ID.
@@ -451,7 +448,7 @@ class FirewallManager:
             )
         except Exception as e:
             logger.error("Error getting port forward by ID %s: %s", rule_id, e)
-            return None
+            raise
 
     async def update_port_forward(self, rule_id: str, updates: Dict[str, Any]) -> bool:
         """Update specific fields of a port forwarding rule.
@@ -464,7 +461,7 @@ class FirewallManager:
             bool: True if successful, False otherwise.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not updates:
             logger.warning("No updates provided for port forward %s.", rule_id)
             return True  # No action needed, considered success
@@ -506,7 +503,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error updating port forward %s: %s", rule_id, e, exc_info=True)
-            return False
+            raise
 
     async def toggle_port_forward(self, rule_id: str) -> bool:
         """Toggle a port forwarding rule on/off.
@@ -536,7 +533,7 @@ class FirewallManager:
 
         except Exception as e:
             logger.error("Error toggling port forward %s: %s", rule_id, e, exc_info=True)
-            return False
+            raise
 
     async def create_port_forward(self, rule_data: Dict[str, Any]) -> Optional[Dict]:
         """Create a new port forwarding rule. Returns the created rule data dict or None.
@@ -589,7 +586,7 @@ class FirewallManager:
                 e,
                 exc_info=True,
             )
-            return None
+            raise
 
     async def delete_port_forward(self, rule_id: str) -> bool:
         """Delete a port forwarding rule by ID.
@@ -601,7 +598,7 @@ class FirewallManager:
             bool: True if successful, False otherwise.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         try:
             # Use V1 endpoint as aiounifi does
             api_request = ApiRequest(
@@ -616,7 +613,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error deleting port forward %s: %s", rule_id, e, exc_info=True)
-            return False
+            raise
 
     async def create_firewall_policy(self, policy_data: Dict[str, Any]) -> Optional[FirewallPolicy]:
         """Create a new firewall policy using the V2 API.
@@ -629,7 +626,7 @@ class FirewallManager:
             The created FirewallPolicy object, or None if creation failed.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             policy_name = policy_data.get("name", "Unnamed Policy")
@@ -681,7 +678,7 @@ class FirewallManager:
             bool: True if successful, False otherwise.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="delete", path=f"/firewall-policies/{policy_id}")
             await self._connection.request(api_request)
@@ -694,7 +691,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error deleting firewall policy %s: %s", policy_id, e, exc_info=True)
-            return False
+            raise
 
     async def get_firewall_zones(self) -> List[Dict[str, Any]]:
         """Return list of firewall zones via V2 API."""
@@ -703,7 +700,7 @@ class FirewallManager:
         if cached is not None:
             return cached
         if not await self._connection.ensure_connected():
-            return []
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path="/firewall/zones")
             resp = await self._connection.request(api_request)
@@ -712,7 +709,7 @@ class FirewallManager:
             return data
         except Exception as e:
             logger.error("Error fetching firewall zones: %s", e)
-            return []
+            raise
 
     # ---- Firewall Groups (v1 REST: address-group, port-group) ----
 
@@ -731,8 +728,7 @@ class FirewallManager:
             return cached
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequest(method="get", path="/rest/firewallgroup")
             response = await self._connection.request(api_request)
@@ -747,7 +743,7 @@ class FirewallManager:
             return data
         except Exception as e:
             logger.error("Error getting firewall groups: %s", e)
-            return []
+            raise
 
     async def get_firewall_group_by_id(self, group_id: str) -> Optional[Dict[str, Any]]:
         """Get a specific firewall group by ID.
@@ -759,7 +755,7 @@ class FirewallManager:
             The firewall group dictionary, or None if not found.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequest(method="get", path=f"/rest/firewallgroup/{group_id}")
@@ -774,7 +770,7 @@ class FirewallManager:
             return data[0] if data else None
         except Exception as e:
             logger.error("Error getting firewall group %s: %s", group_id, e)
-            return None
+            raise
 
     async def create_firewall_group(self, group_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new firewall group.
@@ -788,7 +784,7 @@ class FirewallManager:
             The created firewall group dictionary, or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         if not group_data.get("name") or not group_data.get("group_type"):
             logger.error("Missing required fields 'name' and/or 'group_type' for firewall group")
@@ -810,7 +806,7 @@ class FirewallManager:
             return data[0] if data else None
         except Exception as e:
             logger.error("Error creating firewall group: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_firewall_group(self, group_id: str, group_data: Dict[str, Any]) -> bool:
         """Update an existing firewall group.
@@ -824,7 +820,7 @@ class FirewallManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequest(method="put", path=f"/rest/firewallgroup/{group_id}", data=group_data)
@@ -834,7 +830,7 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error updating firewall group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_firewall_group(self, group_id: str) -> bool:
         """Delete a firewall group.
@@ -846,7 +842,7 @@ class FirewallManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequest(method="delete", path=f"/rest/firewallgroup/{group_id}")
@@ -856,4 +852,4 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error deleting firewall group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/hotspot_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/hotspot_manager.py
@@ -66,7 +66,7 @@ class HotspotManager:
             return vouchers
         except Exception as e:
             logger.error("Error getting vouchers: %s", e)
-            return []
+            raise
 
     async def get_voucher_details(self, voucher_id: str) -> Optional[Dict[str, Any]]:
         """Get details for a specific voucher by ID.
@@ -85,7 +85,7 @@ class HotspotManager:
             return voucher
         except Exception as e:
             logger.error("Error getting voucher details for %s: %s", voucher_id, e)
-            return None
+            raise
 
     async def create_voucher(
         self,
@@ -160,7 +160,7 @@ class HotspotManager:
 
         except Exception as e:
             logger.error("Error creating voucher: %s", e, exc_info=True)
-            return None
+            raise
 
     async def revoke_voucher(self, voucher_id: str) -> bool:
         """Revoke/delete a voucher by its ID.
@@ -193,4 +193,4 @@ class HotspotManager:
 
         except Exception as e:
             logger.error("Error revoking voucher %s: %s", voucher_id, e, exc_info=True)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/network_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/network_manager.py
@@ -72,7 +72,7 @@ class NetworkManager:
         except Exception as e:
             # Log original error for V1 endpoint failure
             logger.error("Error getting networks via V1 /rest/networkconf: %s", e, exc_info=True)
-            return []
+            raise
 
     async def get_network_details(self, network_id: str) -> Optional[Dict[str, Any]]:
         """Get detailed information for a specific network."""
@@ -117,7 +117,7 @@ class NetworkManager:
 
         except Exception as e:
             logger.error("Error creating network: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_network(self, network_id: str, update_data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         """Update a network configuration by merging updates with existing data.
@@ -132,7 +132,7 @@ class NetworkManager:
             API 400 body) so the caller can surface it instead of a generic guess.
         """
         if not await self._connection.ensure_connected():
-            return False, "Failed to update network: controller connection unavailable"
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             logger.warning("No update data provided for network %s.", network_id)
             return True, None  # No action needed
@@ -159,7 +159,7 @@ class NetworkManager:
             return True, None
         except Exception as e:
             logger.error("Error updating network %s: %s", network_id, e, exc_info=True)
-            return False, str(e)
+            raise
 
     async def delete_network(self, network_id: str) -> bool:
         """Delete a network.
@@ -178,7 +178,7 @@ class NetworkManager:
             return True
         except Exception as e:
             logger.error("Error deleting network %s: %s", network_id, e)
-            return False
+            raise
 
     async def get_wlans(self) -> List[Wlan]:
         """Get list of wireless networks (WLANs) for the current site."""
@@ -196,7 +196,7 @@ class NetworkManager:
             return wlans
         except Exception as e:
             logger.error("Error getting WLANs: %s", e)
-            return []
+            raise
 
     async def get_wlan_details(self, wlan_id: str) -> Optional[Dict[str, Any]]:
         """Get detailed information for a specific wireless network as a dictionary."""
@@ -255,7 +255,7 @@ class NetworkManager:
 
         except Exception as e:
             logger.error("Error creating WLAN: %s", e)
-            return None  # Return None on error
+            raise
 
     async def update_wlan(self, wlan_id: str, update_data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         """Update a WLAN configuration by merging updates with existing data.
@@ -270,7 +270,7 @@ class NetworkManager:
             caller can surface it instead of a generic guess.
         """
         if not await self._connection.ensure_connected():
-            return False, "Failed to update WLAN: controller connection unavailable"
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             logger.warning("No update data provided for WLAN %s.", wlan_id)
             return True, None  # No action needed
@@ -297,7 +297,7 @@ class NetworkManager:
             return True, None
         except Exception as e:
             logger.error("Error updating WLAN %s: %s", wlan_id, e, exc_info=True)
-            return False, str(e)
+            raise
 
     async def delete_wlan(self, wlan_id: str) -> bool:
         """Delete a wireless network.
@@ -316,7 +316,7 @@ class NetworkManager:
             return True
         except Exception as e:
             logger.error("Error deleting WLAN %s: %s", wlan_id, e)
-            return False
+            raise
 
     async def toggle_wlan(self, wlan_id: str) -> bool:
         """Toggle a wireless network on/off.
@@ -345,7 +345,7 @@ class NetworkManager:
             return True
         except Exception as e:
             logger.error("Error toggling WLAN %s: %s", wlan_id, e)
-            return False
+            raise
 
     async def list_ap_groups(self) -> List[Dict[str, Any]]:
         """List all AP groups.
@@ -374,7 +374,7 @@ class NetworkManager:
             return groups
         except Exception as e:
             logger.error("Error listing AP groups: %s", e)
-            return []
+            raise
 
     async def get_ap_group_details(self, group_id: str) -> Optional[Dict[str, Any]]:
         """Get details of a specific AP group by ID.
@@ -394,7 +394,7 @@ class NetworkManager:
             return None
         except Exception as e:
             logger.error("Error getting AP group %s: %s", group_id, e)
-            return None
+            raise
 
     async def create_ap_group(self, group_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new AP group.
@@ -430,7 +430,7 @@ class NetworkManager:
                 return None
         except Exception as e:
             logger.error("Error creating AP group: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_ap_group(self, group_id: str, update_data: Dict[str, Any]) -> bool:
         """Update an existing AP group by merging updates with current state.
@@ -460,7 +460,7 @@ class NetworkManager:
             return True
         except Exception as e:
             logger.error("Error updating AP group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_ap_group(self, group_id: str) -> bool:
         """Delete an AP group.
@@ -479,4 +479,4 @@ class NetworkManager:
             return True
         except Exception as e:
             logger.error("Error deleting AP group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/oon_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/oon_manager.py
@@ -54,8 +54,7 @@ class OonManager:
             return cached_data
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequestV2(method="get", path=OON_PATH_LIST)
             response = await self._connection.request(api_request)
@@ -76,7 +75,7 @@ class OonManager:
                 logger.debug("OON policies not available (controller may not support them): %s", e)
                 return []
             logger.error("Error getting OON policies: %s", e)
-            return []
+            raise
 
     async def get_oon_policy_by_id(self, policy_id: str) -> Optional[Dict[str, Any]]:
         """Get a specific OON policy by ID.
@@ -88,7 +87,7 @@ class OonManager:
             The OON policy dictionary, or None if not found.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequestV2(method="get", path=f"{OON_PATH_SINGLE}/{policy_id}")
@@ -106,7 +105,7 @@ class OonManager:
             return next((p for p in policies if p.get("id", p.get("_id")) == policy_id), None)
         except Exception as e:
             logger.error("Error getting OON policy %s: %s", policy_id, e)
-            return None
+            raise
 
     async def create_oon_policy(self, policy_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new OON policy.
@@ -124,7 +123,7 @@ class OonManager:
             The created OON policy dictionary, or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         if not policy_data.get("name"):
             logger.error("Missing required field 'name' for OON policy")
@@ -164,7 +163,7 @@ class OonManager:
                 return None
         except Exception as e:
             logger.error("Error creating OON policy: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_oon_policy(self, policy_id: str, update_data: Dict[str, Any]) -> bool:
         """Update an existing OON policy by merging updates with current state.
@@ -177,7 +176,7 @@ class OonManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             return True
 
@@ -196,7 +195,7 @@ class OonManager:
             return True
         except Exception as e:
             logger.error("Error updating OON policy %s: %s", policy_id, e, exc_info=True)
-            return False
+            raise
 
     async def toggle_oon_policy(self, policy_id: str) -> Optional[bool]:
         """Toggle an OON policy's enabled state.
@@ -211,7 +210,7 @@ class OonManager:
             The new enabled state (True/False), or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             policy = await self.get_oon_policy_by_id(policy_id)
@@ -229,7 +228,7 @@ class OonManager:
             return new_state
         except Exception as e:
             logger.error("Error toggling OON policy %s: %s", policy_id, e, exc_info=True)
-            return None
+            raise
 
     async def delete_oon_policy(self, policy_id: str) -> bool:
         """Delete an OON policy.
@@ -241,7 +240,7 @@ class OonManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             # DELETE may return 204 No Content
@@ -252,7 +251,7 @@ class OonManager:
             return True
         except Exception as e:
             logger.error("Error deleting OON policy %s: %s", policy_id, e, exc_info=True)
-            return False
+            raise
 
     def _invalidate_cache(self):
         """Invalidate all OON policy caches."""

--- a/apps/network/src/unifi_network_mcp/managers/qos_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/qos_manager.py
@@ -44,7 +44,7 @@ class QosManager:
             return rules
         except Exception as e:
             logger.error("Error getting QoS rules: %s", e)
-            return []
+            raise
 
     async def get_qos_rule_details(self, rule_id: str) -> Optional[Dict[str, Any]]:
         """Get detailed information for a specific QoS rule."""
@@ -56,7 +56,7 @@ class QosManager:
             return rule
         except Exception as e:
             logger.error("Error getting QoS rule details for %s: %s", rule_id, e, exc_info=True)
-            return None
+            raise
 
     async def update_qos_rule(self, rule_id: str, update_data: Dict[str, Any]) -> bool:
         """Update a QoS rule by merging updates with existing data.
@@ -69,7 +69,7 @@ class QosManager:
             bool: True if successful, False otherwise
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             logger.warning("No update data provided for QoS rule %s.", rule_id)
             return True  # No action needed
@@ -96,7 +96,7 @@ class QosManager:
             return True
         except Exception as e:
             logger.error("Error updating QoS rule %s: %s", rule_id, e, exc_info=True)
-            return False
+            raise
 
     async def create_qos_rule(self, rule_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new QoS rule.
@@ -135,7 +135,7 @@ class QosManager:
 
         except Exception as e:
             logger.error("Error creating QoS rule: %s", e)
-            return None
+            raise
 
     async def delete_qos_rule(self, rule_id: str) -> bool:
         """Delete a QoS rule.
@@ -154,4 +154,4 @@ class QosManager:
             return True
         except Exception as e:
             logger.error("Error deleting QoS rule %s: %s", rule_id, e)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/routing_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/routing_manager.py
@@ -55,7 +55,7 @@ class RoutingManager:
             return routes
         except Exception as e:
             logger.error("Error getting routes: %s", e)
-            return []
+            raise
 
     async def get_active_routes(self) -> List[Dict[str, Any]]:
         """Get all active routes (including system routes) from the device.
@@ -87,7 +87,7 @@ class RoutingManager:
                 logger.debug("Active routes endpoint /stat/routing not available on this controller")
             else:
                 logger.error("Error getting active routes: %s", e)
-            return []
+            raise
 
     async def get_route_details(self, route_id: str) -> Optional[Dict[str, Any]]:
         """Get details for a specific route by ID.
@@ -106,7 +106,7 @@ class RoutingManager:
             return route
         except Exception as e:
             logger.error("Error getting route details for %s: %s", route_id, e)
-            return None
+            raise
 
     async def create_route(
         self,
@@ -164,7 +164,7 @@ class RoutingManager:
 
         except Exception as e:
             logger.error("Error creating route: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_route(
         self,
@@ -229,4 +229,4 @@ class RoutingManager:
 
         except Exception as e:
             logger.error("Error updating route %s: %s", route_id, e, exc_info=True)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/stats_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/stats_manager.py
@@ -103,7 +103,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting network stats: %s", e)
-            return []
+            raise
 
     async def get_client_stats(
         self, client_mac: str, duration_hours: int = 1, granularity: str = "hourly"
@@ -143,7 +143,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting stats for client %s: %s", client_mac, e)
-            return []
+            raise
 
     async def get_device_stats(
         self,
@@ -222,7 +222,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting stats for device %s: %s", device_mac, e)
-            return []
+            raise
 
     async def get_top_clients(self, duration_hours: int = 24, limit: int = 10) -> List[Dict[str, Any]]:
         """Get top clients by usage.
@@ -287,7 +287,7 @@ class StatsManager:
             return cached_data
 
         if not await self._connection.ensure_connected() or not self._connection.controller:
-            return {"applications": [], "categories": []}
+            raise ConnectionError("Not connected to controller")
 
         try:
             await self._connection.controller.dpi_apps.update()
@@ -300,7 +300,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting DPI stats: %s", e)
-            return {"applications": [], "categories": []}
+            raise
 
     async def get_alerts(self, include_archived: bool = False) -> List[Event]:  # Changed return type
         """Get alerts from the controller."""
@@ -310,8 +310,7 @@ class StatsManager:
             return cached_data
 
         if not await self._connection.ensure_connected() or not self._connection.controller:
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             await self._connection.controller.alerts.update()
             alerts: List[Event] = list(self._connection.controller.alerts.values())
@@ -321,7 +320,7 @@ class StatsManager:
             return alerts
         except Exception as e:
             logger.error("Error getting alerts: %s", e)
-            return []
+            raise
 
     async def get_gateway_stats(self, duration_hours: int = 24, granularity: str = "hourly") -> List[Dict[str, Any]]:
         """Get gateway statistics."""
@@ -358,7 +357,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting gateway stats: %s", e)
-            return []
+            raise
 
     async def get_speedtest_results(self, duration_hours: int = 24) -> List[Dict[str, Any]]:
         """Get speed test results from the controller archive."""
@@ -389,7 +388,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting speedtest results: %s", e)
-            return []
+            raise
 
     async def get_site_dpi_traffic(self, by: str = "by_app") -> List[Dict[str, Any]]:
         """Get site-level DPI traffic statistics.
@@ -412,7 +411,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting site DPI traffic: %s", e)
-            return []
+            raise
 
     async def get_client_dpi_traffic(self, client_mac: str, by: str = "by_app") -> List[Dict[str, Any]]:
         """Get DPI traffic statistics for a specific client.
@@ -436,7 +435,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting DPI traffic for client %s: %s", client_mac, e)
-            return []
+            raise
 
     async def get_ips_events(self, duration_hours: int = 24, limit: int = 50) -> List[Dict[str, Any]]:
         """Get IPS/IDS events.
@@ -467,7 +466,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting IPS events: %s", e)
-            return []
+            raise
 
     async def get_client_sessions(
         self,
@@ -509,7 +508,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting client sessions: %s", e)
-            return []
+            raise
 
     async def get_dashboard(self) -> List[Dict[str, Any]]:
         """Get the site dashboard summary."""
@@ -527,7 +526,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting dashboard: %s", e)
-            return []
+            raise
 
     async def get_anomalies(self, duration_hours: int = 24) -> List[Dict[str, Any]]:
         """Get detected anomalies.
@@ -556,7 +555,7 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting anomalies: %s", e)
-            return []
+            raise
 
     async def get_client_wifi_details(self, client_mac: str) -> Optional[Dict[str, Any]]:
         """Get detailed WiFi information for a specific client.
@@ -621,4 +620,4 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting WiFi details for client %s: %s", client_mac, e)
-            return None
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/switch_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/switch_manager.py
@@ -45,8 +45,7 @@ class SwitchManager:
             return cached
 
         if not await self._connection.ensure_connected():
-            return []
-
+            raise ConnectionError("Not connected to controller")
         try:
             api_request = ApiRequest(method="get", path="/rest/portconf")
             response = await self._connection.request(api_request)
@@ -61,7 +60,7 @@ class SwitchManager:
             return data
         except Exception as e:
             logger.error("Error getting port profiles: %s", e)
-            return []
+            raise
 
     async def get_port_profile_by_id(self, profile_id: str) -> Optional[Dict[str, Any]]:
         """Get a specific port profile by ID.
@@ -73,7 +72,7 @@ class SwitchManager:
             The port profile dictionary, or None if not found.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequest(method="get", path=f"/rest/portconf/{profile_id}")
@@ -88,7 +87,7 @@ class SwitchManager:
             return data[0] if data else None
         except Exception as e:
             logger.error("Error getting port profile %s: %s", profile_id, e)
-            return None
+            raise
 
     async def create_port_profile(self, profile_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new port profile.
@@ -100,7 +99,7 @@ class SwitchManager:
             The created port profile dictionary, or None on failure.
         """
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         if not profile_data.get("name") or not profile_data.get("forward"):
             logger.error("Missing required fields 'name' and/or 'forward' for port profile")
@@ -122,7 +121,7 @@ class SwitchManager:
             return data[0] if data else None
         except Exception as e:
             logger.error("Error creating port profile: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_port_profile(self, profile_id: str, update_data: Dict[str, Any]) -> bool:
         """Update an existing port profile by merging updates with current state.
@@ -135,7 +134,7 @@ class SwitchManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
         if not update_data:
             return True
 
@@ -154,7 +153,7 @@ class SwitchManager:
             return True
         except Exception as e:
             logger.error("Error updating port profile %s: %s", profile_id, e, exc_info=True)
-            return False
+            raise
 
     async def delete_port_profile(self, profile_id: str) -> bool:
         """Delete a port profile.
@@ -168,7 +167,7 @@ class SwitchManager:
             True on success, False on failure.
         """
         if not await self._connection.ensure_connected():
-            return False
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequest(method="delete", path=f"/rest/portconf/{profile_id}")
@@ -178,14 +177,14 @@ class SwitchManager:
             return True
         except Exception as e:
             logger.error("Error deleting port profile %s: %s", profile_id, e, exc_info=True)
-            return False
+            raise
 
     # ---- Device stat helpers ----
 
     async def _get_device_stat(self, device_mac: str) -> Optional[Dict[str, Any]]:
         """Get raw device stat data for a specific device."""
         if not await self._connection.ensure_connected():
-            return None
+            raise ConnectionError("Not connected to controller")
 
         try:
             api_request = ApiRequest(method="get", path=f"/stat/device/{device_mac}")
@@ -200,7 +199,7 @@ class SwitchManager:
             return data[0] if data else None
         except Exception as e:
             logger.error("Error getting device stat for %s: %s", device_mac, e)
-            return None
+            raise
 
     async def _get_device_id(self, device_mac: str) -> Optional[str]:
         """Get the device _id from its MAC address (needed for REST writes)."""

--- a/apps/network/src/unifi_network_mcp/managers/system_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/system_manager.py
@@ -47,7 +47,7 @@ class SystemManager:
             return info
         except Exception as e:
             logger.error("Error getting system info: %s", e)
-            return {}
+            raise
 
     async def get_controller_status(self) -> Dict[str, Any]:
         """Get status information about the controller."""
@@ -61,7 +61,7 @@ class SystemManager:
             return {}
         except Exception as e:
             logger.error("Error getting controller status: %s", e)
-            return {}
+            raise
 
     async def create_backup(self) -> Optional[Dict[str, Any]]:
         """Create a backup of the controller configuration.
@@ -82,7 +82,7 @@ class SystemManager:
             return None
         except Exception as e:
             logger.error("Error creating backup: %s", e, exc_info=True)
-            return None
+            raise
 
     async def restore_backup(self, backup_data: bytes) -> bool:
         """Restore a controller configuration from backup.
@@ -94,9 +94,7 @@ class SystemManager:
             bool: True if successful, False otherwise
         """
         if not await self._connection.ensure_connected() or not self._connection.controller:
-            logger.error("Cannot restore backup: Controller not connected.")
-            return False
-
+            raise ConnectionError("Not connected to controller")
         try:
             form = aiohttp.FormData()
             form.add_field(
@@ -121,7 +119,7 @@ class SystemManager:
                     return False
         except Exception as e:
             logger.error("Exception during backup restore: %s", e)
-            return False
+            raise
 
     async def list_backups(self) -> List[Dict[str, Any]]:
         """List available backups on the controller.
@@ -139,7 +137,7 @@ class SystemManager:
             return []
         except Exception as e:
             logger.error("Error listing backups: %s", e, exc_info=True)
-            return []
+            raise
 
     async def delete_backup(self, filename: str) -> bool:
         """Delete a backup file from the controller.
@@ -161,7 +159,7 @@ class SystemManager:
             return True
         except Exception as e:
             logger.error("Error deleting backup '%s': %s", filename, e, exc_info=True)
-            return False
+            raise
 
     async def get_autobackup_settings(self) -> Dict[str, Any]:
         """Get auto-backup settings from the controller.
@@ -184,7 +182,7 @@ class SystemManager:
             }
         except Exception as e:
             logger.error("Error getting auto-backup settings: %s", e, exc_info=True)
-            return {}
+            raise
 
     async def update_autobackup_settings(self, settings: Dict[str, Any]) -> bool:
         """Update auto-backup settings on the controller.
@@ -200,7 +198,7 @@ class SystemManager:
             return await self.update_settings("super_mgmt", settings)
         except Exception as e:
             logger.error("Error updating auto-backup settings: %s", e, exc_info=True)
-            return False
+            raise
 
     async def check_firmware_updates(self) -> Dict[str, Any]:
         """Check for firmware updates for devices."""
@@ -217,7 +215,7 @@ class SystemManager:
             return {}
         except Exception as e:
             logger.error("Error checking firmware updates: %s", e)
-            return {}
+            raise
 
     async def upgrade_controller(self) -> bool:
         """Upgrade the controller to the latest version (requires confirmation)."""
@@ -236,7 +234,7 @@ class SystemManager:
             return success
         except Exception as e:
             logger.error("Error upgrading controller: %s", e)
-            return False
+            raise
 
     async def reboot_controller(self) -> bool:
         """Reboot the controller (requires confirmation)."""
@@ -255,7 +253,7 @@ class SystemManager:
             return success
         except Exception as e:
             logger.error("Error rebooting controller: %s", e)
-            return False
+            raise
 
     async def get_settings(self, section: str) -> List[Dict[str, Any]]:  # API returns list
         """Get system settings for a specific section.
@@ -279,7 +277,7 @@ class SystemManager:
             return settings_list
         except Exception as e:
             logger.error("Error getting %s settings: %s", section, e)
-            return []
+            raise
 
     async def update_settings(self, section: str, settings_data: Dict[str, Any]) -> bool:
         """Update system settings for a specific section.
@@ -331,7 +329,7 @@ class SystemManager:
             return success
         except Exception as e:
             logger.error("Error updating %s settings: %s", section, e)
-            return False
+            raise
 
     async def get_network_health(self) -> List[Dict[str, Any]]:
         """Return a summary of the controller network health.
@@ -369,7 +367,7 @@ class SystemManager:
             return health
         except Exception as e:
             logger.error("Error getting network health: %s", e)
-            return []
+            raise
 
     async def get_site_settings(self) -> Dict[str, Any]:
         """Retrieve general settings for the current site.
@@ -389,7 +387,7 @@ class SystemManager:
             return {"raw": settings_list}
         except Exception as e:
             logger.error("Error getting site settings: %s", e)
-            return {}
+            raise
 
     async def get_sites(self) -> List[Site]:  # Changed return type
         """Get a list of all sites in the controller."""
@@ -407,7 +405,7 @@ class SystemManager:
             return sites
         except Exception as e:
             logger.error("Error getting sites: %s", e)
-            return []
+            raise
 
     async def get_site_details(self, site_identifier: str) -> Optional[Site]:  # Changed return type
         """Get detailed information for a specific site by ID, name, or description.
@@ -480,7 +478,7 @@ class SystemManager:
                 return None
         except Exception as e:
             logger.error("Error creating site '%s': %s", name, e)
-            return None
+            raise
 
     async def update_site(self, site_id: str, description: str) -> bool:
         """Update a site's description.
@@ -523,7 +521,7 @@ class SystemManager:
             return success
         except Exception as e:
             logger.error("Error updating site %s: %s", site_id, e)
-            return False
+            raise
 
     async def delete_site(self, site_id: str) -> bool:
         """Delete a site.
@@ -574,7 +572,7 @@ class SystemManager:
             return success
         except Exception as e:
             logger.error("Error deleting site %s: %s", site_id, e)
-            return False
+            raise
 
     async def switch_site(self, site_identifier: str) -> bool:
         """Switch the active site for the connection manager.
@@ -599,7 +597,7 @@ class SystemManager:
             return True
         except Exception as e:
             logger.error("Error switching to site '%s': %s", site_identifier, e)
-            return False
+            raise
 
     async def get_admin_users(self) -> List[Dict[str, Any]]:
         """Get a list of admin users for the controller."""
@@ -616,7 +614,7 @@ class SystemManager:
             return admins
         except Exception as e:
             logger.error("Error getting admin users: %s", e)
-            return []
+            raise
 
     async def get_admin_user_details(self, user_identifier: str) -> Optional[Dict[str, Any]]:
         """Get detailed information for a specific admin user by ID or name.
@@ -698,7 +696,7 @@ class SystemManager:
                 return None
         except Exception as e:
             logger.error("Error creating admin user '%s': %s", name, e)
-            return None
+            raise
 
     async def update_admin_user(
         self,
@@ -771,7 +769,7 @@ class SystemManager:
                 return False
         except Exception as e:
             logger.error("Error updating admin user %s: %s", user_id, e)
-            return False
+            raise
 
     async def delete_admin_user(self, user_id: str) -> bool:
         """Delete an admin user.
@@ -808,7 +806,7 @@ class SystemManager:
                 return False
         except Exception as e:
             logger.error("Error deleting admin user %s: %s", user_id, e)
-            return False
+            raise
 
     async def invite_admin_user(
         self,
@@ -847,7 +845,7 @@ class SystemManager:
                 return False
         except Exception as e:
             logger.error("Error inviting admin user %s: %s", email, e)
-            return False
+            raise
 
     async def get_current_admin_user(self) -> Optional[Dict[str, Any]]:  # Keep as Dict
         """Get information about the currently logged in admin user (based on connection username)."""

--- a/apps/network/src/unifi_network_mcp/managers/traffic_route_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/traffic_route_manager.py
@@ -61,7 +61,7 @@ class TrafficRouteManager:
             return routes
         except Exception as e:
             logger.error("Error getting traffic routes: %s", e)
-            return []
+            raise
 
     async def get_traffic_route_details(self, route_id: str) -> Optional[Dict[str, Any]]:
         """Get details for a specific traffic route by ID.
@@ -80,7 +80,7 @@ class TrafficRouteManager:
             return route
         except Exception as e:
             logger.error("Error getting traffic route details for %s: %s", route_id, e)
-            return None
+            raise
 
     async def update_traffic_route(self, route_id: str, enabled: Optional[bool] = None, **kwargs) -> bool:
         """Update a traffic route.
@@ -129,7 +129,7 @@ class TrafficRouteManager:
 
         except Exception as e:
             logger.error("Error updating traffic route %s: %s", route_id, e, exc_info=True)
-            return False
+            raise
 
     async def toggle_traffic_route(self, route_id: str) -> bool:
         """Toggle a traffic route's enabled state.
@@ -190,4 +190,4 @@ class TrafficRouteManager:
                 e,
                 exc_info=True,
             )
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/usergroup_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/usergroup_manager.py
@@ -55,7 +55,7 @@ class UsergroupManager:
             return usergroups
         except Exception as e:
             logger.error("Error getting user groups: %s", e)
-            return []
+            raise
 
     async def get_usergroup_details(self, group_id: str) -> Optional[Dict[str, Any]]:
         """Get details for a specific user group by ID.
@@ -74,7 +74,7 @@ class UsergroupManager:
             return group
         except Exception as e:
             logger.error("Error getting user group details for %s: %s", group_id, e)
-            return None
+            raise
 
     async def create_usergroup(
         self,
@@ -125,7 +125,7 @@ class UsergroupManager:
 
         except Exception as e:
             logger.error("Error creating user group: %s", e, exc_info=True)
-            return None
+            raise
 
     async def update_usergroup(
         self,
@@ -183,4 +183,4 @@ class UsergroupManager:
 
         except Exception as e:
             logger.error("Error updating user group %s: %s", group_id, e, exc_info=True)
-            return False
+            raise

--- a/apps/network/src/unifi_network_mcp/managers/vpn_manager.py
+++ b/apps/network/src/unifi_network_mcp/managers/vpn_manager.py
@@ -111,7 +111,7 @@ class VpnManager:
             return networks
         except Exception as e:
             logger.error("Error fetching network configurations: %s", e)
-            return []
+            raise
 
     async def get_vpn_configs(self, include_clients: bool = True, include_servers: bool = True) -> List[Dict[str, Any]]:
         """Get VPN configurations from the controller.
@@ -157,7 +157,7 @@ class VpnManager:
 
         except Exception as e:
             logger.error("Error getting VPN configurations: %s", e)
-            return []
+            raise
 
     async def get_vpn_clients(self) -> List[Dict[str, Any]]:
         """Get list of VPN client configurations for the current site.
@@ -246,7 +246,7 @@ class VpnManager:
 
         except Exception as e:
             logger.error("Error updating VPN configuration %s: %s", config_id, e)
-            return False
+            raise
 
     async def update_vpn_client_state(self, client_id: str, enabled: bool) -> bool:
         """Update the enabled state of a VPN client.

--- a/apps/network/src/unifi_network_mcp/tools/port_forwards.py
+++ b/apps/network/src/unifi_network_mcp/tools/port_forwards.py
@@ -625,7 +625,12 @@ async def create_simple_port_forward(
             "message": "Set confirm=true to apply.",
         }
 
-    created = await firewall_manager.create_port_forward(payload)
+    try:
+        created = await firewall_manager.create_port_forward(payload)
+    except Exception as exc:
+        logger.error("Error creating simple port forward: %s", exc, exc_info=True)
+        return {"success": False, "error": f"Failed to create port forward: {exc}"}
+
     if created is None or not isinstance(created, dict):
         return {
             "success": False,

--- a/apps/network/tests/unit/test_acl_manager.py
+++ b/apps/network/tests/unit/test_acl_manager.py
@@ -78,18 +78,16 @@ class TestAclManager:
         """Test get_acl_rules returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        rules = await acl_manager.get_acl_rules()
-
-        assert rules == []
-
+        with pytest.raises(Exception):
+            await acl_manager.get_acl_rules()
     @pytest.mark.asyncio
     async def test_get_acl_rules_not_connected(self, acl_manager, mock_connection):
         """Test get_acl_rules returns empty list when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        rules = await acl_manager.get_acl_rules()
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await acl_manager.get_acl_rules()
 
-        assert rules == []
         mock_connection.request.assert_not_called()
 
     @pytest.mark.asyncio
@@ -130,19 +128,16 @@ class TestAclManager:
         """Test get_acl_rule_by_id returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        rule = await acl_manager.get_acl_rule_by_id("r1")
-
-        assert rule is None
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await acl_manager.get_acl_rule_by_id("r1")
 
     @pytest.mark.asyncio
     async def test_get_acl_rule_by_id_handles_error(self, acl_manager, mock_connection):
         """Test get_acl_rule_by_id returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        rule = await acl_manager.get_acl_rule_by_id("r1")
-
-        assert rule is None
-
+        with pytest.raises(Exception):
+            await acl_manager.get_acl_rule_by_id("r1")
     # ---- create_acl_rule ----
 
     @pytest.mark.asyncio
@@ -178,35 +173,31 @@ class TestAclManager:
         """Test create_acl_rule returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await acl_manager.create_acl_rule(
-            {
-                "name": "Test",
-                "acl_index": 0,
-                "action": "ALLOW",
-                "mac_acl_network_id": "net1",
-                "type": "MAC",
-            }
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await acl_manager.create_acl_rule(
+                {
+                    "name": "Test",
+                    "acl_index": 0,
+                    "action": "ALLOW",
+                    "mac_acl_network_id": "net1",
+                    "type": "MAC",
+                }
+            )
     @pytest.mark.asyncio
     async def test_create_acl_rule_handles_error(self, acl_manager, mock_connection):
         """Test create_acl_rule returns None on API error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await acl_manager.create_acl_rule(
-            {
-                "name": "Test",
-                "acl_index": 0,
-                "action": "ALLOW",
-                "mac_acl_network_id": "net1",
-                "type": "MAC",
-            }
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await acl_manager.create_acl_rule(
+                {
+                    "name": "Test",
+                    "acl_index": 0,
+                    "action": "ALLOW",
+                    "mac_acl_network_id": "net1",
+                    "type": "MAC",
+                }
+            )
     @pytest.mark.asyncio
     async def test_create_acl_rule_handles_data_wrapper(self, acl_manager, mock_connection):
         """Test create_acl_rule handles response with data key."""
@@ -245,19 +236,16 @@ class TestAclManager:
         """Test update_acl_rule returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await acl_manager.update_acl_rule("r1", {"name": "Test"})
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await acl_manager.update_acl_rule("r1", {"name": "Test"})
 
     @pytest.mark.asyncio
     async def test_update_acl_rule_handles_error(self, acl_manager, mock_connection):
         """Test update_acl_rule returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await acl_manager.update_acl_rule("r1", {"name": "Test"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await acl_manager.update_acl_rule("r1", {"name": "Test"})
     @pytest.mark.asyncio
     async def test_update_acl_rule_fetches_and_merges(self, acl_manager, mock_connection):
         """Test update_acl_rule fetches current rule, merges updates, PUTs full object."""
@@ -325,19 +313,16 @@ class TestAclManager:
         """Test delete_acl_rule returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await acl_manager.delete_acl_rule("r1")
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await acl_manager.delete_acl_rule("r1")
 
     @pytest.mark.asyncio
     async def test_delete_acl_rule_handles_error(self, acl_manager, mock_connection):
         """Test delete_acl_rule returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await acl_manager.delete_acl_rule("r1")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await acl_manager.delete_acl_rule("r1")
     # ---- API path verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_backup_tools.py
+++ b/apps/network/tests/unit/test_backup_tools.py
@@ -67,10 +67,8 @@ class TestBackupTools:
         """Test create_backup returns None on error."""
         mock_connection.request.side_effect = Exception("Connection failed")
 
-        result = await system_manager.create_backup()
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await system_manager.create_backup()
     # ---- List Backups ----
 
     @pytest.mark.asyncio
@@ -101,10 +99,8 @@ class TestBackupTools:
         """Test list_backups returns empty list on error."""
         mock_connection.request.side_effect = Exception("Connection failed")
 
-        result = await system_manager.list_backups()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await system_manager.list_backups()
     # ---- Delete Backup ----
 
     @pytest.mark.asyncio
@@ -126,10 +122,8 @@ class TestBackupTools:
         """Test delete_backup returns False on error."""
         mock_connection.request.side_effect = Exception("Failed")
 
-        result = await system_manager.delete_backup("nonexistent.unf")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await system_manager.delete_backup("nonexistent.unf")
     # ---- Auto-Backup Settings ----
 
     @pytest.mark.asyncio
@@ -184,10 +178,8 @@ class TestBackupTools:
         """Test update_autobackup_settings returns False on error."""
         mock_connection.request.side_effect = Exception("Failed")
 
-        result = await system_manager.update_autobackup_settings({"autobackup_enabled": True})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await system_manager.update_autobackup_settings({"autobackup_enabled": True})
     # ---- API Path Verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_client_group_manager.py
+++ b/apps/network/tests/unit/test_client_group_manager.py
@@ -63,18 +63,16 @@ class TestClientGroupManager:
         """Test get_client_groups returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        groups = await client_group_manager.get_client_groups()
-
-        assert groups == []
-
+        with pytest.raises(Exception):
+            await client_group_manager.get_client_groups()
     @pytest.mark.asyncio
     async def test_get_client_groups_not_connected(self, client_group_manager, mock_connection):
         """Test get_client_groups returns empty list when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        groups = await client_group_manager.get_client_groups()
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await client_group_manager.get_client_groups()
 
-        assert groups == []
         mock_connection.request.assert_not_called()
 
     @pytest.mark.asyncio
@@ -103,19 +101,16 @@ class TestClientGroupManager:
         """Test get_client_group_by_id returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        group = await client_group_manager.get_client_group_by_id("g1")
-
-        assert group is None
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await client_group_manager.get_client_group_by_id("g1")
 
     @pytest.mark.asyncio
     async def test_get_client_group_by_id_handles_error(self, client_group_manager, mock_connection):
         """Test get_client_group_by_id returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        group = await client_group_manager.get_client_group_by_id("g1")
-
-        assert group is None
-
+        with pytest.raises(Exception):
+            await client_group_manager.get_client_group_by_id("g1")
     # ---- create_client_group ----
 
     @pytest.mark.asyncio
@@ -147,31 +142,27 @@ class TestClientGroupManager:
         """Test create_client_group returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await client_group_manager.create_client_group(
-            {
-                "name": "Test",
-                "members": [],
-                "type": "CLIENTS",
-            }
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await client_group_manager.create_client_group(
+                {
+                    "name": "Test",
+                    "members": [],
+                    "type": "CLIENTS",
+                }
+            )
     @pytest.mark.asyncio
     async def test_create_client_group_handles_error(self, client_group_manager, mock_connection):
         """Test create_client_group returns None on API error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await client_group_manager.create_client_group(
-            {
-                "name": "Test",
-                "members": [],
-                "type": "CLIENTS",
-            }
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await client_group_manager.create_client_group(
+                {
+                    "name": "Test",
+                    "members": [],
+                    "type": "CLIENTS",
+                }
+            )
     @pytest.mark.asyncio
     async def test_create_client_group_handles_data_wrapper(self, client_group_manager, mock_connection):
         """Test create_client_group handles response with data key."""
@@ -208,19 +199,16 @@ class TestClientGroupManager:
         """Test update_client_group returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await client_group_manager.update_client_group("g1", {"name": "Test"})
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await client_group_manager.update_client_group("g1", {"name": "Test"})
 
     @pytest.mark.asyncio
     async def test_update_client_group_handles_error(self, client_group_manager, mock_connection):
         """Test update_client_group returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await client_group_manager.update_client_group("g1", {"name": "Test"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await client_group_manager.update_client_group("g1", {"name": "Test"})
     @pytest.mark.asyncio
     async def test_update_client_group_fetches_and_merges(self, client_group_manager, mock_connection):
         """Test update_client_group fetches current group, merges, PUTs full object."""
@@ -279,19 +267,16 @@ class TestClientGroupManager:
         """Test delete_client_group returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await client_group_manager.delete_client_group("g1")
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await client_group_manager.delete_client_group("g1")
 
     @pytest.mark.asyncio
     async def test_delete_client_group_handles_error(self, client_group_manager, mock_connection):
         """Test delete_client_group returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await client_group_manager.delete_client_group("g1")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await client_group_manager.delete_client_group("g1")
     # ---- API path verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_client_ip_settings.py
+++ b/apps/network/tests/unit/test_client_ip_settings.py
@@ -186,7 +186,6 @@ class TestClientIPSettings:
             client_mac="xx:xx:xx:xx:xx:xx",
             fixed_ip="192.168.1.100",
         )
-
         assert result is False
 
     @pytest.mark.asyncio
@@ -197,9 +196,7 @@ class TestClientIPSettings:
         result = await client_manager.set_client_ip_settings(
             client_mac="aa:bb:cc:dd:ee:ff",
         )
-
         assert result is False
-
     @pytest.mark.asyncio
     async def test_marks_unnoted_client_as_noted(self, client_manager, mock_connection):
         """Test marks unnoted client as noted before setting IP."""
@@ -245,13 +242,11 @@ class TestClientIPSettings:
         mock_connection.controller.clients_all.values.return_value = [mock_client]
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await client_manager.set_client_ip_settings(
-            client_mac="aa:bb:cc:dd:ee:ff",
-            fixed_ip="192.168.1.100",
-        )
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await client_manager.set_client_ip_settings(
+                client_mac="aa:bb:cc:dd:ee:ff",
+                fixed_ip="192.168.1.100",
+            )
     @pytest.mark.asyncio
     async def test_client_missing_id(self, client_manager, mock_connection):
         """Test returns False when client has no _id."""
@@ -267,5 +262,4 @@ class TestClientIPSettings:
             client_mac="aa:bb:cc:dd:ee:ff",
             fixed_ip="192.168.1.100",
         )
-
         assert result is False

--- a/apps/network/tests/unit/test_content_filter_manager.py
+++ b/apps/network/tests/unit/test_content_filter_manager.py
@@ -64,18 +64,16 @@ class TestContentFilterManager:
         """Test get_content_filters returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        filters = await content_filter_manager.get_content_filters()
-
-        assert filters == []
-
+        with pytest.raises(Exception):
+            await content_filter_manager.get_content_filters()
     @pytest.mark.asyncio
     async def test_get_content_filters_not_connected(self, content_filter_manager, mock_connection):
         """Test get_content_filters returns empty list when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        filters = await content_filter_manager.get_content_filters()
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await content_filter_manager.get_content_filters()
 
-        assert filters == []
         mock_connection.request.assert_not_called()
 
     @pytest.mark.asyncio
@@ -118,10 +116,8 @@ class TestContentFilterManager:
         """Test get_content_filter_by_id returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        profile = await content_filter_manager.get_content_filter_by_id("f1")
-
-        assert profile is None
-
+        with pytest.raises(Exception):
+            await content_filter_manager.get_content_filter_by_id("f1")
     # ---- update_content_filter ----
 
     @pytest.mark.asyncio
@@ -143,19 +139,16 @@ class TestContentFilterManager:
         """Test update_content_filter returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await content_filter_manager.update_content_filter("f1", {"name": "Test"})
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await content_filter_manager.update_content_filter("f1", {"name": "Test"})
 
     @pytest.mark.asyncio
     async def test_update_content_filter_handles_error(self, content_filter_manager, mock_connection):
         """Test update_content_filter returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await content_filter_manager.update_content_filter("f1", {"name": "Test"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await content_filter_manager.update_content_filter("f1", {"name": "Test"})
     @pytest.mark.asyncio
     async def test_update_content_filter_fetches_and_merges(self, content_filter_manager, mock_connection):
         """Test update_content_filter fetches current profile, merges, PUTs full object."""
@@ -218,19 +211,16 @@ class TestContentFilterManager:
         """Test delete_content_filter returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await content_filter_manager.delete_content_filter("f1")
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await content_filter_manager.delete_content_filter("f1")
 
     @pytest.mark.asyncio
     async def test_delete_content_filter_handles_error(self, content_filter_manager, mock_connection):
         """Test delete_content_filter returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await content_filter_manager.delete_content_filter("f1")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await content_filter_manager.delete_content_filter("f1")
     # ---- API path verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_device_commands.py
+++ b/apps/network/tests/unit/test_device_commands.py
@@ -58,10 +58,8 @@ class TestDeviceCommands:
         """Test locate_device returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await device_manager.locate_device("aa:bb:cc:dd:ee:ff", True)
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await device_manager.locate_device("aa:bb:cc:dd:ee:ff", True)
     # ---- force_provision ----
 
     @pytest.mark.asyncio
@@ -83,6 +81,5 @@ class TestDeviceCommands:
         """Test force_provision returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await device_manager.force_provision("aa:bb:cc:dd:ee:ff")
-
-        assert result is False
+        with pytest.raises(Exception):
+            await device_manager.force_provision("aa:bb:cc:dd:ee:ff")

--- a/apps/network/tests/unit/test_device_radio.py
+++ b/apps/network/tests/unit/test_device_radio.py
@@ -282,11 +282,8 @@ class TestDeviceManagerUpdateRadio:
         mock_connection.controller.devices.values.return_value = [ap]
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await device_manager.update_device_radio(ap.mac, "na", {"tx_power_mode": "high"})
-
-        assert result is False
-
-
+        with pytest.raises(Exception):
+            await device_manager.update_device_radio(ap.mac, "na", {"tx_power_mode": "high"})
 class TestUpdateDeviceRadioTool:
     """Tests for the unifi_update_device_radio tool function validation logic."""
 

--- a/apps/network/tests/unit/test_dns_manager.py
+++ b/apps/network/tests/unit/test_dns_manager.py
@@ -62,10 +62,8 @@ class TestDnsManager:
         """Test list_dns_records returns empty list on error."""
         mock_connection.request.side_effect = Exception("Connection failed")
 
-        result = await dns_manager.list_dns_records()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await dns_manager.list_dns_records()
     # ---- Get DNS Record ----
 
     @pytest.mark.asyncio
@@ -112,10 +110,8 @@ class TestDnsManager:
         """Test create_dns_record returns None on error."""
         mock_connection.request.side_effect = Exception("Failed")
 
-        result = await dns_manager.create_dns_record({"key": "fail.example.com"})
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await dns_manager.create_dns_record({"key": "fail.example.com"})
     # ---- Update DNS Record ----
 
     @pytest.mark.asyncio
@@ -148,10 +144,8 @@ class TestDnsManager:
         """Test update_dns_record returns False on error."""
         mock_connection.request.side_effect = Exception("Failed")
 
-        result = await dns_manager.update_dns_record("r1", {"value": "10.0.0.2"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await dns_manager.update_dns_record("r1", {"value": "10.0.0.2"})
     # ---- Delete DNS Record ----
 
     @pytest.mark.asyncio
@@ -173,10 +167,8 @@ class TestDnsManager:
         """Test delete_dns_record returns False on error."""
         mock_connection.request.side_effect = Exception("Failed")
 
-        result = await dns_manager.delete_dns_record("r1")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await dns_manager.delete_dns_record("r1")
     # ---- API Path Verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -63,9 +63,9 @@ class TestEventManagerV2:
     @pytest.mark.asyncio
     async def test_get_events_handles_error(self, event_manager, mock_connection):
         mock_connection.request.side_effect = Exception("Network error")
-        events = await event_manager.get_events()
-        assert events == []
 
+        with pytest.raises(Exception):
+            await event_manager.get_events()
     @pytest.mark.asyncio
     async def test_get_alarms_v2(self, event_manager, mock_connection):
         mock_connection.request.return_value = [
@@ -143,9 +143,9 @@ class TestEventManagerLegacy:
     @pytest.mark.asyncio
     async def test_get_events_handles_error(self, event_manager, mock_connection):
         mock_connection.request.side_effect = Exception("Network error")
-        events = await event_manager.get_events()
-        assert events == []
 
+        with pytest.raises(Exception):
+            await event_manager.get_events()
     @pytest.mark.asyncio
     async def test_get_alarms_returns_list(self, event_manager, mock_connection):
         mock_alarms = [
@@ -213,9 +213,9 @@ class TestEventManagerCommon:
     @pytest.mark.asyncio
     async def test_archive_alarm_failure(self, event_manager, mock_connection):
         mock_connection.request.side_effect = Exception("API error")
-        result = await event_manager.archive_alarm("alarm123")
-        assert result is False
 
+        with pytest.raises(Exception):
+            await event_manager.archive_alarm("alarm123")
     @pytest.mark.asyncio
     async def test_archive_all_alarms_success(self, event_manager, mock_connection):
         mock_connection.request.return_value = {}
@@ -225,9 +225,9 @@ class TestEventManagerCommon:
     @pytest.mark.asyncio
     async def test_archive_all_alarms_failure(self, event_manager, mock_connection):
         mock_connection.request.side_effect = Exception("API error")
-        result = await event_manager.archive_all_alarms()
-        assert result is False
 
+        with pytest.raises(Exception):
+            await event_manager.archive_all_alarms()
     @pytest.mark.asyncio
     async def test_auto_detect_v2(self, event_manager, mock_connection):
         """Test that v2 API is detected when system-log/count succeeds."""

--- a/apps/network/tests/unit/test_firewall_groups.py
+++ b/apps/network/tests/unit/test_firewall_groups.py
@@ -63,18 +63,15 @@ class TestFirewallGroups:
         """Test get_firewall_groups returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        groups = await firewall_manager.get_firewall_groups()
-
-        assert groups == []
-
+        with pytest.raises(Exception):
+            await firewall_manager.get_firewall_groups()
     @pytest.mark.asyncio
     async def test_get_firewall_groups_not_connected(self, firewall_manager, mock_connection):
         """Test get_firewall_groups returns empty list when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        groups = await firewall_manager.get_firewall_groups()
-
-        assert groups == []
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await firewall_manager.get_firewall_groups()
 
     # ---- get_firewall_group_by_id ----
 
@@ -96,19 +93,16 @@ class TestFirewallGroups:
         """Test get_firewall_group_by_id returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        group = await firewall_manager.get_firewall_group_by_id("g1")
-
-        assert group is None
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await firewall_manager.get_firewall_group_by_id("g1")
 
     @pytest.mark.asyncio
     async def test_get_firewall_group_by_id_handles_error(self, firewall_manager, mock_connection):
         """Test get_firewall_group_by_id returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        group = await firewall_manager.get_firewall_group_by_id("g1")
-
-        assert group is None
-
+        with pytest.raises(Exception):
+            await firewall_manager.get_firewall_group_by_id("g1")
     @pytest.mark.asyncio
     async def test_get_firewall_group_by_id_empty_data(self, firewall_manager, mock_connection):
         """Test get_firewall_group_by_id returns None when data array is empty."""
@@ -160,23 +154,19 @@ class TestFirewallGroups:
         """Test create_firewall_group returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await firewall_manager.create_firewall_group(
-            {"name": "Test", "group_type": "address-group", "group_members": []}
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await firewall_manager.create_firewall_group(
+                {"name": "Test", "group_type": "address-group", "group_members": []}
+            )
     @pytest.mark.asyncio
     async def test_create_firewall_group_handles_error(self, firewall_manager, mock_connection):
         """Test create_firewall_group returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await firewall_manager.create_firewall_group(
-            {"name": "Test", "group_type": "address-group", "group_members": []}
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await firewall_manager.create_firewall_group(
+                {"name": "Test", "group_type": "address-group", "group_members": []}
+            )
     # ---- update_firewall_group ----
 
     @pytest.mark.asyncio
@@ -196,19 +186,16 @@ class TestFirewallGroups:
         """Test update_firewall_group returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await firewall_manager.update_firewall_group("g1", {"name": "Test"})
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await firewall_manager.update_firewall_group("g1", {"name": "Test"})
 
     @pytest.mark.asyncio
     async def test_update_firewall_group_handles_error(self, firewall_manager, mock_connection):
         """Test update_firewall_group returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await firewall_manager.update_firewall_group("g1", {"name": "Test"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await firewall_manager.update_firewall_group("g1", {"name": "Test"})
     # ---- delete_firewall_group ----
 
     @pytest.mark.asyncio
@@ -226,19 +213,16 @@ class TestFirewallGroups:
         """Test delete_firewall_group returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await firewall_manager.delete_firewall_group("g1")
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await firewall_manager.delete_firewall_group("g1")
 
     @pytest.mark.asyncio
     async def test_delete_firewall_group_handles_error(self, firewall_manager, mock_connection):
         """Test delete_firewall_group returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await firewall_manager.delete_firewall_group("g1")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await firewall_manager.delete_firewall_group("g1")
     # ---- API path verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -109,9 +109,9 @@ class TestUpdateTrafficRouteMutationSafety:
         mock_connection.request = AsyncMock(side_effect=Exception("API error"))
 
         with patch.object(firewall_manager, "get_traffic_routes", new_callable=AsyncMock, return_value=[route]):
-            result = await firewall_manager.update_traffic_route("route001", {"description": "Should not persist"})
+            with pytest.raises(Exception, match="API error"):
+                await firewall_manager.update_traffic_route("route001", {"description": "Should not persist"})
 
-        assert result is False
         assert route.raw == original_raw
 
 

--- a/apps/network/tests/unit/test_forget_client.py
+++ b/apps/network/tests/unit/test_forget_client.py
@@ -52,10 +52,8 @@ class TestForgetClient:
         """Test forget client returns False on API error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await client_manager.forget_client("AA:BB:CC:DD:EE:FF")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await client_manager.forget_client("AA:BB:CC:DD:EE:FF")
     @pytest.mark.asyncio
     async def test_forget_client_invalidates_cache(self, client_manager, mock_connection):
         """Test that cache is invalidated after forgetting a client."""

--- a/apps/network/tests/unit/test_hotspot_manager.py
+++ b/apps/network/tests/unit/test_hotspot_manager.py
@@ -88,10 +88,8 @@ class TestHotspotManager:
         """Test get_vouchers returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        vouchers = await hotspot_manager.get_vouchers()
-
-        assert vouchers == []
-
+        with pytest.raises(Exception):
+            await hotspot_manager.get_vouchers()
     @pytest.mark.asyncio
     async def test_get_voucher_details_found(self, hotspot_manager, mock_connection):
         """Test get_voucher_details returns voucher when found."""
@@ -175,10 +173,8 @@ class TestHotspotManager:
         """Test create_voucher returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await hotspot_manager.create_voucher(expire_minutes=60)
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await hotspot_manager.create_voucher(expire_minutes=60)
     @pytest.mark.asyncio
     async def test_revoke_voucher_success(self, hotspot_manager, mock_connection):
         """Test revoke_voucher returns True on success."""
@@ -206,6 +202,5 @@ class TestHotspotManager:
         """Test revoke_voucher returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await hotspot_manager.revoke_voucher("voucher123")
-
-        assert result is False
+        with pytest.raises(Exception):
+            await hotspot_manager.revoke_voucher("voucher123")

--- a/apps/network/tests/unit/test_oon_manager.py
+++ b/apps/network/tests/unit/test_oon_manager.py
@@ -63,27 +63,26 @@ class TestOonManager:
         """Test get_oon_policies returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        policies = await oon_manager.get_oon_policies()
-
-        assert policies == []
-
+        with pytest.raises(Exception):
+            await oon_manager.get_oon_policies()
     @pytest.mark.asyncio
     async def test_get_oon_policies_handles_404(self, oon_manager, mock_connection):
         """Test get_oon_policies returns empty list on 404 (unsupported controller)."""
         mock_connection.request.side_effect = Exception("404 Not Found")
 
-        policies = await oon_manager.get_oon_policies()
-
-        assert policies == []
+        # 404 is a legitimate fallback path: returns empty list when the
+        # controller does not support OON policies. Other errors raise.
+        result = await oon_manager.get_oon_policies()
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_get_oon_policies_not_connected(self, oon_manager, mock_connection):
         """Test get_oon_policies returns empty list when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        policies = await oon_manager.get_oon_policies()
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await oon_manager.get_oon_policies()
 
-        assert policies == []
         mock_connection.request.assert_not_called()
 
     # ---- get_oon_policy_by_id ----
@@ -103,19 +102,16 @@ class TestOonManager:
         """Test get_oon_policy_by_id returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        policy = await oon_manager.get_oon_policy_by_id("p1")
-
-        assert policy is None
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await oon_manager.get_oon_policy_by_id("p1")
 
     @pytest.mark.asyncio
     async def test_get_oon_policy_by_id_handles_error(self, oon_manager, mock_connection):
         """Test get_oon_policy_by_id returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        policy = await oon_manager.get_oon_policy_by_id("p1")
-
-        assert policy is None
-
+        with pytest.raises(Exception):
+            await oon_manager.get_oon_policy_by_id("p1")
     # ---- create_oon_policy ----
 
     @pytest.mark.asyncio
@@ -161,9 +157,8 @@ class TestOonManager:
         """Test create_oon_policy returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await oon_manager.create_oon_policy({"name": "Test"})
-
-        assert result is None
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await oon_manager.create_oon_policy({"name": "Test"})
 
     @pytest.mark.asyncio
     async def test_create_oon_policy_handles_data_wrapper(self, oon_manager, mock_connection):
@@ -179,10 +174,8 @@ class TestOonManager:
         """Test create_oon_policy returns None on API error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await oon_manager.create_oon_policy({"name": "Test"})
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await oon_manager.create_oon_policy({"name": "Test"})
     # ---- update_oon_policy ----
 
     @pytest.mark.asyncio
@@ -204,19 +197,16 @@ class TestOonManager:
         """Test update_oon_policy returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await oon_manager.update_oon_policy("p1", {"name": "Test"})
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await oon_manager.update_oon_policy("p1", {"name": "Test"})
 
     @pytest.mark.asyncio
     async def test_update_oon_policy_handles_error(self, oon_manager, mock_connection):
         """Test update_oon_policy returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await oon_manager.update_oon_policy("p1", {"name": "Test"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await oon_manager.update_oon_policy("p1", {"name": "Test"})
     @pytest.mark.asyncio
     async def test_update_oon_policy_fetches_and_merges(self, oon_manager, mock_connection):
         """Test update_oon_policy fetches current policy, merges, PUTs full object."""
@@ -251,10 +241,8 @@ class TestOonManager:
         """Test update_oon_policy returns False when policy not found."""
         mock_connection.request.side_effect = Exception("Not found")
 
-        result = await oon_manager.update_oon_policy("nonexistent", {"name": "Test"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await oon_manager.update_oon_policy("nonexistent", {"name": "Test"})
     @pytest.mark.asyncio
     async def test_update_oon_policy_empty_update(self, oon_manager, mock_connection):
         """Test update_oon_policy with empty data is a no-op."""
@@ -294,9 +282,9 @@ class TestOonManager:
         """Test toggle_oon_policy returns None when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await oon_manager.toggle_oon_policy("p1")
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await oon_manager.toggle_oon_policy("p1")
 
-        assert result is None
         mock_connection.request.assert_not_called()
 
     @pytest.mark.asyncio
@@ -337,19 +325,16 @@ class TestOonManager:
         """Test delete_oon_policy returns False when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        result = await oon_manager.delete_oon_policy("p1")
-
-        assert result is False
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await oon_manager.delete_oon_policy("p1")
 
     @pytest.mark.asyncio
     async def test_delete_oon_policy_handles_error(self, oon_manager, mock_connection):
         """Test delete_oon_policy returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await oon_manager.delete_oon_policy("p1")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await oon_manager.delete_oon_policy("p1")
     # ---- API path verification ----
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_routing_manager.py
+++ b/apps/network/tests/unit/test_routing_manager.py
@@ -70,10 +70,8 @@ class TestRoutingManager:
         """Test get_routes returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        routes = await routing_manager.get_routes()
-
-        assert routes == []
-
+        with pytest.raises(Exception):
+            await routing_manager.get_routes()
     @pytest.mark.asyncio
     async def test_get_active_routes_returns_list(self, routing_manager, mock_connection):
         """Test get_active_routes returns active routing table."""
@@ -96,10 +94,8 @@ class TestRoutingManager:
         """Test get_active_routes returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        routes = await routing_manager.get_active_routes()
-
-        assert routes == []
-
+        with pytest.raises(Exception):
+            await routing_manager.get_active_routes()
     @pytest.mark.asyncio
     async def test_get_route_details_found(self, routing_manager, mock_connection):
         """Test get_route_details returns route when found."""
@@ -180,14 +176,12 @@ class TestRoutingManager:
         """Test create_route returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await routing_manager.create_route(
-            name="Test",
-            static_route_network="10.0.0.0/24",
-            static_route_nexthop="192.168.1.1",
-        )
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await routing_manager.create_route(
+                name="Test",
+                static_route_network="10.0.0.0/24",
+                static_route_nexthop="192.168.1.1",
+            )
     @pytest.mark.asyncio
     async def test_update_route_success(self, routing_manager, mock_connection):
         """Test update_route with valid parameters."""
@@ -238,9 +232,7 @@ class TestRoutingManager:
             route_id="nonexistent",
             name="Test",
         )
-
         assert result is False
-
     @pytest.mark.asyncio
     async def test_update_route_no_updates(self, routing_manager, mock_connection):
         """Test update_route with no changes still succeeds (sends full object)."""
@@ -268,12 +260,11 @@ class TestRoutingManager:
 
     @pytest.mark.asyncio
     async def test_update_route_handles_error(self, routing_manager, mock_connection):
-        """Test update_route returns False on error."""
+        """Test update_route raises on API error."""
         mock_connection.request.side_effect = [
             [{"_id": "r1", "name": "Test"}],
             Exception("API error"),
         ]
 
-        result = await routing_manager.update_route(route_id="r1", name="New")
-
-        assert result is False
+        with pytest.raises(Exception, match="API error"):
+            await routing_manager.update_route(route_id="r1", name="New")

--- a/apps/network/tests/unit/test_stats_enhanced.py
+++ b/apps/network/tests/unit/test_stats_enhanced.py
@@ -425,37 +425,29 @@ class TestStatsManagerEnhanced:
         """Test get_gateway_stats returns empty list on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await stats_manager.get_gateway_stats()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await stats_manager.get_gateway_stats()
     @pytest.mark.asyncio
     async def test_get_ips_events_handles_error(self, stats_manager, mock_connection):
         """Test get_ips_events returns empty list on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await stats_manager.get_ips_events()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await stats_manager.get_ips_events()
     @pytest.mark.asyncio
     async def test_get_dashboard_handles_error(self, stats_manager, mock_connection):
         """Test get_dashboard returns empty list on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await stats_manager.get_dashboard()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await stats_manager.get_dashboard()
     @pytest.mark.asyncio
     async def test_get_client_wifi_details_handles_error(self, stats_manager, mock_connection):
         """Test get_client_wifi_details returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await stats_manager.get_client_wifi_details("aa:bb:cc:dd:ee:ff")
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await stats_manager.get_client_wifi_details("aa:bb:cc:dd:ee:ff")
     # ---- Cache tests ----
 
     @pytest.mark.asyncio
@@ -517,10 +509,8 @@ class TestDeviceManagerSpeedtest:
         """Test trigger_speedtest returns False on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await device_manager.trigger_speedtest("aa:bb:cc:dd:ee:ff")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await device_manager.trigger_speedtest("aa:bb:cc:dd:ee:ff")
     @pytest.mark.asyncio
     async def test_get_speedtest_status(self, device_manager, mock_connection):
         """Test get_speedtest_status sends correct command."""
@@ -538,6 +528,5 @@ class TestDeviceManagerSpeedtest:
         """Test get_speedtest_status returns empty dict on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await device_manager.get_speedtest_status("aa:bb:cc:dd:ee:ff")
-
-        assert result == {}
+        with pytest.raises(Exception):
+            await device_manager.get_speedtest_status("aa:bb:cc:dd:ee:ff")

--- a/apps/network/tests/unit/test_switch_manager.py
+++ b/apps/network/tests/unit/test_switch_manager.py
@@ -66,19 +66,16 @@ class TestSwitchManager:
         """Test get_port_profiles returns empty when not connected."""
         mock_connection.ensure_connected.return_value = False
 
-        profiles = await switch_manager.get_port_profiles()
-
-        assert profiles == []
+        with pytest.raises(ConnectionError, match="Not connected to controller"):
+            await switch_manager.get_port_profiles()
 
     @pytest.mark.asyncio
     async def test_get_port_profiles_handles_error(self, switch_manager, mock_connection):
         """Test get_port_profiles returns empty on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        profiles = await switch_manager.get_port_profiles()
-
-        assert profiles == []
-
+        with pytest.raises(Exception):
+            await switch_manager.get_port_profiles()
     @pytest.mark.asyncio
     async def test_get_port_profile_by_id_found(self, switch_manager, mock_connection):
         """Test get_port_profile_by_id returns profile."""

--- a/apps/network/tests/unit/test_system_manager.py
+++ b/apps/network/tests/unit/test_system_manager.py
@@ -74,10 +74,8 @@ class TestGetSystemInfo:
         """Test that an exception returns an empty dict."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        result = await system_manager.get_system_info()
-
-        assert result == {}
-
+        with pytest.raises(Exception):
+            await system_manager.get_system_info()
     @pytest.mark.asyncio
     async def test_cache_hit(self, system_manager, mock_connection):
         """Test that cached data is returned without making a request."""
@@ -162,11 +160,8 @@ class TestGetControllerStatus:
         """Test that an exception returns an empty dict."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await system_manager.get_controller_status()
-
-        assert result == {}
-
-
+        with pytest.raises(Exception):
+            await system_manager.get_controller_status()
 class TestCheckFirmwareUpdates:
     """Tests for SystemManager.check_firmware_updates()."""
 
@@ -229,11 +224,8 @@ class TestCheckFirmwareUpdates:
         """Test that an exception returns an empty dict."""
         mock_connection.request.side_effect = Exception("Timeout")
 
-        result = await system_manager.check_firmware_updates()
-
-        assert result == {}
-
-
+        with pytest.raises(Exception):
+            await system_manager.check_firmware_updates()
 class TestGetNetworkHealth:
     """Tests for SystemManager.get_network_health().
 
@@ -316,9 +308,8 @@ class TestGetNetworkHealth:
         """Test that an exception returns an empty list."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        result = await system_manager.get_network_health()
-
-        assert result == []
+        with pytest.raises(Exception):
+            await system_manager.get_network_health()
         mock_connection.request.assert_called_once()
 
     @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_usergroup_manager.py
+++ b/apps/network/tests/unit/test_usergroup_manager.py
@@ -72,10 +72,8 @@ class TestUsergroupManager:
         """Test get_usergroups returns empty list on error."""
         mock_connection.request.side_effect = Exception("Network error")
 
-        groups = await usergroup_manager.get_usergroups()
-
-        assert groups == []
-
+        with pytest.raises(Exception):
+            await usergroup_manager.get_usergroups()
     @pytest.mark.asyncio
     async def test_get_usergroup_details_found(self, usergroup_manager, mock_connection):
         """Test get_usergroup_details returns group when found."""
@@ -141,10 +139,8 @@ class TestUsergroupManager:
         """Test create_usergroup returns None on error."""
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await usergroup_manager.create_usergroup(name="Test")
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await usergroup_manager.create_usergroup(name="Test")
     @pytest.mark.asyncio
     async def test_update_usergroup_success(self, usergroup_manager, mock_connection):
         """Test update_usergroup with valid parameters."""
@@ -177,9 +173,7 @@ class TestUsergroupManager:
             group_id="nonexistent",
             name="Test",
         )
-
         assert result is False
-
     @pytest.mark.asyncio
     async def test_update_usergroup_no_updates(self, usergroup_manager, mock_connection):
         """Test update_usergroup returns False when no updates provided."""
@@ -203,12 +197,11 @@ class TestUsergroupManager:
 
     @pytest.mark.asyncio
     async def test_update_usergroup_handles_error(self, usergroup_manager, mock_connection):
-        """Test update_usergroup returns False on error."""
+        """Test update_usergroup raises on API error."""
         mock_connection.request.side_effect = [
             [{"_id": "g1", "name": "Test"}],  # get_usergroups succeeds
             Exception("API error"),  # update fails
         ]
 
-        result = await usergroup_manager.update_usergroup(group_id="g1", name="New")
-
-        assert result is False
+        with pytest.raises(Exception, match="API error"):
+            await usergroup_manager.update_usergroup(group_id="g1", name="New")

--- a/apps/network/tests/unit/test_wifi_tools.py
+++ b/apps/network/tests/unit/test_wifi_tools.py
@@ -72,10 +72,8 @@ class TestDeviceManagerWifi:
         """Test list_rogue_aps returns empty list on exception."""
         mock_connection.request.side_effect = Exception("Connection failed")
 
-        result = await device_manager.list_rogue_aps()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await device_manager.list_rogue_aps()
     # ---- Known Rogue APs ----
 
     @pytest.mark.asyncio
@@ -101,10 +99,8 @@ class TestDeviceManagerWifi:
         """Test list_known_rogue_aps returns empty list on exception."""
         mock_connection.request.side_effect = Exception("Connection failed")
 
-        result = await device_manager.list_known_rogue_aps()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await device_manager.list_known_rogue_aps()
     # ---- RF Scan ----
 
     @pytest.mark.asyncio
@@ -126,10 +122,8 @@ class TestDeviceManagerWifi:
         """Test trigger_rf_scan returns False on exception."""
         mock_connection.request.side_effect = Exception("AP unreachable")
 
-        result = await device_manager.trigger_rf_scan("aa:bb:cc:dd:ee:ff")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await device_manager.trigger_rf_scan("aa:bb:cc:dd:ee:ff")
     @pytest.mark.asyncio
     async def test_get_rf_scan_results(self, device_manager, mock_connection):
         """Test get_rf_scan_results calls GET /stat/spectrum-scan/{mac}."""
@@ -154,10 +148,8 @@ class TestDeviceManagerWifi:
         """Test get_rf_scan_results returns empty list on error."""
         mock_connection.request.side_effect = Exception("Not found")
 
-        result = await device_manager.get_rf_scan_results("aa:bb:cc:dd:ee:ff")
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await device_manager.get_rf_scan_results("aa:bb:cc:dd:ee:ff")
     # ---- Available Channels ----
 
     @pytest.mark.asyncio
@@ -219,10 +211,8 @@ class TestDeviceManagerWifi:
         mock_connection.controller.devices.values = MagicMock(return_value=[mock_device])
         mock_connection.request.side_effect = Exception("API error")
 
-        result = await device_manager.set_device_led_override("aa:bb:cc:dd:ee:ff", "on")
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await device_manager.set_device_led_override("aa:bb:cc:dd:ee:ff", "on")
     # ---- Device Disabled ----
 
     @pytest.mark.asyncio
@@ -347,10 +337,8 @@ class TestNetworkManagerApGroups:
         """Test list_ap_groups returns empty list on exception."""
         mock_connection.request.side_effect = Exception("Connection failed")
 
-        result = await network_manager.list_ap_groups()
-
-        assert result == []
-
+        with pytest.raises(Exception):
+            await network_manager.list_ap_groups()
     # ---- Get AP Group Details ----
 
     @pytest.mark.asyncio
@@ -373,10 +361,8 @@ class TestNetworkManagerApGroups:
         """Test get_ap_group_details returns None when group not found."""
         mock_connection.request.side_effect = Exception("Not found")
 
-        result = await network_manager.get_ap_group_details("nonexistent")
-
-        assert result is None
-
+        with pytest.raises(Exception):
+            await network_manager.get_ap_group_details("nonexistent")
     # ---- Create AP Group ----
 
     @pytest.mark.asyncio
@@ -433,10 +419,8 @@ class TestNetworkManagerApGroups:
         """Test update_ap_group returns False when group not found."""
         mock_connection.request.side_effect = Exception("Not found")
 
-        result = await network_manager.update_ap_group("nonexistent", {"name": "New Name"})
-
-        assert result is False
-
+        with pytest.raises(Exception):
+            await network_manager.update_ap_group("nonexistent", {"name": "New Name"})
     # ---- Delete AP Group ----
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #156. Sub-issue of #154.

## Problem

Network manager methods silently swallowed both connection failures and API errors at two layers, producing `{"success": True, "count": 0, ...}` to the client when the controller was unreachable or returned an error. Surfaced during review of #155 (`list_firewall_zones` 404 + silent empty list) and audited across the rest of `apps/network`.

The fix completes the work started by PR #146 (`create_firewall_policy`) and PR #155 (`list_firewall_zones`), which addressed individual methods. This PR extends the same pattern to every silent-return site in `apps/network/src/unifi_network_mcp/managers/`.

## Two layers, two raises

| Layer | Before | After | Why |
|---|---|---|---|
| 1 — `ensure_connected` guard | `return [] / None / False` (53 sites) | `raise ConnectionError("Not connected to controller")` | Connection state is known — typed exception is meaningful. Matches existing pattern in `switch_manager.py`. |
| 2 — broad `except Exception` | `logger.error(...); return X` (164 sites) | bare `raise` | Cause is unknown (404, auth, JSON decode, validation, etc.). Bare raise preserves original type and traceback. Matches PR #146 / #155. |

Both are caught by tool wrappers and converted to `{"success": False, "error": ...}`.

## Scope

`apps/network` only. `apps/protect` and `apps/access` already raise `UniFiConnectionError` from their connection-manager `client` property — silent failure is structurally impossible there. Audit confirmed no changes needed.

- 21 manager files modified
- 1 tool file: `tools/port_forwards.py::create_simple_port_forward` had a thin-coverage gap (no `try/except` around the manager call); added wrapper.
- 20 test files updated.

## Two intentional behavior preservations

These are real fallbacks, not silent failures, and the converter was reverted for them:

1. **`event_manager._detect_api_version`** — Try v2 system-log endpoint; on failure return `False` to use legacy `/stat/event`. Genuine feature detection.
2. **`oon_manager.get_oon_policies`** — Returns `[]` on 404 because some controllers don't support OON policies; non-404 errors raise.

## Test plan

- [x] Updated `*_not_connected` tests from `assert result == []` to `pytest.raises(ConnectionError, match="Not connected to controller")`.
- [x] Updated `*_handles_error` tests from `assert result == [] / None / False` to `pytest.raises(Exception)`.
- [x] Reverted 5 over-matched validation tests (`test_client_not_found`, `test_no_settings_provided`, `test_client_missing_id`, `test_update_route_not_found`, `test_update_usergroup_not_found`) — those are legitimate "not found" returns, not error swallows.
- [x] Updated `test_does_not_mutate_cached_route_on_api_failure` to assert mutation safety under raise (still important; just expects the exception now).
- [x] Full unit suite: **617 passed** (network), **329 passed** (protect, unaffected), **153 passed** (access, unaffected).
- [x] **Live smoke test against a live UDM SE on Network 10.2.x:**
  - Connected normally, then forced `ensure_connected` to return `False`.
  - Called `firewall.get_firewall_zones`, `get_firewall_groups`, `get_firewall_policies`, `acl.get_acl_rules`, `dns.get_dns_record`, `oon.get_oon_policies`.
  - All 6 raised `ConnectionError("Not connected to controller")` ✓
  - End-to-end through tool wrapper produced:
    ```json
    {"success": false, "error": "Failed to list firewall zones: Not connected to controller"}
    ```
    instead of the old `{"success": true, "count": 0, "zones": []}`.

## Breaking changes

**For external consumers (LLM clients via MCP):** None. The shape is still `{"success": bool, ...}`. Where the response previously incorrectly said `success: true, count: 0` on a real failure, it now correctly says `success: false, error: "<cause>"`. This is the intended bug fix.

**For internal callers within the codebase:** Any code that depended on the silent-return contract (e.g., `if result == []: ...` to detect failure) will now see an exception. Audit of the codebase shows no such consumers — every silent return was either ignored entirely or wrapped by a `try/except Exception` at the tool layer that already handles the new exception path identically.

**Future-proofing:** If a richer exception type (e.g., `ControllerConnectionError`) is needed later, subclassing `ConnectionError` is non-breaking — existing `except ConnectionError:` handlers continue to catch the subclass.

## Files

- 21 managers in `apps/network/src/unifi_network_mcp/managers/`
- `apps/network/src/unifi_network_mcp/tools/port_forwards.py`
- 20 test files in `apps/network/tests/unit/`

## Commits

Single commit. The transformation is mechanical and uniform across the surface; splitting into per-file commits would not aid review, while the diff per file is small and self-contained.