### PR TITLE
Phase 3: resources, catalog, and serializer pattern

### DIFF
--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.serializers._base import SerializerContractError
+from unifi_api.serializers._registry import SerializerRegistryError
 from unifi_api.services import actions as actions_svc
 from unifi_api.services.audit import write_audit
 from unifi_api.services.controllers import ControllerNotFound, get_controller
@@ -23,40 +25,6 @@ class ActionIn(BaseModel):
     confirm: bool = False
 
 
-def _to_jsonable(x):
-    """Best-effort coerce a manager return value to a JSON-serializable form.
-
-    The Phase 2 dispatcher (Option D AST introspection) routes from tool_name to
-    the underlying manager method, bypassing the MCP tool function's
-    response-shaping layer. Manager methods like ClientManager.get_clients()
-    return list[aiounifi.models.client.Client] (Pydantic-ish objects), not
-    dicts. This helper coerces them.
-
-    Phase 3 will add proper resource serializers; this is the v1 floor.
-    """
-    if hasattr(x, "raw"):  # aiounifi models expose .raw with the dict payload
-        return x.raw
-    if hasattr(x, "model_dump"):
-        return x.model_dump()
-    if hasattr(x, "dict") and callable(x.dict):
-        try:
-            return x.dict()
-        except Exception:
-            pass
-    return x
-
-
-def _coerce_response(result) -> dict:
-    """Normalize manager output to a {success, data} dict."""
-    if isinstance(result, dict):
-        return result
-    if isinstance(result, (list, tuple)):
-        return {"success": True, "data": [_to_jsonable(item) for item in result]}
-    if isinstance(result, (str, int, float, bool)) or result is None:
-        return {"success": True, "data": result}
-    return {"success": True, "data": _to_jsonable(result)}
-
-
 @router.post(
     "/actions/{tool_name}",
     dependencies=[Depends(require_scope(Scope.WRITE))],
@@ -65,6 +33,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
     sm = request.app.state.sessionmaker
     factory = request.app.state.manager_factory
     registry = request.app.state.manifest_registry
+    serializer_registry = request.app.state.serializer_registry
     key_prefix = getattr(request.state, "api_key_prefix", "(unknown)")
 
     async with sm() as session:
@@ -95,8 +64,9 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 args=body.args,
                 confirm=body.confirm,
             )
-            coerced = _coerce_response(result)
-            outcome = "success" if coerced.get("success", True) else "error"
+            serializer = serializer_registry.serializer_for_tool(tool_name)
+            shaped = serializer.serialize_action(result, tool_name=tool_name)
+            outcome = "success" if shaped.get("success", True) else "error"
             await write_audit(
                 session,
                 key_id_prefix=key_prefix,
@@ -105,7 +75,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 outcome=outcome,
             )
             await session.commit()
-            return coerced
+            return shaped
         except ToolNotFound:
             await write_audit(
                 session,
@@ -128,6 +98,44 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
             )
             await session.commit()
             return {"success": False, "error": str(e)}
+        except SerializerContractError as e:
+            await write_audit(
+                session,
+                key_id_prefix=key_prefix,
+                controller=body.controller,
+                target=tool_name,
+                outcome="error",
+                error_kind="serializer_contract",
+                detail=str(e),
+            )
+            await session.commit()
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "kind": "serializer_contract_error",
+                    "tool": tool_name,
+                    "detail": str(e),
+                },
+            )
+        except SerializerRegistryError as e:
+            await write_audit(
+                session,
+                key_id_prefix=key_prefix,
+                controller=body.controller,
+                target=tool_name,
+                outcome="error",
+                error_kind="serializer_missing",
+                detail=str(e),
+            )
+            await session.commit()
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "kind": "serializer_missing",
+                    "tool": tool_name,
+                    "detail": str(e),
+                },
+            )
         except Exception as e:
             await write_audit(
                 session,

--- a/apps/api/src/unifi_api/routes/catalog.py
+++ b/apps/api/src/unifi_api/routes/catalog.py
@@ -1,0 +1,71 @@
+"""Catalog endpoints — discoverability for tools, categories, render hints."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Depends, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+
+
+router = APIRouter()
+
+
+@router.get("/catalog/tools", dependencies=[Depends(require_scope(Scope.READ))])
+async def get_tools(request: Request) -> dict:
+    manifest = request.app.state.manifest_registry
+    serializer_registry = request.app.state.serializer_registry
+    items = []
+    for tool_name in manifest.all_tools():
+        entry = manifest.resolve(tool_name)
+        try:
+            render_hint = serializer_registry.render_hint_for_tool(tool_name)
+        except Exception:
+            render_hint = {"kind": "empty"}
+        items.append({
+            "name": tool_name,
+            "product": entry.product,
+            "category": entry.category,
+            "manager": entry.manager,
+            "method": entry.method,
+            "render_hint": render_hint,
+        })
+    return {"items": items}
+
+
+@router.get("/catalog/categories", dependencies=[Depends(require_scope(Scope.READ))])
+async def get_categories(request: Request) -> dict:
+    manifest = request.app.state.manifest_registry
+    counts: dict[tuple[str, str], int] = defaultdict(int)
+    for tool_name in manifest.all_tools():
+        entry = manifest.resolve(tool_name)
+        counts[(entry.product, entry.category or "")] += 1
+    items = [
+        {"product": p, "category": c, "tool_count": n}
+        for (p, c), n in sorted(counts.items())
+    ]
+    return {"items": items}
+
+
+@router.get("/catalog/render-hints", dependencies=[Depends(require_scope(Scope.READ))])
+async def get_render_hints(request: Request) -> dict:
+    manifest = request.app.state.manifest_registry
+    serializer_registry = request.app.state.serializer_registry
+    by_kind: dict[str, dict] = {}
+    for tool_name in manifest.all_tools():
+        try:
+            kind = serializer_registry.kind_for_tool(tool_name).value
+        except Exception:
+            continue
+        by_kind.setdefault(kind, {"kind": kind, "tools": [], "resources": []})
+        by_kind[kind]["tools"].append(tool_name)
+    for product, resource in serializer_registry.all_resources():
+        try:
+            kind = serializer_registry.kind_for_resource(product, resource).value
+        except Exception:
+            continue
+        by_kind.setdefault(kind, {"kind": kind, "tools": [], "resources": []})
+        by_kind[kind]["resources"].append({"product": product, "path": resource})
+    return {"items": list(by_kind.values())}

--- a/apps/api/src/unifi_api/routes/resources/__init__.py
+++ b/apps/api/src/unifi_api/routes/resources/__init__.py
@@ -1,0 +1,1 @@
+"""REST resource endpoints (read-only)."""

--- a/apps/api/src/unifi_api/routes/resources/_common.py
+++ b/apps/api/src/unifi_api/routes/resources/_common.py
@@ -1,0 +1,60 @@
+"""Shared dependencies for REST resource endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Query, Request
+
+from unifi_api.db.models import Controller
+from unifi_api.services.controllers import (
+    ControllerNotFound,
+    get_controller,
+    list_controllers,
+)
+
+
+async def resolve_controller(
+    request: Request,
+    controller: str | None = Query(
+        None, description="Controller UUID; omit to use default"
+    ),
+) -> Controller:
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        if controller:
+            try:
+                return await get_controller(session, controller)
+            except ControllerNotFound:
+                raise HTTPException(status_code=404, detail="controller not found")
+        rows = await list_controllers(session)
+        defaults = [r for r in rows if r.is_default]
+        if not defaults:
+            raise HTTPException(
+                status_code=400,
+                detail="no default controller configured; specify ?controller=<id>",
+            )
+        return defaults[0]
+
+
+def require_capability(controller: Controller, product: str) -> None:
+    products = [p for p in controller.product_kinds.split(",") if p]
+    if product not in products:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "kind": "capability_mismatch",
+                "missing_product": product,
+                "available_products": products,
+            },
+        )
+
+
+def _pagination_dep(
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    cursor: str | None = Query(None, description="Opaque pagination cursor"),
+) -> tuple[int, str | None]:
+    return (limit, cursor)
+
+
+PaginationParams = Annotated[tuple[int, str | None], Depends(_pagination_dep)]

--- a/apps/api/src/unifi_api/routes/resources/access/__init__.py
+++ b/apps/api/src/unifi_api/routes/resources/access/__init__.py
@@ -1,0 +1,1 @@
+"""REST resource endpoints (read-only)."""

--- a/apps/api/src/unifi_api/routes/resources/access/credentials.py
+++ b/apps/api/src/unifi_api/routes/resources/access/credentials.py
@@ -1,0 +1,112 @@
+"""GET /v1/sites/{site_id}/credentials[/{credential_id}] — access credentials.
+
+Access is a single-controller, no-site product: the access connection
+manager has no ``set_site`` method. ``site_id`` is accepted for URL
+symmetry but no-ops on access.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _credential_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {})
+    return (0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+@router.get(
+    "/sites/{site_id}/credentials",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_credentials(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "credential_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        all_credentials = await mgr.list_credentials()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_credentials), limit=limit, cursor=cursor_obj, key_fn=_credential_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("access", "credentials")
+    items = [serializer.serialize(c) for c in page]
+    hint = registry.render_hint_for_resource("access", "credentials")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/credentials/{credential_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_credential(
+    request: Request,
+    site_id: str,
+    credential_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "credential_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        try:
+            credential = await mgr.get_credential(credential_id)
+        except ValueError:
+            raise HTTPException(status_code=404, detail="credential not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("access", "credentials/{id}")
+    return {
+        "data": serializer.serialize(credential),
+        "render_hint": registry.render_hint_for_resource("access", "credentials/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/doors.py
+++ b/apps/api/src/unifi_api/routes/resources/access/doors.py
@@ -1,0 +1,118 @@
+"""GET /v1/sites/{site_id}/doors[/{door_id}] — access doors.
+
+Access is a single-controller, no-site product: the access connection
+manager has no ``set_site`` method. We guard the call with ``getattr``
+so the endpoint shape stays consistent with the network resources.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _door_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {})
+    return (0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    """Call cm.set_site(site_id) only if the CM exposes it.
+
+    Access's connection manager is single-controller-no-site and does not
+    define set_site; network's does. Sharing the resource path means we
+    accept ``site_id`` for URL symmetry but no-op on access.
+    """
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+@router.get(
+    "/sites/{site_id}/doors",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_doors(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "door_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        all_doors = await mgr.list_doors()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_doors), limit=limit, cursor=cursor_obj, key_fn=_door_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("access", "doors")
+    items = [serializer.serialize(d) for d in page]
+    hint = registry.render_hint_for_resource("access", "doors")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/doors/{door_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_door(
+    request: Request,
+    site_id: str,
+    door_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "door_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        try:
+            door = await mgr.get_door(door_id)
+        except ValueError:
+            raise HTTPException(status_code=404, detail="door not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("access", "doors/{id}")
+    return {
+        "data": serializer.serialize(door),
+        "render_hint": registry.render_hint_for_resource("access", "doors/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/users.py
+++ b/apps/api/src/unifi_api/routes/resources/access/users.py
@@ -1,0 +1,121 @@
+"""GET /v1/sites/{site_id}/users[/{user_id}] — access users.
+
+The access ``SystemManager`` exposes ``list_users`` but no ``get_user``
+counterpart. The detail endpoint mirrors the firewall_rules / recordings
+pattern: fetch the list and filter by id.
+
+Access is a single-controller, no-site product.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _user_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {})
+    return (0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+@router.get(
+    "/sites/{site_id}/users",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_users(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        all_users = await mgr.list_users()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_users), limit=limit, cursor=cursor_obj, key_fn=_user_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("access", "users")
+    items = [serializer.serialize(u) for u in page]
+    hint = registry.render_hint_for_resource("access", "users")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/users/{user_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_user(
+    request: Request,
+    site_id: str,
+    user_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """Fetch a user by listing then filtering — no native get_user method."""
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        all_users = await mgr.list_users()
+
+    match = None
+    for user in all_users or []:
+        raw = user if isinstance(user, dict) else getattr(user, "raw", {})
+        if raw.get("id") == user_id:
+            match = user
+            break
+    if match is None:
+        raise HTTPException(status_code=404, detail="user not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("access", "users/{id}")
+    return {
+        "data": serializer.serialize(match),
+        "render_hint": registry.render_hint_for_resource("access", "users/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/__init__.py
+++ b/apps/api/src/unifi_api/routes/resources/network/__init__.py
@@ -1,0 +1,1 @@
+"""REST resource endpoints (read-only)."""

--- a/apps/api/src/unifi_api/routes/resources/network/clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/clients.py
@@ -1,0 +1,106 @@
+"""GET /v1/sites/{site_id}/clients[/{mac}] — network clients."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _client_key(obj) -> tuple:
+    """Sort key on raw objects: (last_seen_int, mac) descending.
+
+    We sort BEFORE serialization so we can use the integer last_seen
+    epoch from the manager rather than the ISO string the serializer
+    emits — integer compares are unambiguous, the ISO string isn't a
+    safe sort key after the serializer transforms it.
+    """
+    raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+    return (raw.get("last_seen") or 0, raw.get("mac") or "")
+
+
+@router.get(
+    "/sites/{site_id}/clients",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_clients(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_clients = await mgr.get_clients()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_clients), limit=limit, cursor=cursor_obj, key_fn=_client_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "clients")
+    items = [serializer.serialize(c) for c in page]
+    hint = registry.render_hint_for_resource("network", "clients")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/clients/{mac}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_client(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        client = await mgr.get_client_details(mac)
+    if client is None:
+        raise HTTPException(status_code=404, detail="client not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "clients/{mac}")
+    return {
+        "data": serializer.serialize(client),
+        "render_hint": registry.render_hint_for_resource("network", "clients/{mac}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -1,0 +1,100 @@
+"""GET /v1/sites/{site_id}/devices[/{mac}] — network devices (UniFi APs/switches/gateways)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _device_key(obj) -> tuple:
+    """Sort by (uptime, mac) descending — most-recently-up devices first."""
+    raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+    return (raw.get("uptime") or 0, raw.get("mac") or "")
+
+
+@router.get(
+    "/sites/{site_id}/devices",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_devices(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_devices = await mgr.get_devices()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_devices), limit=limit, cursor=cursor_obj, key_fn=_device_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "devices")
+    items = [serializer.serialize(d) for d in page]
+    hint = registry.render_hint_for_resource("network", "devices")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/devices/{mac}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_device(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        device = await mgr.get_device_details(mac)
+    if device is None:
+        raise HTTPException(status_code=404, detail="device not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "devices/{mac}")
+    return {
+        "data": serializer.serialize(device),
+        "render_hint": registry.render_hint_for_resource("network", "devices/{mac}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -1,0 +1,111 @@
+"""GET /v1/sites/{site_id}/firewall/rules[/{rule_id}] — firewall policies."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _rule_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+@router.get(
+    "/sites/{site_id}/firewall/rules",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_firewall_rules(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_rules = await mgr.get_firewall_policies()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_rules), limit=limit, cursor=cursor_obj, key_fn=_rule_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "firewall/rules")
+    items = [serializer.serialize(r) for r in page]
+    hint = registry.render_hint_for_resource("network", "firewall/rules")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/firewall/rules/{rule_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_firewall_rule(
+    request: Request,
+    site_id: str,
+    rule_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        # firewall_manager exposes get_firewall_policies (list) but not a
+        # singular get_firewall_policy_details. Fetch the list and filter
+        # by id; the manager already caches/normalizes the response.
+        all_rules = await mgr.get_firewall_policies(include_predefined=True)
+
+    rule = None
+    for r in all_rules:
+        raw = getattr(r, "raw", r if isinstance(r, dict) else {})
+        rid = raw.get("_id") or raw.get("id")
+        if rid == rule_id:
+            rule = r
+            break
+    if rule is None:
+        raise HTTPException(status_code=404, detail="firewall rule not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "firewall/rules/{id}")
+    return {
+        "data": serializer.serialize(rule),
+        "render_hint": registry.render_hint_for_resource("network", "firewall/rules/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/networks.py
+++ b/apps/api/src/unifi_api/routes/resources/network/networks.py
@@ -1,0 +1,100 @@
+"""GET /v1/sites/{site_id}/networks[/{network_id}] — LAN/VLAN definitions."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _network_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+@router.get(
+    "/sites/{site_id}/networks",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_networks(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "network_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_networks = await mgr.get_networks()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_networks), limit=limit, cursor=cursor_obj, key_fn=_network_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "networks")
+    items = [serializer.serialize(n) for n in page]
+    hint = registry.render_hint_for_resource("network", "networks")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/networks/{network_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_network(
+    request: Request,
+    site_id: str,
+    network_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "network_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        network = await mgr.get_network_details(network_id)
+    if network is None:
+        raise HTTPException(status_code=404, detail="network not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "networks/{id}")
+    return {
+        "data": serializer.serialize(network),
+        "render_hint": registry.render_hint_for_resource("network", "networks/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/wlans.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wlans.py
@@ -1,0 +1,101 @@
+"""GET /v1/sites/{site_id}/wlans[/{wlan_id}] — WLAN/SSID definitions."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _wlan_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+@router.get(
+    "/sites/{site_id}/wlans",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_wlans(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        # WLANs live on network_manager (see managers.py builder map).
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "network_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_wlans = await mgr.get_wlans()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_wlans), limit=limit, cursor=cursor_obj, key_fn=_wlan_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "wlans")
+    items = [serializer.serialize(w) for w in page]
+    hint = registry.render_hint_for_resource("network", "wlans")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/wlans/{wlan_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_wlan(
+    request: Request,
+    site_id: str,
+    wlan_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "network_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        wlan = await mgr.get_wlan_details(wlan_id)
+    if wlan is None:
+        raise HTTPException(status_code=404, detail="wlan not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("network", "wlans/{id}")
+    return {
+        "data": serializer.serialize(wlan),
+        "render_hint": registry.render_hint_for_resource("network", "wlans/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/__init__.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/__init__.py
@@ -1,0 +1,1 @@
+"""REST resource endpoints (read-only)."""

--- a/apps/api/src/unifi_api/routes/resources/protect/cameras.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/cameras.py
@@ -1,0 +1,118 @@
+"""GET /v1/sites/{site_id}/cameras[/{camera_id}] — protect cameras.
+
+Protect is a single-controller, no-site product: the protect connection
+manager has no ``set_site`` method. We guard the call with ``getattr``
+so the endpoint shape stays consistent with the network resources.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _camera_key(obj) -> tuple:
+    """Sort by (0, id) — id-stable order, no time component."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {})
+    return (0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    """Call cm.set_site(site_id) only if the CM exposes it.
+
+    Protect's connection manager is single-controller-no-site and does not
+    define set_site; network's does. Sharing the resource path means we
+    accept ``site_id`` for URL symmetry but no-op on protect.
+    """
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+@router.get(
+    "/sites/{site_id}/cameras",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_cameras(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "camera_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        all_cameras = await mgr.list_cameras()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_cameras), limit=limit, cursor=cursor_obj, key_fn=_camera_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("protect", "cameras")
+    items = [serializer.serialize(c) for c in page]
+    hint = registry.render_hint_for_resource("protect", "cameras")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/cameras/{camera_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_camera(
+    request: Request,
+    site_id: str,
+    camera_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "camera_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        try:
+            camera = await mgr.get_camera(camera_id)
+        except ValueError:
+            raise HTTPException(status_code=404, detail="camera not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("protect", "cameras/{id}")
+    return {
+        "data": serializer.serialize(camera),
+        "render_hint": registry.render_hint_for_resource("protect", "cameras/{id}"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/events.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/events.py
@@ -1,0 +1,86 @@
+"""GET /v1/sites/{site_id}/events — protect event log.
+
+LIST only (EVENT_LOG render kind). The protect manifest does not expose
+a ``protect_get_event`` tool, so we don't expose a detail endpoint.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _event_key(obj) -> tuple:
+    """Sort by (start, id) descending — most recent first.
+
+    EventManager.list_events already sorts desc server-side, but we
+    re-sort here so paginate() can drive a stable cursor regardless of
+    upstream ordering. The pagination helper sorts ascending, then the
+    manifest's ``sort_default = "start:desc"`` reflects the intended
+    user-facing direction.
+    """
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {})
+    return (raw.get("start") or 0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+@router.get(
+    "/sites/{site_id}/events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_events(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        all_events = await mgr.list_events(limit=max(limit, 100))
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_events), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("protect", "events")
+    items = [serializer.serialize(e) for e in page]
+    hint = registry.render_hint_for_resource("protect", "events")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/recordings.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recordings.py
@@ -1,0 +1,143 @@
+"""GET /v1/sites/{site_id}/recordings[/{recording_id}] — protect recordings.
+
+UniFi Protect does not expose discrete recording segments — recordings
+are a continuous time window per camera. The underlying manager method
+returns a single dict describing that window for a given ``camera_id``.
+
+The endpoint accepts ``camera_id`` as a query parameter and wraps the
+single-dict response in a list for serialization. The detail endpoint
+follows Task 8's firewall_rules pattern: fetch the list and filter by
+id, since the manager exposes no native ``get_recording``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _recording_key(obj) -> tuple:
+    """Sort by (start, id) descending — most recent first."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {})
+    return (raw.get("start") or 0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+def _normalize_recordings(result) -> list[dict]:
+    """Coerce the manager response into a list of dicts.
+
+    ``RecordingManager.list_recordings`` historically returned a single
+    dict (the window for one camera); newer/test stubs may return a
+    list. Accept either.
+    """
+    if isinstance(result, list):
+        return result
+    if isinstance(result, dict):
+        return [result]
+    return []
+
+
+@router.get(
+    "/sites/{site_id}/recordings",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_recordings(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    camera_id: str = Query(..., description="Camera ID to query recordings for"),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "recording_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        result = await mgr.list_recordings(camera_id=camera_id)
+
+    all_recordings = _normalize_recordings(result)
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_recordings), limit=limit, cursor=cursor_obj, key_fn=_recording_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("protect", "recordings")
+    items = [serializer.serialize(r) for r in page]
+    hint = registry.render_hint_for_resource("protect", "recordings")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/recordings/{recording_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_recording(
+    request: Request,
+    site_id: str,
+    recording_id: str,
+    controller=Depends(resolve_controller),
+    camera_id: str = Query(..., description="Camera ID the recording belongs to"),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "recording_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        result = await mgr.list_recordings(camera_id=camera_id)
+
+    all_recordings = _normalize_recordings(result)
+    match = None
+    for rec in all_recordings:
+        raw = rec if isinstance(rec, dict) else getattr(rec, "raw", {})
+        rid = raw.get("id")
+        if rid == recording_id:
+            match = rec
+            break
+    if match is None:
+        raise HTTPException(status_code=404, detail="recording not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("protect", "recordings/{id}")
+    return {
+        "data": serializer.serialize(match),
+        "render_hint": registry.render_hint_for_resource("protect", "recordings/{id}"),
+    }

--- a/apps/api/src/unifi_api/serializers/__init__.py
+++ b/apps/api/src/unifi_api/serializers/__init__.py
@@ -1,0 +1,1 @@
+"""API serializers — see decision-a63cb266."""

--- a/apps/api/src/unifi_api/serializers/_base.py
+++ b/apps/api/src/unifi_api/serializers/_base.py
@@ -1,0 +1,133 @@
+"""Serializer base + decorator. See decision-a63cb266 for ownership rationale."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
+
+
+class RenderKind(str, Enum):
+    LIST = "list"
+    DETAIL = "detail"
+    DIFF = "diff"
+    TIMESERIES = "timeseries"
+    EVENT_LOG = "event_log"
+    EMPTY = "empty"
+
+
+class SerializerContractError(Exception):
+    """Raised when manager-method return type doesn't match declared kind."""
+
+
+class Serializer:
+    """Subclass + override serialize() and declare kind. Optional richer
+    metadata (primary_key, display_columns, sort_default) is per-serializer
+    opt-in and surfaced in the catalog when present."""
+
+    kind: RenderKind = RenderKind.EMPTY
+    primary_key: str | None = None
+    display_columns: list[str] | None = None
+    sort_default: str | None = None
+
+    # Per-tool / per-resource kind overrides — populated by the decorator.
+    _tool_kinds: dict[str, RenderKind] = {}
+    _resource_kinds: dict[tuple[str, str], RenderKind] = {}
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        raise NotImplementedError
+
+    def _kind_for_tool(self, tool_name: str) -> RenderKind:
+        return self._tool_kinds.get(tool_name, self.kind)
+
+    def _kind_for_resource(self, product: str, resource: str) -> RenderKind:
+        return self._resource_kinds.get((product, resource), self.kind)
+
+    def _render_hint(self, kind: RenderKind) -> dict:
+        hint: dict[str, Any] = {"kind": kind.value}
+        if self.primary_key:
+            hint["primary_key"] = self.primary_key
+        if self.display_columns:
+            hint["display_columns"] = list(self.display_columns)
+        if self.sort_default:
+            hint["sort_default"] = self.sort_default
+        return hint
+
+    def serialize_action(self, result, *, tool_name: str) -> dict:
+        kind = self._kind_for_tool(tool_name)
+        hint = self._render_hint(kind)
+        if kind == RenderKind.LIST:
+            if not isinstance(result, list):
+                raise SerializerContractError(
+                    f"tool '{tool_name}' declared kind=list but manager returned "
+                    f"{type(result).__name__}"
+                )
+            return {"success": True, "data": [self.serialize(item) for item in result], "render_hint": hint}
+        if kind == RenderKind.DETAIL:
+            return {"success": True, "data": self.serialize(result), "render_hint": hint}
+        if kind == RenderKind.EMPTY:
+            return {"success": True, "render_hint": hint}
+        if kind == RenderKind.DIFF:
+            return {"success": True, "data": self.serialize(result), "render_hint": hint}
+        if kind in (RenderKind.TIMESERIES, RenderKind.EVENT_LOG):
+            if not isinstance(result, list):
+                raise SerializerContractError(
+                    f"tool '{tool_name}' declared kind={kind.value} but manager returned {type(result).__name__}"
+                )
+            return {"success": True, "data": [self.serialize(item) for item in result], "render_hint": hint}
+        raise SerializerContractError(f"unknown kind {kind} for tool '{tool_name}'")
+
+
+# Module-level registries populated by the decorator. Lookup helpers in _registry.py.
+_TOOL_REGISTRY: dict[str, Serializer] = {}
+_RESOURCE_REGISTRY: dict[tuple[str, str], Serializer] = {}
+_TOOL_KIND_OVERRIDES: dict[str, RenderKind] = {}
+_RESOURCE_KIND_OVERRIDES: dict[tuple[str, str], RenderKind] = {}
+
+
+def register_serializer(
+    *,
+    tools: list[str] | dict[str, dict] | None = None,
+    resources: list[tuple[str, str]] | list[tuple[tuple[str, str], dict]] | None = None,
+) -> Callable[[type[Serializer]], type[Serializer]]:
+    """Decorator: register a Serializer class under tool names and resource paths.
+
+    `tools` accepts:
+      - list[str]: bare tool names; serializer's class-level `kind` applies
+      - dict[str, {"kind": RenderKind, ...}]: per-tool kind override
+    Same shape for `resources` but keys are (product, resource_path) tuples.
+    """
+    def decorator(cls: type[Serializer]) -> type[Serializer]:
+        instance = cls()  # singleton instance per registered serializer class
+        if tools is not None:
+            if isinstance(tools, dict):
+                for name, spec in tools.items():
+                    _TOOL_REGISTRY[name] = instance
+                    if "kind" in spec:
+                        _TOOL_KIND_OVERRIDES[name] = spec["kind"]
+                        cls._tool_kinds = {**cls._tool_kinds, name: spec["kind"]}
+            else:
+                for name in tools:
+                    _TOOL_REGISTRY[name] = instance
+        if resources is not None:
+            for entry in resources:
+                if isinstance(entry, tuple) and len(entry) == 2 and isinstance(entry[0], tuple):
+                    # ((product, resource), spec) form
+                    key, spec = entry
+                    _RESOURCE_REGISTRY[key] = instance
+                    if isinstance(spec, dict) and "kind" in spec:
+                        _RESOURCE_KIND_OVERRIDES[key] = spec["kind"]
+                        cls._resource_kinds = {**cls._resource_kinds, key: spec["kind"]}
+                else:
+                    # (product, resource) bare-tuple form
+                    _RESOURCE_REGISTRY[entry] = instance
+        return cls
+    return decorator
+
+
+def _reset_registries_for_tests() -> None:
+    _TOOL_REGISTRY.clear()
+    _RESOURCE_REGISTRY.clear()
+    _TOOL_KIND_OVERRIDES.clear()
+    _RESOURCE_KIND_OVERRIDES.clear()

--- a/apps/api/src/unifi_api/serializers/_registry.py
+++ b/apps/api/src/unifi_api/serializers/_registry.py
@@ -1,0 +1,105 @@
+"""Serializer registry: lookup helpers + auto-discovery + manifest validation."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Iterable
+
+from unifi_api.serializers import _base
+from unifi_api.serializers._base import (
+    RenderKind, Serializer,
+    _TOOL_REGISTRY, _RESOURCE_REGISTRY,
+    _TOOL_KIND_OVERRIDES, _RESOURCE_KIND_OVERRIDES,
+    _reset_registries_for_tests,
+)
+
+
+class SerializerRegistryError(Exception):
+    """Raised when the registry is in an invalid state (e.g., missing serializer)."""
+
+
+class SerializerRegistry:
+    def serializer_for_tool(self, tool_name: str) -> Serializer:
+        s = _TOOL_REGISTRY.get(tool_name)
+        if s is None:
+            raise SerializerRegistryError(f"no serializer registered for tool '{tool_name}'")
+        return s
+
+    def serializer_for_resource(self, product: str, resource: str) -> Serializer:
+        s = _RESOURCE_REGISTRY.get((product, resource))
+        if s is None:
+            raise SerializerRegistryError(
+                f"no serializer registered for resource ({product}, {resource})"
+            )
+        return s
+
+    def kind_for_tool(self, tool_name: str) -> RenderKind:
+        if tool_name in _TOOL_KIND_OVERRIDES:
+            return _TOOL_KIND_OVERRIDES[tool_name]
+        return self.serializer_for_tool(tool_name).kind
+
+    def kind_for_resource(self, product: str, resource: str) -> RenderKind:
+        key = (product, resource)
+        if key in _RESOURCE_KIND_OVERRIDES:
+            return _RESOURCE_KIND_OVERRIDES[key]
+        return self.serializer_for_resource(product, resource).kind
+
+    def all_tools(self) -> Iterable[str]:
+        return list(_TOOL_REGISTRY.keys())
+
+    def all_resources(self) -> Iterable[tuple[str, str]]:
+        return list(_RESOURCE_REGISTRY.keys())
+
+    def render_hint_for_tool(self, tool_name: str) -> dict:
+        s = self.serializer_for_tool(tool_name)
+        kind = self.kind_for_tool(tool_name)
+        return s._render_hint(kind)
+
+    def render_hint_for_resource(self, product: str, resource: str) -> dict:
+        s = self.serializer_for_resource(product, resource)
+        kind = self.kind_for_resource(product, resource)
+        return s._render_hint(kind)
+
+    def validate_manifest(self, manifest_tool_names: set[str]) -> None:
+        """Every tool in the manifest must have a serializer registered."""
+        missing = manifest_tool_names - set(_TOOL_REGISTRY.keys())
+        if missing:
+            raise SerializerRegistryError(
+                f"missing serializer for {len(missing)} tools: {sorted(missing)[:5]}..."
+            )
+
+
+_singleton: SerializerRegistry | None = None
+
+
+def serializer_registry_singleton() -> SerializerRegistry:
+    global _singleton
+    if _singleton is None:
+        _singleton = SerializerRegistry()
+    return _singleton
+
+
+def discover_serializers(manifest_tool_names: set[str]) -> SerializerRegistry:
+    """Walk the serializers package, import every submodule (decorators self-register),
+    then validate against the manifest. Called once during lifespan startup."""
+    pkg = importlib.import_module("unifi_api.serializers")
+    for product in ("network", "protect", "access"):
+        try:
+            product_pkg = importlib.import_module(f"unifi_api.serializers.{product}")
+        except ModuleNotFoundError:
+            continue
+        for _, modname, ispkg in pkgutil.iter_modules(product_pkg.__path__):
+            if ispkg or modname.startswith("_"):
+                continue
+            importlib.import_module(f"unifi_api.serializers.{product}.{modname}")
+    reg = serializer_registry_singleton()
+    reg.validate_manifest(manifest_tool_names)
+    return reg
+
+
+def _reset_registry_for_tests() -> None:
+    """For test isolation — drops module-level registries."""
+    global _singleton
+    _reset_registries_for_tests()
+    _singleton = None

--- a/apps/api/src/unifi_api/serializers/access/__init__.py
+++ b/apps/api/src/unifi_api/serializers/access/__init__.py
@@ -1,0 +1,1 @@
+"""API serializers — see decision-a63cb266."""

--- a/apps/api/src/unifi_api/serializers/access/credentials.py
+++ b/apps/api/src/unifi_api/serializers/access/credentials.py
@@ -1,0 +1,44 @@
+"""Access credential serializer.
+
+``CredentialManager.list_credentials`` / ``get_credential`` return plain
+dicts as supplied by the proxy/API path. Field names follow the
+controller's snake-case convention.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "access_list_credentials": {"kind": RenderKind.LIST},
+        "access_get_credential": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("access", "credentials"), {"kind": RenderKind.LIST}),
+        (("access", "credentials/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class CredentialSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["user_id", "type", "status", "expiry"]
+    sort_default = "user_id"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "user_id": _get(obj, "user_id"),
+            "type": _get(obj, "type"),
+            "status": _get(obj, "status"),
+            "expiry": _get(obj, "expiry"),
+            "last_used": _get(obj, "last_used"),
+        }

--- a/apps/api/src/unifi_api/serializers/access/doors.py
+++ b/apps/api/src/unifi_api/serializers/access/doors.py
@@ -1,0 +1,74 @@
+"""Access door serializer.
+
+``DoorManager.list_doors`` / ``get_door`` return plain dicts. Two paths
+populate slightly different shapes:
+
+- API-client path: ``id``, ``name``, ``door_position_status``,
+  ``lock_relay_status`` (and ``camera_resource_id``, ``door_guard`` on
+  detail).
+- Proxy path: the raw location dict, which keeps richer fields like
+  ``location_type``, ``devices``, ``is_online``, ``last_event``.
+
+We normalize across both. ``is_locked`` is derived from
+``lock_relay_status`` when present (``"lock"``); otherwise we honor an
+explicit ``is_locked`` key on the dict.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _is_locked(obj: Any) -> bool | None:
+    explicit = _get(obj, "is_locked")
+    if explicit is not None:
+        return bool(explicit)
+    relay = _get(obj, "lock_relay_status")
+    if relay is None:
+        return None
+    return relay == "lock"
+
+
+def _last_event(obj: Any) -> Any:
+    raw = _get(obj, "last_event")
+    if isinstance(raw, dict):
+        return {
+            "name": raw.get("name"),
+            "timestamp": raw.get("timestamp") or raw.get("created_at"),
+        }
+    return raw
+
+
+@register_serializer(
+    tools={
+        "access_list_doors": {"kind": RenderKind.LIST},
+        "access_get_door": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("access", "doors"), {"kind": RenderKind.LIST}),
+        (("access", "doors/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class DoorSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "location", "is_online", "is_locked"]
+    sort_default = "name"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "location": _get(obj, "location") or _get(obj, "location_type"),
+            "is_online": _get(obj, "is_online"),
+            "is_locked": _is_locked(obj),
+            "lock_state": _get(obj, "lock_state") or _get(obj, "lock_relay_status"),
+            "last_event": _last_event(obj),
+        }

--- a/apps/api/src/unifi_api/serializers/access/users.py
+++ b/apps/api/src/unifi_api/serializers/access/users.py
@@ -1,0 +1,57 @@
+"""Access user serializer.
+
+``SystemManager.list_users`` returns dicts shaped by the proxy
+``users`` endpoint. There is no per-user GET tool in the Access manifest
+today, so we register the LIST tool and both LIST + DETAIL resources
+(detail is reachable via the resources endpoint by id).
+
+Name handling: prefer the explicit ``name`` field, otherwise stitch
+``first_name`` + ``last_name`` together.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _name(obj: Any) -> str | None:
+    name = _get(obj, "name")
+    if name:
+        return name
+    first = _get(obj, "first_name") or ""
+    last = _get(obj, "last_name") or ""
+    full = f"{first} {last}".strip()
+    return full or None
+
+
+@register_serializer(
+    tools={
+        "access_list_users": {"kind": RenderKind.LIST},
+    },
+    resources=[
+        (("access", "users"), {"kind": RenderKind.LIST}),
+        (("access", "users/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class UserSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "employee_id", "status", "role"]
+    sort_default = "name"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "name": _name(obj),
+            "employee_id": _get(obj, "employee_id"),
+            "status": _get(obj, "status"),
+            "role": _get(obj, "role"),
+            "created_at": _get(obj, "created_at"),
+        }

--- a/apps/api/src/unifi_api/serializers/network/__init__.py
+++ b/apps/api/src/unifi_api/serializers/network/__init__.py
@@ -1,0 +1,1 @@
+"""API serializers — see decision-a63cb266."""

--- a/apps/api/src/unifi_api/serializers/network/clients.py
+++ b/apps/api/src/unifi_api/serializers/network/clients.py
@@ -1,0 +1,44 @@
+"""Network client serializer."""
+
+from datetime import datetime, timezone
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _iso(ts: int | None) -> str | None:
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+@register_serializer(
+    tools={
+        "unifi_list_clients": {"kind": RenderKind.LIST},
+        "unifi_get_client_details": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("network", "clients"), {"kind": RenderKind.LIST}),
+        (("network", "clients/{mac}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class ClientSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "mac"
+    display_columns = ["hostname", "ip", "status", "last_seen"]
+    sort_default = "last_seen:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+        return {
+            "mac": raw.get("mac"),
+            "ip": raw.get("last_ip") or raw.get("ip"),
+            "hostname": raw.get("hostname") or raw.get("name"),
+            "is_wired": bool(raw.get("is_wired", False)),
+            "is_guest": bool(raw.get("is_guest", False)),
+            "status": "online" if raw.get("is_online") else "offline",
+            "last_seen": _iso(raw.get("last_seen")),
+            "first_seen": _iso(raw.get("first_seen")),
+            "note": raw.get("note") or None,
+            "usergroup_id": raw.get("usergroup_id") or None,
+        }

--- a/apps/api/src/unifi_api/serializers/network/devices.py
+++ b/apps/api/src/unifi_api/serializers/network/devices.py
@@ -1,0 +1,49 @@
+"""Network device serializer."""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+_STATE_MAP = {
+    0: "disconnected",
+    1: "connected",
+    2: "pending",
+    4: "upgrading",
+    5: "provisioning",
+    6: "heartbeat-missed",
+    7: "adopting",
+    9: "adoption-error",
+    11: "isolated",
+}
+
+
+@register_serializer(
+    tools={
+        "unifi_list_devices": {"kind": RenderKind.LIST},
+        "unifi_get_device_details": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("network", "devices"), {"kind": RenderKind.LIST}),
+        (("network", "devices/{mac}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class DeviceSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "mac"
+    display_columns = ["name", "model", "type", "state", "ip"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+        state_raw = raw.get("state")
+        return {
+            "mac": raw.get("mac"),
+            "name": raw.get("name"),
+            "model": raw.get("model"),
+            "type": raw.get("type"),
+            "version": raw.get("version"),
+            "uptime": raw.get("uptime"),
+            "state": _STATE_MAP.get(state_raw, state_raw),
+            "ip": raw.get("ip"),
+            "ports": raw.get("port_table") or raw.get("ports"),
+        }

--- a/apps/api/src/unifi_api/serializers/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/serializers/network/firewall_rules.py
@@ -1,0 +1,33 @@
+"""Firewall policy/rule serializer."""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+@register_serializer(
+    tools={
+        "unifi_list_firewall_policies": {"kind": RenderKind.LIST},
+        "unifi_get_firewall_policy_details": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("network", "firewall/rules"), {"kind": RenderKind.LIST}),
+        (("network", "firewall/rules/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class FirewallRuleSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "action", "enabled", "predefined"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+        return {
+            "id": raw.get("_id") or raw.get("id"),
+            "name": raw.get("name"),
+            "action": raw.get("action"),
+            "enabled": bool(raw.get("enabled", False)),
+            "predefined": bool(raw.get("predefined", False)),
+            "source": raw.get("source"),
+            "destination": raw.get("destination"),
+        }

--- a/apps/api/src/unifi_api/serializers/network/networks.py
+++ b/apps/api/src/unifi_api/serializers/network/networks.py
@@ -1,0 +1,32 @@
+"""Network (LAN/VLAN) serializer."""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+@register_serializer(
+    tools={
+        "unifi_list_networks": {"kind": RenderKind.LIST},
+        "unifi_get_network_details": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("network", "networks"), {"kind": RenderKind.LIST}),
+        (("network", "networks/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class NetworkSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "purpose", "vlan", "subnet", "enabled"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+        return {
+            "id": raw.get("_id") or raw.get("id"),
+            "name": raw.get("name"),
+            "purpose": raw.get("purpose"),
+            "enabled": bool(raw.get("enabled", False)),
+            "vlan": raw.get("vlan"),
+            "subnet": raw.get("ip_subnet") or raw.get("subnet"),
+        }

--- a/apps/api/src/unifi_api/serializers/network/wlans.py
+++ b/apps/api/src/unifi_api/serializers/network/wlans.py
@@ -1,0 +1,33 @@
+"""WLAN/SSID serializer."""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+@register_serializer(
+    tools={
+        "unifi_list_wlans": {"kind": RenderKind.LIST},
+        "unifi_get_wlan_details": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("network", "wlans"), {"kind": RenderKind.LIST}),
+        (("network", "wlans/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class WlanSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "security", "enabled", "vlan_id"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+        return {
+            "id": raw.get("_id") or raw.get("id"),
+            "name": raw.get("name"),
+            "enabled": bool(raw.get("enabled", False)),
+            "security": raw.get("security"),
+            "network_id": raw.get("networkconf_id") or raw.get("network_id"),
+            "hide_ssid": bool(raw.get("hide_ssid", False)),
+            "vlan_id": raw.get("vlan") or raw.get("vlan_id"),
+        }

--- a/apps/api/src/unifi_api/serializers/protect/__init__.py
+++ b/apps/api/src/unifi_api/serializers/protect/__init__.py
@@ -1,0 +1,1 @@
+"""API serializers — see decision-a63cb266."""

--- a/apps/api/src/unifi_api/serializers/protect/cameras.py
+++ b/apps/api/src/unifi_api/serializers/protect/cameras.py
@@ -1,0 +1,49 @@
+"""Protect camera serializer.
+
+Manager methods (``CameraManager.list_cameras`` / ``get_camera``) return
+plain dicts shaped by ``_format_camera_summary`` and the detail merge in
+``get_camera``. We read dict keys directly; if a Pydantic-like object is
+ever passed, fall back to attribute access via ``_get``.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "protect_list_cameras": {"kind": RenderKind.LIST},
+        "protect_get_camera": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("protect", "cameras"), {"kind": RenderKind.LIST}),
+        (("protect", "cameras/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class CameraSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "model", "state", "is_recording"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "mac": _get(obj, "mac"),
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "type": _get(obj, "type"),
+            "state": _get(obj, "state"),
+            "is_recording": _get(obj, "is_recording"),
+            "is_motion_detected": _get(obj, "is_motion_detected"),
+            "is_smart_detected": _get(obj, "is_smart_detected"),
+            "host": _get(obj, "ip_address") or _get(obj, "host"),
+            "channels": _get(obj, "channels") or [],
+        }

--- a/apps/api/src/unifi_api/serializers/protect/events.py
+++ b/apps/api/src/unifi_api/serializers/protect/events.py
@@ -1,0 +1,43 @@
+"""Protect event serializer.
+
+``EventManager.list_events`` returns plain dicts shaped by
+``_event_to_dict``. Registered as EVENT_LOG kind.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "protect_list_events": {"kind": RenderKind.EVENT_LOG},
+    },
+    resources=[
+        (("protect", "events"), {"kind": RenderKind.EVENT_LOG}),
+    ],
+)
+class EventSerializer(Serializer):
+    kind = RenderKind.EVENT_LOG
+    primary_key = "id"
+    display_columns = ["type", "start", "score"]
+    sort_default = "start:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "type": _get(obj, "type"),
+            "start": _get(obj, "start"),
+            "end": _get(obj, "end"),
+            "score": _get(obj, "score"),
+            "smart_detect_types": _get(obj, "smart_detect_types") or [],
+            "camera": _get(obj, "camera_id"),
+            "thumbnail": _get(obj, "thumbnail_id"),
+        }

--- a/apps/api/src/unifi_api/serializers/protect/lights.py
+++ b/apps/api/src/unifi_api/serializers/protect/lights.py
@@ -1,0 +1,41 @@
+"""Protect light serializer.
+
+``LightManager.list_lights`` returns plain dicts shaped by
+``_format_light_summary``.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "protect_list_lights": {"kind": RenderKind.LIST},
+    },
+    resources=[
+        (("protect", "lights"), {"kind": RenderKind.LIST}),
+    ],
+)
+class LightSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "model", "state", "is_light_on"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "mac": _get(obj, "mac"),
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "state": _get(obj, "state"),
+            "is_pir_motion_detected": _get(obj, "is_pir_motion_detected"),
+            "is_light_on": _get(obj, "is_light_on"),
+        }

--- a/apps/api/src/unifi_api/serializers/protect/recordings.py
+++ b/apps/api/src/unifi_api/serializers/protect/recordings.py
@@ -1,0 +1,48 @@
+"""Protect recording serializer.
+
+``RecordingManager.list_recordings`` returns a single dict describing the
+available recording window for a camera (uiprotect does not expose
+discrete segments). The serializer flattens the keys we surface in lists.
+
+Note: there is no ``protect_get_recording`` tool in the protect manifest;
+only ``protect_list_recordings`` exists, so we register LIST only and
+expose the resource as both a list path and a detail path so the
+catalog can surface a per-id link if a future tool is added.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "protect_list_recordings": {"kind": RenderKind.LIST},
+    },
+    resources=[
+        (("protect", "recordings"), {"kind": RenderKind.LIST}),
+        (("protect", "recordings/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class RecordingSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["type", "start", "end", "file_size"]
+    sort_default = "start:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "type": _get(obj, "type"),
+            "camera": _get(obj, "camera_id"),
+            "start": _get(obj, "start"),
+            "end": _get(obj, "end"),
+            "file_size": _get(obj, "file_size"),
+        }

--- a/apps/api/src/unifi_api/serializers/protect/sensors.py
+++ b/apps/api/src/unifi_api/serializers/protect/sensors.py
@@ -1,0 +1,53 @@
+"""Protect sensor serializer.
+
+``SensorManager.list_sensors`` returns plain dicts shaped by
+``_format_sensor_summary``. Battery / humidity / light statuses are
+nested under ``battery`` and ``stats`` so we flatten them here.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _nested_status(obj: Any, parent_key: str, child_key: str = "status") -> Any:
+    parent = _get(obj, parent_key) or {}
+    if isinstance(parent, dict):
+        return parent.get(child_key)
+    return getattr(parent, child_key, None)
+
+
+@register_serializer(
+    tools={
+        "protect_list_sensors": {"kind": RenderKind.LIST},
+    },
+    resources=[
+        (("protect", "sensors"), {"kind": RenderKind.LIST}),
+    ],
+)
+class SensorSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "type", "battery_status", "motion_detected_at"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        stats = _get(obj, "stats") or {}
+        humidity = stats.get("humidity") if isinstance(stats, dict) else getattr(stats, "humidity", None)
+        light = stats.get("light") if isinstance(stats, dict) else getattr(stats, "light", None)
+        return {
+            "id": _get(obj, "id"),
+            "mac": _get(obj, "mac"),
+            "name": _get(obj, "name"),
+            "type": _get(obj, "type"),
+            "battery_status": _nested_status(obj, "battery"),
+            "humidity_status": humidity.get("status") if isinstance(humidity, dict) else None,
+            "light_status": light.get("status") if isinstance(light, dict) else None,
+            "motion_detected_at": _get(obj, "motion_detected_at"),
+        }

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -17,6 +17,7 @@ from unifi_api.logging import request_id_ctx
 from unifi_api.routes import actions as actions_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
+from unifi_api.serializers._registry import discover_serializers
 from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.managers import ManagerFactory
 from unifi_api.services.manifest import ManifestRegistry
@@ -79,6 +80,12 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.state.argon_cache = ArgonVerifyCache()
     app.state.capability_cache = CapabilityCache()
     app.state.manifest_registry = ManifestRegistry.load_from_apps()
+    # Discover and register every Phase 3 serializer module, then validate
+    # against the manifest. We pass an empty set rather than the full ~219-tool
+    # manifest because Phase 3 only ships ~13 serializers; the catalog and
+    # action-endpoint paths handle missing serializers per-call. Phase 4+ may
+    # tighten this to require coverage of the full manifest.
+    app.state.serializer_registry = discover_serializers(set())
 
     app.include_router(health.router, prefix="/v1")
     app.include_router(controllers_routes.router, prefix="/v1")

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -15,6 +15,7 @@ from unifi_api.db.engine import create_engine
 from unifi_api.db.session import get_sessionmaker
 from unifi_api.logging import request_id_ctx
 from unifi_api.routes import actions as actions_routes
+from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
 from unifi_api.routes.resources.network import (
@@ -107,6 +108,7 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(health.router, prefix="/v1")
     app.include_router(controllers_routes.router, prefix="/v1")
     app.include_router(actions_routes.router, prefix="/v1")
+    app.include_router(catalog_routes.router, prefix="/v1")
     for r in (
         net_clients_routes,
         net_devices_routes,

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -29,6 +29,11 @@ from unifi_api.routes.resources.protect import (
     events as protect_events_routes,
     recordings as protect_recordings_routes,
 )
+from unifi_api.routes.resources.access import (
+    credentials as access_credentials_routes,
+    doors as access_doors_routes,
+    users as access_users_routes,
+)
 from unifi_api.serializers._registry import discover_serializers
 from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.managers import ManagerFactory
@@ -114,6 +119,12 @@ def create_app(config: ApiConfig) -> FastAPI:
         protect_cameras_routes,
         protect_events_routes,
         protect_recordings_routes,
+    ):
+        app.include_router(r.router, prefix="/v1")
+    for r in (
+        access_doors_routes,
+        access_users_routes,
+        access_credentials_routes,
     ):
         app.include_router(r.router, prefix="/v1")
 

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -17,6 +17,13 @@ from unifi_api.logging import request_id_ctx
 from unifi_api.routes import actions as actions_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
+from unifi_api.routes.resources.network import (
+    clients as net_clients_routes,
+    devices as net_devices_routes,
+    firewall_rules as net_firewall_routes,
+    networks as net_networks_routes,
+    wlans as net_wlans_routes,
+)
 from unifi_api.serializers._registry import discover_serializers
 from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.managers import ManagerFactory
@@ -90,5 +97,13 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(health.router, prefix="/v1")
     app.include_router(controllers_routes.router, prefix="/v1")
     app.include_router(actions_routes.router, prefix="/v1")
+    for r in (
+        net_clients_routes,
+        net_devices_routes,
+        net_networks_routes,
+        net_firewall_routes,
+        net_wlans_routes,
+    ):
+        app.include_router(r.router, prefix="/v1")
 
     return app

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -24,6 +24,11 @@ from unifi_api.routes.resources.network import (
     networks as net_networks_routes,
     wlans as net_wlans_routes,
 )
+from unifi_api.routes.resources.protect import (
+    cameras as protect_cameras_routes,
+    events as protect_events_routes,
+    recordings as protect_recordings_routes,
+)
 from unifi_api.serializers._registry import discover_serializers
 from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.managers import ManagerFactory
@@ -103,6 +108,12 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_networks_routes,
         net_firewall_routes,
         net_wlans_routes,
+    ):
+        app.include_router(r.router, prefix="/v1")
+    for r in (
+        protect_cameras_routes,
+        protect_events_routes,
+        protect_recordings_routes,
     ):
         app.include_router(r.router, prefix="/v1")
 

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -220,7 +220,7 @@ class ManagerFactory:
             return cm
         if product == "protect":
             from unifi_core.protect.managers.connection_manager import (
-                ConnectionManager as ProtectCM,
+                ProtectConnectionManager as ProtectCM,
             )
 
             cm = ProtectCM(
@@ -235,7 +235,7 @@ class ManagerFactory:
             return cm
         if product == "access":
             from unifi_core.access.managers.connection_manager import (
-                ConnectionManager as AccessCM,
+                AccessConnectionManager as AccessCM,
             )
 
             cm = AccessCM(

--- a/apps/api/src/unifi_api/services/manifest.py
+++ b/apps/api/src/unifi_api/services/manifest.py
@@ -106,6 +106,10 @@ class ManifestRegistry:
     def all_categories_for_product(self, product: str) -> set[str]:
         return {e.category for e in self._entries.values() if e.product == product}
 
+    def all_tools(self) -> list[str]:
+        """Return the registered tool names (sorted for deterministic output)."""
+        return sorted(self._entries.keys())
+
     def __len__(self) -> int:
         return len(self._entries)
 

--- a/apps/api/src/unifi_api/services/pagination.py
+++ b/apps/api/src/unifi_api/services/pagination.py
@@ -1,0 +1,75 @@
+"""Cursor-based pagination over in-memory snapshots.
+
+UniFi managers return full snapshots (e.g., client_manager.get_clients
+returns the entire list). Pagination is applied in-memory after the
+manager call — no per-page round-trip to the controller. Future
+managers with native cursoring can override per-resource.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+class InvalidCursor(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Cursor:
+    last_id: str | int
+    last_ts: int | None = None
+
+    def encode(self) -> str:
+        payload = json.dumps({"last_id": self.last_id, "last_ts": self.last_ts}).encode()
+        return base64.urlsafe_b64encode(payload).decode()
+
+    @classmethod
+    def decode(cls, s: str) -> "Cursor":
+        try:
+            payload = json.loads(base64.urlsafe_b64decode(s.encode()).decode())
+            return cls(last_id=payload["last_id"], last_ts=payload.get("last_ts"))
+        except Exception as e:
+            raise InvalidCursor(f"failed to decode cursor: {e}")
+
+
+def paginate(
+    items: list[Any],
+    *,
+    limit: int,
+    cursor: Cursor | None,
+    key_fn: Callable[[Any], tuple],
+) -> tuple[list[Any], Cursor | None]:
+    """Sort items by key_fn (descending), apply cursor windowing, return (page, next_cursor).
+
+    key_fn returns (ts, id) — lexicographic descending sort. Cursor's last_ts/last_id
+    cuts off items at-or-before that point.
+    """
+    sorted_items = sorted(items, key=key_fn, reverse=True)
+
+    if cursor is not None:
+        cutoff = (cursor.last_ts, cursor.last_id) if cursor.last_ts is not None else (None, cursor.last_id)
+        filtered = []
+        for item in sorted_items:
+            ts, id_ = key_fn(item)
+            if cursor.last_ts is not None:
+                if (ts, id_) < (cursor.last_ts, cursor.last_id):
+                    filtered.append(item)
+            else:
+                # No-ts mode: just exclude items at or before last_id (less robust;
+                # works when ids are sortable).
+                if id_ < cursor.last_id:
+                    filtered.append(item)
+        sorted_items = filtered
+
+    page = sorted_items[:limit]
+    if len(sorted_items) > limit:
+        last = page[-1]
+        ts, id_ = key_fn(last)
+        next_cursor: Cursor | None = Cursor(last_id=id_, last_ts=ts)
+    else:
+        next_cursor = None
+    return page, next_cursor

--- a/apps/api/tests/routes/resources/test_access_resources.py
+++ b/apps/api/tests/routes/resources/test_access_resources.py
@@ -1,0 +1,270 @@
+"""Access resource endpoints — happy paths, capability mismatch, 404."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="access"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="A", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeAccessCM:
+    """Stub access connection manager — no set_site (single-controller-no-site)."""
+
+    async def initialize(self) -> None:
+        return None
+
+
+def _stub_connection(app, cid: str) -> _FakeAccessCM:
+    fake = _FakeAccessCM()
+    app.state.manager_factory._connection_cache[(cid, "access")] = fake
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_list_doors_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_doors = [
+        {
+            "id": f"door-{i}",
+            "name": f"Door {i}",
+            "door_position_status": "closed",
+            "lock_relay_status": "locked",
+        }
+        for i in range(4)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_doors
+
+    from unifi_core.access.managers.door_manager import DoorManager
+    monkeypatch.setattr(DoorManager, "list_doors", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/doors?controller={cid}&limit=2",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["next_cursor"] is not None
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_doors_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")  # no access
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/doors?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "access"
+
+
+@pytest.mark.asyncio
+async def test_get_door_happy_and_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {
+        "id": "door-1",
+        "name": "Lobby",
+        "door_position_status": "closed",
+        "lock_relay_status": "locked",
+    }
+
+    async def fake_get(self, door_id):
+        if door_id == "door-1":
+            return target
+        raise ValueError(f"Door not found: {door_id}")
+
+    from unifi_core.access.managers.door_manager import DoorManager
+    monkeypatch.setattr(DoorManager, "get_door", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/doors/door-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/doors/door-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    body = ok.json()
+    assert body["data"]["id"] == "door-1"
+    assert body["render_hint"]["kind"] == "detail"
+    assert miss.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_users_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_users = [
+        {"id": f"user-{i}", "first_name": "F", "last_name": f"L{i}",
+         "email": f"u{i}@x.com", "status": "active"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_users
+
+    from unifi_core.access.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "list_users", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/users?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+    assert {item["id"] for item in body["items"]} == {"user-0", "user-1", "user-2"}
+
+
+@pytest.mark.asyncio
+async def test_get_user_filter_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_users = [
+        {"id": "user-1", "first_name": "Ada", "last_name": "L",
+         "email": "ada@x.com", "status": "active"},
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_users
+
+    from unifi_core.access.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "list_users", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/users/user-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/users/user-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["data"]["id"] == "user-1"
+    assert miss.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_credentials_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_credentials = [
+        {"id": f"cred-{i}", "type": "card", "user_id": f"user-{i}",
+         "status": "active"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_credentials
+
+    from unifi_core.access.managers.credential_manager import CredentialManager
+    monkeypatch.setattr(CredentialManager, "list_credentials", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/credentials?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_credential_happy_and_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"id": "cred-1", "type": "card", "user_id": "user-1", "status": "active"}
+
+    async def fake_get(self, credential_id):
+        if credential_id == "cred-1":
+            return target
+        raise ValueError(f"Credential not found: {credential_id}")
+
+    from unifi_core.access.managers.credential_manager import CredentialManager
+    monkeypatch.setattr(CredentialManager, "get_credential", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/credentials/cred-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/credentials/cred-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    body = ok.json()
+    assert body["data"]["id"] == "cred-1"
+    assert body["render_hint"]["kind"] == "detail"
+    assert miss.status_code == 404

--- a/apps/api/tests/routes/resources/test_network_resources.py
+++ b/apps/api/tests/routes/resources/test_network_resources.py
@@ -1,0 +1,276 @@
+"""Network resource endpoints — happy paths, capability mismatch, pagination, 404."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    """Stub connection manager that bypasses live initialize/auth."""
+
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+class _FakeRaw:
+    """Tiny stand-in for manager domain objects with a ``raw`` dict."""
+
+    def __init__(self, raw: dict) -> None:
+        self.raw = raw
+
+
+@pytest.mark.asyncio
+async def test_list_clients_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_clients = [
+        _FakeRaw({
+            "mac": f"aa:bb:cc:dd:ee:0{i}",
+            "last_ip": f"10.0.0.{i}",
+            "hostname": f"host-{i}",
+            "is_online": True,
+            "last_seen": 1700000000 - i,
+        })
+        for i in range(5)
+    ]
+
+    async def fake_get_clients(self, *a, **kw):
+        return fake_clients
+
+    from unifi_core.network.managers.client_manager import ClientManager
+    monkeypatch.setattr(ClientManager, "get_clients", fake_get_clients)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/clients?controller={cid}&limit=3",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "items" in body
+    assert "next_cursor" in body
+    assert "render_hint" in body
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 3
+    assert body["next_cursor"] is not None  # 5 total, page=3, more remain
+
+
+@pytest.mark.asyncio
+async def test_list_clients_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")  # no network
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/clients?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "network"
+
+
+@pytest.mark.asyncio
+async def test_get_client_detail_happy_and_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = _FakeRaw({
+        "mac": "aa:bb:cc:dd:ee:00",
+        "last_ip": "10.0.0.0",
+        "hostname": "alpha",
+        "is_online": True,
+        "last_seen": 1700000000,
+    })
+
+    async def fake_details(self, mac):
+        return target if mac == "aa:bb:cc:dd:ee:00" else None
+
+    from unifi_core.network.managers.client_manager import ClientManager
+    monkeypatch.setattr(ClientManager, "get_client_details", fake_details)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/clients/aa:bb:cc:dd:ee:00?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/clients/ff:ff:ff:ff:ff:ff?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    body = ok.json()
+    assert "data" in body and "render_hint" in body
+    assert body["data"]["mac"] == "aa:bb:cc:dd:ee:00"
+    assert body["render_hint"]["kind"] == "detail"
+
+    assert miss.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_devices_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_devices = [
+        _FakeRaw({"mac": f"de:ad:be:ef:00:0{i}", "name": f"ap-{i}", "model": "U6", "uptime": 1000 - i, "state": 1})
+        for i in range(4)
+    ]
+
+    async def fake_get_devices(self, *a, **kw):
+        return fake_devices
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "get_devices", fake_get_devices)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/devices?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 4
+    assert body["next_cursor"] is None
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_networks_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_nets = [
+        {"_id": f"n-{i}", "name": f"net-{i}", "purpose": "corporate", "vlan": 10 + i, "enabled": True}
+        for i in range(3)
+    ]
+
+    async def fake_get_networks(self, *a, **kw):
+        return fake_nets
+
+    from unifi_core.network.managers.network_manager import NetworkManager
+    monkeypatch.setattr(NetworkManager, "get_networks", fake_get_networks)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/networks?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert {item["id"] for item in body["items"]} == {"n-0", "n-1", "n-2"}
+
+
+@pytest.mark.asyncio
+async def test_list_wlans_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_wlans = [
+        _FakeRaw({"_id": f"w-{i}", "name": f"ssid-{i}", "enabled": True, "security": "wpapsk"})
+        for i in range(2)
+    ]
+
+    async def fake_get_wlans(self, *a, **kw):
+        return fake_wlans
+
+    from unifi_core.network.managers.network_manager import NetworkManager
+    monkeypatch.setattr(NetworkManager, "get_wlans", fake_get_wlans)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/wlans?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_firewall_rules_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_rules = [
+        _FakeRaw({"_id": f"r-{i}", "name": f"rule-{i}", "action": "allow", "enabled": True, "predefined": False})
+        for i in range(3)
+    ]
+
+    async def fake_get_policies(self, *a, **kw):
+        return fake_rules
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_firewall_policies", fake_get_policies)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firewall/rules?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert {item["id"] for item in body["items"]} == {"r-0", "r-1", "r-2"}
+    assert body["render_hint"]["kind"] == "list"

--- a/apps/api/tests/routes/resources/test_protect_resources.py
+++ b/apps/api/tests/routes/resources/test_protect_resources.py
@@ -1,0 +1,260 @@
+"""Protect resource endpoints — happy paths, capability mismatch, 404."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="protect"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="P", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeProtectCM:
+    """Stub protect connection manager — no set_site (single-controller-no-site)."""
+
+    async def initialize(self) -> None:
+        return None
+
+
+def _stub_connection(app, cid: str) -> _FakeProtectCM:
+    fake = _FakeProtectCM()
+    app.state.manager_factory._connection_cache[(cid, "protect")] = fake
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_list_cameras_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_cams = [
+        {
+            "id": f"cam-{i}",
+            "name": f"Camera {i}",
+            "model": "G4 Pro",
+            "type": "camera",
+            "state": "CONNECTED",
+            "is_recording": True,
+            "is_motion_detected": False,
+            "ip_address": f"10.0.0.{i}",
+            "channels": [],
+        }
+        for i in range(4)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_cams
+
+    from unifi_core.protect.managers.camera_manager import CameraManager
+    monkeypatch.setattr(CameraManager, "list_cameras", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/cameras?controller={cid}&limit=2",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["next_cursor"] is not None
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_cameras_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")  # no protect
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/cameras?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "protect"
+
+
+@pytest.mark.asyncio
+async def test_get_camera_happy_and_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {
+        "id": "cam-1",
+        "name": "Door",
+        "model": "G4 Doorbell",
+        "type": "camera",
+        "state": "CONNECTED",
+        "is_recording": True,
+        "ip_address": "10.0.0.5",
+        "channels": [],
+    }
+
+    async def fake_get(self, camera_id):
+        if camera_id == "cam-1":
+            return target
+        raise ValueError(f"Camera not found: {camera_id}")
+
+    from unifi_core.protect.managers.camera_manager import CameraManager
+    monkeypatch.setattr(CameraManager, "get_camera", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/cameras/cam-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/cameras/cam-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    body = ok.json()
+    assert body["data"]["id"] == "cam-1"
+    assert body["render_hint"]["kind"] == "detail"
+    assert miss.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_events_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_events = [
+        {
+            "id": f"evt-{i}",
+            "type": "motion",
+            "start": 1700000000 - i,
+            "end": 1700000010 - i,
+            "score": 50 + i,
+            "smart_detect_types": [],
+            "camera_id": "cam-1",
+            "thumbnail_id": f"thumb-{i}",
+        }
+        for i in range(3)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_events
+
+    from unifi_core.protect.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "list_events", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "event_log"
+    assert {item["id"] for item in body["items"]} == {"evt-0", "evt-1", "evt-2"}
+
+
+@pytest.mark.asyncio
+async def test_list_recordings_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_recordings = [
+        {
+            "id": f"rec-{i}",
+            "type": "timelapse",
+            "camera_id": "cam-1",
+            "start": 1700000000 - i,
+            "end": 1700000060 - i,
+            "file_size": 1024,
+        }
+        for i in range(2)
+    ]
+
+    async def fake_list(self, camera_id, *a, **kw):
+        return fake_recordings
+
+    from unifi_core.protect.managers.recording_manager import RecordingManager
+    monkeypatch.setattr(RecordingManager, "list_recordings", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/recordings?controller={cid}&camera_id=cam-1",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_recording_filter_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_recordings = [
+        {"id": "rec-1", "type": "clip", "camera_id": "cam-1",
+         "start": 1700000000, "end": 1700000060, "file_size": 1024},
+    ]
+
+    async def fake_list(self, camera_id, *a, **kw):
+        return fake_recordings
+
+    from unifi_core.protect.managers.recording_manager import RecordingManager
+    monkeypatch.setattr(RecordingManager, "list_recordings", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/recordings/rec-1?controller={cid}&camera_id=cam-1",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/recordings/rec-999?controller={cid}&camera_id=cam-1",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["data"]["id"] == "rec-1"
+    assert miss.status_code == 404

--- a/apps/api/tests/serializers/test_access_serializers.py
+++ b/apps/api/tests/serializers/test_access_serializers.py
@@ -1,0 +1,86 @@
+"""Access serializer unit tests — one fixture per resource.
+
+Access managers in unifi-core return plain dicts (proxy path returns the
+raw location/user/credential dicts; API-client path returns flattened dicts).
+Each fixture below mirrors the proxy-path shape, since that's the richer one
+the catalog will most often see.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    """Trigger discovery once for the test module."""
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+def test_door_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("access", "doors")
+    sample = {
+        "id": "door1",
+        "name": "Front Door",
+        "location_type": "door",
+        "is_online": True,
+        "door_position_status": "close",
+        "lock_relay_status": "lock",
+        "devices": [{"id": "dev1", "name": "G2 Reader", "online": True}],
+        "last_event": {
+            "name": "Access Granted",
+            "timestamp": "2026-04-29T10:00:00+00:00",
+        },
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "door1"
+    assert out["name"] == "Front Door"
+    assert "location" in out
+    assert "is_online" in out
+    assert "is_locked" in out
+    assert "lock_state" in out
+    assert "last_event" in out
+
+
+def test_user_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("access", "users")
+    sample = {
+        "id": "user1",
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+        "name": "Ada Lovelace",
+        "employee_id": "E-1815",
+        "status": "active",
+        "role": "admin",
+        "created_at": "2026-01-01T00:00:00+00:00",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "user1"
+    assert out["name"] == "Ada Lovelace"
+    assert out["employee_id"] == "E-1815"
+    assert out["status"] == "active"
+    assert out["role"] == "admin"
+    assert out["created_at"] == "2026-01-01T00:00:00+00:00"
+
+
+def test_credential_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("access", "credentials")
+    sample = {
+        "id": "cred1",
+        "user_id": "user1",
+        "type": "nfc_card",
+        "status": "active",
+        "expiry": "2027-01-01T00:00:00+00:00",
+        "last_used": "2026-04-28T18:30:00+00:00",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "cred1"
+    assert out["user_id"] == "user1"
+    assert out["type"] == "nfc_card"
+    assert out["status"] == "active"
+    assert out["expiry"] == "2027-01-01T00:00:00+00:00"
+    assert out["last_used"] == "2026-04-28T18:30:00+00:00"

--- a/apps/api/tests/serializers/test_network_serializers.py
+++ b/apps/api/tests/serializers/test_network_serializers.py
@@ -1,0 +1,101 @@
+"""Network serializer unit tests — one fixture per resource."""
+
+from unifi_api.serializers._registry import (
+    serializer_registry_singleton, discover_serializers,
+)
+
+
+def _registry():
+    """Trigger discovery once for the test module."""
+    discover_serializers(manifest_tool_names=set())  # validate_manifest can be no-op for tests
+    return serializer_registry_singleton()
+
+
+def test_client_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("network", "clients")
+    sample_raw = {
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "last_ip": "10.0.0.5",
+        "hostname": "laptop",
+        "is_wired": False,
+        "is_guest": False,
+        "is_online": True,
+        "last_seen": 1700000000,
+        "first_seen": 1600000000,
+    }
+    class FakeClient:
+        raw = sample_raw
+    out = s.serialize(FakeClient())
+    assert out["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert out["ip"] == "10.0.0.5"
+    assert out["hostname"] == "laptop"
+    assert out["is_wired"] is False
+    assert out["status"] == "online"
+
+
+def test_device_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("network", "devices")
+    class FakeDevice:
+        raw = {
+            "mac": "11:22:33:44:55:66",
+            "name": "AP1",
+            "model": "U6-Pro",
+            "type": "uap",
+            "version": "6.5.59",
+            "uptime": 3600,
+            "state": 1,
+        }
+    out = s.serialize(FakeDevice())
+    assert out["mac"] == "11:22:33:44:55:66"
+    assert out["name"] == "AP1"
+    assert out["model"] == "U6-Pro"
+
+
+def test_network_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("network", "networks")
+    class FakeNetwork:
+        raw = {
+            "_id": "net1",
+            "name": "Default",
+            "purpose": "corporate",
+            "enabled": True,
+        }
+    out = s.serialize(FakeNetwork())
+    assert out["id"] == "net1"
+    assert out["name"] == "Default"
+
+
+def test_firewall_rule_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("network", "firewall/rules")
+    class FakeRule:
+        raw = {
+            "_id": "rule1",
+            "name": "Block IoT",
+            "action": "BLOCK",
+            "enabled": True,
+            "predefined": False,
+        }
+    out = s.serialize(FakeRule())
+    assert out["id"] == "rule1"
+    assert out["name"] == "Block IoT"
+    assert out["action"] == "BLOCK"
+
+
+def test_wlan_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("network", "wlans")
+    class FakeWlan:
+        raw = {
+            "_id": "wlan1",
+            "name": "MyWiFi",
+            "enabled": True,
+            "security": "wpapsk",
+        }
+    out = s.serialize(FakeWlan())
+    assert out["id"] == "wlan1"
+    assert out["name"] == "MyWiFi"
+    assert out["security"] == "wpapsk"

--- a/apps/api/tests/serializers/test_protect_serializers.py
+++ b/apps/api/tests/serializers/test_protect_serializers.py
@@ -1,0 +1,123 @@
+"""Protect serializer unit tests — one fixture per resource.
+
+Protect managers in unifi-core return plain dicts (already shaped by
+``_format_*_summary`` / ``_event_to_dict`` helpers), so each fixture is a
+dict and the serializer reads dict keys directly.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    """Trigger discovery once for the test module."""
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+def test_camera_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("protect", "cameras")
+    sample = {
+        "id": "cam1",
+        "mac": "aa:bb:cc:dd:ee:01",
+        "name": "Front Door",
+        "model": "G4 Pro",
+        "type": "G4PRO",
+        "state": "CONNECTED",
+        "is_recording": True,
+        "is_motion_detected": False,
+        "is_smart_detected": False,
+        "ip_address": "10.0.0.50",
+        "channels": [{"id": 0, "name": "high"}],
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "cam1"
+    assert out["mac"] == "aa:bb:cc:dd:ee:01"
+    assert out["name"] == "Front Door"
+    assert out["model"] == "G4 Pro"
+    assert out["state"] == "CONNECTED"
+
+
+def test_event_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("protect", "events")
+    sample = {
+        "id": "evt1",
+        "type": "smartDetectZone",
+        "start": "2026-04-29T10:00:00+00:00",
+        "end": "2026-04-29T10:00:30+00:00",
+        "score": 87,
+        "smart_detect_types": ["person"],
+        "camera_id": "cam1",
+        "thumbnail_id": "thumb1",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "evt1"
+    assert out["type"] == "smartDetectZone"
+    assert out["start"] == "2026-04-29T10:00:00+00:00"
+    assert out["end"] == "2026-04-29T10:00:30+00:00"
+    assert out["score"] == 87
+
+
+def test_light_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("protect", "lights")
+    sample = {
+        "id": "light1",
+        "mac": "aa:bb:cc:dd:ee:02",
+        "name": "Driveway Light",
+        "model": "UFP-FloodLight",
+        "state": "CONNECTED",
+        "is_pir_motion_detected": False,
+        "is_light_on": True,
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "light1"
+    assert out["mac"] == "aa:bb:cc:dd:ee:02"
+    assert out["name"] == "Driveway Light"
+    assert out["state"] == "CONNECTED"
+
+
+def test_recording_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("protect", "recordings")
+    sample = {
+        "id": "rec1",
+        "type": "timelapse",
+        "camera_id": "cam1",
+        "start": "2026-04-29T09:00:00+00:00",
+        "end": "2026-04-29T09:15:00+00:00",
+        "file_size": 12345678,
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "rec1"
+    assert out["type"] == "timelapse"
+    assert out["start"] == "2026-04-29T09:00:00+00:00"
+    assert out["end"] == "2026-04-29T09:15:00+00:00"
+    assert out["file_size"] == 12345678
+
+
+def test_sensor_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_resource("protect", "sensors")
+    sample = {
+        "id": "sensor1",
+        "mac": "aa:bb:cc:dd:ee:03",
+        "name": "Garage Sensor",
+        "type": "UFP-SENSOR",
+        "battery": {"status": "normal", "percentage": 92},
+        "stats": {
+            "humidity": {"status": "normal", "value": 45},
+            "light": {"status": "normal", "value": 120},
+        },
+        "motion_detected_at": "2026-04-29T08:30:00+00:00",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "sensor1"
+    assert out["mac"] == "aa:bb:cc:dd:ee:03"
+    assert out["name"] == "Garage Sensor"
+    assert out["type"] == "UFP-SENSOR"
+    assert out["battery_status"] == "normal"

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -48,15 +48,24 @@ async def _bootstrap(tmp_path: Path):
     return app, material.plaintext, cid
 
 
+class _FakeClient:
+    """Stand-in for an aiounifi.Client with a `.raw` dict attribute."""
+
+    def __init__(self, raw: dict) -> None:
+        self.raw = raw
+
+
 @pytest.mark.asyncio
 async def test_action_endpoint_dispatches_and_audits(tmp_path, monkeypatch) -> None:
     """Happy path: known tool, valid controller, audit log entry written."""
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)
 
-    # Mock the dispatcher so we don't need real controller connectivity
+    # Mock dispatcher to return a RAW list of manager-style objects (mirrors
+    # what ClientManager.get_clients() actually returns: list[aiounifi.Client]).
+    # The action endpoint now runs the result through ClientSerializer.
     from unifi_api.services import actions as actions_svc
-    fake_dispatch = AsyncMock(return_value={"success": True, "data": [{"mac": "aa:bb"}]})
+    fake_dispatch = AsyncMock(return_value=[_FakeClient({"mac": "aa:bb", "is_online": True})])
     monkeypatch.setattr(actions_svc, "dispatch_action", fake_dispatch)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -66,7 +75,24 @@ async def test_action_endpoint_dispatches_and_audits(tmp_path, monkeypatch) -> N
                                "args": {"include_offline": True}, "confirm": False})
 
     assert r.status_code == 200, r.text
-    assert r.json() == {"success": True, "data": [{"mac": "aa:bb"}]}
+    body = r.json()
+    assert body["success"] is True
+    assert body["data"] == [
+        {
+            "mac": "aa:bb",
+            "ip": None,
+            "hostname": None,
+            "is_wired": False,
+            "is_guest": False,
+            "status": "online",
+            "last_seen": None,
+            "first_seen": None,
+            "note": None,
+            "usergroup_id": None,
+        }
+    ]
+    assert body["render_hint"]["kind"] == "list"
+    assert body["render_hint"]["primary_key"] == "mac"
 
     # Audit log row
     sm = app.state.sessionmaker
@@ -77,6 +103,39 @@ async def test_action_endpoint_dispatches_and_audits(tmp_path, monkeypatch) -> N
         action_rows = [r for r in rows if r.target == "unifi_list_clients"]
         assert len(action_rows) == 1
         assert action_rows[0].outcome == "success"
+
+
+@pytest.mark.asyncio
+async def test_action_endpoint_serializer_contract_error(tmp_path, monkeypatch) -> None:
+    """When manager returns wrong type for declared kind, endpoint returns 500."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    # unifi_list_clients is declared kind=LIST; returning a dict should trip
+    # SerializerContractError and surface as 500 with structured detail.
+    from unifi_api.services import actions as actions_svc
+    fake_dispatch = AsyncMock(return_value={"single": "object"})
+    monkeypatch.setattr(actions_svc, "dispatch_action", fake_dispatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post(
+            "/v1/actions/unifi_list_clients",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {}, "confirm": False},
+        )
+    assert r.status_code == 500, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "serializer_contract_error"
+    assert body["detail"]["tool"] == "unifi_list_clients"
+
+    # Audit row should record the contract error
+    sm = app.state.sessionmaker
+    async with sm() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+        action_rows = [r for r in rows if r.target == "unifi_list_clients"]
+        assert len(action_rows) == 1
+        assert action_rows[0].outcome == "error"
+        assert action_rows[0].error_kind == "serializer_contract"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_catalog.py
+++ b/apps/api/tests/test_catalog.py
@@ -1,0 +1,72 @@
+"""Catalog endpoint tests."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.server import create_app
+
+
+async def _bootstrap_with_read_key(tmp_path):
+    app = create_app(ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    ))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+@pytest.mark.asyncio
+async def test_catalog_tools(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_with_read_key(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/catalog/tools", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    assert len(body["items"]) > 0
+    sample = body["items"][0]
+    assert "name" in sample and "product" in sample and "render_hint" in sample
+
+
+@pytest.mark.asyncio
+async def test_catalog_categories(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_with_read_key(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/catalog/categories", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    sample = body["items"][0]
+    assert "product" in sample and "category" in sample and "tool_count" in sample
+
+
+@pytest.mark.asyncio
+async def test_catalog_render_hints(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_with_read_key(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/catalog/render-hints", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    kinds = {item["kind"] for item in body["items"]}
+    assert "list" in kinds  # at least one tool uses LIST kind

--- a/apps/api/tests/test_pagination.py
+++ b/apps/api/tests/test_pagination.py
@@ -1,0 +1,49 @@
+"""Cursor + paginate() tests."""
+
+import pytest
+
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+def test_cursor_encode_decode_roundtrip() -> None:
+    c = Cursor(last_id="aa:bb:cc", last_ts=1000)
+    encoded = c.encode()
+    assert isinstance(encoded, str)
+    decoded = Cursor.decode(encoded)
+    assert decoded.last_id == "aa:bb:cc"
+    assert decoded.last_ts == 1000
+
+
+def test_cursor_decode_invalid_raises() -> None:
+    with pytest.raises(InvalidCursor):
+        Cursor.decode("not-base64-or-json")
+
+
+def test_paginate_first_page_no_cursor() -> None:
+    items = [{"id": str(i), "ts": i} for i in range(10)]
+    page, next_cursor = paginate(items, limit=3, cursor=None,
+                                  key_fn=lambda x: (x["ts"], x["id"]))
+    assert len(page) == 3
+    assert next_cursor is not None
+    assert next_cursor.last_id == page[-1]["id"]
+
+
+def test_paginate_returns_no_cursor_when_done() -> None:
+    items = [{"id": "1", "ts": 1}]
+    page, next_cursor = paginate(items, limit=10, cursor=None,
+                                  key_fn=lambda x: (x["ts"], x["id"]))
+    assert page == items
+    assert next_cursor is None
+
+
+def test_paginate_continuation_with_cursor() -> None:
+    items = [{"id": str(i), "ts": i} for i in range(10)]
+    page1, next_c = paginate(items, limit=4, cursor=None,
+                              key_fn=lambda x: (x["ts"], x["id"]))
+    assert len(page1) == 4
+    page2, next_c2 = paginate(items, limit=4, cursor=next_c,
+                               key_fn=lambda x: (x["ts"], x["id"]))
+    # No overlap between pages
+    p1_ids = {x["id"] for x in page1}
+    p2_ids = {x["id"] for x in page2}
+    assert p1_ids.isdisjoint(p2_ids)

--- a/apps/api/tests/test_resources_common.py
+++ b/apps/api/tests/test_resources_common.py
@@ -1,0 +1,67 @@
+"""Shared resource-route deps tests."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from fastapi import Depends, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import Base, Controller
+from unifi_api.routes.resources._common import resolve_controller, require_capability
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_controller_uses_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    from unifi_api.server import create_app
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    async with sm() as session:
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds="network",
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+
+    @app.get("/test")
+    async def test_endpoint(controller=Depends(resolve_controller)):
+        return {"id": controller.id, "name": controller.name}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/test")
+    assert r.status_code == 200
+    assert r.json()["id"] == cid
+
+
+def test_require_capability_passes_when_present() -> None:
+    class FakeController:
+        product_kinds = "network,protect"
+    require_capability(FakeController(), "network")  # no exception
+
+
+def test_require_capability_raises_409_when_missing() -> None:
+    class FakeController:
+        product_kinds = "network"
+        id = "x"
+    with pytest.raises(HTTPException) as exc:
+        require_capability(FakeController(), "protect")
+    assert exc.value.status_code == 409
+    assert exc.value.detail["kind"] == "capability_mismatch"
+    assert exc.value.detail["missing_product"] == "protect"

--- a/apps/api/tests/test_serializer_base.py
+++ b/apps/api/tests/test_serializer_base.py
@@ -1,0 +1,98 @@
+"""Serializer base + decorator tests."""
+
+import pytest
+
+from unifi_api.serializers._base import (
+    RenderKind, Serializer, register_serializer,
+    SerializerContractError,
+)
+
+
+def test_render_kind_values() -> None:
+    assert RenderKind.LIST.value == "list"
+    assert RenderKind.DETAIL.value == "detail"
+    assert RenderKind.DIFF.value == "diff"
+    assert RenderKind.TIMESERIES.value == "timeseries"
+    assert RenderKind.EVENT_LOG.value == "event_log"
+    assert RenderKind.EMPTY.value == "empty"
+
+
+def test_register_serializer_with_bare_list_form() -> None:
+    @register_serializer(tools=["test_tool_a", "test_tool_b"], resources=[("test_product", "test_resource")])
+    class TestSer(Serializer):
+        kind = RenderKind.LIST
+        @staticmethod
+        def serialize(obj):
+            return {"x": obj}
+    # Decorator returns the class unchanged
+    assert TestSer.kind == RenderKind.LIST
+
+
+def test_register_serializer_with_dict_form_per_tool_kind() -> None:
+    @register_serializer(
+        tools={
+            "tool_x": {"kind": RenderKind.LIST},
+            "tool_y": {"kind": RenderKind.DETAIL},
+        },
+    )
+    class MultiSer(Serializer):
+        @staticmethod
+        def serialize(obj):
+            return obj
+
+
+def test_serialize_action_list_kind() -> None:
+    @register_serializer(tools=["t_list"])
+    class ListSer(Serializer):
+        kind = RenderKind.LIST
+        primary_key = "id"
+        @staticmethod
+        def serialize(obj):
+            return {"id": obj}
+    inst = ListSer()
+    out = inst.serialize_action([1, 2, 3], tool_name="t_list")
+    assert out == {
+        "success": True,
+        "data": [{"id": 1}, {"id": 2}, {"id": 3}],
+        "render_hint": {"kind": "list", "primary_key": "id"},
+    }
+
+
+def test_serialize_action_detail_kind() -> None:
+    @register_serializer(tools=["t_detail"])
+    class DetSer(Serializer):
+        kind = RenderKind.DETAIL
+        @staticmethod
+        def serialize(obj):
+            return {"name": obj}
+    inst = DetSer()
+    out = inst.serialize_action("foo", tool_name="t_detail")
+    assert out == {
+        "success": True,
+        "data": {"name": "foo"},
+        "render_hint": {"kind": "detail"},
+    }
+
+
+def test_serialize_action_empty_kind() -> None:
+    @register_serializer(tools=["t_empty"])
+    class EmpSer(Serializer):
+        kind = RenderKind.EMPTY
+        @staticmethod
+        def serialize(obj):
+            return obj
+    inst = EmpSer()
+    out = inst.serialize_action(None, tool_name="t_empty")
+    assert out == {"success": True, "render_hint": {"kind": "empty"}}
+
+
+def test_contract_error_when_list_kind_gets_non_list() -> None:
+    @register_serializer(tools=["t_mismatch"])
+    class MisSer(Serializer):
+        kind = RenderKind.LIST
+        @staticmethod
+        def serialize(obj):
+            return obj
+    inst = MisSer()
+    with pytest.raises(SerializerContractError, match="declared kind=list"):
+        inst.serialize_action({"single": "object"}, tool_name="t_mismatch")

--- a/apps/api/tests/test_serializer_registry.py
+++ b/apps/api/tests/test_serializer_registry.py
@@ -1,0 +1,75 @@
+"""Serializer registry tests."""
+
+import pytest
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+from unifi_api.serializers._registry import (
+    SerializerRegistry, SerializerRegistryError,
+    serializer_registry_singleton, _reset_registry_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_registry_for_tests()
+    yield
+    _reset_registry_for_tests()
+
+
+def test_lookup_by_tool_name() -> None:
+    @register_serializer(tools=["t1"])
+    class T1(Serializer):
+        kind = RenderKind.LIST
+        @staticmethod
+        def serialize(obj):
+            return obj
+    reg = serializer_registry_singleton()
+    found = reg.serializer_for_tool("t1")
+    assert isinstance(found, T1)
+
+
+def test_lookup_by_resource() -> None:
+    @register_serializer(resources=[("network", "clients")])
+    class C(Serializer):
+        kind = RenderKind.LIST
+        @staticmethod
+        def serialize(obj):
+            return obj
+    reg = serializer_registry_singleton()
+    found = reg.serializer_for_resource("network", "clients")
+    assert isinstance(found, C)
+
+
+def test_kind_for_tool_with_per_tool_override() -> None:
+    @register_serializer(tools={"a": {"kind": RenderKind.LIST}, "b": {"kind": RenderKind.DETAIL}})
+    class S(Serializer):
+        @staticmethod
+        def serialize(obj):
+            return obj
+    reg = serializer_registry_singleton()
+    assert reg.kind_for_tool("a") == RenderKind.LIST
+    assert reg.kind_for_tool("b") == RenderKind.DETAIL
+
+
+def test_validate_against_manifest_fails_on_missing() -> None:
+    @register_serializer(tools=["only_one"])
+    class S(Serializer):
+        kind = RenderKind.LIST
+        @staticmethod
+        def serialize(obj):
+            return obj
+    reg = serializer_registry_singleton()
+    # Manifest has tools the registry doesn't know about
+    with pytest.raises(SerializerRegistryError, match="missing serializer"):
+        reg.validate_manifest({"only_one", "other_tool", "another_tool"})
+
+
+def test_validate_against_manifest_passes_when_all_present() -> None:
+    @register_serializer(tools=["a", "b"])
+    class S(Serializer):
+        kind = RenderKind.LIST
+        @staticmethod
+        def serialize(obj):
+            return obj
+    reg = serializer_registry_singleton()
+    reg.validate_manifest({"a", "b"})  # no exception

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -150,11 +150,14 @@ def parse_args() -> argparse.Namespace:
         "--server",
         choices=["network", "protect", "access", "all"],
         required=False,
-        help="Required for MCP-direct phases. Ignored for --phase api-actions.",
+        help="Required for MCP-direct phases. Ignored for --phase api-actions / api-resources.",
     )
     parser.add_argument(
         "--phase",
-        choices=["inventory", "readonly", "preview", "lifecycle", "approved", "safe", "api-actions"],
+        choices=[
+            "inventory", "readonly", "preview", "lifecycle", "approved", "safe",
+            "api-actions", "api-resources",
+        ],
         default="safe",
         help=(
             "'safe' runs readonly, preview, and named safe lifecycles. "
@@ -162,7 +165,10 @@ def parse_args() -> argparse.Namespace:
             "'api-actions' is a manual-only phase: spins up unifi-api locally, "
             "registers the .env-configured controllers, exercises read-only tools "
             "via POST /v1/actions/{tool}, and compares to the latest MCP-direct "
-            "baseline."
+            "baseline. "
+            "'api-resources' is also manual-only: same bootstrap, but exercises "
+            "GET /v1/sites/{site}/{resource} endpoints and (where the tool "
+            "equivalent exists) compares the data payload to the action endpoint."
         ),
     )
     parser.add_argument("--report-dir", default="live-smoke-results")
@@ -171,8 +177,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--include-heavy-reads", action="store_true")
     parser.add_argument("--interactive-risky", action="store_true")
     args = parser.parse_args()
-    if args.phase != "api-actions" and not args.server:
-        parser.error("--server is required unless --phase api-actions is used")
+    if args.phase not in {"api-actions", "api-resources"} and not args.server:
+        parser.error(
+            "--server is required unless --phase api-actions or --phase api-resources is used"
+        )
     return args
 
 
@@ -1675,10 +1683,392 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
     return 1 if artifact["summary"]["regressions"] > 0 else 0
 
 
+###############################################################################
+# Phase: api-resources
+#
+# Manual-only phase. Same bootstrap as api-actions (spins up unifi-api locally,
+# registers .env-configured controllers), then exercises the GET resource
+# endpoints (clients, devices, networks, wlans, firewall rules, cameras,
+# recordings, events, doors, users, credentials). For each resource that has a
+# tool equivalent, also calls the matching action endpoint and compares the
+# data payloads — the resource version wraps in {items, next_cursor,
+# render_hint} and the action version wraps in {success: true, data,
+# render_hint}; the inner item arrays should match (the action endpoint
+# returns the full collection, the resource endpoint returns a paginated
+# slice, so the comparison checks set-of-ids/MACs).
+#
+# Like api-actions, this phase is intentionally NOT wired into CI and serves
+# as a Phase 3 release-readiness gate.
+###############################################################################
+
+
+# Sample of resource endpoints exercised through GET. Each entry is:
+#   (product, path_template, query_extras, parity_tool_name_or_None,
+#    parity_args_or_None, parity_collection_keys)
+#
+# - path_template uses {site} placeholder.
+# - parity_tool_name: when set, the matching POST /v1/actions/{tool} call is
+#   issued and the data shapes compared.
+# - parity_collection_keys: the keys under the action's data payload that hold
+#   the item collection — we look at each in order and use the first present.
+API_RESOURCES_SAMPLE: list[tuple[str, str, dict[str, Any], str | None, dict[str, Any] | None, tuple[str, ...]]] = [
+    ("network", "/v1/sites/{site}/clients",        {"limit": 10}, "unifi_list_clients",        {},                         ("clients", "items")),
+    ("network", "/v1/sites/{site}/devices",        {"limit": 10}, "unifi_list_devices",        {},                         ("devices", "items")),
+    ("network", "/v1/sites/{site}/networks",       {"limit": 10}, None,                         None,                       ()),
+    ("network", "/v1/sites/{site}/wlans",          {"limit": 10}, None,                         None,                       ()),
+    ("network", "/v1/sites/{site}/firewall/rules", {"limit": 10}, None,                         None,                       ()),
+    ("protect", "/v1/sites/{site}/cameras",        {"limit": 10}, "protect_list_cameras",       {},                         ("cameras", "items")),
+    ("access",  "/v1/sites/{site}/doors",          {"limit": 10}, "access_list_doors",          {},                         ("doors", "items")),
+    ("access",  "/v1/sites/{site}/users",          {"limit": 10}, "access_list_users",          {},                         ("users", "items")),
+]
+
+
+def _items_id_set(items: Any, id_keys: tuple[str, ...] = ("id", "_id", "mac", "uuid")) -> set[str]:
+    """Extract a set of stable identifiers from a list of dict items.
+
+    Used to compare a resource-endpoint page slice to an action-endpoint full
+    collection: the resource set should be a subset of the action set when
+    counts agree, and the *paginated* resource slice should always be ⊆ the
+    full action collection.
+    """
+    out: set[str] = set()
+    if not isinstance(items, list):
+        return out
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        for key in id_keys:
+            value = entry.get(key)
+            if value is not None and value != "":
+                out.add(str(value))
+                break
+    return out
+
+
+def _action_collection(payload: Any, candidate_keys: tuple[str, ...]) -> list[Any]:
+    """Pull the collection list out of an action endpoint response.
+
+    Handles both ``{"data": {...}}`` shapes and ``{...}`` directly. Walks the
+    candidate keys in order; falls back to the first list value found at the
+    top level.
+    """
+    if not isinstance(payload, dict):
+        return []
+    body = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+    if not isinstance(body, dict):
+        return []
+    for key in candidate_keys:
+        value = body.get(key)
+        if isinstance(value, list):
+            return value
+    # last resort: any list-of-dicts at the top level
+    for value in body.values():
+        if isinstance(value, list) and (not value or isinstance(value[0], dict)):
+            return value
+    return []
+
+
+def run_api_resources_phase(args: argparse.Namespace) -> int:
+    """Manual-only phase: exercise GET /v1/sites/{site}/{resource} endpoints.
+
+    Returns 0 when every reachable resource endpoint returns 200 with a valid
+    {items, next_cursor, render_hint} shape. Non-zero on a shape failure or
+    HTTP 5xx. Pre-existing controller-side failures (Access UNAUTHORIZED, etc.)
+    are recorded but do NOT fail the run.
+    """
+    print("\n=== api-resources: spinning up unifi-api locally ===", flush=True)
+    tmp_dir = Path(tempfile.mkdtemp(prefix="unifi-api-resources-smoke-"))
+    db_path = tmp_dir / "state.db"
+    db_key = "smoke-" + datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    port = _pick_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    env = dict(os.environ)
+    env["UNIFI_API_DB_KEY"] = db_key
+    env["UNIFI_API_DB_PATH"] = str(db_path)
+
+    started_at = datetime.now(UTC).isoformat()
+    server_proc: subprocess.Popen[bytes] | None = None
+    server_log = tmp_dir / "server.log"
+    artifact: dict[str, Any] = {
+        "phase": "api-resources",
+        "started_at": started_at,
+        "finished_at": None,
+        "base_url": base_url,
+        "db_path": str(db_path),
+        "controllers": [],
+        "results": [],
+        "summary": {
+            "endpoints_exercised": 0,
+            "passed": 0,
+            "shape_failures": 0,
+            "controller_errors": 0,
+            "skipped_no_controller": 0,
+            "parity_checked": 0,
+            "parity_matches": 0,
+            "parity_mismatches": 0,
+        },
+    }
+
+    try:
+        print(f"  tmp db: {db_path}", flush=True)
+        print(f"  http port: {port}", flush=True)
+        admin_key = _bootstrap_unifi_api(env)
+        print("  unifi-api migrate ok (admin key captured)", flush=True)
+
+        with server_log.open("wb") as log_fh:
+            server_proc = subprocess.Popen(
+                [
+                    "uv", "run", "--package", "unifi-api",
+                    "unifi-api", "serve", "--port", str(port),
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+            )
+
+        if not _wait_for_health(base_url, deadline_s=30.0):
+            raise RuntimeError(
+                f"unifi-api did not become healthy within 30s; see {server_log}"
+            )
+        print("  unifi-api serve ok (/v1/health 200)", flush=True)
+
+        auth_headers = {"Authorization": f"Bearer {admin_key}"}
+
+        # Step 1: register controllers from .env (same as api-actions).
+        controller_payloads = _api_actions_controllers_from_env()
+        if not controller_payloads:
+            raise RuntimeError(
+                "No controllers found in .env (expected UNIFI_{NETWORK,PROTECT,ACCESS}_HOST)."
+            )
+        product_to_controller_id: dict[str, str] = {}
+        for product, payload in controller_payloads.items():
+            status, body = _http_request(
+                "POST", f"{base_url}/v1/controllers",
+                headers=auth_headers, body=payload,
+            )
+            if status != 201 or not isinstance(body, dict) or not body.get("id"):
+                raise RuntimeError(
+                    f"failed to register {product} controller: {status} {body!r}"
+                )
+            product_to_controller_id[product] = body["id"]
+            artifact["controllers"].append({
+                "product": product,
+                "id": body["id"],
+                "name": body.get("name"),
+                "base_url": body.get("base_url"),
+            })
+            print(f"  registered controller: {product} -> {body['id']}", flush=True)
+
+        # Step 2: exercise resource endpoints.
+        site_for_product: dict[str, str] = {
+            "network": os.environ.get("UNIFI_NETWORK_SITE") or "default",
+            "protect": "default",
+            "access": "default",
+        }
+
+        for (product, path_tpl, query_extras, parity_tool, parity_args,
+             parity_keys) in API_RESOURCES_SAMPLE:
+            if product not in product_to_controller_id:
+                artifact["summary"]["skipped_no_controller"] += 1
+                print(f"  api-resources skip: {path_tpl} (no {product} controller)", flush=True)
+                continue
+            controller_id = product_to_controller_id[product]
+            site = site_for_product[product]
+            path = path_tpl.format(site=site)
+            qs = "&".join(
+                [f"controller={controller_id}"]
+                + [f"{k}={v}" for k, v in query_extras.items()]
+            )
+            url = f"{base_url}{path}?{qs}"
+
+            t0 = time.perf_counter()
+            try:
+                status, response = _http_request(
+                    "GET", url, headers=auth_headers, timeout=120.0,
+                )
+            except Exception as exc:
+                status = 0
+                response = f"{type(exc).__name__}: {exc}"
+            duration_ms = int((time.perf_counter() - t0) * 1000)
+
+            # Resource shape: {items, next_cursor, render_hint}
+            shape_match = (
+                status == 200
+                and isinstance(response, dict)
+                and "items" in response
+                and "next_cursor" in response
+                and "render_hint" in response
+                and isinstance(response.get("items"), list)
+            )
+            items = response.get("items") if isinstance(response, dict) else None
+            item_count = len(items) if isinstance(items, list) else None
+
+            classification: str
+            error: str | None = None
+            if shape_match:
+                classification = "pass"
+            elif status == 200 and isinstance(response, dict):
+                classification = "shape_failure"
+                error = f"missing keys / wrong types in 200 body: {sorted(response.keys())}"
+            elif 500 <= (status or 0) < 600:
+                classification = "shape_failure"
+                error = f"HTTP {status}: {response!r}"
+            elif status == 0:
+                classification = "shape_failure"
+                error = f"transport: {response!r}"
+            else:
+                # 4xx — most often controller-side: 401 from Access, 503 when
+                # Protect is unreachable, etc. Recorded but not a failure.
+                classification = "controller_error"
+                error = f"HTTP {status}: {response!r}"
+
+            # Parity comparison: hit the matching action endpoint and compare
+            # item id sets. We treat the resource endpoint as a paginated
+            # subset of the action endpoint; the resource id set should be
+            # ⊆ the action id set.
+            parity: dict[str, Any] | None = None
+            if parity_tool and classification == "pass":
+                action_body = {
+                    "site": site,
+                    "controller": controller_id,
+                    "args": parity_args or {},
+                    "confirm": False,
+                }
+                try:
+                    a_status, a_response = _http_request(
+                        "POST", f"{base_url}/v1/actions/{parity_tool}",
+                        headers=auth_headers, body=action_body, timeout=120.0,
+                    )
+                except Exception as exc:
+                    a_status = 0
+                    a_response = f"{type(exc).__name__}: {exc}"
+
+                if a_status == 200 and isinstance(a_response, dict) and a_response.get("success"):
+                    action_collection = _action_collection(a_response, parity_keys)
+                    resource_ids = _items_id_set(items)
+                    action_ids = _items_id_set(action_collection)
+                    is_subset = resource_ids.issubset(action_ids) if resource_ids else True
+                    parity = {
+                        "tool": parity_tool,
+                        "action_http_status": a_status,
+                        "action_success": True,
+                        "resource_id_count": len(resource_ids),
+                        "action_id_count": len(action_ids),
+                        "resource_subset_of_action": is_subset,
+                    }
+                    artifact["summary"]["parity_checked"] += 1
+                    if is_subset:
+                        artifact["summary"]["parity_matches"] += 1
+                    else:
+                        artifact["summary"]["parity_mismatches"] += 1
+                else:
+                    parity = {
+                        "tool": parity_tool,
+                        "action_http_status": a_status,
+                        "action_success": (
+                            a_response.get("success")
+                            if isinstance(a_response, dict) else None
+                        ),
+                        "note": "action endpoint failed; parity skipped",
+                    }
+
+            artifact["results"].append({
+                "product": product,
+                "path": path,
+                "controller_id": controller_id,
+                "site": site,
+                "http_status": status,
+                "shape_match": shape_match,
+                "item_count": item_count,
+                "next_cursor_present": (
+                    bool(response.get("next_cursor"))
+                    if isinstance(response, dict) else False
+                ),
+                "render_hint_present": (
+                    response.get("render_hint") is not None
+                    if isinstance(response, dict) else False
+                ),
+                "duration_ms": duration_ms,
+                "classification": classification,
+                "error": error,
+                "parity": parity,
+            })
+
+            artifact["summary"]["endpoints_exercised"] += 1
+            if classification == "pass":
+                artifact["summary"]["passed"] += 1
+            elif classification == "shape_failure":
+                artifact["summary"]["shape_failures"] += 1
+            elif classification == "controller_error":
+                artifact["summary"]["controller_errors"] += 1
+
+            parity_note = ""
+            if parity:
+                if "resource_subset_of_action" in parity:
+                    parity_note = (
+                        f" parity={'ok' if parity['resource_subset_of_action'] else 'MISMATCH'}"
+                        f" (r={parity['resource_id_count']} a={parity['action_id_count']})"
+                    )
+                else:
+                    parity_note = " parity=skip"
+            print(
+                f"  api-resources {classification}: {path} "
+                f"http={status} items={item_count} ({duration_ms}ms){parity_note}",
+                flush=True,
+            )
+            if args.delay:
+                time.sleep(args.delay)
+
+    finally:
+        artifact["finished_at"] = datetime.now(UTC).isoformat()
+        if server_proc is not None and server_proc.poll() is None:
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                server_proc.wait(timeout=5)
+
+        report_dir = REPO_ROOT / args.report_dir / "phase3-api-resources"
+        stamp = artifact["started_at"].replace(":", "").replace("+0000", "Z")
+        path = report_dir / f"api-resources-{stamp}.json"
+        write_json(path, artifact)
+        print(f"\nReport: {path}", flush=True)
+
+        # On failure preserve the server log; otherwise tear down the tmp dir.
+        failed = (
+            artifact["summary"]["shape_failures"] > 0
+            or artifact["summary"]["parity_mismatches"] > 0
+        )
+        try:
+            if failed:
+                kept_log = REPO_ROOT / args.report_dir / "phase3-api-resources" / f"server-log-{stamp}.txt"
+                try:
+                    if server_log.exists():
+                        kept_log.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(server_log, kept_log)
+                        print(f"Server log preserved at: {kept_log}", flush=True)
+                except Exception:
+                    pass
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        except Exception:
+            pass
+
+    if artifact["summary"]["shape_failures"] > 0:
+        return 1
+    if artifact["summary"]["parity_mismatches"] > 0:
+        return 1
+    return 0
+
+
 def main() -> int:
     args = parse_args()
     if args.phase == "api-actions":
         return run_api_actions_phase(args)
+    if args.phase == "api-resources":
+        return run_api_resources_phase(args)
     if args.server == "all":
         return run_all_servers(args)
     return asyncio.run(run_one(args))


### PR DESCRIPTION
## Summary

Phase 3 of the rich HTTP API service. Lands the resource and catalog surface on top of Phase 2's action endpoint, replacing the `_coerce_response` shim with a per-tool/per-resource serializer pattern. After Phase 3: 11 paginated REST resource endpoints (read-only), 3 catalog endpoints, decorator-registered serializers, action endpoint dispatches through serializers.

## Scope

**In:**
- Decorator-registered serializers, auto-discovered at lifespan startup (`unifi_api.serializers.{network,protect,access}.*`)
- `RenderKind` enum + per-tool/per-resource render-hint surface (`list`, `detail`, `event_log`, `empty`, `diff`, `timeseries`)
- Cursor-based opaque pagination over in-memory snapshots
- 11 resource endpoint families:
  - **network (5):** clients, devices, networks, firewall/rules, wlans (list + detail each)
  - **protect (3):** cameras (list + detail), events (list), recordings (list + detail)
  - **access (3):** doors, users, credentials (list + detail each)
- 3 catalog endpoints: `/v1/catalog/{tools, categories, render-hints}`
- Action endpoint refactored to dispatch through serializers; `_coerce_response`/`_to_jsonable` removed
- 409 `capability_mismatch` envelope on resource endpoints; `SerializerContractError` -> 500 with structured body and audit row

**Out (deferred):**
- Mutation resource endpoints (`POST/PUT/PATCH/DELETE /v1/sites/...`)
- `?include` related-entity bundling — deferred to a future cross-surface feature (decision-220a2053)
- Streams (Phase 4) · admin UI (Phase 5) · codegen (Phase 6) · per-key restrictions

## Phase 3 ships permissive, Phase 4 will land strict serializer validation

Phase 3 calls `discover_serializers(set())` at lifespan, which trivially passes `validate_manifest` even though the manifest has ~219 tools and only ~13 have serializers. Tools without a registered serializer get `{kind: "empty"}` in `/v1/catalog/tools` (graceful try/except). The strict raise-on-missing code path is in place and unit-tested but not exercised at runtime.

**Phase 4 commitment:** complete serializer coverage for the remaining ~206 tools (in waves: network categories → protect → access), then flip lifespan to `discover_serializers(set(manifest.all_tools()))` and add a CI check that asserts `validate_manifest` doesn't raise. From that commit onward, any new tool added without a serializer fails CI — strict contract enforced as the contributor lint rule. The product vision (API as substrate for AI-powered UniFi UI replacements, decision-36e6842d) requires full coverage anyway, so Phase 4 makes the implicit requirement explicit and gated.

## Verification

| Surface | Result |
|---|---|
| `unifi-core` | 51 passed (unchanged) |
| `unifi-mcp-shared` | 205 passed (unchanged) |
| `unifi-network-mcp` | 628 passed (unchanged) |
| `unifi-protect-mcp` | 336 passed (unchanged) |
| `unifi-access-mcp` | 157 passed (unchanged) |
| `unifi-api` | 139 passed (Phase 2 baseline 82 + 57 new) |
| Live smoke `--phase api-resources` | 8/8 endpoints pass against real controllers; resource ⊆ action parity confirmed for clients (10/432), devices (10/41), cameras (10/13), doors (1/1), users (0/0) |

## Mid-execution adaptations

Surfaced and fixed during the sequential subagent dispatch — same cadence as Phases 1 and 2:

1. **Action-endpoint contract is strict, not passthrough.** The plan claimed shaped-dict mocks would passthrough through `serialize_action`; they don't (kind=LIST asserts `isinstance(result, list)`). Tests were rewritten to mock raw aiounifi-style objects with `.raw` attrs. `SerializerContractError` is desirable — it surfaces dispatch mismatches as 500s with structured bodies.
2. **`validate_manifest` keeps strict semantics.** Lifespan calls `discover_serializers(set())` (trivially passes) so the manifest's ~219 tools don't need serializers in Phase 3; tools without one get `{kind: "empty"}` in the catalog response. Phase 4 closes this gap (see section above).
3. **WLANs live on `network_manager`**, not a separate `wlan_manager`. Wired accordingly.
4. **No singular detail methods** for `firewall_policies`, `recordings`, or `users` — the detail endpoints fetch the list and filter by id (acceptable; managers cache).
5. **Protect/Access connection managers are single-controller-no-site.** Added a `_maybe_set_site` helper that no-ops when `cm.set_site` doesn't exist.
6. **`RecordingManager.list_recordings` requires `camera_id`** and historically returns a single dict; added a required `camera_id` query and a `_normalize_recordings` shim that handles both single-dict and list shapes.
7. **Phase 2 carry-over fix:** `apps/api/src/unifi_api/services/managers.py` imported `ConnectionManager` from the protect/access connection_manager modules, but those modules export `ProtectConnectionManager` / `AccessConnectionManager`. Phase 2's smoke timed out at the transport layer and never surfaced this; Phase 3's resource endpoints raise it visibly. One-line fix included in this PR (commit 472abbd).

## Architectural decisions logged

- API domain owns serializers (Myco `decision-a63cb266`)
- `?include` deferred to cross-surface feature (Myco `decision-220a2053`)
- Product vision: API is the substrate for AI-powered UniFi UI replacements (Myco `decision-36e6842d`)

## Reference

- Spec: `docs/superpowers/specs/2026-04-29-phase-3-resources-catalog-design.md` (Myco `fbaa1193ee1ff1cf`)
- Plan: `docs/superpowers/plans/2026-04-29-phase-3-resources-catalog.md` (Myco `3eb5ea6d11f9d85d`)
- Phase 2 (prerequisite): merged in #162 as `bda3a04`

## Test plan

- [x] Per-package pytest suites all green
- [x] Live smoke `--phase api-resources` passes for all 8 sample endpoints with parity to action endpoint baseline
- [ ] Reviewer: spot-check serializer field selection vs. expected admin-UI columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)