### PR TITLE
Phase 4A PR2: protect serializer coverage (33 tools)

### DIFF
--- a/apps/api/src/unifi_api/serializers/protect/alarms.py
+++ b/apps/api/src/unifi_api/serializers/protect/alarms.py
@@ -1,0 +1,91 @@
+"""Protect Alarm Manager serializers (Phase 4A PR2 Cluster 3).
+
+Covers:
+  * ``protect_alarm_get_status`` — DETAIL detail of current arm state.
+    Manager method: ``AlarmManager.get_arm_state``.
+  * ``protect_alarm_list_profiles`` — DETAIL pass-through of the
+    ``{profiles: [...], count: N}`` wrapper the tool layer constructs.
+    (Plan asked for LIST kind, but the tool layer wraps the bare list
+    in a count-bearing dict — so DETAIL pass-through is the contract-correct
+    choice. Same pattern Cluster 2 used for ``protect_recent_events``.)
+  * ``protect_alarm_arm`` / ``protect_alarm_disarm`` — DETAIL pass-through
+    for the post-confirm ack dict (``{armed, profile_id, profile_name}`` /
+    ``{armed, already_disarmed?}``). Preview dicts also flow through cleanly.
+
+Profile field shape is the manager's flattened form:
+``id, name, record_everything, activation_delay_ms, schedule_count,
+automation_count``. The plan's ``schedule, trigger_camera_ids`` shape does
+not match what the manager actually returns — recorded in the test docstring.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+@register_serializer(
+    tools={
+        "protect_alarm_get_status": {"kind": RenderKind.DETAIL},
+    },
+)
+class AlarmStatusSerializer(Serializer):
+    """Pass-through for the alarm status dict produced by the tool layer."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}
+
+
+@register_serializer(
+    tools={
+        "protect_alarm_list_profiles": {"kind": RenderKind.DETAIL},
+    },
+)
+class AlarmProfileSerializer(Serializer):
+    """Pass-through for the ``{profiles, count}`` wrapper the tool returns.
+
+    Per-profile fields (forwarded as-is): ``id``, ``name``,
+    ``record_everything``, ``activation_delay_ms``, ``schedule_count``,
+    ``automation_count``.
+    """
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        if isinstance(obj, dict):
+            return obj
+        if isinstance(obj, list):
+            # Defensive: if a caller hands us the bare list, wrap it.
+            return {"profiles": list(obj), "count": len(obj)}
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}
+
+
+@register_serializer(
+    tools={
+        "protect_alarm_arm": {"kind": RenderKind.DETAIL},
+        "protect_alarm_disarm": {"kind": RenderKind.DETAIL},
+    },
+)
+class AlarmMutationAckSerializer(Serializer):
+    """Pass-through for arm/disarm acks. Coerces a bare bool into a dict."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        if isinstance(obj, bool):
+            return {"armed": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/cameras.py
+++ b/apps/api/src/unifi_api/serializers/protect/cameras.py
@@ -1,11 +1,19 @@
-"""Protect camera serializer.
+"""Protect camera serializers (Phase 4A PR2 Cluster 1).
 
 Manager methods (``CameraManager.list_cameras`` / ``get_camera``) return
 plain dicts shaped by ``_format_camera_summary`` and the detail merge in
 ``get_camera``. We read dict keys directly; if a Pydantic-like object is
 ever passed, fall back to attribute access via ``_get``.
+
+Phase 4A PR2 Cluster 1 adds:
+  - CameraAnalyticsSerializer (``protect_get_camera_analytics``)
+  - CameraStreamsSerializer (``protect_get_camera_streams``)
+  - SnapshotSerializer (``protect_get_snapshot``) — manager returns raw
+    bytes, so we expose ``{size_bytes, content_type, captured_at}``.
+  - CameraMutationAckSerializer (PTZ/reboot/toggle/update preview tools)
 """
 
+from datetime import datetime, timezone
 from typing import Any
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
@@ -47,3 +55,84 @@ class CameraSerializer(Serializer):
             "host": _get(obj, "ip_address") or _get(obj, "host"),
             "channels": _get(obj, "channels") or [],
         }
+
+
+@register_serializer(tools={"protect_get_camera_analytics": {"kind": RenderKind.DETAIL}})
+class CameraAnalyticsSerializer(Serializer):
+    """Manager returns a flat-ish dict; pass through with normalised keys."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "camera_id": _get(obj, "camera_id"),
+            "camera_name": _get(obj, "camera_name"),
+            "detections": _get(obj, "detections") or {},
+            "smart_detects": _get(obj, "smart_detects") or {},
+            "smart_audio_detects": _get(obj, "smart_audio_detects") or {},
+            "currently_detected": _get(obj, "currently_detected") or {},
+            "motion_zone_count": _get(obj, "motion_zone_count", 0),
+            "smart_detect_zone_count": _get(obj, "smart_detect_zone_count", 0),
+            "stats": _get(obj, "stats") or {},
+        }
+
+
+@register_serializer(tools={"protect_get_camera_streams": {"kind": RenderKind.DETAIL}})
+class CameraStreamsSerializer(Serializer):
+    """Manager returns ``{camera_id, camera_name, channels: {name: {..}}, rtsps_streams: {...}}``."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "camera_id": _get(obj, "camera_id"),
+            "camera_name": _get(obj, "camera_name"),
+            "channels": _get(obj, "channels") or {},
+            "rtsps_streams": _get(obj, "rtsps_streams") or {},
+        }
+
+
+@register_serializer(tools={"protect_get_snapshot": {"kind": RenderKind.DETAIL}})
+class SnapshotSerializer(Serializer):
+    """Manager returns raw JPEG ``bytes``. Surface metadata only — the binary
+    body is encoded by the tool layer separately."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, (bytes, bytearray)):
+            return {
+                "size_bytes": len(obj),
+                "content_type": "image/jpeg",
+                "captured_at": datetime.now(timezone.utc).isoformat(),
+            }
+        if isinstance(obj, dict):
+            return {
+                "size_bytes": obj.get("size_bytes"),
+                "content_type": obj.get("content_type", "image/jpeg"),
+                "captured_at": obj.get("captured_at"),
+                "url": obj.get("url"),
+            }
+        return {"size_bytes": None, "content_type": None, "captured_at": None}
+
+
+@register_serializer(
+    tools={
+        "protect_ptz_move": {"kind": RenderKind.DETAIL},
+        "protect_ptz_preset": {"kind": RenderKind.DETAIL},
+        "protect_ptz_zoom": {"kind": RenderKind.DETAIL},
+        "protect_reboot_camera": {"kind": RenderKind.DETAIL},
+        "protect_toggle_recording": {"kind": RenderKind.DETAIL},
+        "protect_update_camera_settings": {"kind": RenderKind.DETAIL},
+    },
+)
+class CameraMutationAckSerializer(Serializer):
+    """Generic ack for camera-side mutations. Manager methods here return
+    ``Dict[str, Any]`` (preview shape); bool fallback for completeness."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/chimes.py
+++ b/apps/api/src/unifi_api/serializers/protect/chimes.py
@@ -1,0 +1,50 @@
+"""Protect chime serializer (Phase 4A PR2 Cluster 1).
+
+``ChimeManager.list_chimes`` returns plain dicts shaped by
+``_format_chime_summary`` — fields include ``id``, ``mac`` (omitted by the
+helper, but tolerated), ``name``, ``state``, ``camera_ids``,
+``ring_settings``, ``available_tracks``. We expose a LIST view with the
+fields most useful for tabular renderers; ``camera_ids`` is renamed to
+``paired_cameras`` per the spec.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "protect_list_chimes": {"kind": RenderKind.LIST},
+    },
+    resources=[
+        (("protect", "chimes"), {"kind": RenderKind.LIST}),
+    ],
+)
+class ChimeSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "model", "state", "volume"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "mac": _get(obj, "mac"),
+            "name": _get(obj, "name"),
+            "model": _get(obj, "model"),
+            "type": _get(obj, "type"),
+            "state": _get(obj, "state"),
+            "is_connected": _get(obj, "is_connected"),
+            "firmware_version": _get(obj, "firmware_version"),
+            "volume": _get(obj, "volume"),
+            "paired_cameras": _get(obj, "camera_ids") or [],
+            "ring_settings": _get(obj, "ring_settings") or [],
+            "available_tracks": _get(obj, "available_tracks") or [],
+        }

--- a/apps/api/src/unifi_api/serializers/protect/chimes.py
+++ b/apps/api/src/unifi_api/serializers/protect/chimes.py
@@ -1,4 +1,4 @@
-"""Protect chime serializer (Phase 4A PR2 Cluster 1).
+"""Protect chime serializers.
 
 ``ChimeManager.list_chimes`` returns plain dicts shaped by
 ``_format_chime_summary`` — fields include ``id``, ``mac`` (omitted by the
@@ -6,6 +6,13 @@ helper, but tolerated), ``name``, ``state``, ``camera_ids``,
 ``ring_settings``, ``available_tracks``. We expose a LIST view with the
 fields most useful for tabular renderers; ``camera_ids`` is renamed to
 ``paired_cameras`` per the spec.
+
+Phase 4A PR2 Cluster 2 adds ``ChimeMutationAckSerializer`` for
+``protect_trigger_chime`` and ``protect_update_chime``.
+``ChimeManager.trigger_chime`` returns
+``{chime_id, chime_name, triggered, volume, repeat_times}`` and
+``update_chime`` returns
+``{chime_id, chime_name, current_state, proposed_changes}``.
 """
 
 from typing import Any
@@ -48,3 +55,23 @@ class ChimeSerializer(Serializer):
             "ring_settings": _get(obj, "ring_settings") or [],
             "available_tracks": _get(obj, "available_tracks") or [],
         }
+
+
+@register_serializer(
+    tools={
+        "protect_trigger_chime": {"kind": RenderKind.DETAIL},
+        "protect_update_chime": {"kind": RenderKind.DETAIL},
+    },
+)
+class ChimeMutationAckSerializer(Serializer):
+    """Pass-through ack for chime trigger/update preview dicts."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/events.py
+++ b/apps/api/src/unifi_api/serializers/protect/events.py
@@ -1,7 +1,24 @@
-"""Protect event serializer.
+"""Protect event serializers.
 
-``EventManager.list_events`` returns plain dicts shaped by
-``_event_to_dict``. Registered as EVENT_LOG kind.
+``EventManager.list_events`` / ``get_event`` return plain dicts shaped by
+``_event_to_dict``. Phase 4A PR2 Cluster 2 adds:
+
+  - ``EventDetailSerializer`` (``protect_get_event``) — same shape as the LIST
+    serializer, registered as DETAIL.
+  - ``EventThumbnailSerializer`` (``protect_get_event_thumbnail``) — manager
+    returns ``{event_id, thumbnail_id, thumbnail_available, image_base64?,
+    content_type?, message?}``. Pass-through with normalised keys.
+  - ``RecentEventsSerializer`` (``protect_recent_events``) — the tool layer
+    has already wrapped buffer reads as ``{events, count, source, buffer_size}``;
+    we expose this as DETAIL pass-through (the wrapper *is* the payload).
+  - ``SmartDetectionsSerializer`` (``protect_list_smart_detections``) — list
+    of event dicts; EVENT_LOG kind, identical to the events serializer.
+  - ``SubscriptionHandleSerializer`` (``protect_subscribe_events``) — DETAIL
+    pass-through. Tool currently returns ``{resource_uri, summary_uri,
+    instructions, buffer_size}``. If a future revision returns a bare string
+    we wrap it as ``{"subscription_id": <value>}``. Phase 4B precursor.
+  - ``EventMutationAckSerializer`` (``protect_acknowledge_event``) — DETAIL
+    pass-through (manager returns a preview dict).
 """
 
 from typing import Any
@@ -13,6 +30,19 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _event_payload(obj) -> dict:
+    return {
+        "id": _get(obj, "id"),
+        "type": _get(obj, "type"),
+        "start": _get(obj, "start"),
+        "end": _get(obj, "end"),
+        "score": _get(obj, "score"),
+        "smart_detect_types": _get(obj, "smart_detect_types") or [],
+        "camera": _get(obj, "camera_id"),
+        "thumbnail": _get(obj, "thumbnail_id"),
+    }
 
 
 @register_serializer(
@@ -31,13 +61,108 @@ class EventSerializer(Serializer):
 
     @staticmethod
     def serialize(obj) -> dict:
-        return {
-            "id": _get(obj, "id"),
-            "type": _get(obj, "type"),
-            "start": _get(obj, "start"),
-            "end": _get(obj, "end"),
-            "score": _get(obj, "score"),
-            "smart_detect_types": _get(obj, "smart_detect_types") or [],
-            "camera": _get(obj, "camera_id"),
-            "thumbnail": _get(obj, "thumbnail_id"),
-        }
+        return _event_payload(obj)
+
+
+@register_serializer(tools={"protect_get_event": {"kind": RenderKind.DETAIL}})
+class EventDetailSerializer(Serializer):
+    """Single-event detail; mirrors ``EventSerializer`` payload."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return _event_payload(obj)
+
+
+@register_serializer(tools={"protect_get_event_thumbnail": {"kind": RenderKind.DETAIL}})
+class EventThumbnailSerializer(Serializer):
+    """Manager returns a dict with ``image_base64`` (decoded) or fallback message."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, dict):
+            return {
+                "event_id": obj.get("event_id"),
+                "thumbnail_id": obj.get("thumbnail_id"),
+                "thumbnail_available": obj.get("thumbnail_available", False),
+                "image_base64": obj.get("image_base64"),
+                "content_type": obj.get("content_type"),
+                "message": obj.get("message"),
+                "url": obj.get("url"),
+            }
+        if isinstance(obj, (bytes, bytearray)):
+            # Defensive — manager today returns a dict, but if a future
+            # revision passes raw JPEG bytes through, surface metadata.
+            return {
+                "event_id": None,
+                "thumbnail_available": True,
+                "size_bytes": len(obj),
+                "content_type": "image/jpeg",
+            }
+        return {"event_id": None, "thumbnail_available": False, "result": str(obj)}
+
+
+@register_serializer(tools={"protect_list_smart_detections": {"kind": RenderKind.EVENT_LOG}})
+class SmartDetectionsSerializer(Serializer):
+    """List of event dicts (same shape as ``EventSerializer``); EVENT_LOG."""
+
+    kind = RenderKind.EVENT_LOG
+    primary_key = "id"
+    display_columns = ["type", "start", "score", "smart_detect_types"]
+    sort_default = "start:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return _event_payload(obj)
+
+
+@register_serializer(tools={"protect_recent_events": {"kind": RenderKind.DETAIL}})
+class RecentEventsSerializer(Serializer):
+    """The tool layer already wraps buffer reads as
+    ``{events, count, source, buffer_size}``. Pass-through DETAIL — the
+    wrapper *is* the payload, so we surface it as-is rather than treating
+    it as a list (renderers that want per-event rows can read ``data.events``).
+    """
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, dict):
+            return obj
+        if isinstance(obj, list):
+            return {"events": obj, "count": len(obj)}
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}
+
+
+@register_serializer(tools={"protect_subscribe_events": {"kind": RenderKind.DETAIL}})
+class SubscriptionHandleSerializer(Serializer):
+    """Phase 4B precursor. Today the tool returns
+    ``{resource_uri, summary_uri, instructions, buffer_size}`` — pass that
+    through unchanged. If the underlying surface ever returns a bare string
+    or UUID we wrap it as ``{"subscription_id": <value>}``.
+    """
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, dict):
+            return obj
+        if isinstance(obj, str):
+            return {"subscription_id": obj}
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"subscription_id": str(obj)}
+
+
+@register_serializer(tools={"protect_acknowledge_event": {"kind": RenderKind.DETAIL}})
+class EventMutationAckSerializer(Serializer):
+    """Pass-through ack for ``protect_acknowledge_event`` preview dict."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/lights.py
+++ b/apps/api/src/unifi_api/serializers/protect/lights.py
@@ -1,7 +1,11 @@
-"""Protect light serializer.
+"""Protect light serializers (Phase 4A PR2 Cluster 1).
 
 ``LightManager.list_lights`` returns plain dicts shaped by
 ``_format_light_summary``.
+
+PR2 adds ``LightMutationAckSerializer`` for ``protect_update_light``.
+The manager's ``update_light`` returns a preview dict
+``{light_id, light_name, current_state, proposed_changes}``.
 """
 
 from typing import Any
@@ -39,3 +43,19 @@ class LightSerializer(Serializer):
             "is_pir_motion_detected": _get(obj, "is_pir_motion_detected"),
             "is_light_on": _get(obj, "is_light_on"),
         }
+
+
+@register_serializer(tools={"protect_update_light": {"kind": RenderKind.DETAIL}})
+class LightMutationAckSerializer(Serializer):
+    """``LightManager.update_light`` returns the preview dict; pass through.
+    Bool fallback for completeness."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/liveviews.py
+++ b/apps/api/src/unifi_api/serializers/protect/liveviews.py
@@ -1,0 +1,88 @@
+"""Protect liveview serializers (Phase 4A PR2 Cluster 2).
+
+``LiveviewManager.list_liveviews`` returns plain dicts shaped by
+``_format_liveview_summary``. Each entry has::
+
+    {id, name, is_default, is_global, layout, owner_id,
+     slots: [{camera_ids, cycle_mode, cycle_interval}], slot_count, camera_count}
+
+For the LIST view we flatten ``slots`` into a deduped ``cameras`` list of
+camera IDs (preserving order) — that's what consumers actually want for a
+liveview at a glance. The full ``slots`` array is preserved alongside.
+
+Mutation acks cover ``protect_create_liveview`` / ``protect_delete_liveview``.
+NB: both manager methods today return ``supported=False`` preview dicts since
+uiprotect does not expose direct create/delete APIs.
+"""
+
+from typing import Any, List
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _flatten_cameras(slots: list) -> List[str]:
+    seen: set = set()
+    out: List[str] = []
+    for slot in slots or []:
+        cam_ids = _get(slot, "camera_ids") or []
+        for cid in cam_ids:
+            if cid not in seen:
+                seen.add(cid)
+                out.append(cid)
+    return out
+
+
+@register_serializer(
+    tools={
+        "protect_list_liveviews": {"kind": RenderKind.LIST},
+    },
+    resources=[
+        (("protect", "liveviews"), {"kind": RenderKind.LIST}),
+    ],
+)
+class LiveviewSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "layout", "camera_count"]
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        slots = _get(obj, "slots") or []
+        return {
+            "id": _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "layout": _get(obj, "layout"),
+            "is_default": _get(obj, "is_default"),
+            "is_global": _get(obj, "is_global"),
+            "owner_id": _get(obj, "owner_id"),
+            "cameras": _flatten_cameras(slots),
+            "slots": slots,
+            "slot_count": _get(obj, "slot_count", len(slots)),
+            "camera_count": _get(obj, "camera_count"),
+        }
+
+
+@register_serializer(
+    tools={
+        "protect_create_liveview": {"kind": RenderKind.DETAIL},
+        "protect_delete_liveview": {"kind": RenderKind.DETAIL},
+    },
+)
+class LiveviewMutationAckSerializer(Serializer):
+    """Pass-through for liveview create/delete preview dicts. Bool fallback."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/recordings.py
+++ b/apps/api/src/unifi_api/serializers/protect/recordings.py
@@ -1,4 +1,4 @@
-"""Protect recording serializer.
+"""Protect recording serializers.
 
 ``RecordingManager.list_recordings`` returns a single dict describing the
 available recording window for a camera (uiprotect does not expose
@@ -8,6 +8,13 @@ Note: there is no ``protect_get_recording`` tool in the protect manifest;
 only ``protect_list_recordings`` exists, so we register LIST only and
 expose the resource as both a list path and a detail path so the
 catalog can surface a per-id link if a future tool is added.
+
+Phase 4A PR2 Cluster 2 adds:
+
+  - ``RecordingStatusSerializer`` (``protect_get_recording_status``) — manager
+    returns ``{cameras: [...], count}``. Pass-through DETAIL.
+  - ``RecordingMutationAckSerializer`` (``protect_delete_recording``,
+    ``protect_export_clip``) — DETAIL pass-through with bool fallback.
 """
 
 from typing import Any
@@ -46,3 +53,39 @@ class RecordingSerializer(Serializer):
             "end": _get(obj, "end"),
             "file_size": _get(obj, "file_size"),
         }
+
+
+@register_serializer(tools={"protect_get_recording_status": {"kind": RenderKind.DETAIL}})
+class RecordingStatusSerializer(Serializer):
+    """Manager returns ``{cameras: [...], count}`` — pass through normalised."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, dict):
+            return {
+                "cameras": obj.get("cameras") or [],
+                "count": obj.get("count", len(obj.get("cameras") or [])),
+            }
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"cameras": [], "count": 0}
+
+
+@register_serializer(
+    tools={
+        "protect_delete_recording": {"kind": RenderKind.DETAIL},
+        "protect_export_clip": {"kind": RenderKind.DETAIL},
+    },
+)
+class RecordingMutationAckSerializer(Serializer):
+    """Pass-through ack for recording mutations. Bool fallback for completeness."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/protect/system.py
+++ b/apps/api/src/unifi_api/serializers/protect/system.py
@@ -1,0 +1,94 @@
+"""Protect system serializers (Phase 4A PR2 Cluster 3).
+
+Covers four NVR-level system tools:
+  * ``protect_get_system_info`` — DETAIL pass-through of the bootstrap-derived
+    NVR summary (``id, name, model, firmware_version, version, host, mac,
+    uptime_seconds, up_since, is_updating, storage{...}, *_count``).
+  * ``protect_get_health`` — DETAIL pass-through of the nested
+    ``cpu/memory/storage`` health dict (plus ``is_updating``,
+    ``uptime_seconds``).
+  * ``protect_get_firmware_status`` — DETAIL pass-through of
+    ``{nvr, devices, total_devices, devices_with_updates}``.
+  * ``protect_list_viewers`` — DETAIL pass-through of the
+    ``{viewers, count}`` wrapper produced by the tool layer.
+
+The plan spec requested a different field shape (e.g. flat
+``status, storage_used_pct, num_*`` for health, or ``current_version,
+latest_version`` for firmware). The actual managers return richer / nested
+structures, so we pass them through verbatim rather than lossily flattening.
+Per the plan: "if any tool returns shape that diverges from these field
+selections, adapt to actual return and document."
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _passthrough(obj: Any) -> dict:
+    if isinstance(obj, dict):
+        return obj
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    return {"result": str(obj)}
+
+
+@register_serializer(
+    tools={
+        "protect_get_system_info": {"kind": RenderKind.DETAIL},
+    },
+)
+class ProtectSystemInfoSerializer(Serializer):
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        return _passthrough(obj)
+
+
+@register_serializer(
+    tools={
+        "protect_get_health": {"kind": RenderKind.DETAIL},
+    },
+)
+class ProtectHealthSerializer(Serializer):
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        return _passthrough(obj)
+
+
+@register_serializer(
+    tools={
+        "protect_get_firmware_status": {"kind": RenderKind.DETAIL},
+    },
+)
+class FirmwareStatusSerializer(Serializer):
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        return _passthrough(obj)
+
+
+@register_serializer(
+    tools={
+        "protect_list_viewers": {"kind": RenderKind.DETAIL},
+    },
+)
+class ViewerSerializer(Serializer):
+    """Pass-through for the ``{viewers, count}`` wrapper.
+
+    Per-viewer fields (forwarded as-is): ``id, name, type, mac, host,
+    firmware_version, is_connected, is_updating, uptime_seconds, state,
+    software_version, liveview_id``.
+    """
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj: Any) -> dict:
+        if isinstance(obj, list):
+            return {"viewers": list(obj), "count": len(obj)}
+        return _passthrough(obj)

--- a/apps/api/tests/serializers/test_protect_alarms_system.py
+++ b/apps/api/tests/serializers/test_protect_alarms_system.py
@@ -1,0 +1,253 @@
+"""Protect alarms + system serializer tests (Phase 4A PR2 Cluster 3).
+
+Manager + tool methods covered:
+  - ``AlarmManager.get_arm_state`` -> dict; tool wraps as
+    ``{armed, status, active_profile_id, active_profile_name, armed_at, ...,
+       breach_event_count, profile_count}``
+  - ``AlarmManager.list_arm_profiles`` -> list[dict]; tool wraps as
+    ``{profiles: [...], count: N}`` (wrapper dict at serializer boundary)
+  - ``AlarmManager.arm`` / ``disarm`` -> dict (preview or result; pass-through)
+  - ``SystemManager.get_system_info`` -> nested dict (id/name/model/version/storage/...)
+  - ``SystemManager.get_health`` -> nested dict (cpu/memory/storage/...)
+  - ``SystemManager.list_viewers`` -> list[dict]; tool wraps as
+    ``{viewers: [...], count: N}`` (wrapper dict at serializer boundary)
+  - ``SystemManager.get_firmware_status`` -> dict with ``nvr``, ``devices``, totals
+
+Notes on shape divergence from the plan spec (recorded in commit body):
+  * ``protect_alarm_list_profiles`` and ``protect_list_viewers`` are wrapped by
+    the tool layer in ``{profiles|viewers, count}``, so we register DETAIL
+    pass-through serializers (mirroring ``protect_recent_events`` from Cluster 2).
+  * Profile entries are ``id, name, record_everything, activation_delay_ms,
+    schedule_count, automation_count`` — not ``schedule, trigger_camera_ids``.
+  * Health is nested ``cpu/memory/storage`` — not flat ``status,
+    storage_used_pct, num_*``.
+  * Firmware status returns ``nvr``, ``devices``, ``total_devices``,
+    ``devices_with_updates`` — not ``current_version, latest_version, ...``.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- alarms.py ----
+
+
+def test_alarm_status_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_alarm_get_status")
+    sample = {
+        "armed": True,
+        "status": "active",
+        "active_profile_id": "p1",
+        "active_profile_name": "Night",
+        "armed_at": "2026-04-29T08:00:00+00:00",
+        "will_be_armed_at": None,
+        "breach_detected_at": None,
+        "breach_event_count": 0,
+        "profile_count": 3,
+    }
+    out = s.serialize_action(sample, tool_name="protect_alarm_get_status")
+    assert out["success"] is True
+    assert out["data"]["armed"] is True
+    assert out["data"]["status"] == "active"
+    assert out["data"]["active_profile_id"] == "p1"
+    assert out["data"]["active_profile_name"] == "Night"
+    assert out["data"]["breach_event_count"] == 0
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_alarm_list_profiles_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_alarm_list_profiles")
+    # Tool layer wraps manager list in {profiles, count} dict.
+    sample = {
+        "profiles": [
+            {
+                "id": "p1",
+                "name": "Night",
+                "record_everything": False,
+                "activation_delay_ms": 30000,
+                "schedule_count": 1,
+                "automation_count": 2,
+            },
+            {
+                "id": "p2",
+                "name": "Vacation",
+                "record_everything": True,
+                "activation_delay_ms": 0,
+                "schedule_count": 0,
+                "automation_count": 1,
+            },
+        ],
+        "count": 2,
+    }
+    out = s.serialize_action(sample, tool_name="protect_alarm_list_profiles")
+    assert out["success"] is True
+    assert out["data"]["count"] == 2
+    assert out["data"]["profiles"][0]["id"] == "p1"
+    assert out["data"]["profiles"][0]["name"] == "Night"
+    assert out["data"]["profiles"][1]["activation_delay_ms"] == 0
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_alarm_mutation_ack_arm() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_alarm_arm")
+    sample = {
+        "armed": True,
+        "profile_id": "p1",
+        "profile_name": "Night",
+    }
+    out = s.serialize_action(sample, tool_name="protect_alarm_arm")
+    assert out["success"] is True
+    assert out["data"]["armed"] is True
+    assert out["data"]["profile_id"] == "p1"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_alarm_mutation_ack_disarm_idempotent() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_alarm_disarm")
+    sample = {"armed": False, "already_disarmed": True}
+    out = s.serialize_action(sample, tool_name="protect_alarm_disarm")
+    assert out["success"] is True
+    assert out["data"]["armed"] is False
+    assert out["data"]["already_disarmed"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- system.py ----
+
+
+def test_system_info_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_system_info")
+    sample = {
+        "id": "nvr-1",
+        "name": "Home NVR",
+        "model": "UNVR",
+        "hardware_platform": "UNVR",
+        "firmware_version": "4.0.0",
+        "version": "4.0.0",
+        "host": "192.0.2.10",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "uptime_seconds": 12345,
+        "up_since": "2026-04-25T00:00:00+00:00",
+        "is_updating": False,
+        "storage": {
+            "utilization_pct": 42.5,
+            "recording_space_total_bytes": 10_000_000_000,
+            "recording_space_used_bytes": 4_250_000_000,
+        },
+        "camera_count": 5,
+        "light_count": 0,
+        "sensor_count": 1,
+        "viewer_count": 1,
+        "chime_count": 0,
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_system_info")
+    assert out["success"] is True
+    assert out["data"]["id"] == "nvr-1"
+    assert out["data"]["model"] == "UNVR"
+    assert out["data"]["camera_count"] == 5
+    assert out["data"]["storage"]["utilization_pct"] == 42.5
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_health_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_health")
+    sample = {
+        "cpu": {"average_load": 1.2, "temperature_c": 45.0},
+        "memory": {"available_bytes": 1_000_000, "free_bytes": 500_000, "total_bytes": 4_000_000},
+        "storage": {
+            "available_bytes": 5_000_000_000,
+            "size_bytes": 10_000_000_000,
+            "used_bytes": 5_000_000_000,
+            "is_recycling": False,
+            "type": "hdd",
+        },
+        "is_updating": False,
+        "uptime_seconds": 99999,
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_health")
+    assert out["success"] is True
+    assert out["data"]["cpu"]["temperature_c"] == 45.0
+    assert out["data"]["memory"]["total_bytes"] == 4_000_000
+    assert out["data"]["storage"]["is_recycling"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_firmware_status_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_firmware_status")
+    sample = {
+        "nvr": {
+            "id": "nvr-1",
+            "name": "Home NVR",
+            "current_firmware": "4.0.0",
+            "version": "4.0.0",
+            "is_updating": False,
+            "is_protect_updatable": True,
+            "is_ucore_updatable": False,
+            "last_device_fw_check": "2026-04-29T07:00:00+00:00",
+        },
+        "devices": [
+            {
+                "id": "cam1",
+                "name": "Front Door",
+                "type": "camera",
+                "model": "G4",
+                "current_firmware": "4.61.0",
+                "latest_firmware": "4.62.0",
+                "update_available": True,
+                "is_updating": False,
+            }
+        ],
+        "total_devices": 1,
+        "devices_with_updates": 1,
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_firmware_status")
+    assert out["success"] is True
+    assert out["data"]["nvr"]["id"] == "nvr-1"
+    assert out["data"]["devices_with_updates"] == 1
+    assert out["data"]["devices"][0]["update_available"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_list_viewers_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_list_viewers")
+    # Tool layer wraps manager list in {viewers, count} dict.
+    sample = {
+        "viewers": [
+            {
+                "id": "viewer-1",
+                "name": "Living Room",
+                "type": "viewport",
+                "mac": "11:22:33:44:55:66",
+                "host": "192.0.2.20",
+                "firmware_version": "2.0.0",
+                "is_connected": True,
+                "is_updating": False,
+                "uptime_seconds": 3600,
+                "state": "CONNECTED",
+                "software_version": "2.0.0",
+                "liveview_id": "lv-1",
+            }
+        ],
+        "count": 1,
+    }
+    out = s.serialize_action(sample, tool_name="protect_list_viewers")
+    assert out["success"] is True
+    assert out["data"]["count"] == 1
+    assert out["data"]["viewers"][0]["id"] == "viewer-1"
+    assert out["data"]["viewers"][0]["liveview_id"] == "lv-1"
+    assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_protect_cameras_lights_chimes.py
+++ b/apps/api/tests/serializers/test_protect_cameras_lights_chimes.py
@@ -1,0 +1,167 @@
+"""Protect cameras + lights + chimes serializer unit tests (Phase 4A PR2 Cluster 1).
+
+Manager methods in unifi-core return plain dicts already shaped by helpers
+(``_format_chime_summary``, ``get_camera_streams``, ``get_camera_analytics``,
+``get_snapshot``, ptz/toggle/reboot/update preview methods). Tests feed dicts
+(or bytes for snapshot) and check shape + DETAIL/LIST contract.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- chimes.py ----
+
+
+def test_chime_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_list_chimes")
+    sample = [
+        {
+            "id": "chime1",
+            "mac": "aa:bb:cc:dd:ee:01",
+            "name": "Front Door Chime",
+            "model": "UFP-Chime",
+            "type": "UFP-CHIME",
+            "state": "CONNECTED",
+            "is_connected": True,
+            "firmware_version": "1.2.3",
+            "volume": 50,
+            "camera_ids": ["cam1", "cam2"],
+            "ring_settings": [],
+            "available_tracks": [],
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="protect_list_chimes")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "chime1"
+    assert out["data"][0]["name"] == "Front Door Chime"
+    assert out["data"][0]["state"] == "CONNECTED"
+    assert out["data"][0]["paired_cameras"] == ["cam1", "cam2"]
+    assert out["render_hint"]["kind"] == "list"
+
+
+# ---- cameras.py extensions ----
+
+
+def test_camera_analytics_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_camera_analytics")
+    sample = {
+        "camera_id": "cam1",
+        "camera_name": "Front Door",
+        "detections": {
+            "is_motion_detected": False,
+            "is_smart_detected": True,
+            "last_motion": "2026-04-29T08:30:00+00:00",
+        },
+        "smart_detects": {"person": "2026-04-29T08:30:00+00:00"},
+        "smart_audio_detects": {},
+        "currently_detected": {"person": True, "vehicle": False},
+        "motion_zone_count": 2,
+        "smart_detect_zone_count": 1,
+        "stats": {},
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_camera_analytics")
+    assert out["success"] is True
+    assert out["data"]["camera_id"] == "cam1"
+    assert out["data"]["motion_zone_count"] == 2
+    assert out["data"]["smart_detects"] == {"person": "2026-04-29T08:30:00+00:00"}
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_camera_streams_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_camera_streams")
+    sample = {
+        "camera_id": "cam1",
+        "camera_name": "Front Door",
+        "channels": {
+            "high": {
+                "channel_id": 0,
+                "enabled": True,
+                "rtsp_alias": "abc123",
+                "rtsps_url": "rtsps://nvr.local:7441/abc123",
+                "rtsp_url": "rtsp://nvr.local:7447/abc123",
+                "width": 1920,
+                "height": 1080,
+                "fps": 30,
+                "bitrate": 4000,
+            }
+        },
+        "rtsps_streams": {"high": "rtsps://nvr.local:7441/xyz789"},
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_camera_streams")
+    assert out["success"] is True
+    assert out["data"]["camera_id"] == "cam1"
+    assert "high" in out["data"]["channels"]
+    assert out["data"]["channels"]["high"]["rtsps_url"].startswith("rtsps://")
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_snapshot_serializer_bytes_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_snapshot")
+    sample = b"\xff\xd8\xff\xe0" + b"\x00" * 1020  # fake JPEG header + padding
+    out = s.serialize_action(sample, tool_name="protect_get_snapshot")
+    assert out["success"] is True
+    assert out["data"]["size_bytes"] == 1024
+    assert out["data"]["content_type"] == "image/jpeg"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_camera_mutation_ack_ptz_move() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_ptz_move")
+    sample = {
+        "camera_id": "cam1",
+        "camera_name": "Front Door",
+        "movement": {"pan": 50, "tilt": -25, "duration_ms": 250},
+        "actions_taken": ["pan=50", "tilt=-25", "duration_ms=250"],
+    }
+    out = s.serialize_action(sample, tool_name="protect_ptz_move")
+    assert out["success"] is True
+    assert out["data"]["camera_id"] == "cam1"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_camera_mutation_ack_dispatches_for_all() -> None:
+    reg = _registry()
+    for tool in (
+        "protect_ptz_move",
+        "protect_ptz_preset",
+        "protect_ptz_zoom",
+        "protect_reboot_camera",
+        "protect_toggle_recording",
+        "protect_update_camera_settings",
+    ):
+        s = reg.serializer_for_tool(tool)
+        out = s.serialize_action({"camera_id": "cam1"}, tool_name=tool)
+        assert out["render_hint"]["kind"] == "detail"
+        assert out["success"] is True
+
+
+# ---- lights.py extension ----
+
+
+def test_light_mutation_ack_update_light() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_update_light")
+    sample = {
+        "light_id": "light1",
+        "light_name": "Driveway",
+        "current_state": {"light_on": False, "led_level": 3},
+        "proposed_changes": {"light_on": True, "led_level": 5},
+    }
+    out = s.serialize_action(sample, tool_name="protect_update_light")
+    assert out["success"] is True
+    assert out["data"]["light_id"] == "light1"
+    assert out["data"]["proposed_changes"]["light_on"] is True
+    assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_protect_events_recordings_liveviews.py
+++ b/apps/api/tests/serializers/test_protect_events_recordings_liveviews.py
@@ -1,0 +1,337 @@
+"""Protect events + recordings + liveviews + chimes serializer tests
+(Phase 4A PR2 Cluster 2).
+
+Manager methods covered:
+  - ``EventManager.get_event`` -> dict (event detail)
+  - ``EventManager.get_event_thumbnail`` -> dict with image_base64+content_type
+  - ``EventManager.list_smart_detections`` -> list[dict] (event log)
+  - ``EventManager.acknowledge_event`` -> preview dict
+  - ``RecordingManager.get_recording_status`` -> {cameras: [...], count}
+  - ``RecordingManager.delete_recording`` / ``export_clip`` -> preview dicts
+  - ``LiveviewManager.list_liveviews`` -> list[dict] of summaries
+  - ``LiveviewManager.create_liveview`` / ``delete_liveview`` -> preview dicts
+  - ``ChimeManager.trigger_chime`` / ``update_chime`` -> dicts
+
+For ``protect_recent_events`` and ``protect_subscribe_events`` the tool layer
+returns ``{success, data: {events: [...], ...}}`` / ``{success, data: {...}}``
+wrapper dicts. We register DETAIL pass-through serializers — these are not
+list-shaped at the serializer boundary because the wrapper *is* the payload.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- liveviews.py ----
+
+
+def test_liveview_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_list_liveviews")
+    sample = [
+        {
+            "id": "lv-001",
+            "name": "Front Yard",
+            "is_default": True,
+            "is_global": False,
+            "layout": 4,
+            "owner_id": "user-1",
+            "slots": [
+                {"camera_ids": ["cam1", "cam2"], "cycle_mode": "none", "cycle_interval": 0},
+                {"camera_ids": ["cam3"], "cycle_mode": "none", "cycle_interval": 0},
+            ],
+            "slot_count": 2,
+            "camera_count": 3,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="protect_list_liveviews")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "lv-001"
+    assert out["data"][0]["name"] == "Front Yard"
+    assert out["data"][0]["layout"] == 4
+    assert out["data"][0]["cameras"] == ["cam1", "cam2", "cam3"]
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_liveview_mutation_ack_create() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_create_liveview")
+    sample = {
+        "name": "Test View",
+        "camera_ids": ["cam1"],
+        "invalid_camera_ids": [],
+        "camera_count": 1,
+        "supported": False,
+        "message": "Liveview creation is not directly supported...",
+    }
+    out = s.serialize_action(sample, tool_name="protect_create_liveview")
+    assert out["success"] is True
+    assert out["data"]["name"] == "Test View"
+    assert out["data"]["supported"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_liveview_mutation_ack_delete() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_delete_liveview")
+    sample = {
+        "liveview_id": "lv-001",
+        "liveview_name": "Front Yard",
+        "is_default": True,
+        "is_global": False,
+        "slot_count": 2,
+        "supported": False,
+        "message": "Liveview deletion is not directly supported...",
+    }
+    out = s.serialize_action(sample, tool_name="protect_delete_liveview")
+    assert out["success"] is True
+    assert out["data"]["liveview_id"] == "lv-001"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- events.py extensions ----
+
+
+def test_event_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_event")
+    sample = {
+        "id": "evt-1",
+        "type": "smartDetectZone",
+        "start": "2026-04-29T08:00:00+00:00",
+        "end": "2026-04-29T08:00:05+00:00",
+        "score": 87,
+        "smart_detect_types": ["person"],
+        "camera_id": "cam1",
+        "thumbnail_id": "thumb-1",
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_event")
+    assert out["success"] is True
+    assert out["data"]["id"] == "evt-1"
+    assert out["data"]["type"] == "smartDetectZone"
+    assert out["data"]["score"] == 87
+    assert out["data"]["camera"] == "cam1"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_event_thumbnail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_event_thumbnail")
+    sample = {
+        "event_id": "evt-1",
+        "thumbnail_id": "thumb-1",
+        "thumbnail_available": True,
+        "image_base64": "QUJDRA==",
+        "content_type": "image/jpeg",
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_event_thumbnail")
+    assert out["success"] is True
+    assert out["data"]["event_id"] == "evt-1"
+    assert out["data"]["content_type"] == "image/jpeg"
+    assert out["data"]["thumbnail_available"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_event_thumbnail_serializer_unavailable_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_event_thumbnail")
+    sample = {
+        "event_id": "evt-1",
+        "thumbnail_available": False,
+        "message": "Event has no thumbnail (may still be in progress).",
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_event_thumbnail")
+    assert out["success"] is True
+    assert out["data"]["thumbnail_available"] is False
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_smart_detections_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_list_smart_detections")
+    sample = [
+        {
+            "id": "evt-2",
+            "type": "smartDetectZone",
+            "start": "2026-04-29T08:00:00+00:00",
+            "end": "2026-04-29T08:00:05+00:00",
+            "score": 90,
+            "smart_detect_types": ["vehicle"],
+            "camera_id": "cam1",
+            "thumbnail_id": "thumb-2",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="protect_list_smart_detections")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "evt-2"
+    assert out["data"][0]["smart_detect_types"] == ["vehicle"]
+    assert out["render_hint"]["kind"] == "event_log"
+
+
+def test_recent_events_serializer_passthrough() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_recent_events")
+    sample = {
+        "events": [{"id": "evt-3", "type": "motion"}],
+        "count": 1,
+        "source": "websocket_buffer",
+        "buffer_size": 100,
+    }
+    out = s.serialize_action(sample, tool_name="protect_recent_events")
+    assert out["success"] is True
+    assert out["data"]["count"] == 1
+    assert out["data"]["events"][0]["id"] == "evt-3"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_subscribe_events_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_subscribe_events")
+    sample = {
+        "resource_uri": "protect://events/stream",
+        "summary_uri": "protect://events/stream/summary",
+        "instructions": "Read the resource at ...",
+        "buffer_size": 100,
+    }
+    out = s.serialize_action(sample, tool_name="protect_subscribe_events")
+    assert out["success"] is True
+    # Pass-through: at minimum surface a subscription_id-or-uri field
+    assert (
+        out["data"].get("subscription_id") == "protect://events/stream"
+        or out["data"].get("resource_uri") == "protect://events/stream"
+    )
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_subscribe_events_serializer_string_input() -> None:
+    """If the manager ever returns a bare string, wrap as subscription_id."""
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_subscribe_events")
+    out = s.serialize_action("sub-abc-123", tool_name="protect_subscribe_events")
+    assert out["success"] is True
+    assert out["data"]["subscription_id"] == "sub-abc-123"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_event_mutation_ack_acknowledge() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_acknowledge_event")
+    sample = {
+        "event_id": "evt-1",
+        "type": "motion",
+        "camera_id": "cam1",
+        "camera_name": "Front Door",
+        "current_is_favorite": False,
+        "proposed_is_favorite": True,
+    }
+    out = s.serialize_action(sample, tool_name="protect_acknowledge_event")
+    assert out["success"] is True
+    assert out["data"]["event_id"] == "evt-1"
+    assert out["data"]["proposed_is_favorite"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- recordings.py extensions ----
+
+
+def test_recording_status_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_get_recording_status")
+    sample = {
+        "cameras": [
+            {
+                "camera_id": "cam1",
+                "camera_name": "Front Door",
+                "recording_mode": "always",
+                "is_recording": True,
+                "has_recordings": True,
+                "video_stats": {
+                    "recording_start": "2026-04-29T00:00:00+00:00",
+                    "recording_end": "2026-04-29T08:00:00+00:00",
+                    "timelapse_start": None,
+                    "timelapse_end": None,
+                },
+            }
+        ],
+        "count": 1,
+    }
+    out = s.serialize_action(sample, tool_name="protect_get_recording_status")
+    assert out["success"] is True
+    assert out["data"]["count"] == 1
+    assert out["data"]["cameras"][0]["camera_id"] == "cam1"
+    assert out["data"]["cameras"][0]["is_recording"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_recording_mutation_ack_export_clip() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_export_clip")
+    sample = {
+        "camera_id": "cam1",
+        "start": "2026-04-29T08:00:00+00:00",
+        "end": "2026-04-29T08:01:00+00:00",
+        "output_path": "/tmp/clip.mp4",
+        "size_bytes": 524288,
+    }
+    out = s.serialize_action(sample, tool_name="protect_export_clip")
+    assert out["success"] is True
+    assert out["data"]["camera_id"] == "cam1"
+    assert out["data"]["size_bytes"] == 524288
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_recording_mutation_ack_delete_recording() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_delete_recording")
+    sample = {
+        "camera_id": "cam1",
+        "start": "2026-04-29T08:00:00+00:00",
+        "end": "2026-04-29T08:01:00+00:00",
+        "deleted": True,
+    }
+    out = s.serialize_action(sample, tool_name="protect_delete_recording")
+    assert out["success"] is True
+    assert out["data"]["deleted"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- chimes.py extensions ----
+
+
+def test_chime_mutation_ack_trigger() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_trigger_chime")
+    sample = {
+        "chime_id": "chime1",
+        "chime_name": "Front Door Chime",
+        "triggered": True,
+        "volume": 50,
+        "repeat_times": 1,
+    }
+    out = s.serialize_action(sample, tool_name="protect_trigger_chime")
+    assert out["success"] is True
+    assert out["data"]["chime_id"] == "chime1"
+    assert out["data"]["triggered"] is True
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_chime_mutation_ack_update() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("protect_update_chime")
+    sample = {
+        "chime_id": "chime1",
+        "chime_name": "Front Door Chime",
+        "current_state": {"volume": 50},
+        "proposed_changes": {"volume": 75},
+    }
+    out = s.serialize_action(sample, tool_name="protect_update_chime")
+    assert out["success"] is True
+    assert out["data"]["proposed_changes"]["volume"] == 75
+    assert out["render_hint"]["kind"] == "detail"


### PR DESCRIPTION
## Summary

Phase 4A PR2: complete serializer coverage for the protect product. Adds 33 serializers across 3 cluster commits. After this PR merges, protect coverage is complete (39/39 tools); total Phase 4A coverage 211/235.

## Scope (3 cluster commits)

| Cluster | Commit | Tools | Notes |
|---|---|---|---|
| 1 — cameras, lights, chimes | 68a82c4 | 11 | chimes.py NEW; cameras.py extended for analytics/streams/snapshot/PTZ; lights.py + light mutation ack |
| 2 — events, recordings, liveviews, chimes | 1f1ec3e | 14 | liveviews.py NEW; events.py extended (event detail, thumbnail, smart detections, recent events, subscribe handle); recordings.py + status/mutation acks; chimes.py + mutation ack |
| 3 — alarms, system | ff1bbbd | 8 | alarms.py + system.py NEW |

Total: 33 tools across 8 source files (3 NEW, 5 EXTENDED).

## Mid-execution adaptations

1. **`protect_get_snapshot` returns raw bytes (JPEG)** — `SnapshotSerializer` exposes `{size_bytes, content_type, captured_at}` rather than a URL. The bytes are the payload; manager doesn't produce a URL.
2. **`protect_get_camera_streams` returns nested per-channel dict** with separate `rtsps_streams` map — not a flat `rtsp_url`/`rtsps_url`/`hls_url` triple. Pass-through preserves the nested structure.
3. **`protect_subscribe_events` does NOT return a subscription handle today.** It returns guidance text + resource URIs (`{resource_uri, summary_uri, instructions, buffer_size}`). `SubscriptionHandleSerializer` accepts both that shape and a bare-string fallback for the Phase 4B handoff.
4. **`protect_recent_events` is pre-wrapped** as `{events, count, source, buffer_size}` at the tool layer — registered DETAIL passthrough rather than EVENT_LOG to preserve buffer metadata.
5. **`create/delete_liveview` return preview dicts marked \`supported=False\`** because the underlying uiprotect library lacks public CRUD APIs. The mutation-ack serializer passes the preview through unchanged.
6. **Wrapper-dict pattern continues:** `protect_alarm_list_profiles` and `protect_list_viewers` return `{profiles|viewers, count}` dicts (not bare lists), registered DETAIL passthrough — same pattern as PR1's wrapper-dict tools.
7. **Field shapes diverged from spec for several DETAILs** — `protect_get_health` is nested `{cpu, memory, storage}` (not flat status/pct/counts); `protect_get_firmware_status` returns `{nvr, devices, total_devices, devices_with_updates}`; `AlarmStatusSerializer` adds `breach_event_count, profile_count, will_be_armed_at`. Serializers preserve the actual shape rather than forcing the spec's shape.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (51/205/628/336/157) |
| `unifi-api` | 264 passed (PR1 baseline 233 + 31 new) |
| Coverage | protect 39/39 (was 6/39); total 211/235 |

## Out of scope

- Access coverage (PR3 — 24 tools remaining)
- Strict-mode lifespan flip + CI gate (PR4)

## Reference

- Spec: Myco \`f30c9c7cf0cea283\` (§5 amended in PR1)
- Plan: Myco \`d519fc75a1c8f819\`
- PR1 (prerequisite): merged in #164 as \`e11c8bd\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)