### PR TITLE
Phase 1: API skeleton

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Version passed from CI/CD (used by hatch-vcs when git is unavailable)
+ARG VERSION=0.0.0.dev0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
+RUN pip install --upgrade pip \
+ && pip install uv
+
+# Copy workspace root and member pyproject.toml files (uv needs them to resolve)
+COPY pyproject.toml uv.lock ./
+COPY apps/api/pyproject.toml apps/api/pyproject.toml
+COPY apps/api/README.md apps/api/README.md
+COPY packages/unifi-core/pyproject.toml packages/unifi-core/pyproject.toml
+COPY packages/unifi-mcp-shared/pyproject.toml packages/unifi-mcp-shared/pyproject.toml
+COPY packages/unifi-mcp-relay/pyproject.toml packages/unifi-mcp-relay/pyproject.toml
+COPY apps/network/pyproject.toml apps/network/pyproject.toml
+COPY apps/protect/pyproject.toml apps/protect/pyproject.toml
+COPY apps/access/pyproject.toml apps/access/pyproject.toml
+
+# Copy api source and its workspace dependency (unifi-core).
+# unifi-core source is REQUIRED — Phase 0 wisdom about transitive workspace deps applies:
+# without it, hatch-vcs fails with FileNotFoundError writing _version.py.
+COPY apps/api/src apps/api/src
+COPY apps/api/alembic.ini apps/api/alembic.ini
+COPY apps/api/alembic apps/api/alembic
+COPY packages/unifi-core/src packages/unifi-core/src
+
+# Install all packages using uv sync (respects lockfile for reproducible builds)
+RUN uv sync --frozen --no-dev --package unifi-api
+
+# Use the venv Python directly
+ENV PATH="/app/.venv/bin:$PATH"
+ENV UNIFI_API_STATE_DIR=/var/lib/unifi-api
+
+# Non-root user with writable state dir
+RUN useradd -m -u 1000 -d /home/unifi-api unifi-api \
+ && mkdir -p /var/lib/unifi-api \
+ && chown -R unifi-api:unifi-api /var/lib/unifi-api
+USER unifi-api
+
+EXPOSE 8080
+
+# Console-script entrypoint
+CMD ["unifi-api", "serve"]

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,9 @@
+# unifi-api
+
+UniFi rich HTTP API service. Provides a non-MCP API surface for desktop apps,
+web dashboards, Pi extensions, and other consumers that need streaming, live
+feeds, and richer-than-MCP semantics. Depends only on `unifi-core` — does not
+depend on the MCP packages.
+
+See `docs/superpowers/specs/2026-04-28-unifi-rich-api-design.md` for the full
+design.

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,1 @@
+# Placeholder — populated in Phase 1 Task 5.

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,1 +1,39 @@
-# Placeholder — populated in Phase 1 Task 5.
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+version_path_separator = os
+sqlalchemy.url = sqlite+aiosqlite:///./state.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -1,0 +1,64 @@
+"""Alembic env for unifi-api.
+
+The DB file is unencrypted at the engine layer (sensitive columns use
+AES-GCM at the application layer per unifi_api.db.crypto). The DB path is
+resolvable from config or via -x db_path=... on the alembic command line.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+# Make unifi_api importable when alembic runs standalone
+_HERE = Path(__file__).resolve().parent
+_SRC = _HERE.parent / "src"
+if _SRC.exists() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from unifi_api.db.engine import create_engine  # noqa: E402
+from unifi_api.db.models import Base  # noqa: E402
+
+
+target_metadata = Base.metadata
+
+
+def _resolve_db_path() -> Path:
+    cli_args = context.get_x_argument(as_dictionary=True)
+    if "db_path" in cli_args:
+        return Path(cli_args["db_path"])
+    env_path = os.environ.get("UNIFI_API_DB_PATH")
+    if env_path:
+        return Path(env_path)
+    return Path("./state.db")
+
+
+def run_migrations_offline() -> None:
+    raise RuntimeError(
+        "Offline migration mode is not supported; the async engine requires "
+        "a live connection."
+    )
+
+
+async def run_migrations_online() -> None:
+    engine: AsyncEngine = create_engine(_resolve_db_path())
+    async with engine.connect() as conn:
+        await conn.run_sync(_run_sync_migrations)
+    await engine.dispose()
+
+
+def _run_sync_migrations(connection):
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/apps/api/alembic/script.py.mako
+++ b/apps/api/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/apps/api/alembic/versions/0001_initial_schema.py
+++ b/apps/api/alembic/versions/0001_initial_schema.py
@@ -1,0 +1,73 @@
+"""initial schema
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "schema_version",
+        sa.Column("version", sa.Integer, primary_key=True),
+        sa.Column("applied_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("prefix", sa.String(64), nullable=False, unique=True),
+        sa.Column("hash", sa.String(255), nullable=False),
+        sa.Column("scopes", sa.String(64), nullable=False),
+        sa.Column("name", sa.String(128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "controllers",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("name", sa.String(128), nullable=False),
+        sa.Column("base_url", sa.String(255), nullable=False),
+        sa.Column("product_kinds", sa.String(64), nullable=False),
+        sa.Column("credentials_blob", sa.LargeBinary, nullable=False),
+        sa.Column("verify_tls", sa.Boolean, nullable=False, server_default=sa.text("1")),
+        sa.Column("is_default", sa.Boolean, nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("api_key_id", sa.String(36), sa.ForeignKey("api_keys.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("key_id_prefix", sa.String(64), nullable=False),
+        sa.Column("controller", sa.String(36), nullable=True),
+        sa.Column("target", sa.String(128), nullable=False),
+        sa.Column("outcome", sa.String(32), nullable=False),
+        sa.Column("error_kind", sa.String(64), nullable=True),
+        sa.Column("detail", sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_log")
+    op.drop_table("sessions")
+    op.drop_table("controllers")
+    op.drop_table("api_keys")
+    op.drop_table("schema_version")

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,0 +1,67 @@
+[project]
+name = "unifi-api"
+dynamic = ["version"]
+description = "UniFi rich HTTP API service"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "unifi-core>=0.2,<0.3",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
+    "sqlalchemy[asyncio]>=2.0.36",
+    "alembic>=1.14.0",
+    "aiosqlite>=0.20.0",
+    "cryptography>=42.0.0",
+    "argon2-cffi>=23.1.0",
+    "typer>=0.13.0",
+    "pydantic>=2.10.0",
+    "pyyaml>=6.0",
+    "omegaconf>=2.3.0",
+    "python-dotenv>=1.2.2",
+]
+
+[project.scripts]
+unifi-api = "unifi_api.cli:app"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=0.21.0",
+    "httpx>=0.27.0",
+]
+
+[tool.uv.sources]
+unifi-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options.root = "../.."
+raw-options.tag_regex = "^api/v(?P<version>\\d+(?:\\.\\d+)*)(?:\\S*)$"
+raw-options.git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "api/v*"]
+raw-options.fallback_version = "0.0.0"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/unifi_api/_version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/unifi_api"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/unifi_api",
+    "/alembic",
+    "/alembic.ini",
+    "/README.md",
+]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/unifi_api/config.yaml" = "unifi_api/config.yaml"
+"alembic.ini" = "unifi_api/alembic.ini"
+"alembic" = "unifi_api/alembic"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/apps/api/src/unifi_api/__init__.py
+++ b/apps/api/src/unifi_api/__init__.py
@@ -1,0 +1,1 @@
+"""UniFi rich HTTP API service."""

--- a/apps/api/src/unifi_api/__main__.py
+++ b/apps/api/src/unifi_api/__main__.py
@@ -1,0 +1,7 @@
+"""Entry point for `python -m unifi_api`."""
+
+from unifi_api.cli import app
+
+
+if __name__ == "__main__":
+    app()

--- a/apps/api/src/unifi_api/auth/__init__.py
+++ b/apps/api/src/unifi_api/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication module."""

--- a/apps/api/src/unifi_api/auth/api_key.py
+++ b/apps/api/src/unifi_api/auth/api_key.py
@@ -11,13 +11,20 @@ import re
 import secrets
 from base64 import b32encode
 from dataclasses import dataclass
+from enum import Enum
 
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
 
 
-_KEY_PATTERN = re.compile(r"^unifi_(live|test)_[A-Z2-7]{22}$")
+KEY_PATTERN = re.compile(r"^unifi_(live|test)_[A-Z2-7]{22}$")
+KEY_PREFIX_LEN = 15
 _HASHER = PasswordHasher()
+
+
+class ApiKeyEnv(str, Enum):
+    LIVE = "live"
+    TEST = "test"
 
 
 @dataclass(frozen=True)
@@ -26,23 +33,21 @@ class ApiKeyMaterial:
     prefix: str
 
 
-def generate_key(env: str = "live") -> ApiKeyMaterial:
-    if env not in ("live", "test"):
-        raise ValueError(f"env must be 'live' or 'test', got {env!r}")
+def generate_key(env: ApiKeyEnv = ApiKeyEnv.LIVE) -> ApiKeyMaterial:
     body = b32encode(secrets.token_bytes(14)).decode("ascii").rstrip("=")[:22]
-    plaintext = f"unifi_{env}_{body}"
-    prefix = plaintext[:15]
+    plaintext = f"unifi_{env.value}_{body}"
+    prefix = plaintext[:KEY_PREFIX_LEN]
     return ApiKeyMaterial(plaintext=plaintext, prefix=prefix)
 
 
 def hash_key(plaintext: str) -> str:
-    if not _KEY_PATTERN.fullmatch(plaintext):
+    if not KEY_PATTERN.fullmatch(plaintext):
         raise ValueError("invalid key format")
     return _HASHER.hash(plaintext)
 
 
 def verify_key(plaintext: str, digest: str) -> bool:
-    if not _KEY_PATTERN.fullmatch(plaintext):
+    if not KEY_PATTERN.fullmatch(plaintext):
         raise ValueError("invalid key format")
     try:
         return _HASHER.verify(digest, plaintext)

--- a/apps/api/src/unifi_api/auth/api_key.py
+++ b/apps/api/src/unifi_api/auth/api_key.py
@@ -1,0 +1,50 @@
+"""API key generation, format validation, and argon2id hashing.
+
+Format: unifi_<env>_<22-char-base32>
+Env is "live" or "test". The 22-char body is base32-encoded random bytes.
+The "prefix" exposed in audit logs is the first 15 chars (env + first 4 random).
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+from base64 import b32encode
+from dataclasses import dataclass
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+
+_KEY_PATTERN = re.compile(r"^unifi_(live|test)_[A-Z2-7]{22}$")
+_HASHER = PasswordHasher()
+
+
+@dataclass(frozen=True)
+class ApiKeyMaterial:
+    plaintext: str
+    prefix: str
+
+
+def generate_key(env: str = "live") -> ApiKeyMaterial:
+    if env not in ("live", "test"):
+        raise ValueError(f"env must be 'live' or 'test', got {env!r}")
+    body = b32encode(secrets.token_bytes(14)).decode("ascii").rstrip("=")[:22]
+    plaintext = f"unifi_{env}_{body}"
+    prefix = plaintext[:15]
+    return ApiKeyMaterial(plaintext=plaintext, prefix=prefix)
+
+
+def hash_key(plaintext: str) -> str:
+    if not _KEY_PATTERN.fullmatch(plaintext):
+        raise ValueError("invalid key format")
+    return _HASHER.hash(plaintext)
+
+
+def verify_key(plaintext: str, digest: str) -> bool:
+    if not _KEY_PATTERN.fullmatch(plaintext):
+        raise ValueError("invalid key format")
+    try:
+        return _HASHER.verify(digest, plaintext)
+    except VerifyMismatchError:
+        return False

--- a/apps/api/src/unifi_api/auth/middleware.py
+++ b/apps/api/src/unifi_api/auth/middleware.py
@@ -1,4 +1,9 @@
-"""Bearer token auth middleware as a FastAPI dependency factory."""
+"""Bearer token auth middleware as a FastAPI dependency factory.
+
+`_authenticate` resolves a bearer token to an ApiKey row (or raises 401).
+`require_scope(scope)` returns a FastAPI dependency that authenticates and
+then enforces the requested scope (raises 403 on insufficient scope).
+"""
 
 from __future__ import annotations
 
@@ -7,35 +12,37 @@ from typing import Callable
 from fastapi import HTTPException, Request, status
 from sqlalchemy import select
 
-from unifi_api.auth.api_key import verify_key
+from unifi_api.auth.api_key import KEY_PATTERN, KEY_PREFIX_LEN, verify_key
 from unifi_api.auth.scopes import Scope, parse_scopes, scope_allows
 from unifi_api.db.models import ApiKey
 
 
+async def _authenticate(request: Request) -> ApiKey:
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing bearer token")
+    plaintext = auth_header[len("Bearer "):].strip()
+
+    if not KEY_PATTERN.fullmatch(plaintext):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="malformed token")
+
+    prefix = plaintext[:KEY_PREFIX_LEN]
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        row = (await session.execute(select(ApiKey).where(ApiKey.prefix == prefix))).scalar_one_or_none()
+        if row is None or row.revoked_at is not None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unknown token")
+        if not verify_key(plaintext, row.hash):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+        return row
+
+
 def require_scope(required: Scope) -> Callable:
     async def _dep(request: Request) -> ApiKey:
-        auth_header = request.headers.get("authorization", "")
-        if not auth_header.lower().startswith("bearer "):
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing bearer token")
-        plaintext = auth_header[len("Bearer "):].strip()
-
-        prefix = plaintext[:15]
-
-        sm = request.app.state.sessionmaker
-        async with sm() as session:
-            row = (await session.execute(select(ApiKey).where(ApiKey.prefix == prefix))).scalar_one_or_none()
-            if row is None or row.revoked_at is not None:
-                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unknown token")
-            try:
-                ok = verify_key(plaintext, row.hash)
-            except ValueError:
-                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="malformed token")
-            if not ok:
-                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
-
-            held = parse_scopes(row.scopes)
-            if not scope_allows(held, required):
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="insufficient scope")
-            return row
+        api_key = await _authenticate(request)
+        held = parse_scopes(api_key.scopes)
+        if not scope_allows(held, required):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="insufficient scope")
+        return api_key
 
     return _dep

--- a/apps/api/src/unifi_api/auth/middleware.py
+++ b/apps/api/src/unifi_api/auth/middleware.py
@@ -1,0 +1,41 @@
+"""Bearer token auth middleware as a FastAPI dependency factory."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy import select
+
+from unifi_api.auth.api_key import verify_key
+from unifi_api.auth.scopes import Scope, parse_scopes, scope_allows
+from unifi_api.db.models import ApiKey
+
+
+def require_scope(required: Scope) -> Callable:
+    async def _dep(request: Request) -> ApiKey:
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing bearer token")
+        plaintext = auth_header[len("Bearer "):].strip()
+
+        prefix = plaintext[:15]
+
+        sm = request.app.state.sessionmaker
+        async with sm() as session:
+            row = (await session.execute(select(ApiKey).where(ApiKey.prefix == prefix))).scalar_one_or_none()
+            if row is None or row.revoked_at is not None:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unknown token")
+            try:
+                ok = verify_key(plaintext, row.hash)
+            except ValueError:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="malformed token")
+            if not ok:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token")
+
+            held = parse_scopes(row.scopes)
+            if not scope_allows(held, required):
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="insufficient scope")
+            return row
+
+    return _dep

--- a/apps/api/src/unifi_api/auth/scopes.py
+++ b/apps/api/src/unifi_api/auth/scopes.py
@@ -1,0 +1,28 @@
+"""Scope definitions and check helpers."""
+
+from __future__ import annotations
+
+import enum
+
+
+class Scope(str, enum.Enum):
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+def parse_scopes(s: str) -> frozenset[Scope]:
+    parts = [p.strip() for p in s.split(",") if p.strip()]
+    out: set[Scope] = set()
+    for p in parts:
+        try:
+            out.add(Scope(p))
+        except ValueError as e:
+            raise ValueError(f"unknown scope: {p}") from e
+    return frozenset(out)
+
+
+def scope_allows(held: frozenset[Scope], required: Scope) -> bool:
+    if Scope.ADMIN in held:
+        return True
+    return required in held

--- a/apps/api/src/unifi_api/cli.py
+++ b/apps/api/src/unifi_api/cli.py
@@ -39,17 +39,64 @@ def serve(
 def migrate(
     config_path: Path = typer.Option(_DEFAULT_CONFIG_PATH, help="Path to config.yaml"),
 ) -> None:
-    """Run alembic migrations to head."""
+    """Run alembic migrations to head. Bootstraps an admin key on first run."""
+    import asyncio
     import os
     import subprocess
+    import uuid
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from unifi_api.auth.api_key import generate_key, hash_key
+    from unifi_api.db.engine import create_engine
+    from unifi_api.db.models import ApiKey
+    from unifi_api.db.session import get_sessionmaker
 
     cfg = load_config(config_path)
+    db_key = os.environ.get("UNIFI_API_DB_KEY")
+    if not db_key:
+        typer.echo("UNIFI_API_DB_KEY environment variable is required", err=True)
+        raise typer.Exit(code=2)
+
     env = dict(os.environ)
     env["UNIFI_API_DB_PATH"] = cfg.db.path
     alembic_cwd = Path(__file__).parent.parent.parent  # apps/api
     result = subprocess.run(["alembic", "upgrade", "head"], env=env, cwd=alembic_cwd, check=False)
     if result.returncode != 0:
         raise typer.Exit(code=result.returncode)
+
+    # Bootstrap admin key if api_keys is empty
+    async def _maybe_bootstrap() -> str | None:
+        engine = create_engine(cfg.db.path)
+        sm = get_sessionmaker(engine)
+        try:
+            async with sm() as session:
+                existing = (await session.execute(select(ApiKey))).first()
+                if existing is not None:
+                    return None
+                material = generate_key()
+                session.add(
+                    ApiKey(
+                        id=str(uuid.uuid4()),
+                        prefix=material.prefix,
+                        hash=hash_key(material.plaintext),
+                        scopes="admin",
+                        name="bootstrap-admin",
+                        created_at=datetime.now(timezone.utc),
+                    )
+                )
+                await session.commit()
+            return material.plaintext
+        finally:
+            await engine.dispose()
+
+    plaintext = asyncio.run(_maybe_bootstrap())
+    if plaintext:
+        typer.echo("=" * 60)
+        typer.echo("Initial admin API key (shown once, save it now):")
+        typer.echo(plaintext)
+        typer.echo("=" * 60)
 
 
 @keys_app.command("create")

--- a/apps/api/src/unifi_api/cli.py
+++ b/apps/api/src/unifi_api/cli.py
@@ -1,0 +1,94 @@
+"""unifi-api CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+import uvicorn
+
+from unifi_api.config import load_config
+from unifi_api.logging import configure_logging
+from unifi_api.server import create_app
+
+
+app = typer.Typer(no_args_is_help=True, help="UniFi rich HTTP API service.")
+keys_app = typer.Typer(no_args_is_help=True, help="Manage API keys.")
+db_app = typer.Typer(no_args_is_help=True, help="Database operations.")
+app.add_typer(keys_app, name="keys")
+app.add_typer(db_app, name="db")
+
+
+_DEFAULT_CONFIG_PATH = Path(__file__).parent / "config.yaml"
+
+
+@app.command()
+def serve(
+    host: str | None = typer.Option(None, help="Override config http.host"),
+    port: int | None = typer.Option(None, help="Override config http.port"),
+    config_path: Path = typer.Option(_DEFAULT_CONFIG_PATH, help="Path to config.yaml"),
+) -> None:
+    """Start the HTTP server."""
+    cfg = load_config(config_path)
+    configure_logging(cfg.logging.level)
+    app_instance = create_app(cfg)
+    uvicorn.run(app_instance, host=host or cfg.http.host, port=port or cfg.http.port, log_config=None)
+
+
+@app.command()
+def migrate(
+    config_path: Path = typer.Option(_DEFAULT_CONFIG_PATH, help="Path to config.yaml"),
+) -> None:
+    """Run alembic migrations to head."""
+    import os
+    import subprocess
+
+    cfg = load_config(config_path)
+    env = dict(os.environ)
+    env["UNIFI_API_DB_PATH"] = cfg.db.path
+    alembic_cwd = Path(__file__).parent.parent.parent  # apps/api
+    result = subprocess.run(["alembic", "upgrade", "head"], env=env, cwd=alembic_cwd, check=False)
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
+
+
+@keys_app.command("create")
+def keys_create(
+    name: str = typer.Argument(..., help="Human-readable name for the key"),
+    scopes: str = typer.Option("read", help="Comma-separated scopes: read,write,admin"),
+) -> None:
+    """Create a new API key. Prints the plaintext exactly once."""
+    typer.echo("(implemented in a later phase)")
+    raise typer.Exit(code=0)
+
+
+@keys_app.command("list")
+def keys_list() -> None:
+    """List API keys (prefix + scopes only; never plaintext)."""
+    typer.echo("(implemented in a later phase)")
+    raise typer.Exit(code=0)
+
+
+@keys_app.command("revoke")
+def keys_revoke(prefix: str = typer.Argument(..., help="Prefix of the key to revoke")) -> None:
+    """Revoke an API key by prefix."""
+    typer.echo("(implemented in a later phase)")
+    raise typer.Exit(code=0)
+
+
+@db_app.command("backup")
+def db_backup(out_path: Path = typer.Argument(..., help="Backup destination")) -> None:
+    """Encrypted backup."""
+    typer.echo("(implemented in a later phase)")
+    raise typer.Exit(code=0)
+
+
+@db_app.command("rekey")
+def db_rekey(new_key: str = typer.Argument(..., help="New passphrase")) -> None:
+    """Rotate the column encryption key."""
+    typer.echo("(implemented in a later phase)")
+    raise typer.Exit(code=0)
+
+
+if __name__ == "__main__":
+    app()

--- a/apps/api/src/unifi_api/config.py
+++ b/apps/api/src/unifi_api/config.py
@@ -1,0 +1,96 @@
+"""Config loader for unifi-api.
+
+YAML provides defaults; UNIFI_API_* env vars override.
+The column encryption key is env-only (UNIFI_API_DB_KEY).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from omegaconf import OmegaConf
+
+
+@dataclass(frozen=True)
+class HttpConfig:
+    host: str = "0.0.0.0"
+    port: int = 8080
+    cors_origins: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LoggingConfig:
+    level: str = "INFO"
+
+
+@dataclass(frozen=True)
+class DbConfig:
+    path: str = "/var/lib/unifi-api/state.db"
+
+
+@dataclass(frozen=True)
+class ApiConfig:
+    http: HttpConfig
+    logging: LoggingConfig
+    db: DbConfig
+
+    @staticmethod
+    def read_db_key() -> str:
+        key = os.environ.get("UNIFI_API_DB_KEY")
+        if not key:
+            raise RuntimeError(
+                "UNIFI_API_DB_KEY environment variable is required. "
+                "The unifi-api service refuses to start without an "
+                "AES-GCM encryption key for sensitive columns."
+            )
+        return key
+
+
+def load_config(yaml_path: Path) -> ApiConfig:
+    """Load config from YAML, then layer in UNIFI_API_* env overrides."""
+    base = OmegaConf.create(yaml.safe_load(yaml_path.read_text()) or {})
+    env_overrides = OmegaConf.create(_extract_env_overrides())
+    merged = OmegaConf.merge(base, env_overrides)
+    container = OmegaConf.to_container(merged, resolve=True) or {}
+
+    return ApiConfig(
+        http=HttpConfig(
+            host=str(container.get("http", {}).get("host", "0.0.0.0")),
+            port=int(container.get("http", {}).get("port", 8080)),
+            cors_origins=tuple(container.get("http", {}).get("cors_origins", []) or []),
+        ),
+        logging=LoggingConfig(
+            level=str(container.get("logging", {}).get("level", "INFO")),
+        ),
+        db=DbConfig(
+            path=str(container.get("db", {}).get("path", "/var/lib/unifi-api/state.db")),
+        ),
+    )
+
+
+def _extract_env_overrides() -> dict:
+    """Translate UNIFI_API_<SECTION>_<KEY> env vars into a nested dict."""
+    overrides: dict = {}
+    prefix = "UNIFI_API_"
+    skip = {"UNIFI_API_DB_KEY"}  # handled separately, never put in config tree
+    for full_key, value in os.environ.items():
+        if not full_key.startswith(prefix) or full_key in skip:
+            continue
+        path = full_key[len(prefix):].lower().split("_")
+        if len(path) < 2:
+            continue
+        section, key = path[0], "_".join(path[1:])
+        overrides.setdefault(section, {})[key] = _coerce_scalar(value)
+    return overrides
+
+
+def _coerce_scalar(s: str) -> str | int | bool:
+    if s.lower() in ("true", "false"):
+        return s.lower() == "true"
+    try:
+        return int(s)
+    except ValueError:
+        return s

--- a/apps/api/src/unifi_api/config.yaml
+++ b/apps/api/src/unifi_api/config.yaml
@@ -1,1 +1,10 @@
-# Placeholder — populated in Phase 1 Task 1.
+http:
+  host: 0.0.0.0
+  port: 8080
+  cors_origins: []
+
+logging:
+  level: INFO
+
+db:
+  path: /var/lib/unifi-api/state.db

--- a/apps/api/src/unifi_api/config.yaml
+++ b/apps/api/src/unifi_api/config.yaml
@@ -1,0 +1,1 @@
+# Placeholder — populated in Phase 1 Task 1.

--- a/apps/api/src/unifi_api/db/__init__.py
+++ b/apps/api/src/unifi_api/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database engine, session factory, and column-encryption helpers."""

--- a/apps/api/src/unifi_api/db/crypto.py
+++ b/apps/api/src/unifi_api/db/crypto.py
@@ -1,0 +1,71 @@
+"""AES-256-GCM column-level encryption.
+
+The encryption key is supplied via `UNIFI_API_DB_KEY` and consumed via
+`derive_key()`, which accepts either a 32-byte raw key (hex or base64
+encoded) or any shorter string (derived via HKDF-SHA256).
+
+Wire format per encrypted column: nonce (12 bytes) || ciphertext || tag.
+The cryptography AESGCM helper packs ciphertext+tag together; we prepend
+a fresh nonce per encrypt call.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from binascii import unhexlify
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+
+_NONCE_SIZE = 12
+_KEY_SIZE = 32
+
+
+def derive_key(material: str) -> bytes:
+    """Return a 32-byte key.
+
+    If `material` is a 64-char hex or base64 string decodable to 32 bytes,
+    use it directly. Otherwise apply HKDF-SHA256 with a fixed info label
+    so derivations are deterministic for a given passphrase.
+    """
+    if len(material) == 64:
+        try:
+            decoded = unhexlify(material)
+            if len(decoded) == _KEY_SIZE:
+                return decoded
+        except Exception:
+            pass
+    try:
+        decoded = base64.b64decode(material, validate=True)
+        if len(decoded) == _KEY_SIZE:
+            return decoded
+    except Exception:
+        pass
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=_KEY_SIZE,
+        salt=None,
+        info=b"unifi-api column-cipher v1",
+    )
+    return hkdf.derive(material.encode("utf-8"))
+
+
+class ColumnCipher:
+    """Symmetric AES-256-GCM cipher for a single column's values."""
+
+    def __init__(self, key: bytes) -> None:
+        if len(key) != _KEY_SIZE:
+            raise ValueError(f"key must be {_KEY_SIZE} bytes, got {len(key)}")
+        self._aead = AESGCM(key)
+
+    def encrypt(self, plaintext: bytes, *, associated_data: bytes | None = None) -> bytes:
+        nonce = os.urandom(_NONCE_SIZE)
+        ct = self._aead.encrypt(nonce, plaintext, associated_data)
+        return nonce + ct
+
+    def decrypt(self, blob: bytes, *, associated_data: bytes | None = None) -> bytes:
+        nonce, ct = blob[:_NONCE_SIZE], blob[_NONCE_SIZE:]
+        return self._aead.decrypt(nonce, ct, associated_data)

--- a/apps/api/src/unifi_api/db/engine.py
+++ b/apps/api/src/unifi_api/db/engine.py
@@ -1,0 +1,28 @@
+"""Async SQLAlchemy engine backed by plain SQLite via aiosqlite.
+
+Encryption of sensitive columns is handled at the application layer via
+unifi_api.db.crypto.ColumnCipher — see crypto.py and the controllers manager
+(Phase 2) for usage. The DB file itself is unencrypted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+
+def create_engine(db_path: Path | str) -> AsyncEngine:
+    """Create an async engine pointing at a SQLite file.
+
+    Parent directories are created if missing. The DB file is unencrypted;
+    sensitive columns use AES-GCM via `ColumnCipher` at the application layer.
+    """
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    url = f"sqlite+aiosqlite:///{db_path}"
+    return create_async_engine(
+        url,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )

--- a/apps/api/src/unifi_api/db/models.py
+++ b/apps/api/src/unifi_api/db/models.py
@@ -1,0 +1,67 @@
+"""SQLAlchemy 2.0 declarative models for the unifi-api state database.
+
+Skeleton models for Phase 1 — fields evolve in later phases. All tables
+documented in the spec §6.1, §7.3.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, LargeBinary, String, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class SchemaVersion(Base):
+    __tablename__ = "schema_version"
+    version: Mapped[int] = mapped_column(primary_key=True)
+    applied_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    prefix: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    scopes: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+
+
+class Controller(Base):
+    __tablename__ = "controllers"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    base_url: Mapped[str] = mapped_column(String(255), nullable=False)
+    product_kinds: Mapped[str] = mapped_column(String(64), nullable=False)
+    credentials_blob: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    verify_tls: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class Session(Base):
+    __tablename__ = "sessions"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    api_key_id: Mapped[str] = mapped_column(String(36), ForeignKey("api_keys.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    key_id_prefix: Mapped[str] = mapped_column(String(64), nullable=False)
+    controller: Mapped[Optional[str]] = mapped_column(String(36))
+    target: Mapped[str] = mapped_column(String(128), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(32), nullable=False)
+    error_kind: Mapped[Optional[str]] = mapped_column(String(64))
+    detail: Mapped[Optional[str]] = mapped_column(Text)

--- a/apps/api/src/unifi_api/db/session.py
+++ b/apps/api/src/unifi_api/db/session.py
@@ -1,0 +1,9 @@
+"""Async session factory."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+
+def get_sessionmaker(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, expire_on_commit=False)

--- a/apps/api/src/unifi_api/logging.py
+++ b/apps/api/src/unifi_api/logging.py
@@ -1,0 +1,50 @@
+"""Structured JSON logging to stderr.
+
+stderr (not stdout) so it doesn't collide with anything that might write JSON-RPC
+responses on stdout. Container log drivers pick it up either way.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(record.created))
+            + f".{int(record.msecs):03d}Z",
+            "level": record.levelname,
+            "event": record.getMessage(),
+        }
+        # extra= kwargs land on record.__dict__ — pull anything not in the standard set
+        standard = {
+            "name", "msg", "args", "levelname", "levelno", "pathname", "filename",
+            "module", "exc_info", "exc_text", "stack_info", "lineno", "funcName",
+            "created", "msecs", "relativeCreated", "thread", "threadName",
+            "processName", "process", "taskName",
+        }
+        for key, value in record.__dict__.items():
+            if key not in standard and not key.startswith("_"):
+                payload[key] = value
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def configure_logging(level: str = "INFO") -> None:
+    root = logging.getLogger()
+    # Remove existing handlers to avoid duplication on reconfigure
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(JsonFormatter())
+    root.addHandler(handler)
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger(name)

--- a/apps/api/src/unifi_api/routes/__init__.py
+++ b/apps/api/src/unifi_api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route modules."""

--- a/apps/api/src/unifi_api/routes/health.py
+++ b/apps/api/src/unifi_api/routes/health.py
@@ -1,0 +1,29 @@
+"""Health endpoints.
+
+GET /health         - liveness, unauthenticated
+GET /health/ready   - readiness, admin-scoped (DB connectivity check)
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy import text
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def liveness() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/health/ready", dependencies=[Depends(require_scope(Scope.ADMIN))])
+async def readiness(request: Request) -> dict[str, str]:
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        await session.execute(text("SELECT 1"))
+    return {"status": "ready", "db": "ok"}

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -10,6 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from unifi_api.config import ApiConfig
 from unifi_api.db.engine import create_engine
 from unifi_api.db.session import get_sessionmaker
+from unifi_api.routes import health
 
 
 def create_app(config: ApiConfig) -> FastAPI:
@@ -37,5 +38,7 @@ def create_app(config: ApiConfig) -> FastAPI:
     engine = create_engine(config.db.path)
     app.state.engine = engine
     app.state.sessionmaker = get_sessionmaker(engine)
+
+    app.include_router(health.router, prefix="/v1")
 
     return app

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -1,0 +1,41 @@
+"""FastAPI app factory."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI, Request, Response
+from starlette.middleware.cors import CORSMiddleware
+
+from unifi_api.config import ApiConfig
+from unifi_api.db.engine import create_engine
+from unifi_api.db.session import get_sessionmaker
+
+
+def create_app(config: ApiConfig) -> FastAPI:
+    app = FastAPI(title="unifi-api", version="0.1.0", openapi_url="/v1/openapi.json", docs_url="/v1/docs")
+
+    if config.http.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=list(config.http.cors_origins),
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    @app.middleware("http")
+    async def request_id_middleware(request: Request, call_next):
+        rid = request.headers.get("X-Request-ID") or uuid.uuid4().hex[:16]
+        response: Response = await call_next(request)
+        response.headers["X-Request-ID"] = rid
+        return response
+
+    # Wire DB
+    # Validate the encryption key exists at startup; service refuses to start without it.
+    ApiConfig.read_db_key()
+    engine = create_engine(config.db.path)
+    app.state.engine = engine
+    app.state.sessionmaker = get_sessionmaker(engine)
+
+    return app

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -39,6 +39,10 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.state.engine = engine
     app.state.sessionmaker = get_sessionmaker(engine)
 
+    @app.on_event("shutdown")
+    async def _dispose_engine() -> None:
+        await app.state.engine.dispose()
+
     app.include_router(health.router, prefix="/v1")
 
     return app

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration for unifi-api tests."""
+
+import sys
+from pathlib import Path
+
+# Add the api app's src directory to path so unifi_api is importable
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/apps/api/tests/test_api_key.py
+++ b/apps/api/tests/test_api_key.py
@@ -1,0 +1,31 @@
+"""API key format and hashing tests."""
+
+import re
+
+import pytest
+
+from unifi_api.auth.api_key import ApiKeyMaterial, generate_key, hash_key, verify_key
+
+
+def test_generate_key_has_correct_format() -> None:
+    material = generate_key(env="live")
+    assert re.fullmatch(r"unifi_live_[A-Z2-7]{22}", material.plaintext)
+    assert material.prefix == material.plaintext[:15]
+
+
+def test_generate_key_test_env() -> None:
+    material = generate_key(env="test")
+    assert material.plaintext.startswith("unifi_test_")
+
+
+def test_hash_and_verify() -> None:
+    material = generate_key()
+    digest = hash_key(material.plaintext)
+    assert digest.startswith("$argon2id$")
+    assert verify_key(material.plaintext, digest) is True
+    assert verify_key("unifi_live_WRONGTOKENXXXXXXXXXXXX", digest) is False
+
+
+def test_invalid_format_rejected() -> None:
+    with pytest.raises(ValueError):
+        verify_key("not_a_valid_key_format", "$argon2id$some-hash")

--- a/apps/api/tests/test_api_key.py
+++ b/apps/api/tests/test_api_key.py
@@ -4,17 +4,17 @@ import re
 
 import pytest
 
-from unifi_api.auth.api_key import ApiKeyMaterial, generate_key, hash_key, verify_key
+from unifi_api.auth.api_key import ApiKeyEnv, ApiKeyMaterial, generate_key, hash_key, verify_key
 
 
 def test_generate_key_has_correct_format() -> None:
-    material = generate_key(env="live")
+    material = generate_key(env=ApiKeyEnv.LIVE)
     assert re.fullmatch(r"unifi_live_[A-Z2-7]{22}", material.plaintext)
     assert material.prefix == material.plaintext[:15]
 
 
 def test_generate_key_test_env() -> None:
-    material = generate_key(env="test")
+    material = generate_key(env=ApiKeyEnv.TEST)
     assert material.plaintext.startswith("unifi_test_")
 
 

--- a/apps/api/tests/test_auth_middleware.py
+++ b/apps/api/tests/test_auth_middleware.py
@@ -1,0 +1,94 @@
+"""Auth middleware: bearer token resolution + scope enforcement."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+import uuid
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.db.engine import create_engine
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.db.session import get_sessionmaker
+
+
+async def _make_app(tmp_path: Path) -> FastAPI:
+    """Build an app that has middleware wired but no seeded key."""
+    db_path = tmp_path / "state.db"
+    engine = create_engine(db_path)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    sm = get_sessionmaker(engine)
+    app = FastAPI()
+    app.state.sessionmaker = sm
+
+    @app.get("/protected", dependencies=[Depends(require_scope(Scope.READ))])
+    async def protected():
+        return {"ok": True}
+
+    @app.get("/admin-only", dependencies=[Depends(require_scope(Scope.ADMIN))])
+    async def admin_only():
+        return {"ok": True}
+
+    return app
+
+
+async def _seed_key(app: FastAPI, scopes: str) -> str:
+    """Create a row in api_keys and return the plaintext token."""
+    sm = app.state.sessionmaker
+    material = generate_key()
+    digest = hash_key(material.plaintext)
+    async with sm() as session:
+        session.add(
+            ApiKey(
+                id=str(uuid.uuid4()),
+                prefix=material.prefix,
+                hash=digest,
+                scopes=scopes,
+                name="test",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+    return material.plaintext
+
+
+@pytest.mark.asyncio
+async def test_missing_token_401(tmp_path: Path) -> None:
+    app = await _make_app(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/protected")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_401(tmp_path: Path) -> None:
+    app = await _make_app(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/protected", headers={"Authorization": "Bearer unifi_live_XXXXXXXXXXXXXXXXXXXXXX"})
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_valid_token_with_required_scope_200(tmp_path: Path) -> None:
+    app = await _make_app(tmp_path)
+    plaintext = await _seed_key(app, scopes="read")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/protected", headers={"Authorization": f"Bearer {plaintext}"})
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_insufficient_scope_403(tmp_path: Path) -> None:
+    app = await _make_app(tmp_path)
+    plaintext = await _seed_key(app, scopes="read")
+    # /admin-only requires admin; the seeded key only has read
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin-only", headers={"Authorization": f"Bearer {plaintext}"})
+    assert r.status_code == 403

--- a/apps/api/tests/test_bootstrap.py
+++ b/apps/api/tests/test_bootstrap.py
@@ -1,0 +1,43 @@
+"""First-run admin-key bootstrap test."""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+def _run_migrate(cfg_path: Path, db_path: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["UNIFI_API_DB_KEY"] = "test-passphrase"
+    env["UNIFI_API_DB_PATH"] = str(db_path)
+    return subprocess.run(
+        ["uv", "run", "--package", "unifi-api", "unifi-api", "migrate", "--config-path", str(cfg_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_first_migrate_emits_admin_key(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(f"db:\n  path: {db_path}\n")
+    r = _run_migrate(cfg_path, db_path)
+    assert r.returncode == 0, f"migrate failed: stdout={r.stdout!r} stderr={r.stderr!r}"
+    combined = r.stdout + r.stderr
+    assert re.search(r"unifi_(live|test)_[A-Z2-7]{22}", combined), \
+        f"expected admin key in output: {combined!r}"
+
+
+def test_second_migrate_does_not_emit_new_key(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(f"db:\n  path: {db_path}\n")
+    r1 = _run_migrate(cfg_path, db_path)
+    assert r1.returncode == 0
+    r2 = _run_migrate(cfg_path, db_path)
+    assert r2.returncode == 0
+    combined = r2.stdout + r2.stderr
+    assert not re.search(r"unifi_(live|test)_[A-Z2-7]{22}", combined), \
+        f"second migrate must not emit a new admin key: {combined!r}"

--- a/apps/api/tests/test_cli.py
+++ b/apps/api/tests/test_cli.py
@@ -1,0 +1,35 @@
+"""CLI tests."""
+
+import subprocess
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["uv", "run", "--package", "unifi-api", "unifi-api", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_help_lists_subcommands() -> None:
+    r = _run("--help")
+    assert r.returncode == 0
+    out = r.stdout + r.stderr
+    assert "serve" in out
+    assert "migrate" in out
+    assert "keys" in out
+
+
+def test_keys_help() -> None:
+    r = _run("keys", "--help")
+    assert r.returncode == 0
+    out = r.stdout + r.stderr
+    assert "create" in out
+    assert "list" in out
+    assert "revoke" in out
+
+
+def test_serve_help() -> None:
+    r = _run("serve", "--help")
+    assert r.returncode == 0

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -1,0 +1,41 @@
+"""Config loader tests."""
+
+from pathlib import Path
+
+import pytest
+
+from unifi_api.config import ApiConfig, load_config
+
+
+def test_load_default_config_yaml(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text(
+        "http:\n"
+        "  host: 0.0.0.0\n"
+        "  port: 8080\n"
+        "logging:\n"
+        "  level: INFO\n"
+        "db:\n"
+        "  path: /var/lib/unifi-api/state.db\n"
+    )
+    cfg = load_config(yaml_path)
+    assert cfg.http.host == "0.0.0.0"
+    assert cfg.http.port == 8080
+    assert cfg.logging.level == "INFO"
+    assert cfg.db.path == "/var/lib/unifi-api/state.db"
+
+
+def test_env_override_takes_precedence(tmp_path: Path, monkeypatch) -> None:
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text("http:\n  host: 127.0.0.1\n  port: 8080\n")
+    monkeypatch.setenv("UNIFI_API_HTTP_PORT", "9000")
+    cfg = load_config(yaml_path)
+    assert cfg.http.port == 9000
+
+
+def test_db_key_must_come_from_env(monkeypatch) -> None:
+    monkeypatch.delenv("UNIFI_API_DB_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="UNIFI_API_DB_KEY"):
+        ApiConfig.read_db_key()
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "test-key-not-for-prod")
+    assert ApiConfig.read_db_key() == "test-key-not-for-prod"

--- a/apps/api/tests/test_crypto.py
+++ b/apps/api/tests/test_crypto.py
@@ -1,0 +1,42 @@
+"""AES-GCM column encryption tests."""
+
+import os
+
+import pytest
+
+from unifi_api.db.crypto import ColumnCipher, derive_key
+
+
+def test_encrypt_decrypt_roundtrip() -> None:
+    cipher = ColumnCipher(key=os.urandom(32))
+    plaintext = b'{"username":"admin","password":"hunter2"}'
+    ciphertext = cipher.encrypt(plaintext)
+    assert ciphertext != plaintext
+    assert cipher.decrypt(ciphertext) == plaintext
+
+
+def test_wrong_key_fails() -> None:
+    cipher_a = ColumnCipher(key=os.urandom(32))
+    cipher_b = ColumnCipher(key=os.urandom(32))
+    ct = cipher_a.encrypt(b"secret")
+    with pytest.raises(Exception):
+        cipher_b.decrypt(ct)
+
+
+def test_each_encrypt_uses_fresh_nonce() -> None:
+    cipher = ColumnCipher(key=os.urandom(32))
+    a = cipher.encrypt(b"same input")
+    b = cipher.encrypt(b"same input")
+    assert a != b  # different nonces ⇒ different ciphertexts
+
+
+def test_derive_key_from_short_passphrase() -> None:
+    k = derive_key("a-shortish-passphrase")
+    assert isinstance(k, bytes)
+    assert len(k) == 32
+
+
+def test_derive_key_accepts_raw_32_bytes() -> None:
+    raw = os.urandom(32).hex()
+    k = derive_key(raw)
+    assert len(k) == 32

--- a/apps/api/tests/test_engine.py
+++ b/apps/api/tests/test_engine.py
@@ -1,0 +1,41 @@
+"""Plain async engine + session factory tests."""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from unifi_api.db.engine import create_engine
+from unifi_api.db.session import get_sessionmaker
+
+
+@pytest.mark.asyncio
+async def test_engine_creates_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    engine = create_engine(db_path)
+    async with engine.connect() as conn:
+        await conn.execute(text("CREATE TABLE t (id INTEGER PRIMARY KEY)"))
+        await conn.execute(text("INSERT INTO t (id) VALUES (1)"))
+        await conn.commit()
+    await engine.dispose()
+    assert db_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_engine_creates_parent_dirs(tmp_path: Path) -> None:
+    db_path = tmp_path / "nested" / "dir" / "state.db"
+    engine = create_engine(db_path)
+    async with engine.connect() as conn:
+        await conn.execute(text("SELECT 1"))
+    await engine.dispose()
+    assert db_path.parent.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_session_factory_yields_async_session(tmp_path: Path) -> None:
+    engine = create_engine(tmp_path / "state.db")
+    sm = get_sessionmaker(engine)
+    async with sm() as session:
+        result = await session.execute(text("SELECT 1"))
+        assert result.scalar() == 1
+    await engine.dispose()

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -1,0 +1,69 @@
+"""Health endpoint tests."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_unauthenticated(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_health_ready_requires_admin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/health/ready")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_health_ready_with_admin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+    # Create tables and seed admin key
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(
+            ApiKey(
+                id=str(uuid.uuid4()),
+                prefix=material.prefix,
+                hash=hash_key(material.plaintext),
+                scopes="admin",
+                name="admin",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/health/ready", headers={"Authorization": f"Bearer {material.plaintext}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["db"] == "ok"

--- a/apps/api/tests/test_logging.py
+++ b/apps/api/tests/test_logging.py
@@ -1,0 +1,29 @@
+"""Structured logging tests."""
+
+import json
+
+from unifi_api.logging import configure_logging, get_logger
+
+
+def test_emits_json_with_required_fields(capsys) -> None:
+    configure_logging(level="INFO")
+    log = get_logger("test")
+    log.info("event_happened", extra={"request_id": "req-123", "controller": "default"})
+    captured = capsys.readouterr().err.strip().splitlines()
+    assert captured, "expected one JSON log line on stderr"
+    payload = json.loads(captured[-1])
+    assert payload["level"] == "INFO"
+    assert payload["event"] == "event_happened"
+    assert payload["request_id"] == "req-123"
+    assert payload["controller"] == "default"
+    assert "ts" in payload
+
+
+def test_respects_level(capsys) -> None:
+    configure_logging(level="WARNING")
+    log = get_logger("test")
+    log.info("hidden")
+    log.warning("shown")
+    captured = capsys.readouterr().err.strip().splitlines()
+    assert len(captured) == 1
+    assert json.loads(captured[0])["event"] == "shown"

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -1,0 +1,46 @@
+"""Alembic up/down smoke."""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def _run_alembic(*args: str, db_path: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["UNIFI_API_DB_PATH"] = str(db_path)
+    return subprocess.run(
+        ["uv", "run", "--package", "unifi-api", "alembic", *args],
+        cwd=Path(__file__).resolve().parents[1],  # apps/api
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_migration_up_creates_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "migrate.db"
+    result = _run_alembic("-x", f"db_path={db_path}", "upgrade", "head", db_path=db_path)
+    assert result.returncode == 0, f"alembic upgrade failed: {result.stderr}"
+
+    from unifi_api.db.engine import create_engine
+    from sqlalchemy import text
+    import asyncio
+
+    async def _check():
+        engine = create_engine(db_path)
+        async with engine.connect() as conn:
+            tables = (await conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'"))).scalars().all()
+        await engine.dispose()
+        return set(tables)
+
+    tables = asyncio.run(_check())
+    expected = {"schema_version", "api_keys", "controllers", "sessions", "audit_log", "alembic_version"}
+    assert expected.issubset(tables), f"missing tables: {expected - tables}"
+
+
+def test_migration_downgrade(tmp_path: Path) -> None:
+    db_path = tmp_path / "migrate.db"
+    _run_alembic("-x", f"db_path={db_path}", "upgrade", "head", db_path=db_path)
+    result = _run_alembic("-x", f"db_path={db_path}", "downgrade", "base", db_path=db_path)
+    assert result.returncode == 0

--- a/apps/api/tests/test_models.py
+++ b/apps/api/tests/test_models.py
@@ -1,0 +1,43 @@
+"""Model creation + insert/query smoke tests."""
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from unifi_api.db.engine import create_engine
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.db.session import get_sessionmaker
+
+
+@pytest.mark.asyncio
+async def test_create_all_tables(tmp_path: Path) -> None:
+    engine = create_engine(tmp_path / "state.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_api_key_insert_and_query(tmp_path: Path) -> None:
+    engine = create_engine(tmp_path / "state.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = get_sessionmaker(engine)
+    async with sm() as session:
+        key = ApiKey(
+            id=str(uuid.uuid4()),
+            prefix="unifi_live_abcd",
+            hash="$argon2id$...",
+            scopes="read,write",
+            name="test-key",
+            created_at=datetime.now(timezone.utc),
+        )
+        session.add(key)
+        await session.commit()
+        rows = (await session.execute(select(ApiKey))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].name == "test-key"
+    await engine.dispose()

--- a/apps/api/tests/test_scopes.py
+++ b/apps/api/tests/test_scopes.py
@@ -1,0 +1,30 @@
+"""Scope check tests."""
+
+import pytest
+
+from unifi_api.auth.scopes import Scope, parse_scopes, scope_allows
+
+
+def test_parse_scopes() -> None:
+    assert parse_scopes("read") == frozenset({Scope.READ})
+    assert parse_scopes("read,write") == frozenset({Scope.READ, Scope.WRITE})
+    assert parse_scopes("admin") == frozenset({Scope.ADMIN})
+
+
+def test_admin_implies_all() -> None:
+    admin = frozenset({Scope.ADMIN})
+    assert scope_allows(admin, Scope.READ) is True
+    assert scope_allows(admin, Scope.WRITE) is True
+    assert scope_allows(admin, Scope.ADMIN) is True
+
+
+def test_read_does_not_imply_write() -> None:
+    read_only = frozenset({Scope.READ})
+    assert scope_allows(read_only, Scope.READ) is True
+    assert scope_allows(read_only, Scope.WRITE) is False
+    assert scope_allows(read_only, Scope.ADMIN) is False
+
+
+def test_invalid_scope_string() -> None:
+    with pytest.raises(ValueError):
+        parse_scopes("delete")

--- a/apps/api/tests/test_server.py
+++ b/apps/api/tests/test_server.py
@@ -1,0 +1,57 @@
+"""Server factory + request id middleware tests."""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.server import create_app
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_app_returns_fastapi_instance(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+    assert isinstance(app, FastAPI)
+    # state wired
+    assert app.state.engine is not None
+    assert app.state.sessionmaker is not None
+
+
+@pytest.mark.asyncio
+async def test_request_id_header_added(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+
+    @app.get("/_test")
+    async def _t():
+        return {"ok": True}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/_test")
+    assert r.status_code == 200
+    assert r.headers.get("X-Request-ID")
+
+
+@pytest.mark.asyncio
+async def test_request_id_passthrough(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+
+    @app.get("/_test")
+    async def _t():
+        return {"ok": True}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/_test", headers={"X-Request-ID": "client-req-42"})
+    assert r.headers["X-Request-ID"] == "client-req-42"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,3 +68,27 @@ services:
     restart: unless-stopped
     profiles:
       - relay
+
+  unifi-api:
+    build:
+      context: ..
+      dockerfile: apps/api/Dockerfile
+    env_file:
+      - ../.env
+    environment:
+      - UNIFI_API_DB_KEY=${UNIFI_API_DB_KEY:-dev-only-passphrase-change-me}
+      - UNIFI_API_DB_PATH=/var/lib/unifi-api/state.db
+      - UNIFI_API_HTTP_HOST=0.0.0.0
+      - UNIFI_API_HTTP_PORT=8080
+      - UNIFI_API_LOGGING_LEVEL=INFO
+    ports:
+      - "8080:8080"
+    volumes:
+      - unifi-api-state:/var/lib/unifi-api
+    restart: unless-stopped
+    container_name: unifi-api
+    profiles:
+      - api
+
+volumes:
+  unifi-api-state:

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,15 @@
 version = 1
 revision = 1
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [manifest]
 members = [
     "unifi-access-mcp",
+    "unifi-api",
     "unifi-core",
     "unifi-mcp",
     "unifi-mcp-relay",
@@ -125,6 +130,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405 },
+]
+
+[[package]]
 name = "aiounifi"
 version = "88"
 source = { registry = "https://pypi.org/simple" }
@@ -136,6 +150,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e2/27/1f3f5588fc64b15c66355facd3e73276644d3e3726fbfca846f65b1d81e1/aiounifi-88.tar.gz", hash = "sha256:dcad5afddaaefd8a4d694e69e8572fc900303afbfc1b8bac32e86d4b56d32376", size = 54763 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/aa/a2ea6b8fd373bb12f00acba274b67c3b5db5c7e2656b0a8101888099e116/aiounifi-88-py3-none-any.whl", hash = "sha256:5336063727aab481b3c70108992d98735e62169480a7a51eb665200bca40428a", size = 49017 },
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893 },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303 },
 ]
 
 [[package]]
@@ -163,6 +200,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362 },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657 },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393 },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328 },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269 },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558 },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364 },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637 },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934 },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158 },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597 },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231 },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121 },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177 },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090 },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246 },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126 },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343 },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777 },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180 },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715 },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149 },
 ]
 
 [[package]]
@@ -442,6 +522,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683 },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -515,6 +611,43 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066 },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414 },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349 },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234 },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927 },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243 },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893 },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060 },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740 },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525 },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564 },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166 },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792 },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086 },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933 },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799 },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401 },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038 },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835 },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862 },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614 },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723 },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529 },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015 },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364 },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275 },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204 },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480 },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324 },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +667,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889 },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180 },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596 },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268 },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517 },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337 },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743 },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619 },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714 },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909 },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831 },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631 },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910 },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205 },
 ]
 
 [[package]]
@@ -606,6 +761,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -615,6 +782,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622 },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374 },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980 },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990 },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784 },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588 },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041 },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113 },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911 },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658 },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639 },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569 },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284 },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769 },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642 },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612 },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200 },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973 },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619 },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408 },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005 },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821 },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606 },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043 },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747 },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341 },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069 },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670 },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598 },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261 },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835 },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733 },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672 },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
 ]
 
 [[package]]
@@ -1431,6 +1650,50 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547 },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782 },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156 },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832 },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000 },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641 },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498 },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807 },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481 },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565 },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769 },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319 },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104 },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356 },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486 },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479 },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269 },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260 },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463 },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204 },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474 },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567 },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282 },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406 },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151 },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178 },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158 },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1584,6 +1847,56 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+]
+
+[[package]]
+name = "unifi-api"
+source = { editable = "apps/api" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "argon2-cffi" },
+    { name = "cryptography" },
+    { name = "fastapi" },
+    { name = "omegaconf" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "typer" },
+    { name = "unifi-core" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "alembic", specifier = ">=1.14.0" },
+    { name = "argon2-cffi", specifier = ">=23.1.0" },
+    { name = "cryptography", specifier = ">=42.0.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "omegaconf", specifier = ">=2.3.0" },
+    { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
+    { name = "typer", specifier = ">=0.13.0" },
+    { name = "unifi-core", editable = "packages/unifi-core" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
 ]
 
 [[package]]
@@ -1794,6 +2107,100 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109 },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611 },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811 },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562 },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890 },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472 },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051 },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067 },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423 },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437 },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101 },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360 },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790 },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783 },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548 },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065 },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384 },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730 },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321 },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783 },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279 },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405 },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976 },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506 },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936 },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147 },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007 },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280 },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056 },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162 },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909 },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389 },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964 },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114 },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264 },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877 },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176 },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577 },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425 },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826 },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208 },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315 },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869 },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919 },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845 },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027 },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615 },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836 },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099 },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626 },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519 },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078 },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664 },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154 },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510 },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408 },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968 },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096 },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040 },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847 },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072 },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104 },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 1 of the rich HTTP API service. Scaffolds a new `apps/api/` package: FastAPI app, plain async SQLite with AES-256-GCM column-level encryption for sensitive fields, Alembic migrations, API key auth (argon2id hashing), `/v1/health` endpoints, Typer CLI, and a profile-gated Docker compose entry. **Zero MCP coupling** — depends only on `unifi-core`.

## Scope

This PR ships the API skeleton — the service builds, runs, has migrations, has authentication shape, has a working unauthenticated liveness endpoint and an admin-scoped readiness endpoint. **No business endpoints yet** — those land in Phase 2 (controllers + actions).

## Architecture decisions worth flagging

- **Column-level AES-256-GCM via `cryptography` library** instead of whole-DB SQLCipher. The original spec called for SQLCipher; we switched after discovering `sqlcipher3-binary` ships only manylinux x86_64 wheels (no macOS, no arm64), and `pysqlcipher3` requires a Homebrew sqlcipher dep at build time. The `cryptography` library has wheels everywhere, no native build deps. Threat model is essentially identical: api_keys are argon2id-hashed (no plaintext recoverable from the table), audit_log entries store only key prefixes, and the only real secret in the DB is `controllers.credentials_blob` — which is exactly what we encrypt. Spec §7.2 has been updated.
- **Bootstrap admin key on first migrate** prints the plaintext to stdout exactly once. Subsequent migrates are silent. Documented recovery: re-init the DB if the bootstrap key is lost.
- **Profile-gated compose service** (`--profile api`). Default `docker compose up` is unaffected by Phase 1; opt-in via `docker compose --profile api up -d unifi-api`.

## Verification

| Surface | Result |
|---|---|
| All 5 existing packages | 51/205/628/336/157 — exact baseline parity |
| New unifi-api unit suite | 40 tests (config, logging, engine, crypto, models, migrations, api_key, scopes, auth_middleware, server, health, cli, bootstrap) |
| Local end-to-end | `unifi-api migrate` emits admin key, `unifi-api serve` responds on /v1/health and /v1/health/ready |
| Docker build + run | clean build; `unifi-api migrate` works inside container; `/v1/health` reachable via host:18080 |

## Tooling/process notes

Two real plan defects surfaced and got patched mid-execution:
- `[tool.hatch.build.targets.wheel.force-include]` paths are validated at editable-install time, not just wheel-build time. Three placeholder files (later overwritten) keep the editable install green during scaffolding.
- `alembic -x ...` must precede the subcommand (`alembic -x foo=bar upgrade head`), not follow it.
- `asyncio.run()` inside async-test helper functions raises under pytest-asyncio auto mode — helpers must be `async def`.

## Reference

- Spec: `docs/superpowers/specs/2026-04-28-unifi-rich-api-design.md` (Myco `f738634fa497a25f`)
- Plan: `docs/superpowers/plans/2026-04-28-phase-1-api-skeleton.md` (Myco `503b6c95aa913d4f`)
- Phase 0 (prerequisite): merged in #160 as `37659fc`

## Test plan

- [x] CI passes (test-network, test-protect, test-access, test-relay; new test-api workflow may need to be added — out of scope for this PR)
- [x] Manual local: `uv run --package unifi-api pytest apps/api/tests -q` → 40 passed
- [x] Manual Docker: `docker compose -f docker/docker-compose.yml --profile api up -d unifi-api`, then `curl localhost:8080/v1/health` → 200
- [x] Inspect admin-key bootstrap output on first `unifi-api migrate`, ensure subsequent migrates are silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)