### PR TITLE
Phase 5A PR2: network resource routes (waves 4–6, 36 endpoint families)

### DIFF
--- a/apps/api/src/unifi_api/routes/resources/network/acl.py
+++ b/apps/api/src/unifi_api/routes/resources/network/acl.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,14 +84,17 @@ async def get_acl_rule_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "acl_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_acl_rule_by_id(rule_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "acl_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_acl_rule_by_id(rule_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"acl rule {rule_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/acl.py
+++ b/apps/api/src/unifi_api/routes/resources/network/acl.py
@@ -1,0 +1,102 @@
+"""GET /v1/sites/{site_id}/acl-rules[/{rule_id}] — MAC ACL rules.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/acl-rules",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_acl_rules(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "acl_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_acl_rules()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_acl_rules")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_acl_rules"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/acl-rules/{rule_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_acl_rule_details(
+    request: Request,
+    site_id: str,
+    rule_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "acl_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_acl_rule_by_id(rule_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"acl rule {rule_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_acl_rule_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_acl_rule_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -84,14 +86,17 @@ async def get_ap_group_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "network_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_ap_group_details(group_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "network_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_ap_group_details(group_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"ap group {group_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/client_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/client_groups.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -85,14 +87,17 @@ async def get_client_group_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "client_group_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        group = await mgr.get_client_group_by_id(group_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "client_group_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            group = await mgr.get_client_group_by_id(group_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if group is None:
         raise HTTPException(status_code=404, detail="client group not found")
 

--- a/apps/api/src/unifi_api/routes/resources/network/clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/clients.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -87,14 +89,17 @@ async def get_client(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "client_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        client = await mgr.get_client_details(mac)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "client_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            client = await mgr.get_client_details(mac)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if client is None:
         raise HTTPException(status_code=404, detail="client not found")
 

--- a/apps/api/src/unifi_api/routes/resources/network/content_filters.py
+++ b/apps/api/src/unifi_api/routes/resources/network/content_filters.py
@@ -1,0 +1,102 @@
+"""GET /v1/sites/{site_id}/content-filters[/{filter_id}] — content filters.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/content-filters",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_content_filters(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "content_filter_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_content_filters()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_content_filters")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_content_filters"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/content-filters/{filter_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_content_filter_details(
+    request: Request,
+    site_id: str,
+    filter_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "content_filter_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_content_filter_by_id(filter_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"content filter {filter_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_content_filter_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_content_filter_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/content_filters.py
+++ b/apps/api/src/unifi_api/routes/resources/network/content_filters.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,14 +84,17 @@ async def get_content_filter_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "content_filter_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_content_filter_by_id(filter_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "content_filter_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_content_filter_by_id(filter_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"content filter {filter_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -81,14 +83,17 @@ async def get_device(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "device_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        device = await mgr.get_device_details(mac)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "device_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            device = await mgr.get_device_details(mac)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if device is None:
         raise HTTPException(status_code=404, detail="device not found")
 
@@ -113,14 +118,17 @@ async def get_device_radio(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "device_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        radio = await mgr.get_device_radio(mac)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "device_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            radio = await mgr.get_device_radio(mac)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if radio is None:
         raise HTTPException(
             status_code=404,

--- a/apps/api/src/unifi_api/routes/resources/network/dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dns.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,16 +84,19 @@ async def get_dns_record_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "dns_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        # dns_manager exposes get_dns_record (no `_by_id` suffix); the manifest
-        # tool name is unifi_get_dns_record_details.
-        item = await mgr.get_dns_record(record_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "dns_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            # dns_manager exposes get_dns_record (no `_by_id` suffix); the manifest
+            # tool name is unifi_get_dns_record_details.
+            item = await mgr.get_dns_record(record_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"dns record {record_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/dpi.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dpi.py
@@ -1,0 +1,134 @@
+"""GET /v1/sites/{site_id}/dpi-{applications,categories} — DPI lookups.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+
+``DpiManager`` calls the official integration API and returns paginated
+wrapper dicts: ``{"data": [...], "totalCount": int, "offset": int, "limit": int}``.
+The route unwraps ``wrapper["data"]`` before paginating + serializing.
+
+DPI category id ``0`` is real and falsy — pagination/sort handles it via
+the ``or "" `` fallback only on missing keys, not on present-but-falsy values.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    """Sort by id; treats `None` (missing) as `0` so present 0s order naturally."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    ident = raw.get("id")
+    if ident is None:
+        ident = raw.get("_id")
+    if ident is None:
+        ident = 0
+    return (0, ident)
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+def _unwrap(result: Any) -> list:
+    """Extract bare list from a paginated DPI wrapper or pass through."""
+    if isinstance(result, dict) and "data" in result:
+        data = result.get("data") or []
+        return list(data) if isinstance(data, Iterable) else []
+    if isinstance(result, list):
+        return result
+    return []
+
+
+@router.get(
+    "/sites/{site_id}/dpi-applications",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_dpi_applications(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "dpi_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        # Manager returns the integration-API wrapper. Ask for a wide page so
+        # cursor-based pagination on the client side has the full set.
+        result = await mgr.get_dpi_applications(limit=2500, offset=0)
+
+    items_raw = _unwrap(result)
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        items_raw, limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_dpi_applications")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_dpi_applications"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/dpi-categories",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_dpi_categories(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "dpi_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        result = await mgr.get_dpi_categories(limit=500, offset=0)
+
+    items_raw = _unwrap(result)
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        items_raw, limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_dpi_categories")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_dpi_categories"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/events.py
+++ b/apps/api/src/unifi_api/routes/resources/network/events.py
@@ -1,0 +1,225 @@
+"""GET /v1/sites/{site_id}/{events,alerts,anomalies,ips-events} — network EVENT_LOG.
+
+Phase 5A PR2 Cluster 6. Each endpoint paginates per-event using time/_id keys.
+
+The ``/events`` path coexists with the protect events route at the same path —
+the network event-manager handles network controllers; protect event-manager
+handles protect. The capability check (``require_capability``) ensures the
+correct module serves each request based on the controller's product_kinds.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+def _event_key(obj) -> tuple:
+    """Sort by (time, id) descending; tolerate dict or model objects."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    ts = raw.get("time") or raw.get("timestamp") or 0
+    eid = raw.get("_id") or raw.get("id") or ""
+    return (ts, eid)
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    if getattr(cm, "site", None) != site_id:
+        await cm.set_site(site_id)
+
+
+def _list_response(request, items, tool_name, *, limit, cursor):
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool(tool_name)
+    return {
+        "items": [serializer.serialize(e) for e in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool(tool_name),
+    }
+
+
+def _controller_products(controller) -> list[str]:
+    return [p for p in controller.product_kinds.split(",") if p]
+
+
+@router.get(
+    "/sites/{site_id}/events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_events_dispatch(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    """Dispatch to network or protect events based on the controller's products.
+
+    The /events path is shared between network and protect controllers. We
+    select the manager + serializer based on the controller's product_kinds
+    so a single FastAPI route handles both cases without path collision.
+    Network is preferred when the controller supports both (which is rare —
+    multi-product controllers are typically network + access).
+    """
+    products = _controller_products(controller)
+    if "network" in products:
+        return await _list_network_events(
+            request, site_id, controller, limit=limit, cursor=cursor,
+        )
+    if "protect" in products:
+        return await _list_protect_events(
+            request, site_id, controller, limit=limit, cursor=cursor,
+        )
+    # Neither — surface a clean capability mismatch (network is the canonical
+    # owner of the path; the message reflects that).
+    require_capability(controller, "network")
+    return {}  # unreachable
+
+
+async def _list_network_events(
+    request: Request, site_id: str, controller, *, limit: int, cursor: str | None,
+) -> dict:
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        events = await mgr.get_events(limit=max(limit, 100))
+    return _list_response(
+        request, events, "unifi_list_events", limit=limit, cursor=cursor,
+    )
+
+
+async def _list_protect_events(
+    request: Request, site_id: str, controller, *, limit: int, cursor: str | None,
+) -> dict:
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        set_site = getattr(cm, "set_site", None)
+        if set_site is not None and getattr(cm, "site", None) != site_id:
+            await set_site(site_id)
+        events = await mgr.list_events(limit=max(limit, 100))
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(events), limit=limit, cursor=cursor_obj,
+        key_fn=lambda e: (
+            (e.get("start") if isinstance(e, dict) else getattr(e, "raw", {}).get("start")) or 0,
+            (e.get("id") if isinstance(e, dict) else getattr(e, "raw", {}).get("id")) or "",
+        ),
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_resource("protect", "events")
+    return {
+        "items": [serializer.serialize(e) for e in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_resource("protect", "events"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/alerts",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_alerts(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        events = await mgr.get_alerts()
+    return _list_response(
+        request, events, "unifi_get_alerts", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/anomalies",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_anomalies(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        events = await mgr.get_anomalies()
+    return _list_response(
+        request, events, "unifi_get_anomalies", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/ips-events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_ips_events(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        events = await mgr.get_ips_events()
+    return _list_response(
+        request, events, "unifi_get_ips_events", limit=limit, cursor=cursor,
+    )

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,14 +84,17 @@ async def get_firewall_group_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "firewall_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_firewall_group_by_id(group_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "firewall_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_firewall_group_by_id(group_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"firewall group {group_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
@@ -1,0 +1,102 @@
+"""GET /v1/sites/{site_id}/firewall/groups[/{group_id}] — firewall groups.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/firewall/groups",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_firewall_groups(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_firewall_groups()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_firewall_groups")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_firewall_groups"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/firewall/groups/{group_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_firewall_group_details(
+    request: Request,
+    site_id: str,
+    group_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_firewall_group_by_id(group_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"firewall group {group_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_firewall_group_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_firewall_group_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -81,17 +83,20 @@ async def get_firewall_rule(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "firewall_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        # firewall_manager exposes get_firewall_policies (list) but not a
-        # singular get_firewall_policy_details. Fetch the list and filter
-        # by id; the manager already caches/normalizes the response.
-        all_rules = await mgr.get_firewall_policies(include_predefined=True)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "firewall_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            # firewall_manager exposes get_firewall_policies (list) but not a
+            # singular get_firewall_policy_details. Fetch the list and filter
+            # by id; the manager already caches/normalizes the response.
+            all_rules = await mgr.get_firewall_policies(include_predefined=True)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
 
     rule = None
     for r in all_rules:

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_zones.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_zones.py
@@ -1,0 +1,72 @@
+"""GET /v1/sites/{site_id}/firewall/zones — firewall zones.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+
+The manager already strips the inter-zone policy-count matrix
+(``data`` field) from the ``/firewall/zone-matrix`` response.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/firewall/zones",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_firewall_zones(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_firewall_zones()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_firewall_zones")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_firewall_zones"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/lookup.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lookup.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -33,14 +35,17 @@ async def lookup_client_by_ip(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "client_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        client = await mgr.get_client_by_ip(ip)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "client_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            client = await mgr.get_client_by_ip(ip)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if client is None:
         raise HTTPException(status_code=404, detail=f"client with ip {ip} not found")
 

--- a/apps/api/src/unifi_api/routes/resources/network/networks.py
+++ b/apps/api/src/unifi_api/routes/resources/network/networks.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -81,14 +83,17 @@ async def get_network(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "network_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        network = await mgr.get_network_details(network_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "network_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            network = await mgr.get_network_details(network_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if network is None:
         raise HTTPException(status_code=404, detail="network not found")
 

--- a/apps/api/src/unifi_api/routes/resources/network/oon.py
+++ b/apps/api/src/unifi_api/routes/resources/network/oon.py
@@ -1,0 +1,102 @@
+"""GET /v1/sites/{site_id}/oon-policies[/{policy_id}] — OON policies.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/oon-policies",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_oon_policies(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "oon_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_oon_policies()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_oon_policies")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_oon_policies"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/oon-policies/{policy_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_oon_policy_details(
+    request: Request,
+    site_id: str,
+    policy_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "oon_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_oon_policy_by_id(policy_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"oon policy {policy_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_oon_policy_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_oon_policy_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/oon.py
+++ b/apps/api/src/unifi_api/routes/resources/network/oon.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,14 +84,17 @@ async def get_oon_policy_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "oon_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_oon_policy_by_id(policy_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "oon_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_oon_policy_by_id(policy_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"oon policy {policy_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
+++ b/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
@@ -1,0 +1,103 @@
+"""GET /v1/sites/{site_id}/port-forwards[/{port_forward_id}] — port forwards.
+
+Phase 5A PR2 Cluster 5 — port forwards / vouchers / SNMP. Backed by
+``FirewallManager.get_port_forwards`` and ``get_port_forward_by_id``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/port-forwards",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_port_forwards(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_port_forwards()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_port_forwards")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_port_forwards"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/port-forwards/{port_forward_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_port_forward(
+    request: Request,
+    site_id: str,
+    port_forward_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_port_forward_by_id(port_forward_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"port forward {port_forward_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_port_forward")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_port_forward"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
+++ b/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -83,14 +85,17 @@ async def get_port_forward(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "firewall_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_port_forward_by_id(port_forward_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "firewall_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_port_forward_by_id(port_forward_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"port forward {port_forward_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/qos.py
+++ b/apps/api/src/unifi_api/routes/resources/network/qos.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,14 +84,17 @@ async def get_qos_rule_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "qos_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_qos_rule_details(rule_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "qos_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_qos_rule_details(rule_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"qos rule {rule_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/qos.py
+++ b/apps/api/src/unifi_api/routes/resources/network/qos.py
@@ -1,0 +1,102 @@
+"""GET /v1/sites/{site_id}/qos-rules[/{rule_id}] — QoS rules.
+
+Phase 5A PR2 Cluster 4 — network filtering routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/qos-rules",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_qos_rules(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "qos_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_qos_rules()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_qos_rules")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_qos_rules"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/qos-rules/{rule_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_qos_rule_details(
+    request: Request,
+    site_id: str,
+    rule_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "qos_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        item = await mgr.get_qos_rule_details(rule_id)
+    if item is None:
+        raise HTTPException(
+            status_code=404, detail=f"qos rule {rule_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_qos_rule_details")
+    return {
+        "data": serializer.serialize(item),
+        "render_hint": registry.render_hint_for_tool("unifi_get_qos_rule_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/routes.py
+++ b/apps/api/src/unifi_api/routes/resources/network/routes.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -125,14 +127,17 @@ async def get_route_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "routing_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_route_details(route_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "routing_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_route_details(route_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(status_code=404, detail=f"route {route_id} not found")
     registry = request.app.state.serializer_registry
@@ -195,14 +200,17 @@ async def get_traffic_route_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "traffic_route_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_traffic_route_details(route_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "traffic_route_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_traffic_route_details(route_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"traffic route {route_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/snmp.py
+++ b/apps/api/src/unifi_api/routes/resources/network/snmp.py
@@ -1,0 +1,48 @@
+"""GET /v1/sites/{site_id}/snmp-settings — SNMP settings (single GET).
+
+Phase 5A PR2 Cluster 5. SystemManager.get_settings("snmp") returns a
+list[dict]; the SnmpSettingsSerializer unwraps the first element as the
+DETAIL payload.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/sites/{site_id}/snmp-settings",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_snmp_settings(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        settings = await mgr.get_settings("snmp")
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_snmp_settings")
+    return {
+        "data": serializer.serialize(settings),
+        "render_hint": registry.render_hint_for_tool("unifi_get_snmp_settings"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/stats.py
+++ b/apps/api/src/unifi_api/routes/resources/network/stats.py
@@ -1,0 +1,307 @@
+"""GET /v1/sites/{site_id}/stats/* — network stats endpoints.
+
+Phase 5A PR2 Cluster 6. Stats endpoints span TIMESERIES and DETAIL kinds.
+
+Phase 4A registered 5 stats tools as TIMESERIES (dashboard, network, gateway,
+site_dpi_traffic, client_dpi_traffic) and 3 as DETAIL (device_stats,
+client_stats, dpi_stats) because Phase 2's AST captured the lookup method,
+not the stats fetch method. The parallel manager-refactor will eventually
+re-register the 3 DETAIL ones as TIMESERIES; the dual-kind handler below
+makes Phase 5A robust to whichever state is current at request time.
+
+For the 3 currently-DETAIL stats tools, we call the manager method that the
+AST-derived dispatch table currently routes to (verified at module import
+time): device_manager.get_device_details, client_manager.get_client_details,
+stats_manager.get_dpi_stats. When the parallel refactor lands, both the
+serializer kind and the dispatch table will update together — the route
+inherits both via the registry/dispatch.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+def _ts_key(point) -> tuple:
+    """Sort key for timeseries points: (ts, id) descending."""
+    raw = point if isinstance(point, dict) else getattr(point, "raw", {}) or {}
+    ts = raw.get("ts") or raw.get("time") or raw.get("timestamp") or 0
+    return (ts, "")
+
+
+def _stats_response(
+    request: Request,
+    payload,
+    tool_name: str,
+    *,
+    limit: int,
+    cursor: str | None,
+) -> dict:
+    """Dual-kind handler: TIMESERIES paginates per-point; DETAIL passes through."""
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool(tool_name)
+    kind = registry.kind_for_tool(tool_name)
+    hint = registry.render_hint_for_tool(tool_name)
+
+    if kind.value == "timeseries":
+        items_raw = list(payload) if isinstance(payload, list) else []
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            items_raw, limit=limit, cursor=cursor_obj, key_fn=_ts_key,
+        )
+        return {
+            "items": [serializer.serialize(p) for p in page],
+            "next_cursor": next_cursor.encode() if next_cursor else None,
+            "render_hint": hint,
+        }
+    # DETAIL kind (the 3 mis-classified stats tools at present).
+    return {"data": serializer.serialize(payload), "render_hint": hint}
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    if getattr(cm, "site", None) != site_id:
+        await cm.set_site(site_id)
+
+
+# ---------- TIMESERIES — flat /stats/* paths ----------
+
+
+@router.get(
+    "/sites/{site_id}/stats/dashboard",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_dashboard_stats(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_dashboard()
+    return _stats_response(
+        request, payload, "unifi_get_dashboard", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/stats/network",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_network_stats(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_network_stats()
+    return _stats_response(
+        request, payload, "unifi_get_network_stats", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/stats/gateway",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_gateway_stats(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_gateway_stats()
+    return _stats_response(
+        request, payload, "unifi_get_gateway_stats", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/stats/dpi/site",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_site_dpi_traffic(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_site_dpi_traffic()
+    return _stats_response(
+        request, payload, "unifi_get_site_dpi_traffic", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/stats/dpi/clients/{mac}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_client_dpi_traffic(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_client_dpi_traffic(mac)
+    return _stats_response(
+        request, payload, "unifi_get_client_dpi_traffic", limit=limit, cursor=cursor,
+    )
+
+
+# ---------- DETAIL (currently mis-classified) — call dispatch-target methods ----------
+
+
+@router.get(
+    "/sites/{site_id}/stats/dpi",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_dpi_stats(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    """DETAIL kind currently; manager method is stats_manager.get_dpi_stats."""
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_dpi_stats()
+    return _stats_response(
+        request, payload, "unifi_get_dpi_stats", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/stats/devices/{mac}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_device_stats(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    """DETAIL kind currently; dispatch routes to device_manager.get_device_details."""
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_device_details(mac)
+    if payload is None:
+        raise HTTPException(status_code=404, detail=f"device {mac} not found")
+    return _stats_response(
+        request, payload, "unifi_get_device_stats", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/stats/clients/{mac}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_client_stats(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    """DETAIL kind currently; dispatch routes to client_manager.get_client_details."""
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "client_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_client_details(mac)
+    if payload is None:
+        raise HTTPException(status_code=404, detail=f"client {mac} not found")
+    return _stats_response(
+        request, payload, "unifi_get_client_stats", limit=limit, cursor=cursor,
+    )

--- a/apps/api/src/unifi_api/routes/resources/network/stats.py
+++ b/apps/api/src/unifi_api/routes/resources/network/stats.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -263,13 +265,16 @@ async def get_device_stats(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "device_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
-        payload = await mgr.get_device_details(mac)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "device_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_device_details(mac)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if payload is None:
         raise HTTPException(status_code=404, detail=f"device {mac} not found")
     return _stats_response(
@@ -293,13 +298,16 @@ async def get_client_stats(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "client_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
-        payload = await mgr.get_client_details(mac)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "client_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_client_details(mac)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if payload is None:
         raise HTTPException(status_code=404, detail=f"client {mac} not found")
     return _stats_response(

--- a/apps/api/src/unifi_api/routes/resources/network/switch.py
+++ b/apps/api/src/unifi_api/routes/resources/network/switch.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -100,14 +102,17 @@ async def get_port_profile_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "switch_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        profile = await mgr.get_port_profile_by_id(profile_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "switch_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            profile = await mgr.get_port_profile_by_id(profile_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if profile is None:
         raise HTTPException(status_code=404, detail="port profile not found")
 

--- a/apps/api/src/unifi_api/routes/resources/network/system.py
+++ b/apps/api/src/unifi_api/routes/resources/network/system.py
@@ -1,0 +1,351 @@
+"""GET /v1/sites/{site_id}/{alarms,backups,event-types,...} — network system endpoints.
+
+Phase 5A PR2 Cluster 6. Per-tool kind dispatched via the serializer registry:
+
+- LIST: alarms, backups, top-clients, client-sessions, network-health,
+  speedtest-results
+- DETAIL: event-types, autobackup-settings, site-settings, system-info,
+  client-wifi-details (per-resource with `mac` path param)
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    ts = raw.get("time") or raw.get("timestamp") or raw.get("assoc_time") or 0
+    eid = raw.get("_id") or raw.get("id") or raw.get("mac") or raw.get("subsystem") or ""
+    return (ts, eid)
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    if getattr(cm, "site", None) != site_id:
+        await cm.set_site(site_id)
+
+
+def _list_response(request, items, tool_name, *, limit, cursor):
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool(tool_name)
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool(tool_name),
+    }
+
+
+def _detail_response(request, payload, tool_name):
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool(tool_name)
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool(tool_name),
+    }
+
+
+# ---------- LIST ----------
+
+
+@router.get(
+    "/sites/{site_id}/alarms",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_alarms(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.get_alarms()
+    return _list_response(
+        request, items, "unifi_list_alarms", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/backups",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_backups(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_backups()
+    return _list_response(
+        request, items, "unifi_list_backups", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/top-clients",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_top_clients(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.get_top_clients()
+    return _list_response(
+        request, items, "unifi_get_top_clients", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/client-sessions",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_client_sessions(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.get_client_sessions()
+    return _list_response(
+        request, items, "unifi_get_client_sessions", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/network-health",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_network_health(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    """LIST kind per Phase 4A — manager returns multi-element list of subsystems."""
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.get_network_health()
+    return _list_response(
+        request, items, "unifi_get_network_health", limit=limit, cursor=cursor,
+    )
+
+
+@router.get(
+    "/sites/{site_id}/speedtest-results",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_speedtest_results(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.get_speedtest_results()
+    return _list_response(
+        request, items, "unifi_get_speedtest_results", limit=limit, cursor=cursor,
+    )
+
+
+# ---------- DETAIL ----------
+
+
+@router.get(
+    "/sites/{site_id}/event-types",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_event_types(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """DETAIL — event_manager.get_event_type_prefixes (sync method, returns list)."""
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        result = mgr.get_event_type_prefixes()
+        if inspect.isawaitable(result):
+            result = await result
+    return _detail_response(request, result, "unifi_get_event_types")
+
+
+@router.get(
+    "/sites/{site_id}/autobackup-settings",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_autobackup_settings(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_autobackup_settings()
+    return _detail_response(request, payload, "unifi_get_autobackup_settings")
+
+
+@router.get(
+    "/sites/{site_id}/site-settings",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_site_settings(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_site_settings()
+    return _detail_response(request, payload, "unifi_get_site_settings")
+
+
+@router.get(
+    "/sites/{site_id}/system-info",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_system_info(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_system_info()
+    return _detail_response(request, payload, "unifi_get_system_info")
+
+
+@router.get(
+    "/sites/{site_id}/client-wifi-details/{mac}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_client_wifi_details(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "stats_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        await _maybe_set_site(cm, site_id)
+        payload = await mgr.get_client_wifi_details(mac)
+    if payload is None:
+        raise HTTPException(
+            status_code=404, detail=f"client {mac} wifi details not found",
+        )
+    return _detail_response(request, payload, "unifi_get_client_wifi_details")

--- a/apps/api/src/unifi_api/routes/resources/network/user_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/user_groups.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -87,14 +89,17 @@ async def get_user_group_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "usergroup_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        group = await mgr.get_usergroup_details(group_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "usergroup_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            group = await mgr.get_usergroup_details(group_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if group is None:
         raise HTTPException(status_code=404, detail="user group not found")
 

--- a/apps/api/src/unifi_api/routes/resources/network/vouchers.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vouchers.py
@@ -1,0 +1,106 @@
+"""GET /v1/sites/{site_id}/vouchers and /voucher-details/{voucher_id} — hotspot.
+
+Phase 5A PR2 Cluster 5. The detail endpoint uses a deliberately separate
+path (``/voucher-details/{voucher_id}``) — both spec §5 and the underlying
+``HotspotManager.get_voucher_details(voucher_id)`` key on the voucher's
+internal ``_id``. The path param is named ``voucher_id`` to reflect what
+the manager actually accepts.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _voucher_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (raw.get("create_time") or 0, raw.get("_id") or raw.get("code") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/vouchers",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_vouchers(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "hotspot_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_vouchers()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_voucher_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_list_vouchers")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("unifi_list_vouchers"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/voucher-details/{voucher_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_voucher_details(
+    request: Request,
+    site_id: str,
+    voucher_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "network", "hotspot_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        voucher = await mgr.get_voucher_details(voucher_id)
+    if voucher is None:
+        raise HTTPException(
+            status_code=404, detail=f"voucher {voucher_id} not found",
+        )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("unifi_get_voucher_details")
+    return {
+        "data": serializer.serialize(voucher),
+        "render_hint": registry.render_hint_for_tool("unifi_get_voucher_details"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/vouchers.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vouchers.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -86,14 +88,17 @@ async def get_voucher_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "hotspot_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        voucher = await mgr.get_voucher_details(voucher_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "hotspot_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            voucher = await mgr.get_voucher_details(voucher_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if voucher is None:
         raise HTTPException(
             status_code=404, detail=f"voucher {voucher_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/vpn.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vpn.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -85,14 +87,17 @@ async def get_vpn_client_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "vpn_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_vpn_client_details(client_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "vpn_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_vpn_client_details(client_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"vpn client {client_id} not found",
@@ -157,14 +162,17 @@ async def get_vpn_server_details(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "vpn_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        item = await mgr.get_vpn_server_details(server_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "vpn_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_vpn_server_details(server_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if item is None:
         raise HTTPException(
             status_code=404, detail=f"vpn server {server_id} not found",

--- a/apps/api/src/unifi_api/routes/resources/network/wlans.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wlans.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -82,14 +84,17 @@ async def get_wlan(
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
-    async with sm() as session:
-        mgr = await factory.get_domain_manager(
-            session, controller.id, "network", "network_manager",
-        )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
-        wlan = await mgr.get_wlan_details(wlan_id)
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "network_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            wlan = await mgr.get_wlan_details(wlan_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     if wlan is None:
         raise HTTPException(status_code=404, detail="wlan not found")
 

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -20,16 +20,23 @@ from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
 from unifi_api.routes.resources.network import (
+    acl as net_acl_routes,
     ap_groups as net_ap_groups_routes,
     blocked_clients as net_blocked_clients_routes,
     client_groups as net_client_groups_routes,
     clients as net_clients_routes,
+    content_filters as net_content_filters_routes,
     devices as net_devices_routes,
     dns as net_dns_routes,
+    dpi as net_dpi_routes,
+    firewall_groups as net_firewall_groups_routes,
     firewall_rules as net_firewall_routes,
+    firewall_zones as net_firewall_zones_routes,
     lldp as net_lldp_routes,
     lookup as net_lookup_routes,
     networks as net_networks_routes,
+    oon as net_oon_routes,
+    qos as net_qos_routes,
     rogue_aps as net_rogue_aps_routes,
     routes as net_routes_routes,
     speedtest as net_speedtest_routes,
@@ -188,6 +195,13 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_dns_routes,
         net_vpn_routes,
         net_ap_groups_routes,
+        net_firewall_groups_routes,
+        net_firewall_zones_routes,
+        net_qos_routes,
+        net_dpi_routes,
+        net_content_filters_routes,
+        net_acl_routes,
+        net_oon_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -36,12 +36,15 @@ from unifi_api.routes.resources.network import (
     lookup as net_lookup_routes,
     networks as net_networks_routes,
     oon as net_oon_routes,
+    port_forwards as net_port_forwards_routes,
     qos as net_qos_routes,
     rogue_aps as net_rogue_aps_routes,
     routes as net_routes_routes,
+    snmp as net_snmp_routes,
     speedtest as net_speedtest_routes,
     switch as net_switch_routes,
     user_groups as net_user_groups_routes,
+    vouchers as net_vouchers_routes,
     vpn as net_vpn_routes,
     wireless as net_wireless_routes,
     wlans as net_wlans_routes,
@@ -202,6 +205,9 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_content_filters_routes,
         net_acl_routes,
         net_oon_routes,
+        net_port_forwards_routes,
+        net_vouchers_routes,
+        net_snmp_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -29,6 +29,7 @@ from unifi_api.routes.resources.network import (
     devices as net_devices_routes,
     dns as net_dns_routes,
     dpi as net_dpi_routes,
+    events as net_events_routes,
     firewall_groups as net_firewall_groups_routes,
     firewall_rules as net_firewall_routes,
     firewall_zones as net_firewall_zones_routes,
@@ -42,7 +43,9 @@ from unifi_api.routes.resources.network import (
     routes as net_routes_routes,
     snmp as net_snmp_routes,
     speedtest as net_speedtest_routes,
+    stats as net_stats_routes,
     switch as net_switch_routes,
+    system as net_system_routes,
     user_groups as net_user_groups_routes,
     vouchers as net_vouchers_routes,
     vpn as net_vpn_routes,
@@ -208,6 +211,13 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_port_forwards_routes,
         net_vouchers_routes,
         net_snmp_routes,
+        # Cluster 6: stats / events / system. The network events router owns
+        # the bare /events path for both products via a capability-aware
+        # dispatcher; it must be included before protect_events_routes so the
+        # network/protect-aware handler wins the path match.
+        net_stats_routes,
+        net_events_routes,
+        net_system_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/tests/routes/resources/test_network_config.py
+++ b/apps/api/tests/routes/resources/test_network_config.py
@@ -339,6 +339,29 @@ async def test_get_dns_record_details_404(tmp_path, monkeypatch) -> None:
     assert r.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_get_dns_record_details_unifi_not_found(tmp_path, monkeypatch) -> None:
+    """Manager refactor PR #172: get_dns_record raises UniFiNotFoundError."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    from unifi_core.exceptions import UniFiNotFoundError
+    from unifi_core.network.managers.dns_manager import DnsManager
+
+    async def fake_get(self, record_id):
+        raise UniFiNotFoundError("dns_record", record_id)
+
+    monkeypatch.setattr(DnsManager, "get_dns_record", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dns-records/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
 # ---------- VPN clients ----------
 
 

--- a/apps/api/tests/routes/resources/test_network_filtering.py
+++ b/apps/api/tests/routes/resources/test_network_filtering.py
@@ -275,6 +275,29 @@ async def test_get_qos_rule_details_404(tmp_path, monkeypatch) -> None:
     assert r.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_get_qos_rule_details_unifi_not_found(tmp_path, monkeypatch) -> None:
+    """Manager refactor PR #172: get_qos_rule_details raises UniFiNotFoundError."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    from unifi_core.exceptions import UniFiNotFoundError
+    from unifi_core.network.managers.qos_manager import QosManager
+
+    async def fake_get(self, rule_id):
+        raise UniFiNotFoundError("qos_rule", rule_id)
+
+    monkeypatch.setattr(QosManager, "get_qos_rule_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/qos-rules/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
 # ---------- DPI ----------
 
 
@@ -403,6 +426,29 @@ async def test_get_content_filter_details_happy_path(tmp_path, monkeypatch) -> N
     assert body["data"]["id"] == "cf9"
 
 
+@pytest.mark.asyncio
+async def test_get_content_filter_details_unifi_not_found(tmp_path, monkeypatch) -> None:
+    """Manager refactor PR #172: get_content_filter_by_id raises UniFiNotFoundError."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    from unifi_core.exceptions import UniFiNotFoundError
+    from unifi_core.network.managers.content_filter_manager import ContentFilterManager
+
+    async def fake_get(self, filter_id):
+        raise UniFiNotFoundError("content_filter", filter_id)
+
+    monkeypatch.setattr(ContentFilterManager, "get_content_filter_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/content-filters/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
 # ---------- ACL ----------
 
 
@@ -460,6 +506,29 @@ async def test_get_acl_rule_details_happy_path(tmp_path, monkeypatch) -> None:
     body = r.json()
     assert body["render_hint"]["kind"] == "detail"
     assert body["data"]["id"] == "a3"
+
+
+@pytest.mark.asyncio
+async def test_get_acl_rule_details_unifi_not_found(tmp_path, monkeypatch) -> None:
+    """Manager refactor PR #172: get_acl_rule_by_id raises UniFiNotFoundError."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    from unifi_core.exceptions import UniFiNotFoundError
+    from unifi_core.network.managers.acl_manager import AclManager
+
+    async def fake_get(self, rule_id):
+        raise UniFiNotFoundError("acl_rule", rule_id)
+
+    monkeypatch.setattr(AclManager, "get_acl_rule_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/acl-rules/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
 
 
 # ---------- OON ----------

--- a/apps/api/tests/routes/resources/test_network_filtering.py
+++ b/apps/api/tests/routes/resources/test_network_filtering.py
@@ -1,0 +1,520 @@
+"""Phase 5A PR2 Cluster 4 — network filtering resource routes.
+
+Covers firewall groups/zones, QoS rules, DPI applications/categories,
+content-filters, ACL rules, and OON policies (LIST + DETAIL where applicable).
+"""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+# ---------- firewall groups ----------
+
+
+@pytest.mark.asyncio
+async def test_list_firewall_groups_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "g1", "name": "internal", "group_type": "address-group",
+         "group_members": ["10.0.0.0/24"]},
+        {"_id": "g2", "name": "ports", "group_type": "port-group",
+         "group_members": ["80", "443"]},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_firewall_groups", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firewall/groups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    names = {i["name"] for i in body["items"]}
+    assert names == {"internal", "ports"}
+    members = {i["id"]: i["members"] for i in body["items"]}
+    assert "10.0.0.0/24" in members["g1"]
+
+
+@pytest.mark.asyncio
+async def test_get_firewall_group_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "g7", "name": "deny", "group_type": "address-group",
+              "group_members": ["1.2.3.4"]}
+
+    async def fake_get(self, gid):
+        return target if gid == "g7" else None
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_firewall_group_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firewall/groups/g7?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["id"] == "g7"
+    assert body["data"]["members"] == ["1.2.3.4"]
+
+
+@pytest.mark.asyncio
+async def test_get_firewall_group_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, gid):
+        return None
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_firewall_group_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firewall/groups/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_firewall_groups_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firewall/groups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409
+    assert r.json()["detail"]["kind"] == "capability_mismatch"
+
+
+# ---------- firewall zones ----------
+
+
+@pytest.mark.asyncio
+async def test_list_firewall_zones_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "z1", "name": "internal", "default_policy": "ALLOW",
+         "networks": ["n1", "n2"]},
+        {"_id": "z2", "name": "external", "default_policy": "BLOCK",
+         "networks": []},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_firewall_zones", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firewall/zones?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    names = {i["name"] for i in body["items"]}
+    assert names == {"internal", "external"}
+
+
+# ---------- QoS rules ----------
+
+
+@pytest.mark.asyncio
+async def test_list_qos_rules_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "q1", "name": "voice", "enabled": True, "qos_marking": {"dscp_code": 46}},
+        {"_id": "q2", "name": "video", "enabled": False, "qos_marking": {"dscp_code": 34}},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.qos_manager import QosManager
+    monkeypatch.setattr(QosManager, "get_qos_rules", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/qos-rules?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_qos_rule_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "q1", "name": "voice", "enabled": True}
+
+    async def fake_get(self, rule_id):
+        return target if rule_id == "q1" else None
+
+    from unifi_core.network.managers.qos_manager import QosManager
+    monkeypatch.setattr(QosManager, "get_qos_rule_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/qos-rules/q1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["id"] == "q1"
+
+
+@pytest.mark.asyncio
+async def test_get_qos_rule_details_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, rule_id):
+        return None
+
+    from unifi_core.network.managers.qos_manager import QosManager
+    monkeypatch.setattr(QosManager, "get_qos_rule_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/qos-rules/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- DPI ----------
+
+
+@pytest.mark.asyncio
+async def test_list_dpi_applications_happy_path(tmp_path, monkeypatch) -> None:
+    """DPI manager returns a paginated wrapper {data, totalCount, ...}.
+
+    The route unwraps wrapper["data"] before serializing.
+    """
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    wrapper = {
+        "data": [
+            {"id": 65537, "name": "WhatsApp", "categoryId": 0},
+            {"id": 65538, "name": "Telegram", "categoryId": 0},
+        ],
+        "totalCount": 2, "offset": 0, "limit": 100,
+    }
+
+    async def fake_get(self, **kwargs):
+        return wrapper
+
+    from unifi_core.network.managers.dpi_manager import DpiManager
+    monkeypatch.setattr(DpiManager, "get_dpi_applications", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dpi-applications?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+    # category id 0 is real and falsy — verify it round-trips intact.
+    assert body["items"][0]["category_id"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_dpi_categories_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    wrapper = {
+        "data": [
+            {"id": 0, "name": "Instant messengers"},
+            {"id": 1, "name": "Peer-to-peer"},
+        ],
+        "totalCount": 2, "offset": 0, "limit": 100,
+    }
+
+    async def fake_get(self, **kwargs):
+        return wrapper
+
+    from unifi_core.network.managers.dpi_manager import DpiManager
+    monkeypatch.setattr(DpiManager, "get_dpi_categories", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dpi-categories?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    ids = {i["id"] for i in body["items"]}
+    assert ids == {0, 1}
+
+
+# ---------- content filters ----------
+
+
+@pytest.mark.asyncio
+async def test_list_content_filters_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "cf1", "name": "kids", "level": "STRICT"},
+        {"_id": "cf2", "name": "guest", "level": "MODERATE"},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.content_filter_manager import ContentFilterManager
+    monkeypatch.setattr(ContentFilterManager, "get_content_filters", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/content-filters?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_content_filter_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "cf9", "name": "lab", "level": "STRICT"}
+
+    async def fake_get(self, filter_id):
+        return target if filter_id == "cf9" else None
+
+    from unifi_core.network.managers.content_filter_manager import ContentFilterManager
+    monkeypatch.setattr(ContentFilterManager, "get_content_filter_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/content-filters/cf9?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["id"] == "cf9"
+
+
+# ---------- ACL ----------
+
+
+@pytest.mark.asyncio
+async def test_list_acl_rules_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "a1", "name": "block-cam", "action": "BLOCK",
+         "mac_acl_network_id": "n1", "type": "MAC"},
+        {"_id": "a2", "name": "allow-iot", "action": "ALLOW",
+         "mac_acl_network_id": "n1", "type": "MAC"},
+    ]
+
+    async def fake_get(self, network_id=None):
+        return fake
+
+    from unifi_core.network.managers.acl_manager import AclManager
+    monkeypatch.setattr(AclManager, "get_acl_rules", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/acl-rules?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_acl_rule_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "a3", "name": "deny-x", "action": "BLOCK",
+              "mac_acl_network_id": "n1", "type": "MAC"}
+
+    async def fake_get(self, rule_id):
+        return target if rule_id == "a3" else None
+
+    from unifi_core.network.managers.acl_manager import AclManager
+    monkeypatch.setattr(AclManager, "get_acl_rule_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/acl-rules/a3?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["id"] == "a3"
+
+
+# ---------- OON ----------
+
+
+@pytest.mark.asyncio
+async def test_list_oon_policies_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "o1", "name": "guest-throttle", "enabled": True,
+         "targets": [{"id": "t1"}]},
+        {"_id": "o2", "name": "iot-isolate", "enabled": False, "targets": []},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.oon_manager import OonManager
+    monkeypatch.setattr(OonManager, "get_oon_policies", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/oon-policies?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_oon_policy_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "o5", "name": "office-policy", "enabled": True,
+              "targets": [{"id": "t1"}, {"id": "t2"}]}
+
+    async def fake_get(self, policy_id):
+        return target if policy_id == "o5" else None
+
+    from unifi_core.network.managers.oon_manager import OonManager
+    monkeypatch.setattr(OonManager, "get_oon_policy_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/oon-policies/o5?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["id"] == "o5"

--- a/apps/api/tests/routes/resources/test_network_misc.py
+++ b/apps/api/tests/routes/resources/test_network_misc.py
@@ -1,0 +1,243 @@
+"""Phase 5A PR2 Cluster 5 — port forwards / vouchers / SNMP routes."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+# ---------- port forwards ----------
+
+
+@pytest.mark.asyncio
+async def test_list_port_forwards_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "p1", "name": "ssh", "enabled": True,
+         "fwd_port": "22", "dst_port": "22", "proto": "tcp"},
+        {"_id": "p2", "name": "https", "enabled": True,
+         "fwd_port": "443", "dst_port": "443", "proto": "tcp"},
+    ]
+
+    async def fake_get(self):
+        return fake
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_port_forwards", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-forwards?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_port_forwards_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-forwards?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409
+    assert r.json()["detail"]["kind"] == "capability_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_get_port_forward_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "p9", "name": "rdp", "enabled": True,
+              "fwd_port": "3389", "dst_port": "3389", "proto": "tcp"}
+
+    async def fake_get(self, rule_id):
+        return target if rule_id == "p9" else None
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_port_forward_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-forwards/p9?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_port_forward_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, rule_id):
+        return None
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+    monkeypatch.setattr(FirewallManager, "get_port_forward_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-forwards/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------- vouchers ----------
+
+
+@pytest.mark.asyncio
+async def test_list_vouchers_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [
+        {"_id": "v1", "code": "1234567890", "create_time": 1700000000,
+         "duration": 60, "quota": 1, "used": 0},
+        {"_id": "v2", "code": "0987654321", "create_time": 1700000100,
+         "duration": 60, "quota": 1, "used": 1},
+    ]
+
+    async def fake_get(self, create_time=None):
+        return fake
+
+    from unifi_core.network.managers.hotspot_manager import HotspotManager
+    monkeypatch.setattr(HotspotManager, "get_vouchers", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/vouchers?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_voucher_details_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"_id": "v9", "code": "ABCDEFGHIJ", "duration": 120,
+              "quota": 1, "used": 0}
+
+    async def fake_get(self, voucher_id):
+        return target if voucher_id == "v9" else None
+
+    from unifi_core.network.managers.hotspot_manager import HotspotManager
+    monkeypatch.setattr(HotspotManager, "get_voucher_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/voucher-details/v9?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------- SNMP ----------
+
+
+@pytest.mark.asyncio
+async def test_get_snmp_settings_happy_path(tmp_path, monkeypatch) -> None:
+    """SNMP manager returns list[dict]; serializer unwraps the first item."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake = [{"enabled": True, "community": "public", "port": 161, "version": "v2c"}]
+
+    async def fake_get(self, section):
+        assert section == "snmp"
+        return fake
+
+    from unifi_core.network.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_settings", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/snmp-settings?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["enabled"] is True
+    assert body["data"]["community"] == "public"

--- a/apps/api/tests/routes/resources/test_network_misc.py
+++ b/apps/api/tests/routes/resources/test_network_misc.py
@@ -154,6 +154,29 @@ async def test_get_port_forward_404(tmp_path, monkeypatch) -> None:
     assert r.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_get_port_forward_unifi_not_found(tmp_path, monkeypatch) -> None:
+    """Manager refactor PR #172: get_port_forward_by_id raises UniFiNotFoundError."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    from unifi_core.exceptions import UniFiNotFoundError
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+
+    async def fake_get(self, rule_id):
+        raise UniFiNotFoundError("port_forward", rule_id)
+
+    monkeypatch.setattr(FirewallManager, "get_port_forward_by_id", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/port-forwards/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
 # ---------- vouchers ----------
 
 

--- a/apps/api/tests/routes/resources/test_network_stats_events_system.py
+++ b/apps/api/tests/routes/resources/test_network_stats_events_system.py
@@ -1,0 +1,620 @@
+"""Phase 5A PR2 Cluster 6 — network stats / events / system routes."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="network"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeCM:
+    def __init__(self) -> None:
+        self.site = "default"
+
+    async def initialize(self) -> None:
+        return None
+
+    async def set_site(self, s: str) -> None:
+        self.site = s
+
+
+def _stub_connection(app, cid: str) -> _FakeCM:
+    fake = _FakeCM()
+    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    return fake
+
+
+# ---------- TIMESERIES stats ----------
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_stats_timeseries(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    points = [
+        {"time": 1700000000000, "rx_bytes": 100, "tx_bytes": 200,
+         "wan-rx_bytes": 10, "wan-tx_bytes": 20},
+        {"time": 1700000060000, "rx_bytes": 110, "tx_bytes": 220,
+         "wan-rx_bytes": 11, "wan-tx_bytes": 22},
+    ]
+
+    async def fake_get(self):
+        return points
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_dashboard", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/dashboard?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "timeseries"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_network_stats_timeseries(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, duration_hours=1, granularity="hourly"):
+        return [{"time": 1700000000000, "rx_bytes": 1, "tx_bytes": 2}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_network_stats", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/network?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "timeseries"
+    assert len(body["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_gateway_stats_timeseries(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, duration_hours=24, granularity="hourly"):
+        return [{"time": 1700000000000, "wan-rx_bytes": 5, "wan-tx_bytes": 7}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_gateway_stats", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/gateway?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "timeseries"
+
+
+@pytest.mark.asyncio
+async def test_get_site_dpi_traffic_timeseries(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, by="by_app"):
+        return [{"app": 1, "rx_bytes": 5, "tx_bytes": 7}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_site_dpi_traffic", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/dpi/site?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "timeseries"
+
+
+@pytest.mark.asyncio
+async def test_get_client_dpi_traffic_with_mac(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, client_mac, by="by_app"):
+        assert client_mac == "aa:bb:cc:dd:ee:ff"
+        return [{"app": 1, "rx_bytes": 5, "tx_bytes": 7}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_client_dpi_traffic", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/dpi/clients/aa:bb:cc:dd:ee:ff?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "timeseries"
+
+
+# ---------- DETAIL stats (3 mis-classified) ----------
+
+
+@pytest.mark.asyncio
+async def test_get_device_stats_with_mac_detail(tmp_path, monkeypatch) -> None:
+    """device-stats currently DETAIL kind; dispatch routes to device_manager.get_device_details."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, mac):
+        assert mac == "11:22:33:44:55:66"
+        return {"mac": mac, "name": "ap1", "model": "U6-LR", "type": "uap"}
+
+    from unifi_core.network.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "get_device_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/devices/11:22:33:44:55:66?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert "data" in body
+
+
+@pytest.mark.asyncio
+async def test_get_client_stats_with_mac_detail(tmp_path, monkeypatch) -> None:
+    """client-stats currently DETAIL; dispatch routes to client_manager.get_client_details."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, mac):
+        assert mac == "aa:bb:cc:dd:ee:ff"
+        return {"mac": mac, "hostname": "alice"}
+
+    from unifi_core.network.managers.client_manager import ClientManager
+    monkeypatch.setattr(ClientManager, "get_client_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/clients/aa:bb:cc:dd:ee:ff?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_dpi_stats_detail(tmp_path, monkeypatch) -> None:
+    """dpi-stats currently DETAIL; manager method get_dpi_stats."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, by_app=False, client_mac=None):
+        return {"by_app": [], "by_cat": []}
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_dpi_stats", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/dpi?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------- EVENT_LOG ----------
+
+
+@pytest.mark.asyncio
+async def test_list_events_event_log(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, within=24, limit=100, start=0, event_type=None,
+                       categories=None, severities=None):
+        return [
+            {"_id": "e1", "time": 1700000000000, "key": "EVT_WU_Connected", "msg": "alice connected"},
+            {"_id": "e2", "time": 1700000060000, "key": "EVT_WU_Disconnected", "msg": "bob left"},
+        ]
+
+    from unifi_core.network.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_events", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "event_log"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_alerts_event_log(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, include_archived=False):
+        return [{"_id": "a1", "time": 1700000000000, "key": "EVT_AD_AdminLogin", "msg": "admin login"}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_alerts", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/alerts?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "event_log"
+    assert len(body["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_anomalies_event_log(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, duration_hours=24):
+        return [{"_id": "x1", "time": 1700000000000, "key": "ANOMALY", "msg": "weird"}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_anomalies", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/anomalies?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "event_log"
+
+
+@pytest.mark.asyncio
+async def test_get_ips_events_event_log(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, duration_hours=24, limit=50):
+        return [{"_id": "i1", "time": 1700000000000, "key": "IPS", "msg": "blocked"}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_ips_events", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/ips-events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "event_log"
+
+
+# ---------- LIST ----------
+
+
+@pytest.mark.asyncio
+async def test_list_alarms_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, archived=False, limit=100):
+        return [{"_id": "alarm1", "time": 1700000000000, "key": "EVT_NU_LostContact",
+                 "msg": "device offline", "archived": False}]
+
+    from unifi_core.network.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_alarms", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/alarms?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_backups_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self):
+        return [{"_id": "b1", "filename": "backup.unf", "time": 1700000000000, "size": 1234}]
+
+    from unifi_core.network.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "list_backups", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/backups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_top_clients_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, duration_hours=24, limit=10):
+        return [{"mac": "aa:bb:cc:dd:ee:ff", "hostname": "alice", "total_bytes": 1000}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_top_clients", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/top-clients?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_client_sessions_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, client_mac=None, within_hours=168, limit=100):
+        return [{"_id": "s1", "mac": "aa:bb:cc:dd:ee:ff", "assoc_time": 1700000000,
+                 "duration": 100}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_client_sessions", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/client-sessions?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_network_health_list(tmp_path, monkeypatch) -> None:
+    """network-health is registered LIST per Phase 4A — multi-element list of subsystems."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self):
+        return [
+            {"subsystem": "wlan", "status": "ok", "num_user": 5},
+            {"subsystem": "lan", "status": "ok", "num_user": 0},
+        ]
+
+    from unifi_core.network.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_network_health", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/network-health?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_speedtest_results_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, duration_hours=24):
+        return [{"_id": "st1", "timestamp": 1700000000, "download_mbps": 100,
+                 "upload_mbps": 50, "latency_ms": 10}]
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_speedtest_results", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/speedtest-results?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "list"
+
+
+# ---------- DETAIL ----------
+
+
+@pytest.mark.asyncio
+async def test_get_event_types_detail(tmp_path, monkeypatch) -> None:
+    """event-types: event_manager.get_event_type_prefixes (synchronous, returns list)."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    def fake_get(self):
+        return [{"prefix": "EVT_WU_", "description": "Wireless user"}]
+
+    from unifi_core.network.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_event_type_prefixes", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/event-types?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_autobackup_settings_detail(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self):
+        return {"backup_max_files": 5, "backup_schedule": "daily"}
+
+    from unifi_core.network.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_autobackup_settings", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/autobackup-settings?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_site_settings_detail(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self):
+        return {"name": "default", "desc": "Default site", "site_id": "default"}
+
+    from unifi_core.network.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_site_settings", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/site-settings?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_system_info_detail(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self):
+        return {"version": "8.0.0", "uptime": 12345}
+
+    from unifi_core.network.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_system_info", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/system-info?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_client_wifi_details_with_mac_detail(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, client_mac):
+        assert client_mac == "aa:bb:cc:dd:ee:ff"
+        return {"mac": client_mac, "essid": "MyWifi", "rssi": -55}
+
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_client_wifi_details", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/client-wifi-details/aa:bb:cc:dd:ee:ff?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------- capability mismatch ----------
+
+
+@pytest.mark.asyncio
+async def test_stats_dashboard_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/stats/dashboard?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409
+    assert r.json()["detail"]["kind"] == "capability_mismatch"


### PR DESCRIPTION
## Summary

Phase 5A PR2: read-only resource routes for network waves 4–6 (firewall+QoS+DPI+CF+ACL+OON, port-forwards+vouchers+SNMP, stats+events+system). Adds 36 endpoint families across 3 cluster commits, completing the network read surface.

## Cluster commits

| Cluster | Commit | Families | Notes |
|---|---|---|---|
| 4 — firewall+QoS+DPI+CF+ACL+OON | b16cfc6 | 14 | firewall/groups (literal-slash path), firewall/zones, qos-rules, dpi-applications/categories (paginated wrappers, _unwrap helper), content-filters, acl-rules, oon-policies. DPI category 0 falsy-check preserved. |
| 5 — port-forwards/hotspot/vouchers/SNMP | afd258d | 5 | port-forwards LIST+DETAIL, vouchers LIST + voucher-details/{voucher_id}, snmp-settings (single GET routing through system_manager.get_settings("snmp")). |
| 6 — stats/events/system | d78d3f3 | 17 | TIMESERIES stats endpoints with dual-kind dispatch (handles both current DETAIL and future TIMESERIES kinds for the 3 mis-classified stats tools); events/alerts/anomalies/ips-events as EVENT_LOG; capability-aware /events dispatcher; system info/health/alarms/backups/sessions/wifi-details/speedtest-results. |

Total: 36 endpoint families. Network read coverage now complete.

## Mid-execution adaptations

1. **DPI paginated-wrapper handling (Cluster 4):** `dpi_manager.get_dpi_applications` and `get_dpi_categories` return `{data, totalCount, offset, limit}` wrappers. Routes apply an \`_unwrap()\` helper before paginating.
2. **Voucher detail path uses {voucher_id} not {code} (Cluster 5):** \`HotspotManager.get_voucher_details(voucher_id)\` looks up by internal \`_id\`, not the redemption code. URL path stays \`/voucher-details/...\` per spec; param renamed.
3. **SNMP routing through system_manager (Cluster 5):** No dedicated \`get_snmp_settings()\` method exists; route calls \`system_manager.get_settings("snmp")\` (returns \`list[dict]\`); existing \`SnmpSettingsSerializer\` handles list-unwrap.
4. **/events path collision resolved with capability-aware dispatcher (Cluster 6):** The protect events route at \`/v1/sites/{id}/events\` predates this PR (Phase 3). The new network events route would race. Resolved by writing a capability-aware dispatcher in \`network/events.py\` that routes to network or protect manager based on \`controller.product_kinds\`. Network router registered before protect to win path-match. Existing protect events test still passes.
5. **Dual-kind stats handling (Cluster 6):** Routes call \`kind_for_tool()\` at request time and branch — TIMESERIES paginates per-point, DETAIL passes through. The 3 mis-classified stats tools (\`get_device_stats\`, \`get_client_stats\`, \`get_dpi_stats\`) currently route to their dispatch-table targets (\`device_manager.get_device_details\`, etc.). When the parallel manager-refactor lands and re-registers these as TIMESERIES, the response shape switches automatically — no Phase 5A changes needed.
6. **Stats and event_types use sync manager methods occasionally:** \`get_event_type_prefixes\` is sync; route wraps with \`inspect.isawaitable\` for forward-compat.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (69/205/631/336/157) |
| unifi-api | 336 → 383 (+47 tests) |
| Phase 4A serializer-coverage gate | green |

## Out of scope (later PRs)

- Protect routes — PR3
- Access routes — PR4
- Per-resource streams + /v1/catalog/resources + CI gate — PR5
- Write endpoints — Phase 6
- GraphQL overlay — Phase 8

## Reference

- Spec: Myco \`c56c0e0969cd6a9d\`
- Plan: Myco \`aff0da48adac8cee\`
- PR1: merged in #171 as \`bf07f96\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)