### PR TITLE
Phase 4A PR3: access serializer coverage (24 tools) — coverage now 235/235

### DIFF
--- a/apps/api/src/unifi_api/serializers/access/credentials.py
+++ b/apps/api/src/unifi_api/serializers/access/credentials.py
@@ -1,8 +1,12 @@
-"""Access credential serializer.
+"""Access credential serializers.
 
 ``CredentialManager.list_credentials`` / ``get_credential`` return plain
 dicts as supplied by the proxy/API path. Field names follow the
 controller's snake-case convention.
+
+Phase 4A PR3 Cluster 2 adds ``CredentialMutationAckSerializer`` for
+``access_create_credential`` and ``access_revoke_credential`` — both
+managers return preview dicts (``{credential_*, proposed_changes, ...}``).
 """
 
 from typing import Any
@@ -42,3 +46,25 @@ class CredentialSerializer(Serializer):
             "expiry": _get(obj, "expiry"),
             "last_used": _get(obj, "last_used"),
         }
+
+
+@register_serializer(
+    tools={
+        "access_create_credential": {"kind": RenderKind.DETAIL},
+        "access_revoke_credential": {"kind": RenderKind.DETAIL},
+    },
+)
+class CredentialMutationAckSerializer(Serializer):
+    """Pass-through ack for credential preview/apply dicts."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/access/devices.py
+++ b/apps/api/src/unifi_api/serializers/access/devices.py
@@ -1,0 +1,80 @@
+"""Access device serializer.
+
+``DeviceManager.list_devices`` and ``get_device`` return plain dicts.
+Two paths populate slightly different shapes:
+
+- API-client path: ``id``, ``name``, ``type``, ``connected``,
+  ``firmware_version`` (and ``mac``, ``ip`` on detail).
+- Proxy path: the raw topology4 device dict, which uses ``unique_id``,
+  ``device_type``, ``firmware``, ``is_online`` and carries injected
+  ``_door_name`` / ``_door_id`` from the topology flatten step.
+
+We normalize across both. ``access_reboot_device`` returns a preview
+dict from the manager; bool fallback for completeness.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _is_online(obj: Any) -> Any:
+    explicit = _get(obj, "is_online")
+    if explicit is not None:
+        return explicit
+    connected = _get(obj, "connected")
+    if connected is not None:
+        return connected
+    return None
+
+
+@register_serializer(
+    tools={
+        "access_list_devices": {"kind": RenderKind.LIST},
+        "access_get_device": {"kind": RenderKind.DETAIL},
+    },
+)
+class AccessDeviceSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "type", "is_online", "firmware_version"]
+    sort_default = "name"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id") or _get(obj, "unique_id"),
+            "name": _get(obj, "name") or _get(obj, "alias"),
+            "type": _get(obj, "type") or _get(obj, "device_type"),
+            "is_online": _is_online(obj),
+            "firmware_version": _get(obj, "firmware_version") or _get(obj, "firmware"),
+            "location": _get(obj, "location") or _get(obj, "_door_name"),
+        }
+
+
+@register_serializer(
+    tools={
+        "access_reboot_device": {"kind": RenderKind.DETAIL},
+    },
+)
+class AccessDeviceMutationAckSerializer(Serializer):
+    """DETAIL ack for ``access_reboot_device``. Preview/apply both return
+    dicts; pass through. Bool coerces to ``{"success": bool}``."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if obj is None:
+            return {"success": False}
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/access/doors.py
+++ b/apps/api/src/unifi_api/serializers/access/doors.py
@@ -72,3 +72,88 @@ class DoorSerializer(Serializer):
             "lock_state": _get(obj, "lock_state") or _get(obj, "lock_relay_status"),
             "last_event": _last_event(obj),
         }
+
+
+def _door_ids_from_groups(obj: Any) -> list:
+    """Door groups may carry resources/door_ids in either field name."""
+    door_ids = _get(obj, "door_ids")
+    if isinstance(door_ids, list):
+        return door_ids
+    resources = _get(obj, "resources")
+    if isinstance(resources, list):
+        return [
+            r.get("id") if isinstance(r, dict) else r
+            for r in resources
+            if r is not None
+        ]
+    return []
+
+
+@register_serializer(
+    tools={
+        "access_list_door_groups": {"kind": RenderKind.LIST},
+    },
+)
+class DoorGroupSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "location"]
+    sort_default = "name"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "door_ids": _door_ids_from_groups(obj),
+            "location": _get(obj, "location") or _get(obj, "location_type"),
+        }
+
+
+@register_serializer(
+    tools={
+        "access_get_door_status": {"kind": RenderKind.DETAIL},
+    },
+)
+class DoorStatusSerializer(Serializer):
+    kind = RenderKind.DETAIL
+    primary_key = "door_id"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        last = _last_event(obj)
+        last_ts = last.get("timestamp") if isinstance(last, dict) else None
+        last_type = last.get("name") if isinstance(last, dict) else None
+        return {
+            "door_id": _get(obj, "door_id") or _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "is_locked": _is_locked(obj),
+            "lock_state": _get(obj, "lock_state") or _get(obj, "lock_relay_status"),
+            "door_position_status": _get(obj, "door_position_status"),
+            "last_event_at": last_ts,
+            "last_event_type": last_type,
+        }
+
+
+@register_serializer(
+    tools={
+        "access_lock_door": {"kind": RenderKind.DETAIL},
+        "access_unlock_door": {"kind": RenderKind.DETAIL},
+    },
+)
+class DoorMutationAckSerializer(Serializer):
+    """DETAIL ack for lock/unlock. Manager preview returns a dict
+    (door_id + current_state + proposed_changes); pass through. Bool
+    coerces to ``{"success": bool}`` for completeness."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if obj is None:
+            return {"success": False}
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/access/events.py
+++ b/apps/api/src/unifi_api/serializers/access/events.py
@@ -1,0 +1,118 @@
+"""Access event serializers.
+
+``EventManager.list_events`` / ``get_recent_from_buffer`` return
+``list[dict[str, Any]]`` — registered as EVENT_LOG.
+``EventManager.get_event`` returns a single dict — registered as DETAIL.
+``EventManager.get_activity_summary`` returns the histogram payload from
+``activities/histogram`` (a dict) — DETAIL pass-through with normalised
+fields.
+
+The ``access_subscribe_events`` tool composes a guidance dict from
+``event_manager.buffer_size`` (no manager method call), so dispatch
+falls through to ``DispatchEntryMissing`` at runtime; the serializer is
+still registered for coverage. Mirrors PR2's Protect
+``SubscriptionHandleSerializer`` pattern: pass-through dict, or wrap a
+bare string as ``{"subscription_id": value}``.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _event_payload(obj) -> dict:
+    return {
+        "id": _get(obj, "id"),
+        "type": _get(obj, "type"),
+        "timestamp": _get(obj, "timestamp") or _get(obj, "time"),
+        "door_id": _get(obj, "door_id"),
+        "user_id": _get(obj, "user_id"),
+        "credential_id": _get(obj, "credential_id"),
+        "result": _get(obj, "result"),
+    }
+
+
+@register_serializer(
+    tools={
+        "access_list_events": {"kind": RenderKind.EVENT_LOG},
+        "access_recent_events": {"kind": RenderKind.EVENT_LOG},
+    },
+    resources=[
+        (("access", "events"), {"kind": RenderKind.EVENT_LOG}),
+    ],
+)
+class AccessEventSerializer(Serializer):
+    kind = RenderKind.EVENT_LOG
+    primary_key = "id"
+    display_columns = ["type", "timestamp", "door_id", "user_id", "result"]
+    sort_default = "timestamp:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return _event_payload(obj)
+
+
+@register_serializer(tools={"access_get_event": {"kind": RenderKind.DETAIL}})
+class EventDetailSerializer(Serializer):
+    """Single-event detail; mirrors ``AccessEventSerializer`` payload."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return _event_payload(obj)
+
+
+@register_serializer(tools={"access_get_activity_summary": {"kind": RenderKind.DETAIL}})
+class ActivitySummarySerializer(Serializer):
+    """Activity histogram summary (``activities/histogram`` payload).
+
+    Manager passes through the controller's response shape; we surface
+    catalog-level fields with ``None`` fallbacks when keys are absent.
+    """
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if not isinstance(obj, dict):
+            if hasattr(obj, "model_dump"):
+                obj = obj.model_dump()
+            else:
+                return {"result": str(obj)}
+        return {
+            "period_start": obj.get("period_start") or obj.get("since"),
+            "period_end": obj.get("period_end") or obj.get("until"),
+            "total_events": obj.get("total_events") or obj.get("total"),
+            "granted_count": obj.get("granted_count"),
+            "denied_count": obj.get("denied_count"),
+            "top_users": obj.get("top_users"),
+            "buckets": obj.get("buckets") or obj.get("histogram"),
+        }
+
+
+@register_serializer(tools={"access_subscribe_events": {"kind": RenderKind.DETAIL}})
+class AccessSubscriptionHandleSerializer(Serializer):
+    """Phase 4B precursor. Today the tool returns
+    ``{resource_uri, summary_uri, instructions, buffer_size}`` — pass that
+    through unchanged. If the underlying surface ever returns a bare
+    string or UUID we wrap it as ``{"subscription_id": <value>}``.
+    """
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, dict):
+            return obj
+        if isinstance(obj, str):
+            return {"subscription_id": obj}
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"subscription_id": str(obj)}

--- a/apps/api/src/unifi_api/serializers/access/policies.py
+++ b/apps/api/src/unifi_api/serializers/access/policies.py
@@ -1,0 +1,96 @@
+"""Access policy serializer.
+
+``PolicyManager.list_policies`` and ``get_policy`` return dicts from the
+proxy ``access_policies?expand[]=schedule`` endpoint. Policies expose
+schedule and door associations under various field names depending on
+expansion (``resources``, ``door_ids``, ``schedule_id``). We normalize
+to a stable shape for catalog use.
+
+``access_update_policy`` returns a preview dict (current_state +
+proposed_changes); the apply path returns ``{"result": "success", ...}``.
+``PolicyMutationAckSerializer`` passes both through and coerces bools.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _door_ids(obj: Any) -> list:
+    door_ids = _get(obj, "door_ids")
+    if isinstance(door_ids, list):
+        return door_ids
+    resources = _get(obj, "resources")
+    if isinstance(resources, list):
+        return [
+            r.get("id") if isinstance(r, dict) else r
+            for r in resources
+            if r is not None
+        ]
+    return []
+
+
+def _is_enabled(obj: Any) -> bool:
+    explicit = _get(obj, "enabled")
+    if isinstance(explicit, bool):
+        return explicit
+    status = _get(obj, "status")
+    if isinstance(status, str):
+        return status.lower() in {"active", "enabled", "on"}
+    return True
+
+
+@register_serializer(
+    tools={
+        "access_list_policies": {"kind": RenderKind.LIST},
+        "access_get_policy": {"kind": RenderKind.DETAIL},
+    },
+)
+class PolicySerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "schedule_id", "enabled"]
+    sort_default = "name"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        schedule = _get(obj, "schedule")
+        schedule_id = _get(obj, "schedule_id")
+        if not schedule_id and isinstance(schedule, dict):
+            schedule_id = schedule.get("id")
+        return {
+            "id": _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "schedule_id": schedule_id,
+            "door_ids": _door_ids(obj),
+            "user_group_ids": _get(obj, "user_group_ids") or [],
+            "enabled": _is_enabled(obj),
+        }
+
+
+@register_serializer(
+    tools={
+        "access_update_policy": {"kind": RenderKind.DETAIL},
+    },
+)
+class PolicyMutationAckSerializer(Serializer):
+    """DETAIL ack for ``access_update_policy``. Preview/apply both return
+    dicts; pass through. Bool coerces to ``{"success": bool}``."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if obj is None:
+            return {"success": False}
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/serializers/access/schedules.py
+++ b/apps/api/src/unifi_api/serializers/access/schedules.py
@@ -1,0 +1,53 @@
+"""Access schedule serializer.
+
+``PolicyManager.list_schedules`` returns dicts from the proxy
+``schedules?expand[]=week_schedule`` endpoint. Each schedule carries a
+``week_schedule`` dict (per-weekday windows). We surface that as
+``weekly_pattern`` for a stable catalog field name.
+
+Only LIST is registered for this cluster — there is no detail/get tool
+for schedules in Phase 4A.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _is_enabled(obj: Any) -> bool:
+    explicit = _get(obj, "enabled")
+    if isinstance(explicit, bool):
+        return explicit
+    status = _get(obj, "status")
+    if isinstance(status, str):
+        return status.lower() in {"active", "enabled", "on"}
+    return True
+
+
+@register_serializer(
+    tools={
+        "access_list_schedules": {"kind": RenderKind.LIST},
+    },
+)
+class ScheduleSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "enabled"]
+    sort_default = "name"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "weekly_pattern": _get(obj, "weekly_pattern")
+            or _get(obj, "week_schedule")
+            or {},
+            "enabled": _is_enabled(obj),
+        }

--- a/apps/api/src/unifi_api/serializers/access/system.py
+++ b/apps/api/src/unifi_api/serializers/access/system.py
@@ -1,0 +1,77 @@
+"""Access system info + health serializers.
+
+``SystemManager.get_system_info`` returns either a connectivity probe
+dict (api_client path: ``source``, ``host``, ``api_port``, ``connected``,
+``door_count``) or the raw ``access/info`` proxy payload (which carries
+``name``, ``version``, ``hostname``, ``uptime``, etc.). We normalize to
+the catalog spec fields, falling back to whatever the probe path
+exposes.
+
+``SystemManager.get_health`` returns a per-probe status dict
+(``api_client_healthy``, ``proxy_healthy``, etc.). We derive a single
+``status`` field plus optional door/device counts when the caller
+supplies them via ``num_*`` keys.
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _derive_health_status(obj: Any) -> str:
+    explicit = _get(obj, "status")
+    if isinstance(explicit, str):
+        return explicit
+    api_h = _get(obj, "api_client_healthy")
+    proxy_h = _get(obj, "proxy_healthy")
+    flags = [v for v in (api_h, proxy_h) if v is not None]
+    if not flags:
+        is_connected = _get(obj, "is_connected")
+        return "healthy" if is_connected else "unknown"
+    if all(flags):
+        return "healthy"
+    if any(flags):
+        return "degraded"
+    return "unhealthy"
+
+
+@register_serializer(
+    tools={
+        "access_get_system_info": {"kind": RenderKind.DETAIL},
+    },
+)
+class AccessSystemInfoSerializer(Serializer):
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "name": _get(obj, "name") or _get(obj, "source"),
+            "version": _get(obj, "version"),
+            "hostname": _get(obj, "hostname") or _get(obj, "host"),
+            "uptime": _get(obj, "uptime"),
+        }
+
+
+@register_serializer(
+    tools={
+        "access_get_health": {"kind": RenderKind.DETAIL},
+    },
+)
+class AccessHealthSerializer(Serializer):
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "status": _derive_health_status(obj),
+            "num_doors": _get(obj, "num_doors"),
+            "num_devices": _get(obj, "num_devices"),
+            "num_offline_devices": _get(obj, "num_offline_devices"),
+        }

--- a/apps/api/src/unifi_api/serializers/access/visitors.py
+++ b/apps/api/src/unifi_api/serializers/access/visitors.py
@@ -1,0 +1,73 @@
+"""Access visitor serializers.
+
+``VisitorManager.list_visitors`` / ``get_visitor`` return plain dicts from
+the proxy ``visitors`` endpoint (path is best-effort; the manager returns
+``[]`` on 404). Field names follow the controller convention; we expose
+the catalog-level fields and gracefully fall back to ``None``.
+
+``create_visitor`` / ``delete_visitor`` are preview-pattern mutations —
+they return dicts with ``visitor_data`` / ``visitor_id`` and
+``proposed_changes``. ``VisitorMutationAckSerializer`` passes those
+through unchanged (matches Cluster 1's mutation-ack pattern).
+"""
+
+from typing import Any
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+@register_serializer(
+    tools={
+        "access_list_visitors": {"kind": RenderKind.LIST},
+        "access_get_visitor": {"kind": RenderKind.DETAIL},
+    },
+    resources=[
+        (("access", "visitors"), {"kind": RenderKind.LIST}),
+        (("access", "visitors/{id}"), {"kind": RenderKind.DETAIL}),
+    ],
+)
+class VisitorSerializer(Serializer):
+    kind = RenderKind.LIST
+    primary_key = "id"
+    display_columns = ["name", "host_user_id", "valid_from", "valid_until", "status"]
+    sort_default = "valid_from:desc"
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            "id": _get(obj, "id"),
+            "name": _get(obj, "name"),
+            "host_user_id": _get(obj, "host_user_id"),
+            "valid_from": _get(obj, "valid_from") or _get(obj, "access_start"),
+            "valid_until": _get(obj, "valid_until") or _get(obj, "access_end"),
+            "status": _get(obj, "status"),
+            "credential_count": _get(obj, "credential_count"),
+        }
+
+
+@register_serializer(
+    tools={
+        "access_create_visitor": {"kind": RenderKind.DETAIL},
+        "access_delete_visitor": {"kind": RenderKind.DETAIL},
+    },
+)
+class VisitorMutationAckSerializer(Serializer):
+    """Pass-through ack for visitor preview/apply dicts."""
+
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/tests/serializers/test_access_credentials_visitors_events.py
+++ b/apps/api/tests/serializers/test_access_credentials_visitors_events.py
@@ -1,0 +1,249 @@
+"""Access credentials + visitors + events serializer tests
+(Phase 4A PR3 Cluster 2).
+
+Manager methods covered:
+  - ``CredentialManager.create_credential`` / ``revoke_credential`` -> preview dicts
+  - ``VisitorManager.list_visitors`` -> list[dict]
+  - ``VisitorManager.get_visitor`` -> dict
+  - ``VisitorManager.create_visitor`` / ``delete_visitor`` -> preview dicts
+  - ``EventManager.list_events`` -> list[dict]  (event log)
+  - ``EventManager.get_event`` -> dict (event detail)
+  - ``EventManager.get_recent_from_buffer`` -> list[dict]  (event log)
+  - ``EventManager.get_activity_summary`` -> dict (histogram payload)
+
+The ``access_subscribe_events`` tool has no AST-discoverable manager call
+(it composes a dict from ``event_manager.buffer_size``); the serializer still
+needs to be registered for coverage. We mirror PR2's
+``SubscriptionHandleSerializer`` pattern: pass-through dict, or wrap a bare
+string as ``{"subscription_id": value}``.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+# ---- credentials (mutation acks) ----
+
+
+def test_credential_mutation_ack_create() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_create_credential")
+    sample = {
+        "credential_type": "nfc",
+        "credential_data": {"user_id": "user-1", "token": "abc123"},
+        "proposed_changes": {"action": "create", "type": "nfc", "user_id": "user-1"},
+    }
+    out = s.serialize_action(sample, tool_name="access_create_credential")
+    assert out["success"] is True
+    assert out["data"]["credential_type"] == "nfc"
+    assert out["data"]["proposed_changes"]["action"] == "create"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_credential_mutation_ack_revoke() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_revoke_credential")
+    sample = {
+        "credential_id": "cred-001",
+        "current_state": {"id": "cred-001", "user_id": "user-1", "type": "nfc"},
+        "proposed_changes": {"action": "revoke"},
+    }
+    out = s.serialize_action(sample, tool_name="access_revoke_credential")
+    assert out["success"] is True
+    assert out["data"]["credential_id"] == "cred-001"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- visitors ----
+
+
+def test_visitor_list_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_list_visitors")
+    sample = [
+        {
+            "id": "vis-001",
+            "name": "Jane Doe",
+            "host_user_id": "user-1",
+            "valid_from": "2026-04-29T08:00:00Z",
+            "valid_until": "2026-04-29T18:00:00Z",
+            "status": "active",
+            "credential_count": 1,
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="access_list_visitors")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "vis-001"
+    assert out["data"][0]["name"] == "Jane Doe"
+    assert out["data"][0]["status"] == "active"
+    assert out["render_hint"]["kind"] == "list"
+
+
+def test_visitor_detail_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_get_visitor")
+    sample = {
+        "id": "vis-002",
+        "name": "John Roe",
+        "host_user_id": "user-2",
+        "valid_from": "2026-04-29T09:00:00Z",
+        "valid_until": "2026-04-29T17:00:00Z",
+        "status": "scheduled",
+        "credential_count": 0,
+    }
+    out = s.serialize_action(sample, tool_name="access_get_visitor")
+    assert out["success"] is True
+    assert out["data"]["id"] == "vis-002"
+    assert out["data"]["host_user_id"] == "user-2"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_visitor_mutation_ack_create() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_create_visitor")
+    sample = {
+        "visitor_data": {
+            "name": "Alice",
+            "access_start": "2026-04-29T08:00:00Z",
+            "access_end": "2026-04-29T18:00:00Z",
+        },
+        "proposed_changes": {"action": "create", "name": "Alice"},
+    }
+    out = s.serialize_action(sample, tool_name="access_create_visitor")
+    assert out["success"] is True
+    assert out["data"]["visitor_data"]["name"] == "Alice"
+    assert out["data"]["proposed_changes"]["action"] == "create"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_visitor_mutation_ack_delete() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_delete_visitor")
+    sample = {
+        "visitor_id": "vis-001",
+        "visitor_name": "Jane Doe",
+        "current_state": {"id": "vis-001", "name": "Jane Doe"},
+        "proposed_changes": {"action": "delete"},
+    }
+    out = s.serialize_action(sample, tool_name="access_delete_visitor")
+    assert out["success"] is True
+    assert out["data"]["visitor_id"] == "vis-001"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+# ---- events ----
+
+
+def test_access_event_log_list_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_list_events")
+    sample = [
+        {
+            "id": "evt-1",
+            "type": "access_granted",
+            "timestamp": "2026-04-29T08:00:00Z",
+            "door_id": "door-1",
+            "user_id": "user-1",
+            "credential_id": "cred-001",
+            "result": "granted",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="access_list_events")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "evt-1"
+    assert out["data"][0]["result"] == "granted"
+    assert out["render_hint"]["kind"] == "event_log"
+
+
+def test_access_recent_events_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_recent_events")
+    sample = [
+        {
+            "id": "evt-2",
+            "type": "access_denied",
+            "timestamp": "2026-04-29T08:01:00Z",
+            "door_id": "door-1",
+            "user_id": "user-2",
+            "credential_id": None,
+            "result": "denied",
+        }
+    ]
+    out = s.serialize_action(sample, tool_name="access_recent_events")
+    assert out["success"] is True
+    assert out["data"][0]["id"] == "evt-2"
+    assert out["data"][0]["result"] == "denied"
+    assert out["render_hint"]["kind"] == "event_log"
+
+
+def test_access_event_detail_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_get_event")
+    sample = {
+        "id": "evt-3",
+        "type": "door_open",
+        "timestamp": "2026-04-29T08:02:00Z",
+        "door_id": "door-2",
+        "user_id": "user-3",
+        "credential_id": "cred-002",
+        "result": "granted",
+    }
+    out = s.serialize_action(sample, tool_name="access_get_event")
+    assert out["success"] is True
+    assert out["data"]["id"] == "evt-3"
+    assert out["data"]["door_id"] == "door-2"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_activity_summary_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_get_activity_summary")
+    sample = {
+        "period_start": "2026-04-22T00:00:00Z",
+        "period_end": "2026-04-29T00:00:00Z",
+        "total_events": 142,
+        "granted_count": 130,
+        "denied_count": 12,
+        "top_users": [{"user_id": "user-1", "count": 47}],
+    }
+    out = s.serialize_action(sample, tool_name="access_get_activity_summary")
+    assert out["success"] is True
+    assert out["data"]["total_events"] == 142
+    assert out["data"]["granted_count"] == 130
+    assert out["data"]["top_users"][0]["user_id"] == "user-1"
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_subscribe_events_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_subscribe_events")
+    sample = {
+        "resource_uri": "access://events/stream",
+        "summary_uri": "access://events/stream/summary",
+        "instructions": "Read the resource at ...",
+        "buffer_size": 100,
+    }
+    out = s.serialize_action(sample, tool_name="access_subscribe_events")
+    assert out["success"] is True
+    assert (
+        out["data"].get("subscription_id") == "access://events/stream"
+        or out["data"].get("resource_uri") == "access://events/stream"
+    )
+    assert out["render_hint"]["kind"] == "detail"
+
+
+def test_subscribe_events_string_input() -> None:
+    """If the tool body or future revision returns a bare string, wrap as subscription_id."""
+    reg = _registry()
+    s = reg.serializer_for_tool("access_subscribe_events")
+    out = s.serialize_action("sub-xyz-789", tool_name="access_subscribe_events")
+    assert out["success"] is True
+    assert out["data"]["subscription_id"] == "sub-xyz-789"
+    assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/serializers/test_access_doors_policies_system.py
+++ b/apps/api/tests/serializers/test_access_doors_policies_system.py
@@ -1,0 +1,151 @@
+"""Phase 4A PR3 Cluster 1 — access doors/policies/schedules/devices/system.
+
+Each manager returns plain dicts (or list of dicts). For lock/unlock/reboot
+the manager preview returns a dict (current_state + proposed_changes); we
+pass that through. The mutation acks coerce bools to ``{"success": bool}``.
+"""
+
+from unifi_api.serializers._registry import (
+    discover_serializers,
+    serializer_registry_singleton,
+)
+
+
+def _registry():
+    discover_serializers(manifest_tool_names=set())
+    return serializer_registry_singleton()
+
+
+def test_door_group_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_list_door_groups")
+    sample = {
+        "id": "grp1",
+        "name": "Lobby Group",
+        "door_ids": ["door1", "door2"],
+        "location": "HQ Floor 1",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "grp1"
+    assert out["name"] == "Lobby Group"
+    assert out["door_ids"] == ["door1", "door2"]
+    assert out["location"] == "HQ Floor 1"
+
+
+def test_door_status_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_get_door_status")
+    sample = {
+        "id": "door1",
+        "name": "Front Door",
+        "door_position_status": "close",
+        "lock_relay_status": "lock",
+    }
+    out = s.serialize(sample)
+    assert out["door_id"] == "door1"
+    assert out["is_locked"] is True
+    assert out["lock_state"] == "lock"
+
+
+def test_policy_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_get_policy")
+    sample = {
+        "id": "pol1",
+        "name": "Office Hours",
+        "schedule_id": "sch1",
+        "resources": [{"id": "door1"}, {"id": "door2"}],
+        "user_group_ids": ["ug1"],
+        "status": "active",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "pol1"
+    assert out["name"] == "Office Hours"
+    assert out["schedule_id"] == "sch1"
+    assert "door_ids" in out
+    assert "user_group_ids" in out
+    assert "enabled" in out
+
+
+def test_schedule_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_list_schedules")
+    sample = {
+        "id": "sch1",
+        "name": "Weekdays 9-5",
+        "week_schedule": {"monday": [{"start": "09:00", "end": "17:00"}]},
+        "status": "active",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "sch1"
+    assert out["name"] == "Weekdays 9-5"
+    assert out["weekly_pattern"] == sample["week_schedule"]
+    assert out["enabled"] is True
+
+
+def test_access_device_serializer_shape() -> None:
+    reg = _registry()
+    s = reg.serializer_for_tool("access_list_devices")
+    sample = {
+        "unique_id": "dev1",
+        "name": "Front Reader",
+        "device_type": "UA-G2",
+        "is_online": True,
+        "firmware": "2.10.0",
+        "_door_name": "Front Door",
+    }
+    out = s.serialize(sample)
+    assert out["id"] == "dev1"
+    assert out["name"] == "Front Reader"
+    assert out["type"] == "UA-G2"
+    assert out["is_online"] is True
+    assert out["firmware_version"] == "2.10.0"
+    assert out["location"] == "Front Door"
+
+
+def test_access_system_info_and_health() -> None:
+    reg = _registry()
+    info = reg.serializer_for_tool("access_get_system_info")
+    info_sample = {
+        "name": "Access Application",
+        "version": "1.24.0",
+        "hostname": "udm-pro",
+        "uptime": 12345,
+    }
+    info_out = info.serialize(info_sample)
+    assert info_out["name"] == "Access Application"
+    assert info_out["version"] == "1.24.0"
+    assert info_out["hostname"] == "udm-pro"
+    assert info_out["uptime"] == 12345
+
+    health = reg.serializer_for_tool("access_get_health")
+    health_sample = {
+        "host": "10.0.0.1",
+        "is_connected": True,
+        "api_client_available": True,
+        "proxy_available": True,
+        "api_client_healthy": True,
+        "proxy_healthy": True,
+    }
+    health_out = health.serialize(health_sample)
+    assert "status" in health_out
+    assert health_out["status"] == "healthy"
+
+
+def test_access_mutation_acks() -> None:
+    reg = _registry()
+    lock = reg.serializer_for_tool("access_lock_door")
+    # Manager preview shape passes through unchanged
+    preview = {"door_id": "d1", "proposed_changes": {"action": "lock"}}
+    assert lock.serialize(preview) == preview
+    # Bool coerces to {"success": bool}
+    assert lock.serialize(True) == {"success": True}
+
+    reboot = reg.serializer_for_tool("access_reboot_device")
+    assert reboot.serialize(False) == {"success": False}
+
+    upd = reg.serializer_for_tool("access_update_policy")
+    assert upd.serialize({"policy_id": "p1", "result": "success"}) == {
+        "policy_id": "p1",
+        "result": "success",
+    }


### PR DESCRIPTION
## Summary

Phase 4A PR3: complete serializer coverage for the access product. Adds 24 serializers across 2 cluster commits. **After this PR merges, coverage hits 235/235** — every manifest tool has a registered serializer with a real `render_hint`. PR4 (strict-gate flip + CI assertion) follows.

## Scope (2 cluster commits)

| Cluster | Commit | Tools | Notes |
|---|---|---|---|
| 1 — doors, policies, schedules, devices, system | 2a966aa | 13 | doors.py extended (door_groups, door_status, lock/unlock acks); policies/schedules/devices/system.py NEW |
| 2 — credentials, visitors, events | 9eaca5e | 11 | credentials.py extended; visitors.py + events.py NEW (subscription handle precursor for Phase 4B) |

Total: 24 tools across 7 source files (5 NEW, 2 EXTENDED).

## Mid-execution adaptations

1. **Dual-path normalization in `system.py`.** `access_get_system_info` returns two distinct shapes depending on whether the api_client probe path or the proxy `access/info` path is taken. Serializer falls back source→name and host→hostname.
2. **`access_get_health` synthesizes `status`.** Manager returns per-probe boolean flags (`api_client_healthy`, `proxy_healthy`); serializer derives `status` (`healthy`/`degraded`/`unhealthy`/`unknown`) from the boolean grid.
3. **Policy `door_ids` extraction.** Proxy path returns `door_ids` nested as `resources: [{"id": ...}]`. `_door_ids` helper handles both flat and nested shapes.
4. **`access_recent_events` registered as EVENT_LOG, not DETAIL passthrough.** AST resolves to `event_manager.get_recent_from_buffer` which returns a bare `list[dict]` — the tool layer's `{events, count, source, buffer_size}` wrapper is bypassed by API dispatch. Differs from PR2's `protect_recent_events` (which is wrapper-DETAIL because of how protect's tool layer composes).
5. **`access_subscribe_events` has no AST-discoverable manager call** (composes from `event_manager.buffer_size` attribute) — same Phase 4B precursor pattern as protect's `subscribe_events`. `AccessSubscriptionHandleSerializer` accepts dict passthrough or bare-string fallback.
6. **Mutation acks continue the bool→`{success: bool}` coercion pattern** established in PR1.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (51/205/628/336/157) |
| `unifi-api` | 283 passed (PR2 baseline 264 + 19 new) |
| Coverage | access 29/29 (was 5/29); **total 235/235 — complete** |

## Out of scope

- PR4: strict-mode lifespan flip + CI assertion (next; small change — 1 lifespan one-liner + 1 new test file)

## Reference

- Spec: Myco \`f30c9c7cf0cea283\`
- Plan: Myco \`d519fc75a1c8f819\`
- PR1 (network coverage): merged in #164 as \`e11c8bd\`
- PR2 (protect coverage): merged in #165 as \`04564ac\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)