### PR TITLE
Phase 4B PR2: network MCP tools + provisional STREAM serializers

### DIFF
--- a/apps/api/src/unifi_api/serializers/_base.py
+++ b/apps/api/src/unifi_api/serializers/_base.py
@@ -14,6 +14,7 @@ class RenderKind(str, Enum):
     TIMESERIES = "timeseries"
     EVENT_LOG = "event_log"
     EMPTY = "empty"
+    STREAM = "stream"
 
 
 class SerializerContractError(Exception):
@@ -69,6 +70,8 @@ class Serializer:
         if kind == RenderKind.EMPTY:
             return {"success": True, "render_hint": hint}
         if kind == RenderKind.DIFF:
+            return {"success": True, "data": self.serialize(result), "render_hint": hint}
+        if kind == RenderKind.STREAM:
             return {"success": True, "data": self.serialize(result), "render_hint": hint}
         if kind in (RenderKind.TIMESERIES, RenderKind.EVENT_LOG):
             if not isinstance(result, list):

--- a/apps/api/src/unifi_api/serializers/network/events.py
+++ b/apps/api/src/unifi_api/serializers/network/events.py
@@ -60,3 +60,29 @@ class EventLogSerializer(Serializer):
         if sev is not None:
             out["severity"] = sev
         return out
+
+
+@register_serializer(tools={"unifi_recent_events": {"kind": RenderKind.EVENT_LOG}})
+class NetworkRecentEventsSerializer(EventLogSerializer):
+    """unifi_recent_events emits the same per-event shape as unifi_list_events."""
+
+    pass
+
+
+@register_serializer(tools={"unifi_subscribe_events": {"kind": RenderKind.STREAM}})
+class NetworkStreamSubscriptionSerializer(Serializer):
+    """Phase 4B precursor — returns the SSE URL + buffer metadata.
+
+    Replaces the Phase 4A handle pattern.
+    """
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, dict):
+            return {
+                "stream_url": "/v1/streams/network/events",
+                "transport": "sse",
+                "buffer_size": obj.get("buffer_size"),
+                "instructions": obj.get("instructions"),
+            }
+        return {"stream_url": "/v1/streams/network/events", "transport": "sse"}

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -116,6 +116,65 @@ async def list_alarms(
 
 
 @server.tool(
+    name="unifi_recent_events",
+    description=(
+        "Get recent events from the in-memory websocket buffer. This is fast "
+        "(no API call) and returns events received via the real-time websocket "
+        "stream. Supports filtering by event_type prefix, client/device mac, "
+        "and limit. Use this for real-time monitoring; use unifi_list_events "
+        "for historical queries."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def unifi_recent_events(
+    event_type: Annotated[
+        Optional[str],
+        Field(
+            description="Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events). Use unifi_get_event_types for valid prefixes."
+        ),
+    ] = None,
+    mac: Annotated[
+        Optional[str],
+        Field(description="Filter events to a specific client or device by MAC address. Omit to include all."),
+    ] = None,
+    limit: Annotated[
+        Optional[int],
+        Field(description="Maximum number of events to return from the buffer. Omit to return all buffered events."),
+    ] = None,
+) -> Dict[str, Any]:
+    """Return recent events from the websocket ring buffer."""
+    logger.info("unifi_recent_events called (type=%s, mac=%s)", event_type, mac)
+    mgr = _get_event_manager()
+    events = mgr.get_recent_from_buffer(event_type=event_type, mac=mac, limit=limit)
+    return {"events": events, "count": len(events), "buffer_size": mgr.buffer_size}
+
+
+@server.tool(
+    name="unifi_subscribe_events",
+    description=(
+        "Returns a handle describing how to subscribe to live network events. "
+        "Provides the MCP resource URI for the event stream and pointers to the "
+        "buffered-event tool. Use this to set up continuous event monitoring."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def unifi_subscribe_events() -> Dict[str, Any]:
+    """Return a handle describing how to subscribe to live network events."""
+    logger.info("unifi_subscribe_events called")
+    mgr = _get_event_manager()
+    return {
+        "resource_uri": "unifi://network/events",
+        "summary_uri": "unifi://network/events/recent",
+        "buffer_size": mgr.buffer_size,
+        "instructions": (
+            "Call unifi_recent_events to read buffered events. The unifi-api "
+            "service (if running) exposes /v1/streams/network/events for live "
+            "SSE consumption."
+        ),
+    }
+
+
+@server.tool(
     name="unifi_get_event_types",
     description="""Get a list of known event type prefixes for filtering events.
 

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 167,
+  "count": 169,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -127,6 +127,7 @@
     "unifi_lookup_by_ip": "unifi_network_mcp.tools.clients",
     "unifi_power_cycle_port": "unifi_network_mcp.tools.switch",
     "unifi_reboot_device": "unifi_network_mcp.tools.devices",
+    "unifi_recent_events": "unifi_network_mcp.tools.events",
     "unifi_rename_client": "unifi_network_mcp.tools.clients",
     "unifi_rename_device": "unifi_network_mcp.tools.devices",
     "unifi_revoke_voucher": "unifi_network_mcp.tools.hotspot",
@@ -135,6 +136,7 @@
     "unifi_set_jumbo_frames": "unifi_network_mcp.tools.switch",
     "unifi_set_site_leds": "unifi_network_mcp.tools.devices",
     "unifi_set_switch_port_profile": "unifi_network_mcp.tools.switch",
+    "unifi_subscribe_events": "unifi_network_mcp.tools.events",
     "unifi_toggle_device": "unifi_network_mcp.tools.devices",
     "unifi_toggle_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_toggle_oon_policy": "unifi_network_mcp.tools.oon",
@@ -3228,6 +3230,33 @@
     },
     {
       "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by event_type prefix, client/device mac, and limit. Use this for real-time monitoring; use unifi_list_events for historical queries.",
+      "name": "unifi_recent_events",
+      "schema": {
+        "input": {
+          "properties": {
+            "event_type": {
+              "description": "Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events). Use unifi_get_event_types for valid prefixes.",
+              "type": "string"
+            },
+            "limit": {
+              "description": "Maximum number of events to return from the buffer. Omit to return all buffered events.",
+              "type": "integer"
+            },
+            "mac": {
+              "description": "Filter events to a specific client or device by MAC address. Omit to include all.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false,
@@ -3503,6 +3532,20 @@
             "device_mac",
             "port_overrides"
           ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Returns a handle describing how to subscribe to live network events. Provides the MCP resource URI for the event stream and pointers to the buffered-event tool. Use this to set up continuous event monitoring.",
+      "name": "unifi_subscribe_events",
+      "schema": {
+        "input": {
+          "properties": {},
           "type": "object"
         }
       }

--- a/apps/network/tests/unit/test_subscribe_events_tool.py
+++ b/apps/network/tests/unit/test_subscribe_events_tool.py
@@ -1,0 +1,65 @@
+"""Tests for unifi_subscribe_events and unifi_recent_events MCP tools."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_event_manager():
+    """Patch the network event_manager singleton accessor."""
+    mgr = MagicMock()
+    with patch(
+        "unifi_network_mcp.tools.events._get_event_manager",
+        return_value=mgr,
+    ):
+        yield mgr
+
+
+class TestUnifiRecentEvents:
+    @pytest.mark.asyncio
+    async def test_unifi_recent_events_returns_buffered(self, mock_event_manager):
+        from unifi_network_mcp.tools.events import unifi_recent_events
+
+        mock_event_manager.get_recent_from_buffer.return_value = [
+            {"key": "EVT_WU_Connected", "msg": "client x connected"},
+            {"key": "EVT_WU_Disconnected", "msg": "client x disconnected"},
+        ]
+        mock_event_manager.buffer_size = 7
+
+        result = await unifi_recent_events()
+
+        assert result["count"] == 2
+        assert result["buffer_size"] == 7
+        assert len(result["events"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_unifi_recent_events_passes_filters(self, mock_event_manager):
+        from unifi_network_mcp.tools.events import unifi_recent_events
+
+        mock_event_manager.get_recent_from_buffer.return_value = []
+        mock_event_manager.buffer_size = 0
+
+        await unifi_recent_events(event_type="EVT_WU_", mac="aa:bb:cc:dd:ee:ff", limit=5)
+
+        mock_event_manager.get_recent_from_buffer.assert_called_once_with(
+            event_type="EVT_WU_",
+            mac="aa:bb:cc:dd:ee:ff",
+            limit=5,
+        )
+
+
+class TestUnifiSubscribeEvents:
+    @pytest.mark.asyncio
+    async def test_unifi_subscribe_events_returns_handle_dict(self, mock_event_manager):
+        from unifi_network_mcp.tools.events import unifi_subscribe_events
+
+        mock_event_manager.buffer_size = 12
+        result = await unifi_subscribe_events()
+
+        assert result["resource_uri"] == "unifi://network/events"
+        assert result["summary_uri"] == "unifi://network/events/recent"
+        assert result["buffer_size"] == 12
+        assert "instructions" in result

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (167 tools)
+# Network Server Tool Reference (169 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -384,13 +384,15 @@ Always available, regardless of registration mode.
 ## Events & Alarms
 
 <!-- AUTO:tools:events -->
-5 tools.
+7 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_event_types` | Read | Get a list of known event type prefixes for filtering events. |
 | `unifi_list_alarms` | Read | Returns active alarms (security alerts, connectivity issues, firmware warnings). |
 | `unifi_list_events` | Read | Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest... |
+| `unifi_recent_events` | Read | Get recent events from the in-memory websocket buffer. |
+| `unifi_subscribe_events` | Read | Returns a handle describing how to subscribe to live network events. |
 | `unifi_archive_alarm` | Mutate | Archive (resolve/dismiss) a specific alarm by its ID |
 | `unifi_archive_all_alarms` | Mutate | Archive (resolve/dismiss) all active alarms |
 <!-- /AUTO:tools:events -->


### PR DESCRIPTION
## Summary

Phase 4B PR2: adds \`unifi_subscribe_events\` and \`unifi_recent_events\` MCP tools for parity with protect/access, plus the new \`RenderKind.STREAM\` enum value and provisional serializer registrations to keep Phase 4A's coverage gate green. No HTTP surface yet — that lands in PR3.

## Scope (2 commits)

| Commit | What |
|---|---|
| bc754fc | \`unifi_subscribe_events\` + \`unifi_recent_events\` in \`apps/network/.../tools/events.py\`; manifest regenerated via \`make manifest\` (167 → 169 tools); 3 unit tests |
| c0839d1 | \`RenderKind.STREAM\` added to enum; \`serialize_action\` passes STREAM through like DETAIL; \`NetworkRecentEventsSerializer\` (EVENT_LOG, subclasses existing \`EventLogSerializer\`) and \`NetworkStreamSubscriptionSerializer\` (STREAM, returns SSE URL + buffer metadata) registered. Coverage gate green again. |

## Behavior

- \`unifi_recent_events(event_type, mac, limit)\` → \`{events, count, buffer_size}\` from the network EventManager's ring buffer (populated by PR1's websocket subscription).
- \`unifi_subscribe_events()\` → handle dict pointing to the future SSE URL: \`{resource_uri: \"unifi://network/events\", summary_uri: ..., buffer_size, instructions}\`. PR3 wires the actual \`/v1/streams/network/events\` endpoint.
- \`NetworkStreamSubscriptionSerializer.serialize\` returns \`{stream_url: \"/v1/streams/network/events\", transport: \"sse\", buffer_size, instructions}\` when the action endpoint is called with the subscribe tool.

## Mid-execution adaptations

1. **Network event tools live in \`tools/events.py\`**, not \`tools/system.py\` — the package already has a dedicated events module. Used the existing \`_get_event_manager()\` lazy accessor pattern (matches sibling tools \`list_events\`/\`list_alarms\` in the same file) to avoid the circular-import dance protect/access do.
2. **3 tests instead of 2** — added \`test_unifi_recent_events_passes_filters\` to verify kwargs forwarded to \`get_recent_from_buffer\`.

## Verification

| Surface | Result |
|---|---|
| unifi-core | unchanged (69) |
| unifi-mcp-shared | unchanged (205) |
| unifi-network-mcp | 628 → 631 (+3 tests) |
| unifi-protect-mcp | unchanged (336) |
| unifi-access-mcp | unchanged (157) |
| unifi-api | 284 (unchanged; gate intact) |
| Strict-mode lifespan | covers 237 tools (235 + 2 new) |

## Out of scope

- apps/api SSE surface, SubscriberPool, stream routes, lifespan eager start_listening — PR3
- Migration of existing protect/access \`SubscriptionHandleSerializer\` precursors to STREAM kind — PR3

## Reference

- Spec: Myco \`4dbc206be74e59fa\`
- Plan: Myco \`34590feb305192d9\`
- PR1: merged in #168 as \`86881a1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)