### PR TITLE
Phase 4A PR4: strict serializer validation + CI gate

### DIFF
--- a/apps/api/src/unifi_api/serializers/_registry.py
+++ b/apps/api/src/unifi_api/serializers/_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
+import sys
 from typing import Iterable
 
 from unifi_api.serializers import _base
@@ -99,7 +100,16 @@ def discover_serializers(manifest_tool_names: set[str]) -> SerializerRegistry:
 
 
 def _reset_registry_for_tests() -> None:
-    """For test isolation — drops module-level registries."""
+    """For test isolation — drops module-level registries AND evicts serializer
+    submodules from sys.modules so the next discover_serializers re-imports
+    them and re-runs the @register_serializer decorators. Without the eviction,
+    importlib.import_module is a no-op for already-loaded modules and the
+    registry stays empty after reset."""
     global _singleton
     _reset_registries_for_tests()
     _singleton = None
+    for product in ("network", "protect", "access"):
+        prefix = f"unifi_api.serializers.{product}"
+        for modname in list(sys.modules.keys()):
+            if modname == prefix or modname.startswith(prefix + "."):
+                sys.modules.pop(modname, None)

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -98,12 +98,14 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.state.argon_cache = ArgonVerifyCache()
     app.state.capability_cache = CapabilityCache()
     app.state.manifest_registry = ManifestRegistry.load_from_apps()
-    # Discover and register every Phase 3 serializer module, then validate
-    # against the manifest. We pass an empty set rather than the full ~219-tool
-    # manifest because Phase 3 only ships ~13 serializers; the catalog and
-    # action-endpoint paths handle missing serializers per-call. Phase 4+ may
-    # tighten this to require coverage of the full manifest.
-    app.state.serializer_registry = discover_serializers(set())
+    # Discover and register every serializer module, then validate against the
+    # full manifest. Phase 4A landed coverage for all 235 manifest tools, so
+    # strict mode is now the runtime contract: any tool added to the manifest
+    # without a registered serializer raises SerializerRegistryError at lifespan
+    # startup. The CI gate test_every_tool_has_a_serializer enforces the same
+    # invariant in apps/api/tests/.
+    manifest_tool_names = set(app.state.manifest_registry.all_tools())
+    app.state.serializer_registry = discover_serializers(manifest_tool_names)
 
     app.include_router(health.router, prefix="/v1")
     app.include_router(controllers_routes.router, prefix="/v1")

--- a/apps/api/tests/test_serializer_coverage.py
+++ b/apps/api/tests/test_serializer_coverage.py
@@ -1,0 +1,24 @@
+"""CI gate: every manifest tool must have a registered serializer.
+
+This test is the contributor lint rule for Phase 4A onwards. Adding a new
+MCP tool without registering a serializer in apps/api/src/unifi_api/serializers/
+will fail this test — the SerializerRegistryError lists the missing tool names
+in its message, so the fix is to add the appropriate serializer.
+
+The same invariant is enforced at lifespan startup in server.py
+(`discover_serializers(set(manifest.all_tools()))`); this test catches the
+regression in CI before the app fails to start.
+"""
+
+from unifi_api.serializers._registry import (
+    _reset_registry_for_tests,
+    discover_serializers,
+)
+from unifi_api.services.manifest import ManifestRegistry
+
+
+def test_every_tool_has_a_serializer() -> None:
+    _reset_registry_for_tests()
+    manifest = ManifestRegistry.load_from_apps()
+    # Will raise SerializerRegistryError if any tool lacks a serializer.
+    discover_serializers(set(manifest.all_tools()))


### PR DESCRIPTION
## Summary

Final PR of Phase 4A. Flips \`discover_serializers\` to validate against the full manifest at lifespan startup (strict mode) and adds a unit-test CI gate that fails when any tool ships without a serializer.

PR4 is small — two commits, four file edits.

## Changes

### 1. \`apps/api/src/unifi_api/server.py\` (lifespan flip)

**Before:** \`discover_serializers(set())\` — trivially passes; missing serializers produced \`{kind: \"empty\"}\` in the catalog.
**After:** \`discover_serializers(set(app.state.manifest_registry.all_tools()))\` — raises \`SerializerRegistryError\` at startup if any tool lacks a serializer.

### 2. \`apps/api/src/unifi_api/serializers/_registry.py\` (test isolation)

\`_reset_registry_for_tests()\` now evicts \`unifi_api.serializers.{network,protect,access}.*\` from \`sys.modules\` so the next \`discover_serializers\` re-imports them and re-fires \`@register_serializer\` decorators. Without this, the module-level registry dicts stayed empty after a reset and any later test calling \`create_app\` failed strict validation. (Phase 3's permissive lifespan didn't surface this gap.)

### 3. \`apps/api/tests/test_serializer_coverage.py\` (CI gate)

```python
def test_every_tool_has_a_serializer() -> None:
    _reset_registry_for_tests()
    manifest = ManifestRegistry.load_from_apps()
    discover_serializers(set(manifest.all_tools()))
```

Sanity-checked by renaming one tool registration — the gate fails with:
\`SerializerRegistryError: missing serializer for 1 tools: ['unifi_list_clients']...\` — exactly the actionable message contributors need.

## Behavior change

Any future MCP tool added without a corresponding serializer:
1. Fails the \`test_every_tool_has_a_serializer\` test in CI
2. Fails app startup in production with the same error message

This is the contributor lint rule for the API surface. Combined with PR1–PR3's curated coverage of all 235 tools, the API now exposes a real \`render_hint\` for every tool — no \`{kind: empty}\` fallbacks.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (51/205/628/336/157) |
| \`unifi-api\` | 284 passed (PR3 baseline 283 + 1 new CI gate test) |
| Manual lifespan smoke | \`lifespan startup ok; covered: 235\` |
| Coverage | 235/235 (complete) |
| Sanity check | gate fails with actionable message when registration removed |

## Phase 4A complete

After PR4 merges, Phase 4A's deliverables are all landed:
- ✅ 235/235 tools have curated serializers (PR1 + PR2 + PR3)
- ✅ Strict \`validate_manifest\` at lifespan startup (PR4)
- ✅ CI gate prevents regression (PR4)
- ✅ Spec §5 amendment for TIMESERIES per-point shape (in PR1)
- ✅ Zero changes outside \`apps/api/\`; zero MCP runtime impact

## Reference

- Spec: Myco \`f30c9c7cf0cea283\` (§5 amended in PR1)
- Plan: Myco \`d519fc75a1c8f819\` (\`docs/superpowers/plans/2026-04-29-phase-4a-serializer-coverage.md\`)
- PR1 (network coverage): merged in #164 as \`e11c8bd\`
- PR2 (protect coverage): merged in #165 as \`04564ac\`
- PR3 (access coverage): merged in #166 as \`ac8eb8d\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)