### PR TITLE
Phase 5A PR1: network resource routes (waves 1–3, 32 endpoint families)

### DIFF
--- a/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
@@ -1,0 +1,104 @@
+"""GET /v1/sites/{site_id}/ap-groups[/{group_id}] — AP groups (NetworkManager).
+
+Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing.
+AP groups live on ``NetworkManager`` per Phase 4A discovery, not a separate
+``ApGroupManager``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/ap-groups",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_ap_groups(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "network_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.list_ap_groups()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_ap_groups")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_ap_groups"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/ap-groups/{group_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_ap_group_details(
+    request: Request,
+    site_id: str,
+    group_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "network_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_ap_group_details(group_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"ap group {group_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_ap_group_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_ap_group_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/blocked_clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/blocked_clients.py
@@ -1,0 +1,72 @@
+"""GET /v1/sites/{site_id}/blocked-clients — clients currently blocked from network.
+
+Phase 5A PR1 Cluster 2 — clients & user groups.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _blocked_key(obj) -> tuple:
+    raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+    return (raw.get("last_seen") or 0, raw.get("mac") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/blocked-clients",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_blocked_clients(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_blocked = await mgr.get_blocked_clients()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(all_blocked), limit=limit, cursor=cursor_obj, key_fn=_blocked_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_blocked_clients")
+    items = [serializer.serialize(c) for c in page]
+    hint = registry.render_hint_for_tool("unifi_list_blocked_clients")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/client_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/client_groups.py
@@ -1,0 +1,104 @@
+"""GET /v1/sites/{site_id}/client-groups[/{group_id}] — network member client groups.
+
+Phase 5A PR1 Cluster 2 — clients & user groups.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _group_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/client-groups",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_client_groups(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_group_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_groups = await mgr.get_client_groups()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(all_groups), limit=limit, cursor=cursor_obj, key_fn=_group_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_client_groups")
+    items = [serializer.serialize(g) for g in page]
+    hint = registry.render_hint_for_tool("unifi_list_client_groups")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/client-groups/{group_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_client_group_details(
+    request: Request,
+    site_id: str,
+    group_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_group_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        group = await mgr.get_client_group_by_id(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="client group not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_client_group_details")
+    return {
+        "data": serializer.serialize(group),
+        "render_hint": registry.render_hint_for_tool("unifi_get_client_group_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -98,3 +98,38 @@ async def get_device(
         "data": serializer.serialize(device),
         "render_hint": registry.render_hint_for_resource("network", "devices/{mac}"),
     }
+
+
+@router.get(
+    "/sites/{site_id}/devices/{mac}/radio",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_device_radio(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        radio = await mgr.get_device_radio(mac)
+    if radio is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"device radio config for {mac} not found",
+        )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_device_radio")
+    return {
+        "data": serializer.serialize(radio),
+        "render_hint": registry.render_hint_for_tool("unifi_get_device_radio"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dns.py
@@ -1,0 +1,104 @@
+"""GET /v1/sites/{site_id}/dns-records[/{record_id}] — V2 static-DNS records.
+
+Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/dns-records",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_dns_records(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "dns_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.list_dns_records()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_dns_records")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_dns_records"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/dns-records/{record_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_dns_record_details(
+    request: Request,
+    site_id: str,
+    record_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "dns_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        # dns_manager exposes get_dns_record (no `_by_id` suffix); the manifest
+        # tool name is unifi_get_dns_record_details.
+        item = await mgr.get_dns_record(record_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"dns record {record_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_dns_record_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_dns_record_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/lldp.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lldp.py
@@ -1,0 +1,86 @@
+"""GET /v1/sites/{site_id}/lldp-neighbors — LLDP discovery (wrapper-dict → LIST).
+
+Manager returns ``{name, model, lldp_table: [...]}`` per device. The route
+unwraps the ``lldp_table`` array and exposes it as a paginated LIST.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _lldp_key(row) -> tuple:
+    if isinstance(row, dict):
+        return (row.get("local_port_idx") or 0, row.get("chassis_id") or "")
+    return (0, "")
+
+
+def _normalize_lldp_row(r: dict) -> dict:
+    return {
+        "local_port_idx": r.get("local_port_idx"),
+        "chassis_id": r.get("chassis_id"),
+        "port_id": r.get("port_id"),
+        "system_name": r.get("system_name"),
+        "capabilities": r.get("capabilities", []) or [],
+    }
+
+
+@router.get(
+    "/sites/{site_id}/lldp-neighbors",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_lldp_neighbors(
+    request: Request,
+    site_id: str,
+    device_mac: str = Query(..., description="MAC address of the switch"),
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "switch_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        wrapper = await mgr.get_lldp_neighbors(device_mac)
+    if wrapper is None:
+        raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")
+
+    items_raw = wrapper.get("lldp_table", []) if isinstance(wrapper, dict) else []
+
+    cursor_obj: Cursor | None = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(items_raw), limit=limit, cursor=cursor_obj, key_fn=_lldp_key,
+    )
+
+    items = [_normalize_lldp_row(r) for r in page]
+    registry = request.app.state.serializer_registry
+    hint = registry.render_hint_for_tool("unifi_get_lldp_neighbors")
+    hint = {**hint, "kind": "list"}
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/lookup.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lookup.py
@@ -1,0 +1,52 @@
+"""GET /v1/sites/{site_id}/lookup-by-ip — find a client by IP address.
+
+Phase 5A PR1 Cluster 2 — clients & user groups. Single DETAIL endpoint
+backed by ``ClientManager.get_client_by_ip`` (Phase 4A discovered the
+manager method name diverges from the tool name).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/sites/{site_id}/lookup-by-ip",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def lookup_client_by_ip(
+    request: Request,
+    site_id: str,
+    ip: str = Query(..., description="Client IP address to look up"),
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        client = await mgr.get_client_by_ip(ip)
+    if client is None:
+        raise HTTPException(status_code=404, detail=f"client with ip {ip} not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_lookup_by_ip")
+    return {
+        "data": serializer.serialize(client),
+        "render_hint": registry.render_hint_for_tool("unifi_lookup_by_ip"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/rogue_aps.py
+++ b/apps/api/src/unifi_api/routes/resources/network/rogue_aps.py
@@ -1,0 +1,168 @@
+"""GET /v1/sites/{site_id}/{rogue-aps,known-rogue-aps,rf-scan-results}.
+
+RF environment LIST endpoints. ``rogue-aps`` and ``known-rogue-aps`` share the
+RogueApSerializer (Phase 4A) — the route passes ``tool_name`` so the serializer
+can stamp ``is_known`` correctly.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _bssid_key(row) -> tuple:
+    if isinstance(row, dict):
+        return (row.get("last_seen") or 0, row.get("bssid") or "")
+    return (0, "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+def _serialize_rogue(row, *, is_known: bool) -> dict:
+    """Mirror RogueApSerializer._row — kept inline because the serializer's
+    tool-name-aware path is `serialize_action`, not `serialize`."""
+    if not isinstance(row, dict):
+        return {}
+    return {
+        "bssid": row.get("bssid"),
+        "ssid": row.get("essid") or row.get("ssid"),
+        "channel": row.get("channel"),
+        "signal_dbm": row.get("rssi") or row.get("signal"),
+        "last_seen": row.get("last_seen"),
+        "is_known": is_known,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/rogue-aps",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_rogue_aps(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    within_hours: int = Query(24, ge=1, le=168),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        rows = await mgr.list_rogue_aps(within_hours)
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(rows), limit=limit, cursor=cursor_obj, key_fn=_bssid_key,
+    )
+
+    items = [_serialize_rogue(r, is_known=False) for r in page]
+    registry = request.app.state.serializer_registry
+    hint = registry.render_hint_for_tool("unifi_list_rogue_aps")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/known-rogue-aps",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_known_rogue_aps(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        rows = await mgr.list_known_rogue_aps()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(rows), limit=limit, cursor=cursor_obj, key_fn=_bssid_key,
+    )
+
+    items = [_serialize_rogue(r, is_known=True) for r in page]
+    registry = request.app.state.serializer_registry
+    hint = registry.render_hint_for_tool("unifi_list_known_rogue_aps")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/rf-scan-results",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_rf_scan_results(
+    request: Request,
+    site_id: str,
+    ap_mac: str = Query(..., description="MAC address of the access point"),
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        rows = await mgr.get_rf_scan_results(ap_mac)
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(rows or []), limit=limit, cursor=cursor_obj, key_fn=_bssid_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_rf_scan_results")
+    items = [serializer.serialize(r) for r in page]
+    hint = registry.render_hint_for_tool("unifi_get_rf_scan_results")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/routes.py
+++ b/apps/api/src/unifi_api/routes/resources/network/routes.py
@@ -1,0 +1,215 @@
+"""GET routes for active routes, static routes, and traffic routes.
+
+Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing.
+Three resources in one module since they all live in the routing domain.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+# ---------- active routes ----------
+
+
+@router.get(
+    "/sites/{site_id}/active-routes",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_active_routes(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "routing_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_active_routes()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_active_routes")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_active_routes"),
+    }
+
+
+# ---------- static routes ----------
+
+
+@router.get(
+    "/sites/{site_id}/static-routes",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_routes(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "routing_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_routes()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_routes")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_routes"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/static-routes/{route_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_route_details(
+    request: Request,
+    site_id: str,
+    route_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "routing_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_route_details(route_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail=f"route {route_id} not found")
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_route_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_route_details"),
+    }
+
+
+# ---------- traffic routes ----------
+
+
+@router.get(
+    "/sites/{site_id}/traffic-routes",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_traffic_routes(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "traffic_route_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_traffic_routes()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_traffic_routes")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_traffic_routes"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/traffic-routes/{route_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_traffic_route_details(
+    request: Request,
+    site_id: str,
+    route_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "traffic_route_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_traffic_route_details(route_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"traffic route {route_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_traffic_route_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_traffic_route_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/speedtest.py
+++ b/apps/api/src/unifi_api/routes/resources/network/speedtest.py
@@ -1,0 +1,45 @@
+"""GET /v1/sites/{site_id}/speedtest-status — gateway speedtest status (DETAIL)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/sites/{site_id}/speedtest-status",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_speedtest_status(
+    request: Request,
+    site_id: str,
+    gateway_mac: str = Query(..., description="MAC address of the gateway device"),
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        status = await mgr.get_speedtest_status(gateway_mac)
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_speedtest_status")
+    return {
+        "data": serializer.serialize(status or {}),
+        "render_hint": registry.render_hint_for_tool("unifi_get_speedtest_status"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/switch.py
+++ b/apps/api/src/unifi_api/routes/resources/network/switch.py
@@ -1,0 +1,276 @@
+"""GET /v1/sites/{site_id}/{port-profiles,switch-ports,port-stats,switch-capabilities}.
+
+Phase 5A PR1 Cluster 1 — switch-side read endpoints.
+
+Wrapper-dict tools (``switch-ports``, ``port-stats``) return the inner array
+of rows for the LIST contract — the manager produces ``{name, model, port_table: [...]}``
+which the route unwraps before paginating. The Phase 4A serializer for these
+tools is registered as DETAIL on the wrapper, so the route handler does the
+row-level serialization inline (matching the wrapper serializer's row shape).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _profile_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _port_idx_key(p) -> tuple:
+    if isinstance(p, dict):
+        return (p.get("port_idx") or 0, "")
+    return (0, "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+# ---------------- port profiles ----------------
+
+
+@router.get(
+    "/sites/{site_id}/port-profiles",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_port_profiles(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "switch_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_profiles = await mgr.get_port_profiles()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(all_profiles), limit=limit, cursor=cursor_obj, key_fn=_profile_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_port_profiles")
+    items = [serializer.serialize(p) for p in page]
+    hint = registry.render_hint_for_tool("unifi_list_port_profiles")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/port-profiles/{profile_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_port_profile_details(
+    request: Request,
+    site_id: str,
+    profile_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "switch_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        profile = await mgr.get_port_profile_by_id(profile_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="port profile not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_port_profile_details")
+    return {
+        "data": serializer.serialize(profile),
+        "render_hint": registry.render_hint_for_tool("unifi_get_port_profile_details"),
+    }
+
+
+# ---------------- switch ports (wrapper-dict → LIST) ----------------
+
+
+def _normalize_port_override(p: dict) -> dict:
+    return {
+        "port_idx": p.get("port_idx"),
+        "name": p.get("name"),
+        "portconf_id": p.get("portconf_id"),
+        "poe_mode": p.get("poe_mode"),
+        "op_mode": p.get("op_mode"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/switch-ports",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_switch_ports(
+    request: Request,
+    site_id: str,
+    device_mac: str = Query(..., description="MAC address of the switch"),
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "switch_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        wrapper = await mgr.get_switch_ports(device_mac)
+    if wrapper is None:
+        raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")
+
+    items_raw = wrapper.get("port_overrides", []) if isinstance(wrapper, dict) else []
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items_raw), limit=limit, cursor=cursor_obj, key_fn=_port_idx_key,
+    )
+
+    items = [_normalize_port_override(p) for p in page]
+    registry = request.app.state.serializer_registry
+    hint = registry.render_hint_for_tool("unifi_get_switch_ports")
+    # Override kind to list since the route exposes the unwrapped rows.
+    hint = {**hint, "kind": "list"}
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+# ---------------- port stats (wrapper-dict → LIST) ----------------
+
+
+def _normalize_port_stat(p: dict) -> dict:
+    return {
+        "port_idx": p.get("port_idx"),
+        "name": p.get("name"),
+        "enable": bool(p.get("enable", True)),
+        "speed": p.get("speed"),
+        "duplex": p.get("full_duplex"),
+        "tx_bytes": p.get("tx_bytes", 0),
+        "rx_bytes": p.get("rx_bytes", 0),
+        "tx_packets": p.get("tx_packets", 0),
+        "rx_packets": p.get("rx_packets", 0),
+        "tx_dropped": p.get("tx_dropped", 0),
+        "rx_dropped": p.get("rx_dropped", 0),
+        "poe_enable": bool(p.get("poe_enable", False)),
+        "poe_mode": p.get("poe_mode"),
+        "poe_power": p.get("poe_power"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/port-stats",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_port_stats(
+    request: Request,
+    site_id: str,
+    device_mac: str = Query(..., description="MAC address of the switch"),
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "switch_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        wrapper = await mgr.get_port_stats(device_mac)
+    if wrapper is None:
+        raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")
+
+    items_raw = wrapper.get("port_table", []) if isinstance(wrapper, dict) else []
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items_raw), limit=limit, cursor=cursor_obj, key_fn=_port_idx_key,
+    )
+
+    items = [_normalize_port_stat(p) for p in page]
+    registry = request.app.state.serializer_registry
+    hint = registry.render_hint_for_tool("unifi_get_port_stats")
+    hint = {**hint, "kind": "list"}
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+# ---------------- switch capabilities (DETAIL) ----------------
+
+
+@router.get(
+    "/sites/{site_id}/switch-capabilities",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_switch_capabilities(
+    request: Request,
+    site_id: str,
+    device_mac: str = Query(..., description="MAC address of the switch"),
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "switch_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        caps = await mgr.get_switch_capabilities(device_mac)
+    if caps is None:
+        raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_switch_capabilities")
+    return {
+        "data": serializer.serialize(caps),
+        "render_hint": registry.render_hint_for_tool("unifi_get_switch_capabilities"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/user_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/user_groups.py
@@ -1,0 +1,106 @@
+"""GET /v1/sites/{site_id}/user-groups[/{group_id}] — usergroups (QoS bandwidth profiles).
+
+Phase 5A PR1 Cluster 2 — clients & user groups. Manager methods are
+``UsergroupManager.get_usergroups`` (LIST) and ``get_usergroup_details``
+(DETAIL); the route exposes the canonical ``/user-groups`` path.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _group_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/user-groups",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_user_groups(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "usergroup_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        all_groups = await mgr.get_usergroups()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(all_groups), limit=limit, cursor=cursor_obj, key_fn=_group_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_usergroups")
+    items = [serializer.serialize(g) for g in page]
+    hint = registry.render_hint_for_tool("unifi_list_usergroups")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/user-groups/{group_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_user_group_details(
+    request: Request,
+    site_id: str,
+    group_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "usergroup_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        group = await mgr.get_usergroup_details(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="user group not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_usergroup_details")
+    return {
+        "data": serializer.serialize(group),
+        "render_hint": registry.render_hint_for_tool("unifi_get_usergroup_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/vpn.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vpn.py
@@ -1,0 +1,177 @@
+"""GET routes for VPN clients and VPN servers.
+
+Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+# ---------- VPN clients ----------
+
+
+@router.get(
+    "/sites/{site_id}/vpn-clients",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_vpn_clients(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "vpn_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_vpn_clients()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_vpn_clients")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_vpn_clients"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/vpn-clients/{client_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_vpn_client_details(
+    request: Request,
+    site_id: str,
+    client_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "vpn_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_vpn_client_details(client_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"vpn client {client_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_vpn_client_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_vpn_client_details"),
+    }
+
+
+# ---------- VPN servers ----------
+
+
+@router.get(
+    "/sites/{site_id}/vpn-servers",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_vpn_servers(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "vpn_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_vpn_servers()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_vpn_servers")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_vpn_servers"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/vpn-servers/{server_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_vpn_server_details(
+    request: Request,
+    site_id: str,
+    server_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "vpn_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_vpn_server_details(server_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"vpn server {server_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_vpn_server_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_vpn_server_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/wireless.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wireless.py
@@ -1,0 +1,67 @@
+"""GET /v1/sites/{site_id}/available-channels — regulatory-domain channel list."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _channel_key(row) -> tuple:
+    if isinstance(row, dict):
+        return (row.get("channel") or 0, "")
+    return (0, "")
+
+
+@router.get(
+    "/sites/{site_id}/available-channels",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_available_channels(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        rows = await mgr.list_available_channels()
+
+    cursor_obj: Cursor | None = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(rows or []), limit=limit, cursor=cursor_obj, key_fn=_channel_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_available_channels")
+    items = [serializer.serialize(r) for r in page]
+    hint = registry.render_hint_for_tool("unifi_list_available_channels")
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -20,18 +20,22 @@ from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
 from unifi_api.routes.resources.network import (
+    ap_groups as net_ap_groups_routes,
     blocked_clients as net_blocked_clients_routes,
     client_groups as net_client_groups_routes,
     clients as net_clients_routes,
     devices as net_devices_routes,
+    dns as net_dns_routes,
     firewall_rules as net_firewall_routes,
     lldp as net_lldp_routes,
     lookup as net_lookup_routes,
     networks as net_networks_routes,
     rogue_aps as net_rogue_aps_routes,
+    routes as net_routes_routes,
     speedtest as net_speedtest_routes,
     switch as net_switch_routes,
     user_groups as net_user_groups_routes,
+    vpn as net_vpn_routes,
     wireless as net_wireless_routes,
     wlans as net_wlans_routes,
 )
@@ -180,6 +184,10 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_client_groups_routes,
         net_user_groups_routes,
         net_lookup_routes,
+        net_routes_routes,
+        net_dns_routes,
+        net_vpn_routes,
+        net_ap_groups_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -23,7 +23,12 @@ from unifi_api.routes.resources.network import (
     clients as net_clients_routes,
     devices as net_devices_routes,
     firewall_rules as net_firewall_routes,
+    lldp as net_lldp_routes,
     networks as net_networks_routes,
+    rogue_aps as net_rogue_aps_routes,
+    speedtest as net_speedtest_routes,
+    switch as net_switch_routes,
+    wireless as net_wireless_routes,
     wlans as net_wlans_routes,
 )
 from unifi_api.routes.resources.protect import (
@@ -162,6 +167,11 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_networks_routes,
         net_firewall_routes,
         net_wlans_routes,
+        net_switch_routes,
+        net_lldp_routes,
+        net_rogue_aps_routes,
+        net_wireless_routes,
+        net_speedtest_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -20,14 +20,18 @@ from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
 from unifi_api.routes.resources.network import (
+    blocked_clients as net_blocked_clients_routes,
+    client_groups as net_client_groups_routes,
     clients as net_clients_routes,
     devices as net_devices_routes,
     firewall_rules as net_firewall_routes,
     lldp as net_lldp_routes,
+    lookup as net_lookup_routes,
     networks as net_networks_routes,
     rogue_aps as net_rogue_aps_routes,
     speedtest as net_speedtest_routes,
     switch as net_switch_routes,
+    user_groups as net_user_groups_routes,
     wireless as net_wireless_routes,
     wlans as net_wlans_routes,
 )
@@ -172,6 +176,10 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_rogue_aps_routes,
         net_wireless_routes,
         net_speedtest_routes,
+        net_blocked_clients_routes,
+        net_client_groups_routes,
+        net_user_groups_routes,
+        net_lookup_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/tests/routes/resources/test_network_clients_groups.py
+++ b/apps/api/tests/routes/resources/test_network_clients_groups.py
@@ -1,0 +1,312 @@
+"""Phase 5A PR1 Cluster 2 — clients & user groups resource routes."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+# ---------- blocked clients ----------
+
+
+@pytest.mark.asyncio
+async def test_list_blocked_clients_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_blocked = [
+        {"mac": f"aa:bb:cc:dd:ee:0{i}", "hostname": f"host-{i}",
+         "blocked": True, "last_seen": 1700000000 - i}
+        for i in range(3)
+    ]
+
+    async def fake_get_blocked(self):
+        return fake_blocked
+
+    from unifi_core.network.managers.client_manager import ClientManager
+    monkeypatch.setattr(ClientManager, "get_blocked_clients", fake_get_blocked)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/blocked-clients?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "items" in body and "next_cursor" in body and "render_hint" in body
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 3
+    assert all(item["blocked"] is True for item in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_list_blocked_clients_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")  # no network
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/blocked-clients?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "network"
+
+
+# ---------- client groups ----------
+
+
+@pytest.mark.asyncio
+async def test_list_client_groups_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_groups = [
+        {"_id": f"cg-{i}", "name": f"group-{i}", "type": "manual"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self):
+        return fake_groups
+
+    from unifi_core.network.managers.client_group_manager import ClientGroupManager
+    monkeypatch.setattr(ClientGroupManager, "get_client_groups", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/client-groups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_client_group_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "cg-1", "name": "marketing", "type": "manual"}
+
+    async def fake_get(self, group_id):
+        return target if group_id == "cg-1" else None
+
+    from unifi_core.network.managers.client_group_manager import ClientGroupManager
+    monkeypatch.setattr(ClientGroupManager, "get_client_group_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/client-groups/cg-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "data" in body and "render_hint" in body
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_client_group_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, group_id):
+        return None
+
+    from unifi_core.network.managers.client_group_manager import ClientGroupManager
+    monkeypatch.setattr(ClientGroupManager, "get_client_group_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/client-groups/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- user groups (usergroups, bandwidth profiles) ----------
+
+
+@pytest.mark.asyncio
+async def test_list_user_groups_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_groups = [
+        {"_id": f"ug-{i}", "name": f"qos-{i}",
+         "qos_rate_max_down": 1000, "qos_rate_max_up": 500}
+        for i in range(2)
+    ]
+
+    async def fake_list(self):
+        return fake_groups
+
+    from unifi_core.network.managers.usergroup_manager import UsergroupManager
+    monkeypatch.setattr(UsergroupManager, "get_usergroups", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/user-groups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_user_group_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "ug-1", "name": "premium",
+              "qos_rate_max_down": 5000, "qos_rate_max_up": 2000}
+
+    async def fake_get(self, group_id):
+        return target if group_id == "ug-1" else None
+
+    from unifi_core.network.managers.usergroup_manager import UsergroupManager
+    monkeypatch.setattr(UsergroupManager, "get_usergroup_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/user-groups/ug-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "data" in body and "render_hint" in body
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------- lookup-by-ip ----------
+
+
+@pytest.mark.asyncio
+async def test_lookup_by_ip_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"mac": "aa:bb:cc:dd:ee:01", "last_ip": "10.0.0.5",
+              "hostname": "kiosk-1", "is_online": True, "last_seen": 1700000000}
+
+    async def fake_lookup(self, ip):
+        return target if ip == "10.0.0.5" else None
+
+    from unifi_core.network.managers.client_manager import ClientManager
+    monkeypatch.setattr(ClientManager, "get_client_by_ip", fake_lookup)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/lookup-by-ip?controller={cid}&ip=10.0.0.5",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "data" in body and "render_hint" in body
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["ip"] == "10.0.0.5"
+    assert body["data"]["is_online"] is True
+
+
+@pytest.mark.asyncio
+async def test_lookup_by_ip_missing_ip_query_param(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/lookup-by-ip?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    # FastAPI returns 422 for missing required query parameters.
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_lookup_by_ip_not_found(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_lookup(self, ip):
+        return None
+
+    from unifi_core.network.managers.client_manager import ClientManager
+    monkeypatch.setattr(ClientManager, "get_client_by_ip", fake_lookup)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/lookup-by-ip?controller={cid}&ip=10.0.0.99",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404

--- a/apps/api/tests/routes/resources/test_network_config.py
+++ b/apps/api/tests/routes/resources/test_network_config.py
@@ -1,0 +1,505 @@
+"""Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing config resource routes.
+
+Covers active routes, static routes, traffic routes, DNS records, VPN clients,
+VPN servers, and AP groups (LIST + DETAIL where the manifest has details).
+"""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+# ---------- active routes ----------
+
+
+@pytest.mark.asyncio
+async def test_list_active_routes_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"pfx": "10.0.0.0/24", "nh": [{"via": "10.0.0.1", "intf": "eth0"}], "metric": 1},
+        {"pfx": "192.168.1.0/24", "nh": [{"via": "192.168.1.1", "intf": "eth1"}], "metric": 2},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.routing_manager import RoutingManager
+    monkeypatch.setattr(RoutingManager, "get_active_routes", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/active-routes?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    assert body["items"][0]["gateway"] == "10.0.0.1"
+    assert body["items"][0]["interface"] == "eth0"
+
+
+@pytest.mark.asyncio
+async def test_list_active_routes_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/active-routes?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409
+    assert r.json()["detail"]["kind"] == "capability_mismatch"
+
+
+# ---------- static routes ----------
+
+
+@pytest.mark.asyncio
+async def test_list_routes_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": f"sr-{i}", "name": f"route-{i}",
+         "static-route_network": f"10.{i}.0.0/24",
+         "static-route_nexthop": f"10.{i}.0.1",
+         "static-route_distance": 1, "enabled": True}
+        for i in range(2)
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.routing_manager import RoutingManager
+    monkeypatch.setattr(RoutingManager, "get_routes", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/static-routes?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    # paginate() sorts descending; sr-1 comes before sr-0.
+    subnets = {i["target_subnet"] for i in body["items"]}
+    assert subnets == {"10.0.0.0/24", "10.1.0.0/24"}
+
+
+@pytest.mark.asyncio
+async def test_get_route_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "sr-1", "name": "office",
+              "static-route_network": "10.5.0.0/24",
+              "static-route_nexthop": "10.5.0.1", "enabled": True}
+
+    async def fake_get(self, route_id):
+        return target if route_id == "sr-1" else None
+
+    from unifi_core.network.managers.routing_manager import RoutingManager
+    monkeypatch.setattr(RoutingManager, "get_route_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/static-routes/sr-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["target_subnet"] == "10.5.0.0/24"
+
+
+@pytest.mark.asyncio
+async def test_get_route_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, route_id):
+        return None
+
+    from unifi_core.network.managers.routing_manager import RoutingManager
+    monkeypatch.setattr(RoutingManager, "get_route_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/static-routes/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- traffic routes ----------
+
+
+@pytest.mark.asyncio
+async def test_list_traffic_routes_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "tr-1", "description": "vpn-traffic",
+         "matching_target": "DOMAIN", "domains": ["example.com"],
+         "next_hop": "wg0", "enabled": True},
+        {"_id": "tr-2", "description": "iot",
+         "matching_target": "IP", "ip_addresses": ["8.8.8.8"],
+         "enabled": False},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.traffic_route_manager import TrafficRouteManager
+    monkeypatch.setattr(TrafficRouteManager, "get_traffic_routes", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/traffic-routes?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    # Note: traffic routes use `description` for the human-readable name.
+    names = {i["name"] for i in body["items"]}
+    assert names == {"vpn-traffic", "iot"}
+
+
+@pytest.mark.asyncio
+async def test_get_traffic_route_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "tr-1", "description": "vpn-traffic",
+              "matching_target": "DOMAIN", "domains": ["example.com"],
+              "enabled": True}
+
+    async def fake_get(self, route_id):
+        return target if route_id == "tr-1" else None
+
+    from unifi_core.network.managers.traffic_route_manager import TrafficRouteManager
+    monkeypatch.setattr(TrafficRouteManager, "get_traffic_route_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/traffic-routes/tr-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["name"] == "vpn-traffic"
+
+
+# ---------- DNS records ----------
+
+
+@pytest.mark.asyncio
+async def test_list_dns_records_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": f"dns-{i}", "key": f"host-{i}.local",
+         "value": f"10.0.0.{10 + i}", "record_type": "A", "enabled": True}
+        for i in range(2)
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.dns_manager import DnsManager
+    monkeypatch.setattr(DnsManager, "list_dns_records", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dns-records?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dns_record_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "dns-1", "key": "host-1.local",
+              "value": "10.0.0.11", "record_type": "A", "enabled": True}
+
+    async def fake_get(self, record_id):
+        return target if record_id == "dns-1" else None
+
+    from unifi_core.network.managers.dns_manager import DnsManager
+    monkeypatch.setattr(DnsManager, "get_dns_record", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dns-records/dns-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_dns_record_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, record_id):
+        return None
+
+    from unifi_core.network.managers.dns_manager import DnsManager
+    monkeypatch.setattr(DnsManager, "get_dns_record", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dns-records/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- VPN clients ----------
+
+
+@pytest.mark.asyncio
+async def test_list_vpn_clients_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": f"vc-{i}", "name": f"client-{i}",
+         "vpn_type": "wireguard-client", "enabled": True}
+        for i in range(2)
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.vpn_manager import VpnManager
+    monkeypatch.setattr(VpnManager, "get_vpn_clients", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/vpn-clients?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_vpn_client_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "vc-1", "name": "client-1",
+              "vpn_type": "wireguard-client", "enabled": True}
+
+    async def fake_get(self, client_id):
+        return target if client_id == "vc-1" else None
+
+    from unifi_core.network.managers.vpn_manager import VpnManager
+    monkeypatch.setattr(VpnManager, "get_vpn_client_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/vpn-clients/vc-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------- VPN servers ----------
+
+
+@pytest.mark.asyncio
+async def test_list_vpn_servers_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": f"vs-{i}", "name": f"server-{i}",
+         "vpn_type": "wireguard-server", "enabled": True}
+        for i in range(2)
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.vpn_manager import VpnManager
+    monkeypatch.setattr(VpnManager, "get_vpn_servers", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/vpn-servers?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_vpn_server_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, server_id):
+        return None
+
+    from unifi_core.network.managers.vpn_manager import VpnManager
+    monkeypatch.setattr(VpnManager, "get_vpn_server_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/vpn-servers/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- AP groups ----------
+
+
+@pytest.mark.asyncio
+async def test_list_ap_groups_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": f"apg-{i}", "name": f"group-{i}",
+         "device_macs": [f"aa:bb:cc:dd:ee:0{i}"]}
+        for i in range(2)
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.network_manager import NetworkManager
+    monkeypatch.setattr(NetworkManager, "list_ap_groups", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/ap-groups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_ap_group_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "apg-1", "name": "lobby",
+              "device_macs": ["aa:bb:cc:dd:ee:01"]}
+
+    async def fake_get(self, group_id):
+        return target if group_id == "apg-1" else None
+
+    from unifi_core.network.managers.network_manager import NetworkManager
+    monkeypatch.setattr(NetworkManager, "get_ap_group_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/ap-groups/apg-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/routes/resources/test_network_devices_switches.py
+++ b/apps/api/tests/routes/resources/test_network_devices_switches.py
@@ -1,0 +1,407 @@
+"""Phase 5A PR1 Cluster 1 — devices & switches resource routes."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+# ---------- port profiles ----------
+
+
+@pytest.mark.asyncio
+async def test_list_port_profiles_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_profiles = [
+        {"_id": f"pp-{i}", "name": f"profile-{i}", "poe_mode": "auto",
+         "native_networkconf_id": f"net-{i}"}
+        for i in range(3)
+    ]
+
+    async def fake_get_port_profiles(self, *a, **kw):
+        return fake_profiles
+
+    from unifi_core.network.managers.switch_manager import SwitchManager
+    monkeypatch.setattr(SwitchManager, "get_port_profiles", fake_get_port_profiles)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-profiles?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "items" in body and "next_cursor" in body and "render_hint" in body
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 3
+    assert {item["id"] for item in body["items"]} == {"pp-0", "pp-1", "pp-2"}
+
+
+@pytest.mark.asyncio
+async def test_list_port_profiles_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")  # no network
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-profiles?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "network"
+
+
+@pytest.mark.asyncio
+async def test_get_port_profile_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "pp-1", "name": "trunk-all", "poe_mode": "off",
+              "native_networkconf_id": "n-1"}
+
+    async def fake_get(self, profile_id):
+        return target if profile_id == "pp-1" else None
+
+    from unifi_core.network.managers.switch_manager import SwitchManager
+    monkeypatch.setattr(SwitchManager, "get_port_profile_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-profiles/pp-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "data" in body and "render_hint" in body
+    assert body["data"]["id"] == "pp-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_port_profile_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, profile_id):
+        return None
+
+    from unifi_core.network.managers.switch_manager import SwitchManager
+    monkeypatch.setattr(SwitchManager, "get_port_profile_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-profiles/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- switch ports (wrapper-dict) ----------
+
+
+@pytest.mark.asyncio
+async def test_list_switch_ports_unwraps_wrapper_dict(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    wrapper = {
+        "name": "sw-1",
+        "model": "US-24",
+        "port_overrides": [
+            {"port_idx": i, "name": f"Port {i}", "portconf_id": f"pc-{i}",
+             "poe_mode": "auto", "op_mode": "switch"}
+            for i in range(4)
+        ],
+    }
+
+    async def fake_get_switch_ports(self, mac):
+        return wrapper
+
+    from unifi_core.network.managers.switch_manager import SwitchManager
+    monkeypatch.setattr(SwitchManager, "get_switch_ports", fake_get_switch_ports)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/switch-ports?controller={cid}&device_mac=aa:bb:cc:dd:ee:01",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "items" in body
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 4
+    # Pagination sorts descending by (port_idx, ""), so highest comes first.
+    assert body["items"][0]["port_idx"] == 3
+    assert body["items"][-1]["port_idx"] == 0
+
+
+# ---------- LLDP neighbors (wrapper-dict) ----------
+
+
+@pytest.mark.asyncio
+async def test_list_lldp_neighbors_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    wrapper = {
+        "name": "sw-1",
+        "model": "US-24",
+        "lldp_table": [
+            {"local_port_idx": 1, "chassis_id": "11:22:33:44:55:66",
+             "port_id": "1", "system_name": "neighbor-a", "capabilities": ["bridge"]},
+            {"local_port_idx": 2, "chassis_id": "aa:bb:cc:dd:ee:ff",
+             "port_id": "2", "system_name": "neighbor-b", "capabilities": []},
+        ],
+    }
+
+    async def fake_lldp(self, mac):
+        return wrapper
+
+    from unifi_core.network.managers.switch_manager import SwitchManager
+    monkeypatch.setattr(SwitchManager, "get_lldp_neighbors", fake_lldp)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/lldp-neighbors?controller={cid}&device_mac=aa:bb:cc:dd:ee:01",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    # Descending sort by local_port_idx — neighbor-b (port 2) first.
+    assert body["items"][0]["system_name"] == "neighbor-b"
+    assert body["items"][-1]["system_name"] == "neighbor-a"
+
+
+# ---------- rogue APs ----------
+
+
+@pytest.mark.asyncio
+async def test_list_rogue_aps_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_rogues = [
+        {"bssid": f"de:ad:be:ef:00:0{i}", "essid": f"NeighborSSID-{i}",
+         "channel": 6, "rssi": -60 - i, "last_seen": 1700000000 - i}
+        for i in range(3)
+    ]
+
+    async def fake_list(self, within_hours=24):
+        return fake_rogues
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "list_rogue_aps", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/rogue-aps?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 3
+    assert body["items"][0]["bssid"].startswith("de:ad:be:ef:")
+
+
+@pytest.mark.asyncio
+async def test_list_known_rogue_aps_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_known = [
+        {"bssid": f"11:22:33:44:55:0{i}", "essid": f"Known-{i}",
+         "channel": 36, "rssi": -55, "last_seen": 1700000000}
+        for i in range(2)
+    ]
+
+    async def fake_known_list(self, *a, **kw):
+        return fake_known
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "list_known_rogue_aps", fake_known_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/known-rogue-aps?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    assert all(item["is_known"] for item in body["items"])
+
+
+# ---------- speedtest status ----------
+
+
+@pytest.mark.asyncio
+async def test_get_speedtest_status_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_status = {"status": 0, "status_download": 875.5, "status_upload": 42.1,
+                   "latency": 8, "rundate": 1700000000}
+
+    async def fake_get_status(self, gateway_mac):
+        return fake_status
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "get_speedtest_status", fake_get_status)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/speedtest-status?controller={cid}&gateway_mac=00:11:22:33:44:55",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "data" in body and "render_hint" in body
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["download_mbps"] == 875.5
+    assert body["data"]["status"] == "idle"
+
+
+# ---------- available channels ----------
+
+
+@pytest.mark.asyncio
+async def test_list_available_channels_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_channels = [
+        {"channel": 1, "freq": 2412, "ht": 20, "allowed": True},
+        {"channel": 6, "freq": 2437, "ht": 20, "allowed": True},
+        {"channel": 11, "freq": 2462, "ht": 20, "allowed": True},
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_channels
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "list_available_channels", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/available-channels?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 3
+    # Descending sort by channel — 11 first, 1 last.
+    assert {item["channel"] for item in body["items"]} == {1, 6, 11}
+    assert body["items"][0]["channel"] == 11
+
+
+# ---------- device radio (extension to /devices/{mac}/radio) ----------
+
+
+@pytest.mark.asyncio
+async def test_get_device_radio_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_radio = {
+        "mac": "aa:bb:cc:dd:ee:01",
+        "name": "ap-1",
+        "model": "U6",
+        "radios": [
+            {"name": "wifi0", "radio": "ng", "channel": 6, "ht": "20",
+             "tx_power": 20, "tx_power_mode": "auto",
+             "current_channel": 6, "current_tx_power": 20, "num_sta": 5},
+        ],
+    }
+
+    async def fake_radio_get(self, mac):
+        return fake_radio if mac == "aa:bb:cc:dd:ee:01" else None
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "get_device_radio", fake_radio_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/devices/aa:bb:cc:dd:ee:01/radio?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "data" in body and "render_hint" in body
+    assert body["data"]["mac"] == "aa:bb:cc:dd:ee:01"
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["radios"][0]["channel"] == 6


### PR DESCRIPTION
## Summary

Phase 5A PR1: read-only resource routes for network waves 1–3 (devices+switches, clients+groups, networks+WLANs+VPN+DNS+routing). Adds 32 endpoint families across 3 cluster commits, each commit scoped to a category cluster mirroring Phase 4A's structure.

## Cluster commits

| Cluster | Commit | Families | Notes |
|---|---|---|---|
| 1 — devices & switches | 987db18 | 12 | port-profiles, port-stats (wrapper-dict), switch-ports (wrapper-dict), switch-capabilities, lldp-neighbors (wrapper-dict), rogue-aps, known-rogue-aps, rf-scan-results, available-channels, speedtest-status, /devices/{mac}/radio. Required query params: device_mac, ap_mac, gateway_mac. |
| 2 — clients & user groups | 8f1d5e4 | 6 | blocked-clients, client-groups (LIST+DETAIL), user-groups (LIST+DETAIL), lookup-by-ip (required ?ip query param). |
| 3 — networks/WLANs/VPN/DNS/routing | 5b0fe37 | 14 | active-routes (LIST), static-routes (LIST+DETAIL), traffic-routes (LIST+DETAIL), dns-records (LIST+DETAIL), vpn-clients (LIST+DETAIL), vpn-servers (LIST+DETAIL), ap-groups (LIST+DETAIL). |

Total: 32 endpoint families, ~50 routes (list+detail pairs where applicable).

## Mid-execution adaptations

1. **Wrapper-dict pattern (PR1 Cluster 1):** \`switch-ports\` (key \`port_overrides\`), \`port-stats\` (key \`port_table\`), \`lldp-neighbors\` (key \`lldp_table\`). Routes unwrap inline and override \`render_hint.kind\` to \`\"list\"\` for the LIST contract. PR5's catalog gate may need to accommodate the kind override (or wrappers grow LIST resource registrations).
2. **Required query params for per-device data (PR1 Cluster 1):** \`switch-ports\`, \`port-stats\`, \`switch-capabilities\`, \`lldp-neighbors\` require \`device_mac\`; \`rf-scan-results\` requires \`ap_mac\`; \`speedtest-status\` requires \`gateway_mac\`. Exposed as required \`Query(...)\` params per the plan note.
3. **Manager method names diverged (PR1 Cluster 1):** plan said \`list_port_profiles\`/\`get_port_profile_details\`, actual managers are \`get_port_profiles\`/\`get_port_profile_by_id\`.
4. **DNS detail manager method is \`get_dns_record\` (PR1 Cluster 3)** — no \`_by_id\` or \`_details\` suffix.
5. **AP groups confirmed on \`network_manager\` (PR1 Cluster 3)** — Phase 4A finding still holds.
6. **TOOL_ROUTE_OVERRIDES candidates** flagged for PR5's CI gate: \`unifi_list_usergroups\` → \`list_user_groups\` and \`unifi_get_usergroup_details\` → \`get_user_group_details\` (URL path uses kebab-case \`user-groups\` while tool uses \`usergroups\`).

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (69/205/631/336/157) |
| unifi-api | 299 → 336 (+37 tests) |
| Phase 4A serializer-coverage gate | green |

## Out of scope (later PRs)

- Network waves 4–6 (firewall+QoS+DPI+CF+ACL+OON, port-forwards+vouchers+SNMP, stats+events+system) — PR2
- Protect routes — PR3
- Access routes — PR4
- Per-resource streams + /v1/catalog/resources + CI gate — PR5
- Write endpoints — Phase 6
- GraphQL overlay — Phase 8

## Reference

- Spec: Myco \`c56c0e0969cd6a9d\`
- Plan: Myco \`aff0da48adac8cee\`
- Phase 4B: closed via PRs #168–#170

🤖 Generated with [Claude Code](https://claude.com/claude-code)