### PR TITLE
Phase 4A PR1: network serializer coverage (157 tools)

### DIFF
--- a/apps/api/src/unifi_api/serializers/network/acl.py
+++ b/apps/api/src/unifi_api/serializers/network/acl.py
@@ -1,0 +1,76 @@
+"""ACL rule serializers (Phase 4A PR1 Cluster 4).
+
+``AclManager`` exposes ``get_acl_rules()`` / ``get_acl_rule_by_id()`` /
+``create_acl_rule()`` / ``update_acl_rule()`` / ``delete_acl_rule()`` on
+V2 ``/acl-rules``. ``GET /acl-rules/{id}`` returns 405, so detail lookups
+are served by list-then-filter inside the manager — both LIST and DETAIL
+receive the same dict shape here.
+
+The API stores source/destination match config under ``traffic_source`` /
+``traffic_destination``; we surface them as ``source`` / ``destination``
+to match the firewall-rule serializer's vocabulary.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_acl_rules": {"kind": RenderKind.LIST},
+        "unifi_get_acl_rule_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class AclRuleSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "enabled", "action"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "action": _get(obj, "action"),
+            "source": _get(obj, "traffic_source") or _get(obj, "source"),
+            "destination": _get(obj, "traffic_destination")
+            or _get(obj, "destination"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_acl_rule": {"kind": RenderKind.DETAIL},
+        "unifi_update_acl_rule": {"kind": RenderKind.DETAIL},
+        "unifi_delete_acl_rule": {"kind": RenderKind.DETAIL},
+    },
+)
+class AclMutationAckSerializer(Serializer):
+    """DETAIL ack for ACL rule mutations.
+
+    ``create_acl_rule`` returns the created dict; update + delete return
+    ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/ap_groups.py
+++ b/apps/api/src/unifi_api/serializers/network/ap_groups.py
@@ -1,0 +1,76 @@
+"""AP group serializers (Phase 4A PR1 Cluster 3).
+
+AP groups live on V2 ``/apgroups`` and ride on ``NetworkManager`` (not a
+dedicated manager). Methods:
+
+* ``list_ap_groups()`` → ``List[Dict]``
+* ``get_ap_group_details(group_id)`` → ``Optional[Dict]`` (V2 ``GET /{id}``
+  returns 405; manager fetches all and filters)
+* ``create_ap_group(group_data)`` → ``Optional[Dict]``
+* ``update_ap_group(group_id, data)`` → ``bool``
+* ``delete_ap_group(group_id)`` → ``bool``
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_ap_groups": {"kind": RenderKind.LIST},
+        "unifi_get_ap_group_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class ApGroupSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "ap_count"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        device_macs = _get(obj, "device_macs") or []
+        if not isinstance(device_macs, list):
+            device_macs = []
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "ap_count": len(device_macs),
+            "device_macs": list(device_macs),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_ap_group": {"kind": RenderKind.DETAIL},
+        "unifi_update_ap_group": {"kind": RenderKind.DETAIL},
+        "unifi_delete_ap_group": {"kind": RenderKind.DETAIL},
+    },
+)
+class ApGroupMutationAckSerializer(Serializer):
+    """DETAIL ack for AP group CUD operations.
+
+    ``create_ap_group`` returns the created dict; ``update_*``/``delete_*``
+    return ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/client_groups.py
+++ b/apps/api/src/unifi_api/serializers/network/client_groups.py
@@ -1,0 +1,100 @@
+"""Client group + usergroup serializers (Phase 4A PR1 Cluster 2).
+
+UniFi exposes two parallel "group" entities under different APIs:
+
+* ``ClientGroupManager`` — V2 ``/network-members-group`` endpoint, used for
+  OON/firewall membership grouping. Manager returns ``List[Dict]`` (list),
+  ``Optional[Dict]`` (create/get-by-id), and ``bool`` (update/delete).
+* ``UsergroupManager`` — V1 ``/rest/usergroup`` endpoint, used for QoS
+  bandwidth limits. Manager returns ``List[Dict]`` (list / details), an
+  ``Optional[Dict]`` (create), and ``bool`` (update).
+
+Both expose the same useful list/detail fields (``_id``, ``name``,
+``qos_rate_max_down``, ``qos_rate_max_up``) so we render them with the same
+shape. Mutations across both managers normalise to ``{"success": bool}``
+when the manager returns a bare ``bool`` to satisfy the DETAIL contract
+(spec section 5 EMPTY discipline).
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_client_groups": {"kind": RenderKind.LIST},
+        "unifi_get_client_group_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class ClientGroupSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "qos_rate_max_down", "qos_rate_max_up"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "qos_rate_max_down": _get(obj, "qos_rate_max_down"),
+            "qos_rate_max_up": _get(obj, "qos_rate_max_up"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_usergroups": {"kind": RenderKind.LIST},
+        "unifi_get_usergroup_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class UserGroupSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "qos_rate_max_down", "qos_rate_max_up"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "qos_rate_max_down": _get(obj, "qos_rate_max_down"),
+            "qos_rate_max_up": _get(obj, "qos_rate_max_up"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_client_group": {"kind": RenderKind.DETAIL},
+        "unifi_update_client_group": {"kind": RenderKind.DETAIL},
+        "unifi_delete_client_group": {"kind": RenderKind.DETAIL},
+        "unifi_create_usergroup": {"kind": RenderKind.DETAIL},
+        "unifi_update_usergroup": {"kind": RenderKind.DETAIL},
+    },
+)
+class ClientGroupMutationAckSerializer(Serializer):
+    """Generic ack for client_group / usergroup mutations.
+
+    Manager returns vary: ``update_*``/``delete_*`` return ``bool``, while
+    ``create_*`` returns the created dict. Coerce both to a DETAIL-shaped
+    payload."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/clients.py
+++ b/apps/api/src/unifi_api/serializers/network/clients.py
@@ -1,6 +1,20 @@
-"""Network client serializer."""
+"""Network client serializers (LIST/DETAIL) plus Phase 4A Cluster 2 extensions.
+
+The base ``ClientSerializer`` covers ``unifi_list_clients`` and
+``unifi_get_client_details``. Cluster 2 adds:
+
+* ``BlockedClientSerializer`` — LIST view for ``unifi_list_blocked_clients``.
+  Manager (``ClientManager.get_blocked_clients``) returns ``List[Client]``
+  (a filtered subset of all clients where ``client.blocked`` is True).
+* ``ClientLookupSerializer`` — DETAIL view for ``unifi_lookup_by_ip``.
+  Manager returns ``Optional[Client]`` from ``get_client_by_ip``.
+* ``ClientMutationAckSerializer`` — DETAIL ack for the eight
+  client-mutation tools. All underlying managers return ``bool``; coerce
+  to ``{"success": bool}`` per spec section 5 EMPTY discipline.
+"""
 
 from datetime import datetime, timezone
+from typing import Any
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
 
@@ -9,6 +23,15 @@ def _iso(ts: int | None) -> str | None:
     if ts is None:
         return None
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
 
 
 @register_serializer(
@@ -42,3 +65,68 @@ class ClientSerializer(Serializer):
             "note": raw.get("note") or None,
             "usergroup_id": raw.get("usergroup_id") or None,
         }
+
+
+@register_serializer(
+    tools={"unifi_list_blocked_clients": {"kind": RenderKind.LIST}},
+)
+class BlockedClientSerializer(Serializer):
+    primary_key = "mac"
+    display_columns = ["mac", "hostname", "last_seen"]
+    sort_default = "last_seen:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "mac": _get(obj, "mac"),
+            "hostname": _get(obj, "hostname") or _get(obj, "name"),
+            "last_seen": _iso(_get(obj, "last_seen")),
+            "blocked": bool(_get(obj, "blocked", True)),
+        }
+
+
+@register_serializer(
+    tools={"unifi_lookup_by_ip": {"kind": RenderKind.DETAIL}},
+)
+class ClientLookupSerializer(Serializer):
+    primary_key = "mac"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "mac": _get(obj, "mac"),
+            "ip": _get(obj, "last_ip") or _get(obj, "ip"),
+            "hostname": _get(obj, "hostname") or _get(obj, "name"),
+            "is_online": bool(_get(obj, "is_online", False)),
+            "last_seen": _iso(_get(obj, "last_seen")),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_block_client": {"kind": RenderKind.DETAIL},
+        "unifi_unblock_client": {"kind": RenderKind.DETAIL},
+        "unifi_forget_client": {"kind": RenderKind.DETAIL},
+        "unifi_rename_client": {"kind": RenderKind.DETAIL},
+        "unifi_force_reconnect_client": {"kind": RenderKind.DETAIL},
+        "unifi_set_client_ip_settings": {"kind": RenderKind.DETAIL},
+        "unifi_authorize_guest": {"kind": RenderKind.DETAIL},
+        "unifi_unauthorize_guest": {"kind": RenderKind.DETAIL},
+    },
+)
+class ClientMutationAckSerializer(Serializer):
+    """Generic ack for client-side mutations. All underlying managers
+    return ``bool`` — coerce to ``{"success": bool}``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/content_filter.py
+++ b/apps/api/src/unifi_api/serializers/network/content_filter.py
@@ -1,0 +1,70 @@
+"""Content filter serializers (Phase 4A PR1 Cluster 4).
+
+``ContentFilterManager`` exposes ``get_content_filters()`` /
+``get_content_filter_by_id()`` / ``update_content_filter()`` /
+``delete_content_filter()`` on V2 ``/content-filtering``. The UniFi API
+does not support creating new content filtering profiles (the controller
+ships a fixed set); only update + delete mutations exist.
+
+GET /content-filtering/{id} returns 405, so detail lookups are served by
+list-then-filter at the manager layer — by the time we serialize, both
+LIST and DETAIL receive the same dict shape.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_content_filters": {"kind": RenderKind.LIST},
+        "unifi_get_content_filter_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class ContentFilterSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "enabled", "profile"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "profile": _get(obj, "profile"),
+            "applies_to": _get(obj, "applies_to") or _get(obj, "network_ids") or [],
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_update_content_filter": {"kind": RenderKind.DETAIL},
+        "unifi_delete_content_filter": {"kind": RenderKind.DETAIL},
+    },
+)
+class ContentFilterMutationAckSerializer(Serializer):
+    """DETAIL ack for content-filter update + delete (both return ``bool``)."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/devices.py
+++ b/apps/api/src/unifi_api/serializers/network/devices.py
@@ -1,4 +1,24 @@
-"""Network device serializer."""
+"""Network device serializer + Phase 4A PR1 Cluster 1 extensions.
+
+The base ``DeviceSerializer`` covers ``unifi_list_devices`` /
+``unifi_get_device_details``. The remaining device-side tools in the
+"devices & switches" cluster are covered here:
+
+  - ``DeviceRadioSerializer`` (DETAIL) — ``unifi_get_device_radio``;
+    manager returns ``{mac, name, model, radios: [...]}``.
+  - ``LldpNeighborSerializer`` (DETAIL) — ``unifi_get_lldp_neighbors``;
+    manager returns wrapper dict ``{name, model, lldp_table: [...]}``,
+    so DETAIL (matches the SwitchPortsSerializer pattern).
+  - ``RogueApSerializer`` (LIST) — both ``unifi_list_rogue_aps`` and
+    ``unifi_list_known_rogue_aps``; the second sets ``is_known=True``.
+  - ``RfScanResultSerializer`` (LIST) — ``unifi_get_rf_scan_results``.
+  - ``AvailableChannelSerializer`` (LIST) — ``unifi_list_available_channels``.
+  - ``SpeedtestStatusSerializer`` (DETAIL) — ``unifi_get_speedtest_status``.
+  - ``DeviceMutationAckSerializer`` (DETAIL passthrough) — covers all
+    bool-returning mutation tools per spec section 5 EMPTY discipline.
+"""
+
+from typing import Any
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
 
@@ -14,6 +34,15 @@ _STATE_MAP = {
     9: "adoption-error",
     11: "isolated",
 }
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
 
 
 @register_serializer(
@@ -47,3 +76,194 @@ class DeviceSerializer(Serializer):
             "ip": raw.get("ip"),
             "ports": raw.get("port_table") or raw.get("ports"),
         }
+
+
+@register_serializer(tools={"unifi_get_device_radio": {"kind": RenderKind.DETAIL}})
+class DeviceRadioSerializer(Serializer):
+    """Manager returns ``{mac, name, model, radios: [...]}`` (or None for
+    non-AP devices). Pass through with light field whitelisting on the
+    radio entries."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        radios = _get(obj, "radios", []) or []
+        return {
+            "mac": _get(obj, "mac"),
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "radios": [
+                {
+                    "name": _get(r, "name"),
+                    "radio": _get(r, "radio"),
+                    "channel": _get(r, "channel"),
+                    "ht": _get(r, "ht"),
+                    "tx_power": _get(r, "tx_power"),
+                    "tx_power_mode": _get(r, "tx_power_mode"),
+                    "current_channel": _get(r, "current_channel"),
+                    "current_tx_power": _get(r, "current_tx_power"),
+                    "num_sta": _get(r, "num_sta"),
+                }
+                for r in radios
+            ],
+        }
+
+
+@register_serializer(tools={"unifi_get_lldp_neighbors": {"kind": RenderKind.DETAIL}})
+class LldpNeighborSerializer(Serializer):
+    """Manager returns ``{name, model, lldp_table: [...]}``. The lldp_table
+    rows are passed through with field whitelisting."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        rows = _get(obj, "lldp_table", []) or []
+        return {
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "lldp_table": [
+                {
+                    "local_port_idx": _get(r, "local_port_idx"),
+                    "chassis_id": _get(r, "chassis_id"),
+                    "port_id": _get(r, "port_id"),
+                    "system_name": _get(r, "system_name"),
+                    "capabilities": _get(r, "capabilities", []) or [],
+                }
+                for r in rows
+            ],
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_rogue_aps": {"kind": RenderKind.LIST},
+        "unifi_list_known_rogue_aps": {"kind": RenderKind.LIST},
+    },
+)
+class RogueApSerializer(Serializer):
+    """Both endpoints return list[dict]. ``is_known`` is derived from the
+    tool name at the registry layer — it cannot be inferred from the row
+    alone, so we look at a hint key set by ``serialize_action``. We
+    override ``serialize_action`` to thread ``tool_name`` into ``serialize``
+    for this single class."""
+
+    primary_key = "bssid"
+    display_columns = ["bssid", "ssid", "channel", "signal_dbm", "last_seen"]
+
+    @staticmethod
+    def _row(obj, *, is_known: bool) -> dict:
+        return {
+            "bssid": _get(obj, "bssid"),
+            "ssid": _get(obj, "essid") or _get(obj, "ssid"),
+            "channel": _get(obj, "channel"),
+            "signal_dbm": _get(obj, "rssi") or _get(obj, "signal"),
+            "last_seen": _get(obj, "last_seen"),
+            "is_known": is_known,
+        }
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        # Default path (callers that bypass serialize_action) — assume unknown.
+        return RogueApSerializer._row(obj, is_known=False)
+
+    def serialize_action(self, result, *, tool_name: str) -> dict:
+        kind = self._kind_for_tool(tool_name)
+        hint = self._render_hint(kind)
+        is_known = tool_name == "unifi_list_known_rogue_aps"
+        if not isinstance(result, list):
+            from unifi_api.serializers._base import SerializerContractError
+
+            raise SerializerContractError(
+                f"tool '{tool_name}' declared kind=list but manager returned "
+                f"{type(result).__name__}"
+            )
+        return {
+            "success": True,
+            "data": [RogueApSerializer._row(item, is_known=is_known) for item in result],
+            "render_hint": hint,
+        }
+
+
+@register_serializer(tools={"unifi_get_rf_scan_results": {"kind": RenderKind.LIST}})
+class RfScanResultSerializer(Serializer):
+    primary_key = "bssid"
+    display_columns = ["bssid", "ssid", "channel", "signal_dbm"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "bssid": _get(obj, "bssid"),
+            "ssid": _get(obj, "essid") or _get(obj, "ssid"),
+            "channel": _get(obj, "channel"),
+            "signal_dbm": _get(obj, "rssi") or _get(obj, "signal"),
+            "captured_at": _get(obj, "ts") or _get(obj, "captured_at"),
+        }
+
+
+@register_serializer(tools={"unifi_list_available_channels": {"kind": RenderKind.LIST}})
+class AvailableChannelSerializer(Serializer):
+    primary_key = "channel"
+    display_columns = ["channel", "frequency_mhz", "width_mhz", "allowed"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "channel": _get(obj, "channel"),
+            "frequency_mhz": _get(obj, "freq") or _get(obj, "frequency_mhz"),
+            "width_mhz": _get(obj, "ht") or _get(obj, "width_mhz"),
+            "allowed": bool(_get(obj, "allowed", True)),
+        }
+
+
+@register_serializer(tools={"unifi_get_speedtest_status": {"kind": RenderKind.DETAIL}})
+class SpeedtestStatusSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        # Controller exposes status_download/status_upload as Mbps and
+        # latency in ms; status int (0=idle, 1=running) is mapped to a label.
+        status_raw = _get(obj, "status")
+        if isinstance(status_raw, int):
+            status_label = "running" if status_raw == 1 else "idle"
+        elif isinstance(status_raw, str):
+            status_label = status_raw
+        else:
+            status_label = None
+        return {
+            "status": status_label,
+            "download_mbps": _get(obj, "status_download") or _get(obj, "download_mbps"),
+            "upload_mbps": _get(obj, "status_upload") or _get(obj, "upload_mbps"),
+            "latency_ms": _get(obj, "latency") or _get(obj, "latency_ms"),
+            "last_run": _get(obj, "rundate") or _get(obj, "last_run"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_adopt_device": {"kind": RenderKind.DETAIL},
+        "unifi_force_provision_device": {"kind": RenderKind.DETAIL},
+        "unifi_locate_device": {"kind": RenderKind.DETAIL},
+        "unifi_reboot_device": {"kind": RenderKind.DETAIL},
+        "unifi_rename_device": {"kind": RenderKind.DETAIL},
+        "unifi_set_device_led": {"kind": RenderKind.DETAIL},
+        "unifi_set_site_leds": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_device": {"kind": RenderKind.DETAIL},
+        "unifi_trigger_rf_scan": {"kind": RenderKind.DETAIL},
+        "unifi_trigger_speedtest": {"kind": RenderKind.DETAIL},
+        "unifi_update_device_radio": {"kind": RenderKind.DETAIL},
+        "unifi_upgrade_device": {"kind": RenderKind.DETAIL},
+    },
+)
+class DeviceMutationAckSerializer(Serializer):
+    """Generic ack for device-side mutations. All managers here return
+    ``bool``; coerce to ``{"success": bool}`` to satisfy the DETAIL contract."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/dns.py
+++ b/apps/api/src/unifi_api/serializers/network/dns.py
@@ -1,0 +1,77 @@
+"""Static DNS record serializers (Phase 4A PR1 Cluster 3).
+
+``DnsManager`` exposes:
+
+* ``list_dns_records()`` → ``List[Dict]``
+* ``get_dns_record(record_id)`` → ``Optional[Dict]``
+* ``create_dns_record(record_data)`` → ``Optional[Dict]`` (created record)
+* ``update_dns_record(record_id, data)`` → ``bool``
+* ``delete_dns_record(record_id)`` → ``bool``
+
+UniFi's V2 ``/static-dns`` endpoint stores hostname under ``key`` and the
+resolved value under ``value``; we surface them as ``hostname`` / ``ip`` so
+the hint-shape matches caller expectations across record types.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_dns_records": {"kind": RenderKind.LIST},
+        "unifi_get_dns_record_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class DnsRecordSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["hostname", "type", "ip", "ttl", "enabled"]
+    sort_default = "hostname:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "hostname": _get(obj, "key") or _get(obj, "hostname"),
+            "ip": _get(obj, "value") or _get(obj, "ip"),
+            "type": _get(obj, "record_type") or _get(obj, "type"),
+            "ttl": _get(obj, "ttl"),
+            "enabled": bool(_get(obj, "enabled", True)),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_dns_record": {"kind": RenderKind.DETAIL},
+        "unifi_update_dns_record": {"kind": RenderKind.DETAIL},
+        "unifi_delete_dns_record": {"kind": RenderKind.DETAIL},
+    },
+)
+class DnsMutationAckSerializer(Serializer):
+    """DETAIL ack for DNS-record CUD operations.
+
+    ``create_dns_record`` returns the created dict; ``update_*`` /
+    ``delete_*`` return ``bool``. Coerce both to a DETAIL-shaped payload."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/dpi.py
+++ b/apps/api/src/unifi_api/serializers/network/dpi.py
@@ -1,0 +1,75 @@
+"""DPI application + category serializers (Phase 4A PR1 Cluster 4).
+
+``DpiManager`` reaches the official integration API and returns paginated
+wrapper dicts (``{"data": [...], "totalCount", "offset", "limit"}``).
+The DPI tool layer unwraps to a bare list for the action layer, so this
+serializer expects a list of dicts; if the wrapper itself slips through
+the registry will emit a sensible single-record DETAIL of the wrapper
+metadata, but the LIST flow only ever sees the items.
+
+Each application carries an ``id`` (compound:
+``(category_id << 16) | app_id``), a ``name``, and (often) a
+``categoryId`` linking it to a DPI category. Categories carry just
+``id`` + ``name``.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_dpi_applications": {"kind": RenderKind.LIST},
+    },
+)
+class DpiApplicationSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "category_id"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        # DPI ids can be 0 (e.g. category 0 = Instant messengers); avoid the
+        # ``a or b`` pattern that collapses 0 → None.
+        ident = _get(obj, "id")
+        if ident is None:
+            ident = _get(obj, "_id")
+        cat = _get(obj, "categoryId")
+        if cat is None:
+            cat = _get(obj, "category_id")
+        return {
+            "id": ident,
+            "name": _get(obj, "name"),
+            "category_id": cat,
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_dpi_categories": {"kind": RenderKind.LIST},
+    },
+)
+class DpiCategorySerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        ident = _get(obj, "id")
+        if ident is None:
+            ident = _get(obj, "_id")
+        return {
+            "id": ident,
+            "name": _get(obj, "name"),
+        }

--- a/apps/api/src/unifi_api/serializers/network/events.py
+++ b/apps/api/src/unifi_api/serializers/network/events.py
@@ -1,0 +1,62 @@
+"""Event log serializers (Phase 4A PR1 Cluster 6).
+
+Covers the EVENT_LOG kind for ``unifi_list_events``, ``unifi_get_alerts``,
+``unifi_get_anomalies``, ``unifi_get_ips_events``. Each event entry is
+serialized to a curated subset of fields:
+
+- ``id`` (from ``_id``)
+- ``key`` (event type, e.g. ``EVT_WU_Connected``)
+- ``msg`` (human-readable description)
+- ``severity`` (when present — alerts/IPS)
+- ``time`` (epoch milliseconds)
+- ``mac`` (associated client/device MAC)
+- ``ip`` (associated IP, when present)
+
+``sort_default = "time:desc"`` matches Phase 3's EVENT_LOG convention.
+"""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj, *keys):
+    """Return the first non-None value among the listed keys."""
+    if not isinstance(obj, dict):
+        return None
+    for k in keys:
+        v = obj.get(k)
+        if v is not None:
+            return v
+    return None
+
+
+@register_serializer(
+    tools={
+        "unifi_list_events": {"kind": RenderKind.EVENT_LOG},
+        "unifi_get_alerts": {"kind": RenderKind.EVENT_LOG},
+        "unifi_get_anomalies": {"kind": RenderKind.EVENT_LOG},
+        "unifi_get_ips_events": {"kind": RenderKind.EVENT_LOG},
+    },
+)
+class EventLogSerializer(Serializer):
+    """Curated event-log shape across UniFi event-style endpoints."""
+
+    primary_key = "id"
+    sort_default = "time:desc"
+    display_columns = ["time", "key", "msg", "mac"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {"id": None}
+        out = {
+            "id": _get(record, "_id", "id"),
+            "key": _get(record, "key", "event_type", "type"),
+            "msg": _get(record, "msg", "message", "description"),
+            "time": _get(record, "time", "timestamp", "ts"),
+            "mac": _get(record, "user", "mac", "ap", "ap_mac", "device_mac"),
+            "ip": _get(record, "ip", "src_ip"),
+        }
+        sev = _get(record, "severity", "level")
+        if sev is not None:
+            out["severity"] = sev
+        return out

--- a/apps/api/src/unifi_api/serializers/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/serializers/network/firewall_rules.py
@@ -1,6 +1,35 @@
-"""Firewall policy/rule serializer."""
+"""Firewall policy/rule, group, and zone serializers.
+
+The original ``FirewallRuleSerializer`` (Phase 3) covers
+``unifi_list_firewall_policies`` / ``unifi_get_firewall_policy_details``
+from ``firewall_manager.get_firewall_policies``.
+
+Phase 4A PR1 Cluster 4 extends this module with:
+
+* ``FirewallGroupSerializer`` — V1 ``/rest/firewallgroup``. Members live
+  under ``group_members`` (re-exposed as ``members``); ``group_type``
+  is one of ``address-group`` / ``ipv6-address-group`` / ``port-group``.
+* ``FirewallZoneSerializer`` — V2 ``/firewall/zone-matrix`` (with a
+  fallback to ``/firewall/zones``). The matrix payload is dropped at the
+  manager layer so we only see zone metadata here.
+* ``FirewallMutationAckSerializer`` — DETAIL ack for all firewall-policy
+  and firewall-group CUD/toggle mutations. ``create_*`` may return a
+  dict (or ``FirewallPolicy``); ``update_*`` / ``delete_*`` /
+  ``toggle_*`` return ``bool``.
+"""
+
+from typing import Any
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
 
 
 @register_serializer(
@@ -31,3 +60,78 @@ class FirewallRuleSerializer(Serializer):
             "source": raw.get("source"),
             "destination": raw.get("destination"),
         }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_firewall_groups": {"kind": RenderKind.LIST},
+        "unifi_get_firewall_group_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class FirewallGroupSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "group_type", "members"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        members = _get(obj, "group_members") or _get(obj, "members") or []
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "group_type": _get(obj, "group_type"),
+            "members": members,
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_firewall_zones": {"kind": RenderKind.LIST},
+    },
+)
+class FirewallZoneSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "default_policy", "networks"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "networks": _get(obj, "networks") or _get(obj, "network_ids") or [],
+            "default_policy": _get(obj, "default_policy")
+            or _get(obj, "default_action"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_firewall_policy": {"kind": RenderKind.DETAIL},
+        "unifi_create_simple_firewall_policy": {"kind": RenderKind.DETAIL},
+        "unifi_update_firewall_policy": {"kind": RenderKind.DETAIL},
+        "unifi_delete_firewall_policy": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_firewall_policy": {"kind": RenderKind.DETAIL},
+        "unifi_create_firewall_group": {"kind": RenderKind.DETAIL},
+        "unifi_update_firewall_group": {"kind": RenderKind.DETAIL},
+        "unifi_delete_firewall_group": {"kind": RenderKind.DETAIL},
+    },
+)
+class FirewallMutationAckSerializer(Serializer):
+    """DETAIL ack for firewall policy + group mutations.
+
+    ``create_*`` returns a dict or ``FirewallPolicy``; ``update_*`` /
+    ``delete_*`` / ``toggle_*`` return ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/networks.py
+++ b/apps/api/src/unifi_api/serializers/network/networks.py
@@ -1,4 +1,11 @@
-"""Network (LAN/VLAN) serializer."""
+"""Network (LAN/VLAN) serializer.
+
+Phase 4A PR1 Cluster 3 adds the ``NetworkMutationAckSerializer`` for
+``unifi_create_network`` and ``unifi_update_network``. Both underlying
+``NetworkManager`` methods return either an ``Optional[Dict]`` (create) or
+``bool`` (update), so the ack serializer normalises to a DETAIL-shaped
+payload.
+"""
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
 
@@ -30,3 +37,29 @@ class NetworkSerializer(Serializer):
             "vlan": raw.get("vlan"),
             "subnet": raw.get("ip_subnet") or raw.get("subnet"),
         }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_network": {"kind": RenderKind.DETAIL},
+        "unifi_update_network": {"kind": RenderKind.DETAIL},
+    },
+)
+class NetworkMutationAckSerializer(Serializer):
+    """DETAIL ack for network create/update.
+
+    ``create_network`` returns the created dict; ``update_network`` returns
+    ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/oon.py
+++ b/apps/api/src/unifi_api/serializers/network/oon.py
@@ -1,0 +1,85 @@
+"""Out-of-network (OON) policy serializers (Phase 4A PR1 Cluster 4).
+
+``OonManager`` exposes ``get_oon_policies()`` / ``get_oon_policy_by_id()``
+/ ``create_oon_policy()`` / ``update_oon_policy()`` /
+``toggle_oon_policy()`` / ``delete_oon_policy()`` on V2 OON endpoints.
+Mutations return ``bool`` (or ``Optional[bool]`` for toggle) and
+``create_*`` returns the created dict.
+
+OON policies bundle ``targets`` (a list of ``{type, value}`` matchers
+covering MACs, group IDs, etc.) plus a ``secure`` config (with nested
+``internet`` mode), a ``qos`` slice, and a ``route`` slice. For the LIST
+render we only need name/enabled and the target list (re-exposed as
+``applies_to``); the registry preserves everything else through normal
+serialization.
+
+``restriction_level`` is a controller-side label that the manager passes
+through unchanged when present — newer firmware exposes it; older
+firmware leaves it out.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_oon_policies": {"kind": RenderKind.LIST},
+        "unifi_get_oon_policy_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class OonPolicySerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "enabled", "restriction_level"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "applies_to": _get(obj, "targets") or _get(obj, "applies_to") or [],
+            "restriction_level": _get(obj, "restriction_level"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_oon_policy": {"kind": RenderKind.DETAIL},
+        "unifi_update_oon_policy": {"kind": RenderKind.DETAIL},
+        "unifi_delete_oon_policy": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_oon_policy": {"kind": RenderKind.DETAIL},
+    },
+)
+class OonMutationAckSerializer(Serializer):
+    """DETAIL ack for OON policy mutations.
+
+    ``create_oon_policy`` returns the created dict; ``update_*`` and
+    ``delete_*`` return ``bool``; ``toggle_oon_policy`` returns
+    ``Optional[bool]``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if obj is None:
+            return {"success": False}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/port_forwards.py
+++ b/apps/api/src/unifi_api/serializers/network/port_forwards.py
@@ -1,0 +1,77 @@
+"""Port forward serializers (Phase 4A PR1 Cluster 5).
+
+* ``PortForwardSerializer`` — V1 ``/rest/portforward``. The manager
+  returns ``PortForward`` aiounifi models on read paths; the underlying
+  payload is exposed via ``raw``. ``fwd_protocol`` may also surface as
+  ``protocol`` on certain firmware versions, but the manager normalizes
+  to ``fwd_protocol``.
+* ``PortForwardMutationAckSerializer`` — DETAIL ack for create/update/
+  toggle. ``create_*`` returns a dict; ``update_*`` / ``toggle_*`` return
+  ``bool``.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_port_forwards": {"kind": RenderKind.LIST},
+        "unifi_get_port_forward": {"kind": RenderKind.DETAIL},
+    },
+)
+class PortForwardSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "enabled", "fwd_protocol", "dst_port", "fwd_port"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "fwd_protocol": _get(obj, "fwd_protocol") or _get(obj, "protocol"),
+            "dst_port": _get(obj, "dst_port"),
+            "fwd_port": _get(obj, "fwd_port"),
+            "src": _get(obj, "src"),
+            "log": bool(_get(obj, "log", False)),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_port_forward": {"kind": RenderKind.DETAIL},
+        "unifi_create_simple_port_forward": {"kind": RenderKind.DETAIL},
+        "unifi_update_port_forward": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_port_forward": {"kind": RenderKind.DETAIL},
+    },
+)
+class PortForwardMutationAckSerializer(Serializer):
+    """DETAIL ack for port forward mutations.
+
+    ``create_*`` returns a dict (or None); ``update_*`` / ``toggle_*``
+    return ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if obj is None:
+            return {"success": False}
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/qos.py
+++ b/apps/api/src/unifi_api/serializers/network/qos.py
@@ -1,0 +1,83 @@
+"""QoS rule serializers (Phase 4A PR1 Cluster 4).
+
+``QosManager`` exposes:
+
+* ``get_qos_rules()`` → ``List[Dict]`` (V2 ``/qos-rules``; controller wraps
+  in ``{"data": [...]}`` which the manager unwraps)
+* ``get_qos_rule_details(rule_id)`` → ``Optional[Dict]``
+* ``create_qos_rule(rule_data)`` → ``Optional[Dict]``
+* ``update_qos_rule(rule_id, data)`` → ``bool``
+* ``delete_qos_rule(rule_id)`` → ``bool``
+
+The toggle / simple-create helpers live on the QoS *tool* layer and end
+up calling ``update_qos_rule`` / ``create_qos_rule``; both still resolve
+to ``bool`` / ``dict`` results.
+
+Surface fields ``rate_max_down`` / ``rate_max_up`` and ``priority`` so the
+LIST render can show the numbers a human cares about; everything else is
+preserved on the wrapped object via the registry's normal serialize flow.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_qos_rules": {"kind": RenderKind.LIST},
+        "unifi_get_qos_rule_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class QosRuleSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "enabled", "priority", "rate_max_down", "rate_max_up"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "rate_max_down": _get(obj, "rate_max_down"),
+            "rate_max_up": _get(obj, "rate_max_up"),
+            "priority": _get(obj, "priority"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_qos_rule": {"kind": RenderKind.DETAIL},
+        "unifi_create_simple_qos_rule": {"kind": RenderKind.DETAIL},
+        "unifi_update_qos_rule": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_qos_rule_enabled": {"kind": RenderKind.DETAIL},
+    },
+)
+class QosMutationAckSerializer(Serializer):
+    """DETAIL ack for QoS rule mutations.
+
+    ``create_*`` returns the created dict; ``update_*`` and toggle
+    return ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/routes.py
+++ b/apps/api/src/unifi_api/serializers/network/routes.py
@@ -1,0 +1,155 @@
+"""Static + active + traffic route serializers (Phase 4A PR1 Cluster 3).
+
+Three managers feed this module:
+
+* ``RoutingManager`` — ``get_routes()`` / ``get_route_details()`` /
+  ``get_active_routes()``. Static routes use the V1 ``/rest/routing``
+  endpoint with hyphen-prefixed fields (``static-route_network``,
+  ``static-route_nexthop``, ``static-route_distance``). Active routes come
+  from the undocumented ``/stat/routing`` endpoint and may include nh
+  (next-hop) sublists, ``pfx`` (prefix), ``metric``, and ``t`` (type).
+* ``TrafficRouteManager`` — V2 ``/trafficroutes``. Returns ``List[Dict]``.
+  Note: traffic routes use ``description`` for the human-readable name and
+  ``matching_target`` (DOMAIN/IP/REGION) for what triggers the route.
+* Cross-cutting mutation ack covering all CUD entry points across both.
+
+``unifi_create_route`` is from RoutingManager; ``unifi_update_traffic_route``
+and ``unifi_toggle_traffic_route`` are from TrafficRouteManager — all return
+``bool`` (or in the case of create, an ``Optional[Dict]``).
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _summarize_targets(value: Any) -> Any:
+    """Collapse a list of target dicts to either a count or the raw list."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    return value
+
+
+@register_serializer(
+    tools={
+        "unifi_list_routes": {"kind": RenderKind.LIST},
+        "unifi_get_route_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class RouteSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "target_subnet", "gateway", "distance", "enabled"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "target_subnet": _get(obj, "static-route_network")
+            or _get(obj, "target_subnet")
+            or _get(obj, "network"),
+            "gateway": _get(obj, "static-route_nexthop")
+            or _get(obj, "gateway")
+            or _get(obj, "nexthop"),
+            "distance": _get(obj, "static-route_distance")
+            or _get(obj, "distance"),
+            "enabled": bool(_get(obj, "enabled", True)),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_active_routes": {"kind": RenderKind.LIST},
+    },
+)
+class ActiveRouteSerializer(Serializer):
+    primary_key = "target_subnet"
+    display_columns = ["target_subnet", "gateway", "interface", "distance"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        # /stat/routing returns nh as a list of {via, intf} dicts; pluck the
+        # first to populate gateway/interface. Falls through cleanly when the
+        # endpoint emits a flatter shape.
+        nh_list = _get(obj, "nh") or []
+        first_nh: dict[str, Any] = nh_list[0] if isinstance(nh_list, list) and nh_list else {}
+        return {
+            "target_subnet": _get(obj, "pfx")
+            or _get(obj, "target_subnet")
+            or _get(obj, "network"),
+            "gateway": first_nh.get("via")
+            or _get(obj, "gateway")
+            or _get(obj, "nexthop"),
+            "interface": first_nh.get("intf")
+            or _get(obj, "interface")
+            or _get(obj, "intf"),
+            "distance": _get(obj, "metric") or _get(obj, "distance"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_traffic_routes": {"kind": RenderKind.LIST},
+        "unifi_get_traffic_route_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class TrafficRouteSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "matching_target", "next_hop", "enabled"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "description") or _get(obj, "name"),
+            "matching_target": _get(obj, "matching_target"),
+            "source_targets": _summarize_targets(_get(obj, "target_devices")),
+            "destination_targets": _summarize_targets(
+                _get(obj, "domains")
+                or _get(obj, "ip_addresses")
+                or _get(obj, "ip_ranges")
+                or _get(obj, "regions")
+            ),
+            "next_hop": _get(obj, "next_hop") or _get(obj, "network_id"),
+            "enabled": bool(_get(obj, "enabled", True)),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_route": {"kind": RenderKind.DETAIL},
+        "unifi_update_route": {"kind": RenderKind.DETAIL},
+        "unifi_update_traffic_route": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_traffic_route": {"kind": RenderKind.DETAIL},
+    },
+)
+class RouteMutationAckSerializer(Serializer):
+    """DETAIL ack for static + traffic route mutations.
+
+    ``create_route`` returns the created dict; the rest return ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/sessions.py
+++ b/apps/api/src/unifi_api/serializers/network/sessions.py
@@ -1,0 +1,68 @@
+"""Client sessions and wifi-details serializers (Phase 4A PR1 Cluster 6).
+
+- ``unifi_get_client_sessions`` (LIST) — historical association sessions
+  with ``connected_at``/``disconnected_at`` and duration.
+- ``unifi_get_client_wifi_details`` (DETAIL) — current WiFi parameters for
+  a specific client (signal, rates, channel).
+"""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj, *keys, default=None):
+    if not isinstance(obj, dict):
+        return default
+    for k in keys:
+        v = obj.get(k)
+        if v is not None:
+            return v
+    return default
+
+
+@register_serializer(
+    tools={
+        "unifi_get_client_sessions": {"kind": RenderKind.LIST},
+    },
+)
+class ClientSessionSerializer(Serializer):
+    primary_key = "connected_at"
+    sort_default = "connected_at:desc"
+    display_columns = ["mac", "hostname", "ssid", "connected_at", "duration"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {}
+        return {
+            "mac": _get(record, "mac"),
+            "hostname": _get(record, "hostname", "name"),
+            "ap": _get(record, "ap", "ap_mac"),
+            "ssid": _get(record, "essid", "ssid"),
+            "connected_at": _get(record, "assoc_time", "connected_at", "first_seen"),
+            "disconnected_at": _get(record, "disassoc_time", "disconnected_at", "last_seen"),
+            "duration": _get(record, "duration"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_get_client_wifi_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class ClientWifiDetailsSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        if obj is None:
+            return {}
+        if not isinstance(obj, dict):
+            raw = getattr(obj, "raw", None)
+            obj = raw if isinstance(raw, dict) else {}
+        return {
+            "mac": _get(obj, "mac"),
+            "ssid": _get(obj, "essid", "ssid"),
+            "ap": _get(obj, "ap_mac", "ap"),
+            "signal": _get(obj, "signal", "rssi"),
+            "tx_rate": _get(obj, "tx_rate"),
+            "rx_rate": _get(obj, "rx_rate"),
+            "channel": _get(obj, "channel"),
+        }

--- a/apps/api/src/unifi_api/serializers/network/snmp.py
+++ b/apps/api/src/unifi_api/serializers/network/snmp.py
@@ -1,0 +1,34 @@
+"""SNMP settings serializer (Phase 4A PR1 Cluster 5).
+
+The SNMP tool exposes only a single mutation
+(``unifi_update_snmp_settings``); reads are not currently surfaced as
+tools. This serializer provides a passthrough DETAIL ack with bool
+coercion to match the established mutation-ack pattern.
+"""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+@register_serializer(
+    tools={
+        "unifi_update_snmp_settings": {"kind": RenderKind.DETAIL},
+    },
+)
+class SnmpMutationAckSerializer(Serializer):
+    """DETAIL ack for SNMP settings update.
+
+    Manager returns ``bool`` on success; passes through dict payloads
+    unchanged for any future detail-style responses."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if obj is None:
+            return {"success": False}
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/stats.py
+++ b/apps/api/src/unifi_api/serializers/network/stats.py
@@ -1,0 +1,108 @@
+"""Stats serializers (Phase 4A PR1 Cluster 6).
+
+TIMESERIES tools share a per-point shape — `{ts: <ms>, ...metrics}` — locked
+in spec §5 (amended April 29, 2026). Window/step metadata moves to
+`render_hint`, not `data`, to fit Phase 3's `serialize_action` contract
+(TIMESERIES iterates `serialize` per item, same as EVENT_LOG).
+
+A handful of nominally-stats tools are registered as DETAIL because the
+AST-captured manager method returns a single dict rather than a list:
+
+- ``unifi_get_device_stats`` → ``device_manager.get_device_details`` (dict)
+- ``unifi_get_client_stats`` → ``client_manager.get_client_details`` (dict)
+- ``unifi_get_dpi_stats`` → ``stats_manager.get_dpi_stats`` (Dict[str, List])
+
+For these, fields are passed through and curated to the keys most relevant
+for stats consumption. Phase 5 (which fixes the AST limitation) can revisit
+whether dedicated stats endpoints exist.
+"""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _normalize_ts(point: dict) -> int:
+    ts = point.get("ts") or point.get("time") or point.get("timestamp") or 0
+    if ts and ts < 10_000_000_000:  # likely seconds → ms
+        ts = ts * 1000
+    return ts
+
+
+@register_serializer(
+    tools={
+        "unifi_get_dashboard": {"kind": RenderKind.TIMESERIES},
+        "unifi_get_network_stats": {"kind": RenderKind.TIMESERIES},
+        "unifi_get_gateway_stats": {"kind": RenderKind.TIMESERIES},
+        "unifi_get_client_dpi_traffic": {"kind": RenderKind.TIMESERIES},
+        "unifi_get_site_dpi_traffic": {"kind": RenderKind.TIMESERIES},
+    },
+)
+class TimeseriesSerializer(Serializer):
+    """Serialize a single point: ``{ts: <ms>, ...metric_keys}``.
+
+    Window/step metadata lives in ``render_hint``; per spec §5 the
+    serialized ``data`` is ``list[point]``.
+    """
+
+    sort_default = "ts:desc"
+
+    @staticmethod
+    def serialize(point) -> dict:
+        if not isinstance(point, dict):
+            return {"ts": 0}
+        ts = _normalize_ts(point)
+        return {
+            "ts": ts,
+            **{k: v for k, v in point.items() if k not in ("time", "timestamp", "ts")},
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_get_device_stats": {"kind": RenderKind.DETAIL},
+        "unifi_get_client_stats": {"kind": RenderKind.DETAIL},
+    },
+)
+class StatsDetailSerializer(Serializer):
+    """Detail serializer for stats tools whose AST-captured manager method
+    returns a single dict (e.g. ``get_device_details``)."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if obj is None:
+            return {}
+        if isinstance(obj, dict):
+            return dict(obj)
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return dict(raw)
+        return {"value": str(obj)}
+
+
+@register_serializer(
+    tools={
+        "unifi_get_dpi_stats": {"kind": RenderKind.DETAIL},
+    },
+)
+class DpiStatsSerializer(Serializer):
+    """``get_dpi_stats`` returns ``{applications: [...], categories: [...]}``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if not isinstance(obj, dict):
+            return {"applications": [], "categories": []}
+
+        def _itemize(items):
+            out = []
+            for it in items or []:
+                if isinstance(it, dict):
+                    out.append(it)
+                else:
+                    raw = getattr(it, "raw", None)
+                    if isinstance(raw, dict):
+                        out.append(dict(raw))
+            return out
+
+        return {
+            "applications": _itemize(obj.get("applications")),
+            "categories": _itemize(obj.get("categories")),
+        }

--- a/apps/api/src/unifi_api/serializers/network/switch.py
+++ b/apps/api/src/unifi_api/serializers/network/switch.py
@@ -1,0 +1,161 @@
+"""Switch + port-related serializers (Phase 4A PR1 Cluster 1).
+
+Manager methods in ``SwitchManager`` largely return either:
+  - a list of dicts (port profiles), or
+  - a wrapper dict with ``name``, ``model`` and a nested array of rows
+    (port_overrides / port_table / lldp_table).
+
+The wrapper-dict shape forces these tools to register as ``DETAIL``
+rather than ``LIST`` — the contract checker (``Serializer.serialize_action``)
+otherwise rejects a dict for a list-kind tool. The nested rows are
+exposed verbatim inside ``data`` so renderers can table them.
+
+Mutation-ack tools (``set_*``, ``configure_*``, ``power_cycle_*``,
+``create/update/delete_port_profile``, ``update_switch_stp``) all return
+``bool`` from their managers; the ack serializer normalises those into
+``{"success": True}`` to satisfy the DETAIL contract per spec
+section 5 (EMPTY discipline — prefer DETAIL with a tiny shape).
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_port_profiles": {"kind": RenderKind.LIST},
+        "unifi_get_port_profile_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class PortProfileSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "poe_mode", "native_networkconf_id"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "native_networkconf_id": _get(obj, "native_networkconf_id"),
+            "tagged_networkconf_ids": _get(obj, "tagged_networkconf_ids", []) or [],
+            "poe_mode": _get(obj, "poe_mode"),
+            "isolation": _get(obj, "isolation"),
+        }
+
+
+@register_serializer(tools={"unifi_get_switch_ports": {"kind": RenderKind.DETAIL}})
+class SwitchPortsSerializer(Serializer):
+    """Wrapper around ``SwitchManager.get_switch_ports`` — manager returns a
+    dict ``{name, model, port_overrides: [...]}``, which is DETAIL-shaped."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        port_overrides = _get(obj, "port_overrides", []) or []
+        normalised = [
+            {
+                "port_idx": _get(p, "port_idx"),
+                "name": _get(p, "name"),
+                "portconf_id": _get(p, "portconf_id"),
+                "poe_mode": _get(p, "poe_mode"),
+                "op_mode": _get(p, "op_mode"),
+            }
+            for p in port_overrides
+        ]
+        return {
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "port_overrides": normalised,
+        }
+
+
+@register_serializer(tools={"unifi_get_port_stats": {"kind": RenderKind.DETAIL}})
+class PortStatsSerializer(Serializer):
+    """Manager returns ``{name, model, port_table: [...]}``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        port_table = _get(obj, "port_table", []) or []
+        normalised = [
+            {
+                "port_idx": _get(p, "port_idx"),
+                "name": _get(p, "name"),
+                "enable": bool(_get(p, "enable", True)),
+                "speed": _get(p, "speed"),
+                "duplex": _get(p, "full_duplex"),
+                "tx_bytes": _get(p, "tx_bytes", 0),
+                "rx_bytes": _get(p, "rx_bytes", 0),
+                "tx_packets": _get(p, "tx_packets", 0),
+                "rx_packets": _get(p, "rx_packets", 0),
+                "tx_dropped": _get(p, "tx_dropped", 0),
+                "rx_dropped": _get(p, "rx_dropped", 0),
+                "poe_enable": bool(_get(p, "poe_enable", False)),
+                "poe_mode": _get(p, "poe_mode"),
+                "poe_power": _get(p, "poe_power"),
+            }
+            for p in port_table
+        ]
+        return {
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "port_table": normalised,
+        }
+
+
+@register_serializer(tools={"unifi_get_switch_capabilities": {"kind": RenderKind.DETAIL}})
+class SwitchCapabilitiesSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        caps = _get(obj, "switch_caps", {}) or {}
+        return {
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "switch_caps": caps,
+            "stp_version": _get(obj, "stp_version"),
+            "stp_priority": _get(obj, "stp_priority"),
+            "jumboframe_enabled": _get(obj, "jumboframe_enabled"),
+            "dot1x_portctrl_enabled": _get(obj, "dot1x_portctrl_enabled"),
+        }
+
+
+# Mutation acks — DETAIL with tiny shape (spec section 5 EMPTY discipline).
+# Manager methods here return bool/dict; we normalise to a small DETAIL payload.
+@register_serializer(
+    tools={
+        "unifi_create_port_profile": {"kind": RenderKind.DETAIL},
+        "unifi_update_port_profile": {"kind": RenderKind.DETAIL},
+        "unifi_delete_port_profile": {"kind": RenderKind.DETAIL},
+        "unifi_set_switch_port_profile": {"kind": RenderKind.DETAIL},
+        "unifi_configure_port_aggregation": {"kind": RenderKind.DETAIL},
+        "unifi_configure_port_mirror": {"kind": RenderKind.DETAIL},
+        "unifi_power_cycle_port": {"kind": RenderKind.DETAIL},
+        "unifi_set_jumbo_frames": {"kind": RenderKind.DETAIL},
+        "unifi_update_switch_stp": {"kind": RenderKind.DETAIL},
+    },
+)
+class SwitchMutationAckSerializer(Serializer):
+    """Generic ack for switch-side mutations. Most managers return ``bool``
+    — coerce to ``{"success": bool}``. Dict responses (e.g. ``create_port_profile``
+    returns the created profile) pass through with minimal coercion."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/system.py
+++ b/apps/api/src/unifi_api/serializers/network/system.py
@@ -1,0 +1,299 @@
+"""System / alarms / backups / settings serializers (Phase 4A PR1 Cluster 6).
+
+Covers:
+- LIST: ``unifi_list_alarms``, ``unifi_list_backups``, ``unifi_get_top_clients``,
+  ``unifi_get_speedtest_results``, ``unifi_get_network_health`` (manager
+  returns multi-element list of subsystems).
+- DETAIL: ``unifi_get_system_info``, ``unifi_get_site_settings``,
+  ``unifi_get_snmp_settings`` (manager returns ``list[dict]``; serializer
+  unwraps the first item), ``unifi_get_event_types`` (list of prefix
+  descriptors wrapped under ``event_types`` key for stable shape),
+  ``unifi_get_autobackup_settings``.
+- DETAIL passthrough+bool coercion (mutation acks):
+  ``unifi_archive_alarm``, ``unifi_archive_all_alarms``,
+  ``unifi_create_backup``, ``unifi_delete_backup``,
+  ``unifi_update_autobackup_settings``.
+"""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj, *keys, default=None):
+    if not isinstance(obj, dict):
+        return default
+    for k in keys:
+        v = obj.get(k)
+        if v is not None:
+            return v
+    return default
+
+
+# ---- Alarms (LIST) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_list_alarms": {"kind": RenderKind.LIST},
+    },
+)
+class AlarmSerializer(Serializer):
+    primary_key = "id"
+    sort_default = "time:desc"
+    display_columns = ["time", "key", "msg", "archived"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {"id": None}
+        return {
+            "id": _get(record, "_id", "id"),
+            "key": _get(record, "key", "event_type"),
+            "msg": _get(record, "msg", "message"),
+            "archived": bool(record.get("archived", False)),
+            "time": _get(record, "time", "timestamp"),
+        }
+
+
+# ---- Backups (LIST) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_list_backups": {"kind": RenderKind.LIST},
+    },
+)
+class BackupSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["filename", "size", "created_at"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {"id": None}
+        return {
+            "id": _get(record, "_id", "id"),
+            "filename": _get(record, "filename", "name"),
+            "size": _get(record, "size"),
+            "created_at": _get(record, "time", "created_at", "timestamp"),
+        }
+
+
+# ---- System info (DETAIL) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_system_info": {"kind": RenderKind.DETAIL},
+    },
+)
+class SystemInfoSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        if not isinstance(obj, dict):
+            return {}
+        return {
+            "name": _get(obj, "name", "controller_name"),
+            "version": _get(obj, "version", "build"),
+            "hostname": _get(obj, "hostname", "host"),
+            "uptime": _get(obj, "uptime"),
+            "num_devices": _get(obj, "num_devices"),
+            "num_clients": _get(obj, "num_clients"),
+        }
+
+
+# ---- Network health (LIST — manager returns multiple subsystems) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_network_health": {"kind": RenderKind.LIST},
+    },
+)
+class NetworkHealthSerializer(Serializer):
+    primary_key = "subsystem"
+    display_columns = ["subsystem", "status", "num_user", "rx_bytes", "tx_bytes"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {}
+        return {
+            "subsystem": _get(record, "subsystem"),
+            "status": _get(record, "status"),
+            "num_user": _get(record, "num_user"),
+            "num_guest": _get(record, "num_guest"),
+            "num_iot": _get(record, "num_iot"),
+            "rx_bytes": _get(record, "rx_bytes-r", "rx_bytes"),
+            "tx_bytes": _get(record, "tx_bytes-r", "tx_bytes"),
+        }
+
+
+# ---- Site settings (DETAIL) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_site_settings": {"kind": RenderKind.DETAIL},
+    },
+)
+class SiteSettingsSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        if not isinstance(obj, dict):
+            return {}
+        return {
+            "site_id": _get(obj, "_id", "site_id"),
+            "name": _get(obj, "name"),
+            "role": _get(obj, "role"),
+            "country": _get(obj, "country"),
+        }
+
+
+# ---- SNMP settings (DETAIL — manager returns list[dict], unwrap first) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_snmp_settings": {"kind": RenderKind.DETAIL},
+    },
+)
+class SnmpSettingsSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        # Manager returns list[dict]; serializer unwraps first item.
+        if isinstance(obj, list):
+            obj = obj[0] if obj else {}
+        if not isinstance(obj, dict):
+            return {}
+        return {
+            "enabled": bool(obj.get("enabled", False)),
+            "community": _get(obj, "community", default=""),
+            "port": _get(obj, "port"),
+            "version": _get(obj, "version"),
+        }
+
+
+# ---- Event types (DETAIL — wrap list under stable key) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_event_types": {"kind": RenderKind.DETAIL},
+    },
+)
+class EventTypesSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, list):
+            return {"event_types": [e for e in obj if isinstance(e, dict)]}
+        if isinstance(obj, dict):
+            # Already shaped {prefix: descriptor} or wrapping list.
+            inner = obj.get("event_types")
+            if isinstance(inner, list):
+                return {"event_types": inner}
+            return {"event_types": [obj]}
+        return {"event_types": []}
+
+
+# ---- Auto-backup settings (DETAIL) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_autobackup_settings": {"kind": RenderKind.DETAIL},
+    },
+)
+class AutoBackupSettingsSerializer(Serializer):
+    @staticmethod
+    def serialize(obj) -> dict:
+        if not isinstance(obj, dict):
+            return {}
+        return {
+            "enabled": bool(obj.get("enabled", False)),
+            "schedule": _get(obj, "schedule", "cron"),
+            "max_count": _get(obj, "max_count", "max_backups"),
+        }
+
+
+# ---- Top clients (LIST) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_top_clients": {"kind": RenderKind.LIST},
+    },
+)
+class TopClientsSerializer(Serializer):
+    primary_key = "mac"
+    sort_default = "total_bytes:desc"
+    display_columns = ["mac", "hostname", "total_bytes"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {"mac": None}
+        return {
+            "mac": _get(record, "mac"),
+            "hostname": _get(record, "name", "hostname"),
+            "tx_bytes": _get(record, "tx_bytes"),
+            "rx_bytes": _get(record, "rx_bytes"),
+            "total_bytes": _get(record, "total_bytes", "bytes"),
+        }
+
+
+# ---- Speedtest results (LIST) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_get_speedtest_results": {"kind": RenderKind.LIST},
+    },
+)
+class SpeedtestResultSerializer(Serializer):
+    sort_default = "timestamp:desc"
+    display_columns = ["timestamp", "download_mbps", "upload_mbps", "latency_ms"]
+
+    @staticmethod
+    def serialize(record) -> dict:
+        if not isinstance(record, dict):
+            return {}
+        return {
+            "timestamp": _get(record, "time", "timestamp"),
+            "download_mbps": _get(record, "xput_download", "download_mbps"),
+            "upload_mbps": _get(record, "xput_upload", "upload_mbps"),
+            "latency_ms": _get(record, "latency", "latency_ms"),
+        }
+
+
+# ---- Mutation acks (DETAIL passthrough + bool coercion) ----
+
+
+@register_serializer(
+    tools={
+        "unifi_archive_alarm": {"kind": RenderKind.DETAIL},
+        "unifi_archive_all_alarms": {"kind": RenderKind.DETAIL},
+        "unifi_create_backup": {"kind": RenderKind.DETAIL},
+        "unifi_delete_backup": {"kind": RenderKind.DETAIL},
+        "unifi_update_autobackup_settings": {"kind": RenderKind.DETAIL},
+    },
+)
+class SystemMutationAckSerializer(Serializer):
+    """DETAIL ack for system mutations.
+
+    Managers return ``bool`` (archive/delete/update) or ``Optional[Dict]``
+    (``create_backup``). Bool maps to ``{"success": <bool>}``; dicts pass
+    through; ``None`` maps to ``{"success": False}``.
+    """
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if obj is None:
+            return {"success": False}
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/vouchers.py
+++ b/apps/api/src/unifi_api/serializers/network/vouchers.py
@@ -1,0 +1,75 @@
+"""Hotspot voucher serializers (Phase 4A PR1 Cluster 5).
+
+* ``VoucherSerializer`` — ``/stat/voucher`` payloads from
+  ``HotspotManager``. The controller exposes creation as ``create_time``
+  (Unix epoch); we re-emit it as ``created_at`` for downstream
+  consistency with other resources.
+* ``VoucherMutationAckSerializer`` — DETAIL ack for create + revoke.
+  ``create_voucher`` returns a list of new voucher dicts (or ``None``);
+  ``revoke_voucher`` returns ``bool``.
+
+The manifest "hotspot" category currently contains only voucher tools;
+no separate non-voucher hotspot serializer is required.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "unifi_list_vouchers": {"kind": RenderKind.LIST},
+        "unifi_get_voucher_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class VoucherSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["code", "status", "duration", "created_at"]
+    sort_default = "created_at:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "code": _get(obj, "code"),
+            "status": _get(obj, "status"),
+            "duration": _get(obj, "duration"),
+            "qos_overwrite": bool(_get(obj, "qos_overwrite", False)),
+            "created_at": _get(obj, "create_time") or _get(obj, "created_at"),
+            "used_at": _get(obj, "used_at") or _get(obj, "end_time"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_voucher": {"kind": RenderKind.DETAIL},
+        "unifi_revoke_voucher": {"kind": RenderKind.DETAIL},
+    },
+)
+class VoucherMutationAckSerializer(Serializer):
+    """DETAIL ack for voucher create + revoke.
+
+    ``create_voucher`` returns a list of new voucher dicts (or ``None``);
+    ``revoke_voucher`` returns ``bool``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, list):
+            return {"success": True, "vouchers": obj}
+        if isinstance(obj, dict):
+            return obj
+        if obj is None:
+            return {"success": False}
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/vpn.py
+++ b/apps/api/src/unifi_api/serializers/network/vpn.py
@@ -1,0 +1,133 @@
+"""VPN serializers (Phase 4A PR1 Cluster 3).
+
+VPN configurations live inside the ``networkconf`` API and are filtered by
+purpose / vpn_type. ``VpnManager`` returns:
+
+* ``get_vpn_clients()`` / ``get_vpn_servers()`` → ``List[Dict]``
+* ``get_vpn_client_details()`` / ``get_vpn_server_details()`` → ``Optional[Dict]``
+* ``update_vpn_client_state()`` / ``update_vpn_server_state()`` → ``bool``
+
+The common fields surfaced here mirror the manager output without
+re-classifying — we expose ``vpn_type`` directly as ``type`` so callers can
+disambiguate wireguard vs openvpn vs l2tp.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _vpn_server_address(obj: Any) -> str | None:
+    # Wireguard client peer endpoint, openvpn remote, or generic server.
+    return (
+        _get(obj, "wireguard_client_peer_endpoint")
+        or _get(obj, "openvpn_remote_host")
+        or _get(obj, "remote_address")
+        or _get(obj, "server_address")
+    )
+
+
+def _vpn_listen_port(obj: Any) -> int | None:
+    return (
+        _get(obj, "wireguard_server_listen_port")
+        or _get(obj, "openvpn_server_listen_port")
+        or _get(obj, "vpn_listen_port")
+        or _get(obj, "listen_port")
+    )
+
+
+def _vpn_allowed_subnets(obj: Any) -> list[str] | None:
+    # Wireguard server uses ``wireguard_server_subnet``; openvpn uses
+    # ``openvpn_server_subnet`` or ``ip_subnet``.
+    val = (
+        _get(obj, "wireguard_server_subnet")
+        or _get(obj, "openvpn_server_subnet")
+        or _get(obj, "ip_subnet")
+        or _get(obj, "allowed_subnets")
+    )
+    if val is None:
+        return None
+    if isinstance(val, list):
+        return list(val)
+    return [str(val)]
+
+
+@register_serializer(
+    tools={
+        "unifi_list_vpn_clients": {"kind": RenderKind.LIST},
+        "unifi_get_vpn_client_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class VpnClientSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "type", "enabled", "server_address"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "type": _get(obj, "vpn_type") or _get(obj, "purpose"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "server_address": _vpn_server_address(obj),
+            "last_handshake": _get(obj, "wireguard_client_last_handshake")
+            or _get(obj, "last_handshake"),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_list_vpn_servers": {"kind": RenderKind.LIST},
+        "unifi_get_vpn_server_details": {"kind": RenderKind.DETAIL},
+    },
+)
+class VpnServerSerializer(Serializer):
+    primary_key = "id"
+    display_columns = ["name", "type", "enabled", "listen_port"]
+    sort_default = "name:asc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "type": _get(obj, "vpn_type") or _get(obj, "purpose"),
+            "enabled": bool(_get(obj, "enabled", False)),
+            "listen_port": _vpn_listen_port(obj),
+            "allowed_subnets": _vpn_allowed_subnets(obj),
+        }
+
+
+@register_serializer(
+    tools={
+        "unifi_update_vpn_client_state": {"kind": RenderKind.DETAIL},
+        "unifi_update_vpn_server_state": {"kind": RenderKind.DETAIL},
+    },
+)
+class VpnMutationAckSerializer(Serializer):
+    """DETAIL ack for VPN state-mutation tools.
+
+    Both managers return a bare ``bool`` — coerce to ``{"success": bool}``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/network/wlans.py
+++ b/apps/api/src/unifi_api/serializers/network/wlans.py
@@ -1,4 +1,8 @@
-"""WLAN/SSID serializer."""
+"""WLAN/SSID serializer.
+
+Phase 4A PR1 Cluster 3 adds the ``WlanMutationAckSerializer`` covering
+create / update / delete / toggle on ``NetworkManager``'s WLAN endpoints.
+``create_wlan`` returns the created dict; the rest return ``bool``."""
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
 
@@ -31,3 +35,28 @@ class WlanSerializer(Serializer):
             "hide_ssid": bool(raw.get("hide_ssid", False)),
             "vlan_id": raw.get("vlan") or raw.get("vlan_id"),
         }
+
+
+@register_serializer(
+    tools={
+        "unifi_create_wlan": {"kind": RenderKind.DETAIL},
+        "unifi_update_wlan": {"kind": RenderKind.DETAIL},
+        "unifi_delete_wlan": {"kind": RenderKind.DETAIL},
+        "unifi_toggle_wlan": {"kind": RenderKind.DETAIL},
+    },
+)
+class WlanMutationAckSerializer(Serializer):
+    """DETAIL ack for WLAN CUD + toggle."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/tests/serializers/test_network_client_groups.py
+++ b/apps/api/tests/serializers/test_network_client_groups.py
@@ -1,0 +1,173 @@
+"""Client + usergroup cluster serializer unit tests (Phase 4A PR1 Cluster 2)."""
+
+from unifi_api.serializers._registry import (
+    serializer_registry_singleton,
+    discover_serializers,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- client_groups.py ----
+
+
+def test_client_group_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_client_groups")
+    sample = [
+        {
+            "_id": "cg1",
+            "name": "Engineering",
+            "qos_rate_max_down": 100000,
+            "qos_rate_max_up": 50000,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_client_groups")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "cg1"
+    assert out["data"][0]["name"] == "Engineering"
+    assert out["data"][0]["qos_rate_max_down"] == 100000
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_client_group_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_client_group_details")
+    sample = {"_id": "cg2", "name": "Guests", "qos_rate_max_down": -1, "qos_rate_max_up": -1}
+    out = s.serialize_action(sample, tool_name="unifi_get_client_group_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "cg2"
+    assert out["data"]["name"] == "Guests"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_usergroup_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_usergroups")
+    sample = [
+        {"_id": "ug1", "name": "Default", "qos_rate_max_down": -1, "qos_rate_max_up": -1},
+        {"_id": "ug2", "name": "Limited", "qos_rate_max_down": 5000, "qos_rate_max_up": 1000},
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_usergroups")
+    assert out["success"] is True
+    assert len(out["data"]) == 2
+    assert out["data"][1]["id"] == "ug2"
+    assert out["data"][1]["qos_rate_max_down"] == 5000
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_usergroup_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_usergroup_details")
+    sample = {"_id": "ug3", "name": "VIP", "qos_rate_max_down": 1000000, "qos_rate_max_up": 500000}
+    out = s.serialize_action(sample, tool_name="unifi_get_usergroup_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "ug3"
+    assert out["data"]["name"] == "VIP"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_client_group_mutation_ack_bool() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_update_client_group")
+    out = s.serialize_action(True, tool_name="unifi_update_client_group")
+    assert out["success"] is True
+    assert out["data"] == {"success": True}
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_client_group_mutation_ack_dict_passthrough() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_create_client_group")
+    out = s.serialize_action(
+        {"_id": "cg9", "name": "NewGroup"}, tool_name="unifi_create_client_group"
+    )
+    assert out["success"] is True
+    assert out["data"]["_id"] == "cg9"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_client_group_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_client_group",
+        "unifi_update_client_group",
+        "unifi_delete_client_group",
+        "unifi_create_usergroup",
+        "unifi_update_usergroup",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- clients.py extensions ----
+
+
+def test_blocked_client_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_blocked_clients")
+    sample = [
+        {
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "hostname": "BadGuy",
+            "name": None,
+            "last_seen": 1700000000,
+            "blocked": True,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_blocked_clients")
+    assert out["success"] is True
+    assert out["data"][0]["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert out["data"][0]["hostname"] == "BadGuy"
+    assert out["data"][0]["blocked"] is True
+    assert out["data"][0]["last_seen"] is not None
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_client_lookup_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_lookup_by_ip")
+    sample = {
+        "mac": "11:22:33:44:55:66",
+        "last_ip": "192.168.1.50",
+        "hostname": "laptop",
+        "is_online": True,
+        "last_seen": 1700000000,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_lookup_by_ip")
+    assert out["success"] is True
+    assert out["data"]["mac"] == "11:22:33:44:55:66"
+    assert out["data"]["ip"] == "192.168.1.50"
+    assert out["data"]["hostname"] == "laptop"
+    assert out["data"]["is_online"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_client_mutation_ack_bool() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_block_client")
+    out = s.serialize_action(True, tool_name="unifi_block_client")
+    assert out["success"] is True
+    assert out["data"] == {"success": True}
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_client_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_block_client",
+        "unifi_unblock_client",
+        "unifi_forget_client",
+        "unifi_rename_client",
+        "unifi_force_reconnect_client",
+        "unifi_set_client_ip_settings",
+        "unifi_authorize_guest",
+        "unifi_unauthorize_guest",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_network_config.py
+++ b/apps/api/tests/serializers/test_network_config.py
@@ -1,0 +1,368 @@
+"""Network config cluster serializer unit tests (Phase 4A PR1 Cluster 3).
+
+Covers VPN clients/servers, DNS records, static + active + traffic routes,
+AP groups, and the mutation-ack registrations for create/update/delete on
+networks, wlans, dns, routes, and ap_groups.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- VPN clients ----
+
+
+def test_vpn_client_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_vpn_clients")
+    sample = [
+        {
+            "_id": "vc1",
+            "name": "Wireguard-Home",
+            "purpose": "vpn-client",
+            "vpn_type": "wireguard-client",
+            "enabled": True,
+            "wireguard_client_peer_endpoint": "vpn.example.com:51820",
+            "wireguard_client_last_handshake": 1700000000,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_vpn_clients")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "vc1"
+    assert out["data"][0]["name"] == "Wireguard-Home"
+    assert out["data"][0]["type"] == "wireguard-client"
+    assert out["data"][0]["enabled"] is True
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_vpn_client_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_vpn_client_details")
+    sample = {
+        "_id": "vc2",
+        "name": "OpenVPN-Site",
+        "purpose": "vpn-client",
+        "vpn_type": "openvpn-client",
+        "enabled": False,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_vpn_client_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "vc2"
+    assert out["data"]["type"] == "openvpn-client"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- VPN servers ----
+
+
+def test_vpn_server_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_vpn_servers")
+    sample = [
+        {
+            "_id": "vs1",
+            "name": "Remote Access",
+            "purpose": "remote-user-vpn",
+            "vpn_type": "wireguard-server",
+            "enabled": True,
+            "wireguard_server_listen_port": 51820,
+            "wireguard_server_subnet": "10.10.0.0/24",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_vpn_servers")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "vs1"
+    assert out["data"][0]["name"] == "Remote Access"
+    assert out["data"][0]["type"] == "wireguard-server"
+    assert out["data"][0]["listen_port"] == 51820
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_vpn_server_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_vpn_server_details")
+    sample = {
+        "_id": "vs2",
+        "name": "L2TP",
+        "purpose": "vpn-server",
+        "vpn_type": "l2tp-server",
+        "enabled": True,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_vpn_server_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "vs2"
+    assert out["data"]["type"] == "l2tp-server"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- DNS records ----
+
+
+def test_dns_record_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_dns_records")
+    sample = [
+        {
+            "_id": "dns1",
+            "key": "router.local",
+            "value": "192.168.1.1",
+            "record_type": "A",
+            "ttl": 300,
+            "enabled": True,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_dns_records")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "dns1"
+    assert out["data"][0]["hostname"] == "router.local"
+    assert out["data"][0]["ip"] == "192.168.1.1"
+    assert out["data"][0]["type"] == "A"
+    assert out["data"][0]["ttl"] == 300
+    assert out["data"][0]["enabled"] is True
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_dns_record_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_dns_record_details")
+    sample = {
+        "_id": "dns2",
+        "key": "alias.local",
+        "value": "router.local",
+        "record_type": "CNAME",
+        "ttl": 0,
+        "enabled": False,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_dns_record_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "dns2"
+    assert out["data"]["hostname"] == "alias.local"
+    assert out["data"]["type"] == "CNAME"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- Static routes ----
+
+
+def test_route_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_routes")
+    sample = [
+        {
+            "_id": "r1",
+            "name": "Office subnet",
+            "static-route_network": "10.0.0.0/24",
+            "static-route_nexthop": "192.168.1.1",
+            "static-route_distance": 1,
+            "enabled": True,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_routes")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "r1"
+    assert out["data"][0]["name"] == "Office subnet"
+    assert out["data"][0]["target_subnet"] == "10.0.0.0/24"
+    assert out["data"][0]["gateway"] == "192.168.1.1"
+    assert out["data"][0]["distance"] == 1
+    assert out["data"][0]["enabled"] is True
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_route_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_route_details")
+    sample = {
+        "_id": "r2",
+        "name": "Lab",
+        "static-route_network": "172.16.0.0/16",
+        "static-route_nexthop": "192.168.99.1",
+        "static-route_distance": 5,
+        "enabled": False,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_route_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "r2"
+    assert out["data"]["target_subnet"] == "172.16.0.0/16"
+    assert out["data"]["gateway"] == "192.168.99.1"
+    assert out["data"]["distance"] == 5
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- Active routes ----
+
+
+def test_active_route_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_active_routes")
+    sample = [
+        {
+            "nh": [{"intf": "eth0", "via": "192.168.1.1"}],
+            "pfx": "0.0.0.0/0",
+            "metric": 0,
+            "t": "S",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_active_routes")
+    assert out["success"] is True
+    assert out["data"][0]["target_subnet"] == "0.0.0.0/0"
+    # Either gateway or interface should be derivable from nh; both fields exist
+    assert "gateway" in out["data"][0]
+    assert "interface" in out["data"][0]
+    assert out["render_hint"]["kind"] == "list"
+
+
+# ---- Traffic routes ----
+
+
+def test_traffic_route_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_traffic_routes")
+    sample = [
+        {
+            "_id": "tr1",
+            "description": "VPN-routed traffic",
+            "enabled": True,
+            "matching_target": "DOMAIN",
+            "domains": [{"domain": "example.com"}],
+            "target_devices": [{"client_mac": "aa:bb:cc:dd:ee:ff"}],
+            "next_hop": "vpn-iface",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_traffic_routes")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "tr1"
+    assert out["data"][0]["name"] == "VPN-routed traffic"
+    assert out["data"][0]["enabled"] is True
+    assert out["data"][0]["next_hop"] == "vpn-iface"
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_traffic_route_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_traffic_route_details")
+    sample = {
+        "_id": "tr2",
+        "description": "Block region",
+        "enabled": False,
+        "matching_target": "REGION",
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_traffic_route_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "tr2"
+    assert out["data"]["name"] == "Block region"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- AP groups ----
+
+
+def test_ap_group_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_ap_groups")
+    sample = [
+        {
+            "_id": "apg1",
+            "name": "Office APs",
+            "device_macs": ["aa:bb:cc:00:11:22", "aa:bb:cc:00:11:33"],
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_ap_groups")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "apg1"
+    assert out["data"][0]["name"] == "Office APs"
+    assert out["data"][0]["ap_count"] == 2
+    assert out["data"][0]["device_macs"] == ["aa:bb:cc:00:11:22", "aa:bb:cc:00:11:33"]
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_ap_group_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_ap_group_details")
+    sample = {"_id": "apg2", "name": "Guest APs", "device_macs": []}
+    out = s.serialize_action(sample, tool_name="unifi_get_ap_group_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "apg2"
+    assert out["data"]["name"] == "Guest APs"
+    assert out["data"]["ap_count"] == 0
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- Mutation acks ----
+
+
+def test_vpn_mutation_ack_bool() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_update_vpn_client_state")
+    out = s.serialize_action(True, tool_name="unifi_update_vpn_client_state")
+    assert out["success"] is True
+    assert out["data"] == {"success": True}
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_dns_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_dns_record",
+        "unifi_update_dns_record",
+        "unifi_delete_dns_record",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+def test_route_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_route",
+        "unifi_update_route",
+        "unifi_update_traffic_route",
+        "unifi_toggle_traffic_route",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+def test_ap_group_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_ap_group",
+        "unifi_update_ap_group",
+        "unifi_delete_ap_group",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+def test_network_mutation_ack_dispatches() -> None:
+    reg = _registry()
+    for tool in ("unifi_create_network", "unifi_update_network"):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["data"] == {"success": True}
+        assert out["render_hint"]["kind"] == "detail"
+
+
+def test_wlan_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_wlan",
+        "unifi_update_wlan",
+        "unifi_delete_wlan",
+        "unifi_toggle_wlan",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_network_events.py
+++ b/apps/api/tests/serializers/test_network_events.py
@@ -1,0 +1,63 @@
+"""Network events cluster serializer unit tests (Phase 4A PR1 Cluster 6).
+
+Covers EVENT_LOG tools (`unifi_list_events`, `unifi_get_alerts`,
+`unifi_get_anomalies`, `unifi_get_ips_events`).
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+def test_event_log_serializer_basic_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_events")
+    sample = [
+        {
+            "_id": "evt1",
+            "key": "EVT_WU_Connected",
+            "msg": "Client connected",
+            "time": 1714000000000,
+            "user": "aa:bb:cc:dd:ee:ff",
+            "ip": "10.0.0.5",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_events")
+    assert out["success"] is True
+    assert out["render_hint"]["kind"] == "event_log"
+    assert out["render_hint"]["sort_default"] == "time:desc"
+    item = out["data"][0]
+    assert item["id"] == "evt1"
+    assert item["key"] == "EVT_WU_Connected"
+    assert item["msg"] == "Client connected"
+    assert item["time"] == 1714000000000
+    assert item["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert item["ip"] == "10.0.0.5"
+
+
+def test_event_log_severity_passthrough() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_alerts")
+    sample = [{"_id": "a1", "key": "EVT_AD_Login", "msg": "x", "severity": "warn", "time": 100}]
+    out = s.serialize_action(sample, tool_name="unifi_get_alerts")
+    assert out["data"][0]["severity"] == "warn"
+    assert out["data"][0]["id"] == "a1"
+
+
+def test_event_log_dispatches_for_all_event_tools() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_list_events",
+        "unifi_get_alerts",
+        "unifi_get_anomalies",
+        "unifi_get_ips_events",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action([], tool_name=tool)
+        assert out["render_hint"]["kind"] == "event_log"

--- a/apps/api/tests/serializers/test_network_filtering.py
+++ b/apps/api/tests/serializers/test_network_filtering.py
@@ -1,0 +1,347 @@
+"""Network filtering cluster serializer unit tests (Phase 4A PR1 Cluster 4).
+
+Covers firewall groups + zones + mutation acks, QoS rules, DPI applications/
+categories, content filters, ACL rules, and OON policies.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- Firewall groups ----
+
+
+def test_firewall_group_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_firewall_groups")
+    sample = [
+        {
+            "_id": "fg1",
+            "name": "Trusted IPs",
+            "group_type": "address-group",
+            "group_members": ["10.0.0.1", "10.0.0.2"],
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_firewall_groups")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "fg1"
+    assert out["data"][0]["name"] == "Trusted IPs"
+    assert out["data"][0]["group_type"] == "address-group"
+    assert out["data"][0]["members"] == ["10.0.0.1", "10.0.0.2"]
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_firewall_group_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_firewall_group_details")
+    sample = {
+        "_id": "fg2",
+        "name": "Web ports",
+        "group_type": "port-group",
+        "group_members": ["80", "443"],
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_firewall_group_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "fg2"
+    assert out["data"]["group_type"] == "port-group"
+    assert out["data"]["members"] == ["80", "443"]
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- Firewall zones ----
+
+
+def test_firewall_zone_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_firewall_zones")
+    sample = [
+        {
+            "_id": "z1",
+            "name": "Internal",
+            "networks": ["net1", "net2"],
+            "default_policy": "ALLOW",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_firewall_zones")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "z1"
+    assert out["data"][0]["name"] == "Internal"
+    assert out["data"][0]["networks"] == ["net1", "net2"]
+    assert out["data"][0]["default_policy"] == "ALLOW"
+    assert out["render_hint"]["kind"] == "list"
+
+
+# ---- Firewall mutation acks ----
+
+
+def test_firewall_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_firewall_policy",
+        "unifi_create_simple_firewall_policy",
+        "unifi_update_firewall_policy",
+        "unifi_delete_firewall_policy",
+        "unifi_toggle_firewall_policy",
+        "unifi_create_firewall_group",
+        "unifi_update_firewall_group",
+        "unifi_delete_firewall_group",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- QoS rules ----
+
+
+def test_qos_rule_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_qos_rules")
+    sample = [
+        {
+            "_id": "qos1",
+            "name": "VoIP",
+            "enabled": True,
+            "rate_max_down": 50000,
+            "rate_max_up": 25000,
+            "priority": 7,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_qos_rules")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "qos1"
+    assert out["data"][0]["name"] == "VoIP"
+    assert out["data"][0]["enabled"] is True
+    assert out["data"][0]["rate_max_down"] == 50000
+    assert out["data"][0]["rate_max_up"] == 25000
+    assert out["data"][0]["priority"] == 7
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_qos_rule_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_qos_rule_details")
+    sample = {
+        "_id": "qos2",
+        "name": "Backup limiter",
+        "enabled": False,
+        "rate_max_down": 10000,
+        "rate_max_up": 5000,
+        "priority": 1,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_qos_rule_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "qos2"
+    assert out["data"]["enabled"] is False
+    assert out["data"]["priority"] == 1
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_qos_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_qos_rule",
+        "unifi_create_simple_qos_rule",
+        "unifi_update_qos_rule",
+        "unifi_toggle_qos_rule_enabled",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- DPI applications + categories ----
+
+
+def test_dpi_application_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_dpi_applications")
+    # The DPI manager returns a wrapper dict; the action layer surfaces
+    # the bare list (or wrapper) — the serializer accepts either via the
+    # registry's normal LIST flow.
+    sample = [
+        {"id": 65537, "name": "Skype", "categoryId": 1},
+        {"id": 65538, "name": "Telegram"},
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_dpi_applications")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == 65537
+    assert out["data"][0]["name"] == "Skype"
+    assert out["data"][0]["category_id"] == 1
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_dpi_category_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_dpi_categories")
+    sample = [{"id": 0, "name": "Instant messengers"}, {"id": 1, "name": "Peer-to-peer"}]
+    out = s.serialize_action(sample, tool_name="unifi_list_dpi_categories")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == 0
+    assert out["data"][0]["name"] == "Instant messengers"
+    assert out["render_hint"]["kind"] == "list"
+
+
+# ---- Content filters ----
+
+
+def test_content_filter_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_content_filters")
+    sample = [
+        {
+            "_id": "cf1",
+            "name": "Family-safe",
+            "enabled": True,
+            "profile": "FAMILY",
+            "applies_to": ["net1", "net2"],
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_content_filters")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "cf1"
+    assert out["data"][0]["name"] == "Family-safe"
+    assert out["data"][0]["enabled"] is True
+    assert out["data"][0]["profile"] == "FAMILY"
+    assert out["data"][0]["applies_to"] == ["net1", "net2"]
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_content_filter_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_content_filter_details")
+    sample = {
+        "_id": "cf2",
+        "name": "Workplace",
+        "enabled": False,
+        "profile": "WORK",
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_content_filter_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "cf2"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_content_filter_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in ("unifi_update_content_filter", "unifi_delete_content_filter"):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- ACL rules ----
+
+
+def test_acl_rule_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_acl_rules")
+    sample = [
+        {
+            "_id": "acl1",
+            "name": "Block guest IoT",
+            "enabled": True,
+            "action": "BLOCK",
+            "traffic_source": {"type": "MAC", "value": "aa:bb:cc:dd:ee:ff"},
+            "traffic_destination": {"type": "ANY"},
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_acl_rules")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "acl1"
+    assert out["data"][0]["name"] == "Block guest IoT"
+    assert out["data"][0]["enabled"] is True
+    assert out["data"][0]["action"] == "BLOCK"
+    assert out["data"][0]["source"] == {"type": "MAC", "value": "aa:bb:cc:dd:ee:ff"}
+    assert out["data"][0]["destination"] == {"type": "ANY"}
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_acl_rule_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_acl_rule_details")
+    sample = {
+        "_id": "acl2",
+        "name": "Allow staff",
+        "enabled": False,
+        "action": "ALLOW",
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_acl_rule_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "acl2"
+    assert out["data"]["action"] == "ALLOW"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_acl_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_acl_rule",
+        "unifi_update_acl_rule",
+        "unifi_delete_acl_rule",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- OON policies ----
+
+
+def test_oon_policy_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_oon_policies")
+    sample = [
+        {
+            "_id": "oon1",
+            "name": "Kids weekday curfew",
+            "enabled": True,
+            "targets": [{"type": "MAC", "value": "aa:bb:cc:dd:ee:ff"}],
+            "restriction_level": "STRICT",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_oon_policies")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "oon1"
+    assert out["data"][0]["name"] == "Kids weekday curfew"
+    assert out["data"][0]["enabled"] is True
+    assert out["data"][0]["applies_to"] == [{"type": "MAC", "value": "aa:bb:cc:dd:ee:ff"}]
+    assert out["data"][0]["restriction_level"] == "STRICT"
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_oon_policy_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_oon_policy_details")
+    sample = {
+        "_id": "oon2",
+        "name": "Guest cap",
+        "enabled": False,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_oon_policy_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "oon2"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_oon_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_oon_policy",
+        "unifi_update_oon_policy",
+        "unifi_delete_oon_policy",
+        "unifi_toggle_oon_policy",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_network_misc.py
+++ b/apps/api/tests/serializers/test_network_misc.py
@@ -1,0 +1,148 @@
+"""Network misc cluster serializer unit tests (Phase 4A PR1 Cluster 5).
+
+Covers port forwards (LIST + DETAIL + mutation ack), vouchers (LIST + DETAIL
++ mutation ack), and SNMP settings mutation ack. The hotspot category in
+the manifest currently contains only voucher tools — there are no
+non-voucher hotspot tools to serialize.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- Port forwards ----
+
+
+def test_port_forward_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_port_forwards")
+    sample = [
+        {
+            "_id": "pf1",
+            "name": "Web",
+            "enabled": True,
+            "fwd_protocol": "tcp",
+            "dst_port": "443",
+            "fwd_port": "443",
+            "src": "any",
+            "log": False,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_port_forwards")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "pf1"
+    assert out["data"][0]["name"] == "Web"
+    assert out["data"][0]["enabled"] is True
+    assert out["data"][0]["fwd_protocol"] == "tcp"
+    assert out["data"][0]["dst_port"] == "443"
+    assert out["data"][0]["fwd_port"] == "443"
+    assert out["data"][0]["src"] == "any"
+    assert out["data"][0]["log"] is False
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_port_forward_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_port_forward")
+    sample = {
+        "_id": "pf2",
+        "name": "SSH",
+        "enabled": False,
+        "fwd_protocol": "tcp",
+        "dst_port": "22",
+        "fwd_port": "22",
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_port_forward")
+    assert out["success"] is True
+    assert out["data"]["id"] == "pf2"
+    assert out["data"]["name"] == "SSH"
+    assert out["data"]["enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_port_forward_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_create_port_forward",
+        "unifi_create_simple_port_forward",
+        "unifi_update_port_forward",
+        "unifi_toggle_port_forward",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- Vouchers ----
+
+
+def test_voucher_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_vouchers")
+    sample = [
+        {
+            "_id": "v1",
+            "code": "12345-67890",
+            "status": "VALID_MULTI",
+            "duration": 1440,
+            "qos_overwrite": False,
+            "create_time": 1714000000,
+            "used_at": None,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_vouchers")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "v1"
+    assert out["data"][0]["code"] == "12345-67890"
+    assert out["data"][0]["status"] == "VALID_MULTI"
+    assert out["data"][0]["duration"] == 1440
+    assert out["data"][0]["qos_overwrite"] is False
+    assert out["data"][0]["created_at"] == 1714000000
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_voucher_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_voucher_details")
+    sample = {
+        "_id": "v2",
+        "code": "abcde-fghij",
+        "status": "USED_MULTIPLE",
+        "duration": 60,
+        "qos_overwrite": True,
+        "create_time": 1714111111,
+        "end_time": 1714222222,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_voucher_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "v2"
+    assert out["data"]["code"] == "abcde-fghij"
+    assert out["data"]["status"] == "USED_MULTIPLE"
+    assert out["data"]["qos_overwrite"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_voucher_mutation_ack_dispatches_for_all_mutations() -> None:
+    reg = _registry()
+    for tool in ("unifi_create_voucher", "unifi_revoke_voucher"):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- SNMP settings ----
+
+
+def test_snmp_mutation_ack_dispatches() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_update_snmp_settings")
+    out = s.serialize_action(True, tool_name="unifi_update_snmp_settings")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["success"] is True

--- a/apps/api/tests/serializers/test_network_sessions.py
+++ b/apps/api/tests/serializers/test_network_sessions.py
@@ -1,0 +1,68 @@
+"""Network sessions / wifi-details serializer unit tests (Phase 4A PR1 Cluster 6)."""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+def test_client_sessions_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_client_sessions")
+    sample = [
+        {
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "hostname": "laptop",
+            "ap_mac": "11:22:33:44:55:66",
+            "essid": "MyWiFi",
+            "assoc_time": 1714000000,
+            "disassoc_time": 1714003600,
+            "duration": 3600,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_client_sessions")
+    assert out["render_hint"]["kind"] == "list"
+    item = out["data"][0]
+    assert item["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert item["hostname"] == "laptop"
+    assert item["ap"] == "11:22:33:44:55:66"
+    assert item["ssid"] == "MyWiFi"
+    assert item["connected_at"] == 1714000000
+    assert item["disconnected_at"] == 1714003600
+    assert item["duration"] == 3600
+
+
+def test_client_wifi_details_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_client_wifi_details")
+    sample = {
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "essid": "MyWiFi",
+        "ap_mac": "11:22:33:44:55:66",
+        "signal": -55,
+        "tx_rate": 866000,
+        "rx_rate": 433000,
+        "channel": 36,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_client_wifi_details")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert out["data"]["ssid"] == "MyWiFi"
+    assert out["data"]["ap"] == "11:22:33:44:55:66"
+    assert out["data"]["signal"] == -55
+    assert out["data"]["tx_rate"] == 866000
+    assert out["data"]["rx_rate"] == 433000
+    assert out["data"]["channel"] == 36
+
+
+def test_client_wifi_details_handles_none() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_client_wifi_details")
+    out = s.serialize_action(None, tool_name="unifi_get_client_wifi_details")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"] == {}

--- a/apps/api/tests/serializers/test_network_stats.py
+++ b/apps/api/tests/serializers/test_network_stats.py
@@ -1,0 +1,94 @@
+"""Network stats cluster serializer unit tests (Phase 4A PR1 Cluster 6).
+
+Covers TIMESERIES tools (per-point shape: {ts, ...metrics}) plus a small
+number of stats tools whose AST-captured manager method returns a single
+dict and therefore lands as DETAIL instead of TIMESERIES (device_stats,
+client_stats, dpi_stats).
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- TIMESERIES (list-returning manager methods) ----
+
+
+def test_timeseries_serializer_normalizes_seconds_to_ms() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_dashboard")
+    sample = [
+        {"time": 1714000000, "rx_bytes": 1024, "tx_bytes": 2048},
+        {"time": 1714000300, "rx_bytes": 4096, "tx_bytes": 8192},
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_dashboard")
+    assert out["success"] is True
+    assert out["render_hint"]["kind"] == "timeseries"
+    assert out["data"][0]["ts"] == 1714000000 * 1000
+    assert out["data"][0]["rx_bytes"] == 1024
+    assert out["data"][1]["ts"] == 1714000300 * 1000
+    assert "time" not in out["data"][0]
+
+
+def test_timeseries_serializer_passes_ms_through() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_network_stats")
+    sample = [{"ts": 1714000000123, "wan_rx": 100}]
+    out = s.serialize_action(sample, tool_name="unifi_get_network_stats")
+    assert out["data"][0]["ts"] == 1714000000123
+    assert out["data"][0]["wan_rx"] == 100
+
+
+def test_timeseries_dispatches_for_all_list_returning_stats_tools() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_get_dashboard",
+        "unifi_get_network_stats",
+        "unifi_get_gateway_stats",
+        "unifi_get_client_dpi_traffic",
+        "unifi_get_site_dpi_traffic",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action([{"time": 1, "v": 2}], tool_name=tool)
+        assert out["render_hint"]["kind"] == "timeseries"
+
+
+# ---- DETAIL stats (dict-returning AST capture) ----
+
+
+def test_device_stats_detail_serializer_shape() -> None:
+    """get_device_details (AST capture) returns a single device dict."""
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_device_stats")
+    sample = {"mac": "aa:bb:cc:dd:ee:ff", "name": "AP-1", "uptime": 3600, "rx_bytes": 1, "tx_bytes": 2}
+    out = s.serialize_action(sample, tool_name="unifi_get_device_stats")
+    assert out["success"] is True
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert out["data"]["uptime"] == 3600
+
+
+def test_client_stats_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_client_stats")
+    sample = {"mac": "11:22:33:44:55:66", "hostname": "laptop", "tx_bytes": 100}
+    out = s.serialize_action(sample, tool_name="unifi_get_client_stats")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["mac"] == "11:22:33:44:55:66"
+
+
+def test_dpi_stats_detail_serializer_shape() -> None:
+    """get_dpi_stats returns dict {applications: [...], categories: [...]}."""
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_dpi_stats")
+    sample = {"applications": [{"name": "Netflix"}], "categories": [{"name": "Streaming"}]}
+    out = s.serialize_action(sample, tool_name="unifi_get_dpi_stats")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["applications"][0]["name"] == "Netflix"
+    assert out["data"]["categories"][0]["name"] == "Streaming"

--- a/apps/api/tests/serializers/test_network_switch.py
+++ b/apps/api/tests/serializers/test_network_switch.py
@@ -1,0 +1,282 @@
+"""Switch + device cluster serializer unit tests (Phase 4A PR1 Cluster 1)."""
+
+from unifi_api.serializers._registry import (
+    serializer_registry_singleton,
+    discover_serializers,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- switch.py ----
+
+
+def test_port_profile_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_port_profiles")
+    sample = {
+        "_id": "pp1",
+        "name": "All-Tagged",
+        "native_networkconf_id": "net1",
+        "tagged_networkconf_ids": ["net2"],
+        "poe_mode": "auto",
+        "isolation": False,
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "pp1"
+    assert out["name"] == "All-Tagged"
+    assert out["poe_mode"] == "auto"
+    assert out["tagged_networkconf_ids"] == ["net2"]
+
+
+def test_port_profile_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_port_profile_details")
+    sample = {"_id": "pp2", "name": "Voice", "poe_mode": "passive"}
+    out = s.serialize_action(sample, tool_name="unifi_get_port_profile_details")
+    assert out["success"] is True
+    assert out["data"]["id"] == "pp2"
+    assert out["data"]["name"] == "Voice"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_switch_ports_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_switch_ports")
+    sample = {
+        "name": "USW-24",
+        "model": "US24P250",
+        "port_overrides": [
+            {"port_idx": 1, "name": "Trunk", "portconf_id": "pp1", "poe_mode": "auto"},
+            {"port_idx": 2, "name": "Voice", "portconf_id": "pp2"},
+        ],
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_switch_ports")
+    assert out["success"] is True
+    assert out["data"]["name"] == "USW-24"
+    assert len(out["data"]["port_overrides"]) == 2
+    assert out["data"]["port_overrides"][0]["port_idx"] == 1
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_port_stats_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_port_stats")
+    sample = {
+        "name": "USW-24",
+        "model": "US24P250",
+        "port_table": [
+            {
+                "port_idx": 1,
+                "tx_bytes": 1000,
+                "rx_bytes": 2000,
+                "tx_packets": 5,
+                "rx_packets": 10,
+                "speed": 1000,
+                "enable": True,
+            }
+        ],
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_port_stats")
+    assert out["success"] is True
+    assert out["data"]["name"] == "USW-24"
+    assert out["data"]["port_table"][0]["tx_bytes"] == 1000
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_switch_capabilities_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_switch_capabilities")
+    sample = {
+        "name": "USW-24",
+        "model": "US24P250",
+        "switch_caps": {"max_aggregate_sessions": 8, "max_mirror_sessions": 1},
+        "stp_version": "rstp",
+        "stp_priority": "32768",
+        "jumboframe_enabled": False,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_switch_capabilities")
+    assert out["success"] is True
+    assert out["data"]["name"] == "USW-24"
+    assert out["data"]["stp_version"] == "rstp"
+    assert out["data"]["jumboframe_enabled"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_switch_mutation_ack_bool() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_update_switch_stp")
+    out = s.serialize_action(True, tool_name="unifi_update_switch_stp")
+    assert out["success"] is True
+    assert out["data"] == {"success": True}
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_switch_mutation_ack_dict_passthrough() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_create_port_profile")
+    out = s.serialize_action({"_id": "pp9", "name": "New"}, tool_name="unifi_create_port_profile")
+    assert out["success"] is True
+    assert out["data"]["_id"] == "pp9"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- devices.py extensions ----
+
+
+def test_device_radio_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_device_radio")
+    sample = {
+        "mac": "11:22:33:44:55:66",
+        "name": "AP1",
+        "model": "U6-Pro",
+        "radios": [
+            {"name": "wifi0", "radio": "ng", "channel": 6, "tx_power": 17, "ht": 20},
+            {"name": "wifi1", "radio": "na", "channel": 36, "tx_power": 23, "ht": 80},
+        ],
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_device_radio")
+    assert out["success"] is True
+    assert out["data"]["mac"] == "11:22:33:44:55:66"
+    assert len(out["data"]["radios"]) == 2
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_lldp_neighbors_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_lldp_neighbors")
+    sample = {
+        "name": "USW-24",
+        "model": "US24P250",
+        "lldp_table": [
+            {
+                "local_port_idx": 1,
+                "chassis_id": "aa:bb:cc:dd:ee:ff",
+                "port_id": "Gi1/0/1",
+                "system_name": "neighbor-sw",
+                "capabilities": ["bridge"],
+            }
+        ],
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_lldp_neighbors")
+    assert out["success"] is True
+    assert out["data"]["lldp_table"][0]["chassis_id"] == "aa:bb:cc:dd:ee:ff"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_rogue_ap_serializer_shape() -> None:
+    reg = _registry()
+    s_unknown = reg.serializer_for_tool("unifi_list_rogue_aps")
+    s_known = reg.serializer_for_tool("unifi_list_known_rogue_aps")
+    sample = [
+        {
+            "bssid": "aa:bb:cc:11:22:33",
+            "essid": "EvilTwin",
+            "channel": 11,
+            "rssi": -55,
+            "last_seen": 1700000000,
+            "is_rogue": True,
+        }
+    ]
+    out = s_unknown.serialize_action(sample, tool_name="unifi_list_rogue_aps")
+    assert out["success"] is True
+    assert out["data"][0]["bssid"] == "aa:bb:cc:11:22:33"
+    assert out["data"][0]["ssid"] == "EvilTwin"
+    assert out["data"][0]["is_known"] is False
+    assert out["render_hint"]["kind"] == "list"
+
+    out2 = s_known.serialize_action(sample, tool_name="unifi_list_known_rogue_aps")
+    assert out2["data"][0]["is_known"] is True
+
+
+def test_rf_scan_result_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_rf_scan_results")
+    sample = [
+        {
+            "bssid": "aa:bb:cc:11:22:33",
+            "essid": "Neighbor",
+            "channel": 6,
+            "rssi": -70,
+            "ts": 1700000000,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_rf_scan_results")
+    assert out["success"] is True
+    assert out["data"][0]["bssid"] == "aa:bb:cc:11:22:33"
+    assert out["data"][0]["channel"] == 6
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_available_channel_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_available_channels")
+    sample = [{"channel": 36, "freq": 5180, "ht": 80, "allowed": True}]
+    out = s.serialize_action(sample, tool_name="unifi_list_available_channels")
+    assert out["success"] is True
+    assert out["data"][0]["channel"] == 36
+    assert out["data"][0]["frequency_mhz"] == 5180
+    assert out["data"][0]["width_mhz"] == 80
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_speedtest_status_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_speedtest_status")
+    sample = {
+        "status_download": 500.5,
+        "status_upload": 50.1,
+        "latency": 12,
+        "rundate": 1700000000,
+        "status": 0,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_speedtest_status")
+    assert out["success"] is True
+    assert out["data"]["download_mbps"] == 500.5
+    assert out["data"]["upload_mbps"] == 50.1
+    assert out["data"]["latency_ms"] == 12
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_device_mutation_ack_bool() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_reboot_device")
+    out = s.serialize_action(True, tool_name="unifi_reboot_device")
+    assert out["success"] is True
+    assert out["data"] == {"success": True}
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_device_mutation_ack_dispatches_for_all_mutations() -> None:
+    """Every mutation tool registered should resolve via the registry."""
+    reg = _registry()
+    for tool in (
+        "unifi_adopt_device",
+        "unifi_force_provision_device",
+        "unifi_locate_device",
+        "unifi_reboot_device",
+        "unifi_rename_device",
+        "unifi_set_device_led",
+        "unifi_set_site_leds",
+        "unifi_toggle_device",
+        "unifi_trigger_rf_scan",
+        "unifi_trigger_speedtest",
+        "unifi_update_device_radio",
+        "unifi_upgrade_device",
+        "unifi_create_port_profile",
+        "unifi_update_port_profile",
+        "unifi_delete_port_profile",
+        "unifi_set_switch_port_profile",
+        "unifi_configure_port_aggregation",
+        "unifi_configure_port_mirror",
+        "unifi_power_cycle_port",
+        "unifi_set_jumbo_frames",
+        "unifi_update_switch_stp",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_network_system.py
+++ b/apps/api/tests/serializers/test_network_system.py
@@ -1,0 +1,216 @@
+"""Network system cluster serializer unit tests (Phase 4A PR1 Cluster 6).
+
+Covers alarms (LIST), backups (LIST), system info / network health /
+site settings / SNMP settings / event types / autobackup settings (DETAIL),
+top clients (LIST), client sessions (LIST), client wifi details (DETAIL),
+speedtest results (LIST), and mutation acks for archive/backup/autobackup
+operations.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- Alarms ----
+
+
+def test_alarm_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_alarms")
+    sample = [
+        {"_id": "al1", "key": "EVT_FW_Block", "msg": "Blocked", "archived": False, "time": 1714000000}
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_list_alarms")
+    assert out["success"] is True
+    assert out["render_hint"]["kind"] == "list"
+    item = out["data"][0]
+    assert item["id"] == "al1"
+    assert item["key"] == "EVT_FW_Block"
+    assert item["msg"] == "Blocked"
+    assert item["archived"] is False
+    assert item["time"] == 1714000000
+
+
+# ---- Backups ----
+
+
+def test_backup_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_list_backups")
+    sample = [{"_id": "b1", "filename": "auto-2026-04-29.unf", "size": 12345, "time": 1714000000}]
+    out = s.serialize_action(sample, tool_name="unifi_list_backups")
+    assert out["render_hint"]["kind"] == "list"
+    item = out["data"][0]
+    assert item["id"] == "b1"
+    assert item["filename"] == "auto-2026-04-29.unf"
+    assert item["size"] == 12345
+    assert item["created_at"] == 1714000000
+
+
+# ---- System info ----
+
+
+def test_system_info_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_system_info")
+    sample = {
+        "name": "UniFi Controller",
+        "version": "8.1.113",
+        "hostname": "unifi.local",
+        "uptime": 86400,
+        "num_devices": 12,
+        "num_clients": 47,
+    }
+    out = s.serialize_action(sample, tool_name="unifi_get_system_info")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["name"] == "UniFi Controller"
+    assert out["data"]["version"] == "8.1.113"
+    assert out["data"]["uptime"] == 86400
+    assert out["data"]["num_devices"] == 12
+
+
+# ---- Network health (manager returns list of subsystems) ----
+
+
+def test_network_health_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_network_health")
+    sample = [
+        {"subsystem": "wan", "status": "ok", "num_user": 5, "num_guest": 1, "num_iot": 2, "rx_bytes-r": 100, "tx_bytes-r": 200},
+        {"subsystem": "wlan", "status": "ok", "num_user": 8},
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_network_health")
+    assert out["render_hint"]["kind"] == "list"
+    assert out["data"][0]["subsystem"] == "wan"
+    assert out["data"][0]["status"] == "ok"
+    assert out["data"][0]["num_user"] == 5
+    assert out["data"][1]["subsystem"] == "wlan"
+
+
+# ---- Site settings (DETAIL) ----
+
+
+def test_site_settings_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_site_settings")
+    sample = {"_id": "site_id_1", "name": "default", "role": "admin", "country": 840}
+    out = s.serialize_action(sample, tool_name="unifi_get_site_settings")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["site_id"] == "site_id_1"
+    assert out["data"]["name"] == "default"
+    assert out["data"]["country"] == 840
+
+
+# ---- SNMP settings (manager returns list[dict]) ----
+
+
+def test_snmp_settings_detail_first_item_unwrap() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_snmp_settings")
+    sample = [{"enabled": True, "community": "public", "port": 161, "version": "v2c", "key": "snmp"}]
+    out = s.serialize_action(sample, tool_name="unifi_get_snmp_settings")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["enabled"] is True
+    assert out["data"]["community"] == "public"
+    assert out["data"]["port"] == 161
+    assert out["data"]["version"] == "v2c"
+
+
+# ---- Event types ----
+
+
+def test_event_types_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_event_types")
+    sample = [
+        {"prefix": "EVT_WU_", "description": "Wireless user events"},
+        {"prefix": "EVT_SW_", "description": "Switch events"},
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_event_types")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["event_types"][0]["prefix"] == "EVT_WU_"
+    assert out["data"]["event_types"][1]["prefix"] == "EVT_SW_"
+
+
+# ---- Auto-backup settings ----
+
+
+def test_autobackup_settings_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_autobackup_settings")
+    sample = {"enabled": True, "schedule": "daily", "max_count": 10}
+    out = s.serialize_action(sample, tool_name="unifi_get_autobackup_settings")
+    assert out["render_hint"]["kind"] == "detail"
+    assert out["data"]["enabled"] is True
+    assert out["data"]["schedule"] == "daily"
+    assert out["data"]["max_count"] == 10
+
+
+# ---- Top clients ----
+
+
+def test_top_clients_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_top_clients")
+    sample = [
+        {"mac": "aa:bb:cc:dd:ee:ff", "name": "laptop", "rx_bytes": 100, "tx_bytes": 200, "total_bytes": 300}
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_top_clients")
+    assert out["render_hint"]["kind"] == "list"
+    item = out["data"][0]
+    assert item["mac"] == "aa:bb:cc:dd:ee:ff"
+    assert item["hostname"] == "laptop"
+    assert item["rx_bytes"] == 100
+    assert item["tx_bytes"] == 200
+    assert item["total_bytes"] == 300
+
+
+# ---- Speedtest ----
+
+
+def test_speedtest_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_get_speedtest_results")
+    sample = [
+        {"time": 1714000000, "xput_download": 500.5, "xput_upload": 50.1, "latency": 12}
+    ]
+    out = s.serialize_action(sample, tool_name="unifi_get_speedtest_results")
+    assert out["render_hint"]["kind"] == "list"
+    item = out["data"][0]
+    assert item["timestamp"] == 1714000000
+    assert item["download_mbps"] == 500.5
+    assert item["upload_mbps"] == 50.1
+    assert item["latency_ms"] == 12
+
+
+# ---- System mutation acks ----
+
+
+def test_system_mutation_acks_dispatch() -> None:
+    reg = _registry()
+    for tool in (
+        "unifi_archive_alarm",
+        "unifi_archive_all_alarms",
+        "unifi_create_backup",
+        "unifi_delete_backup",
+        "unifi_update_autobackup_settings",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action(True, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+        assert out["data"]["success"] is True
+
+
+def test_create_backup_returns_dict_passthrough() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("unifi_create_backup")
+    sample = {"filename": "backup.unf", "url": "/dl/backup/backup.unf"}
+    out = s.serialize_action(sample, tool_name="unifi_create_backup")
+    assert out["data"]["filename"] == "backup.unf"


### PR DESCRIPTION
## Summary

Phase 4A PR1: complete serializer coverage for the network product. Adds 157 serializers across 6 cluster commits, each commit scoped to a category cluster. After this PR, every network tool in the manifest has a registered serializer with a real `render_hint`.

## Scope (6 cluster commits)

| Cluster | Commit | Tools | Notes |
|---|---|---|---|
| 1 — devices & switches | 877da1c | 33 | switch.py NEW; devices.py extended for radio/LLDP/rogue APs/speedtest/mutations |
| 2 — clients & user groups | eeaca5c | 19 | client_groups.py NEW; clients.py extended for blocked/lookup/mutations |
| 3 — networks/WLANs/VPN/DNS/routing | 9027c7d | 31 | vpn/dns/routes/ap_groups.py NEW; networks/wlans extended |
| 4 — firewall/QoS/DPI/CF/ACL/OON | 1224fca | 34 | qos/dpi/content_filter/acl/oon.py NEW; firewall_rules extended |
| 5 — port forwards/vouchers/SNMP | 5d11369 | 11 | port_forwards/vouchers/snmp.py NEW |
| 6 — stats/events/system | 01ca27c | 29 | stats/events/system/sessions.py NEW; spec §5 amendment for TIMESERIES |

Total: 157 tools across 22 source files (8 NEW, 6 EXTENDED). 178/235 tools covered after this PR (Phase 3's 21 + PR1's 157).

## Mid-execution adaptations (per Phase 1-3 cadence)

1. **Wrapper-dict-shaped \"list\" tools registered as DETAIL** — `unifi_get_switch_ports`, `unifi_get_port_stats`, `unifi_get_lldp_neighbors`, `unifi_get_snmp_settings`, `unifi_get_dpi_stats`, etc. all return `{name, ...wrapper_keys, table: [...]}` dicts. The serializer contract requires LIST tools to receive a list; these are registered as DETAIL with the nested array exposed inside `data`.
2. **TIMESERIES envelope clarification (spec §5 amendment).** Phase 3's `serialize_action` for `RenderKind.TIMESERIES` iterates `serialize` per item, so the spec's proposed `{points, window}` envelope didn't fit. TIMESERIES `data` is now `list[point]` where each point is `{ts, ...metrics}`; window/step metadata moves to `render_hint`. Saved to Myco; preserves Phase 3 contract; no `_base.py` changes.
3. **3 stats tools registered as DETAIL not TIMESERIES** because Phase 2's AST dispatch captures the detail-returning manager method (not a list-returning stats method) for `unifi_get_device_stats`, `unifi_get_client_stats`, `unifi_get_dpi_stats`. Followed plan's option (a) — minimum blast radius. Phase 5 AST fix will let them register as TIMESERIES.
4. **`unifi_get_network_health` is LIST not DETAIL** — manager returns multi-element list of subsystems (gateway, www, wan, lan, wlan, vpn).
5. **Mutation acks coerce `bool` returns to `{success: bool}`** — many manager update/delete methods return bare `True`/`False`; established pattern across all 6 clusters.
6. **Manager-shape surprises documented per cluster commit** — DPI id 0 is real (falsy-check), DNS records use `key`/`value` not `hostname`/`ip` (V2 quirk), traffic routes use `description` for name, static routes use `static-route_*` hyphenated keys, AP groups live on `NetworkManager`, vouchers split between `hotspot` and `vouchers` categories in the manifest.

## Out of scope

- Protect coverage (PR2)
- Access coverage (PR3)
- Strict-mode lifespan flip + CI gate (PR4)

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (51/205/628/336/157) |
| `unifi-api` | 233 passed (Phase 3 baseline 139 + 94 new) |
| Coverage | network 167/167 (was 10/167); total 178/235 |

## Reference

- Spec: Myco \`f30c9c7cf0cea283\` (§5 amended in Cluster 6 commit)
- Plan: Myco \`d519fc75a1c8f819\` (\`docs/superpowers/plans/2026-04-29-phase-4a-serializer-coverage.md\`)
- Phase 3 (prerequisite): merged in #163 as \`63d8911\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)