### PR TITLE
PR4: dispatch overrides + stats serializer re-registration (finale)

### DIFF
--- a/apps/api/src/unifi_api/routes/resources/network/stats.py
+++ b/apps/api/src/unifi_api/routes/resources/network/stats.py
@@ -1,20 +1,16 @@
 """GET /v1/sites/{site_id}/stats/* — network stats endpoints.
 
-Phase 5A PR2 Cluster 6. Stats endpoints span TIMESERIES and DETAIL kinds.
+Phase 5A PR2 Cluster 6, amended PR4 of mgr-existence-refactor.
 
-Phase 4A registered 5 stats tools as TIMESERIES (dashboard, network, gateway,
-site_dpi_traffic, client_dpi_traffic) and 3 as DETAIL (device_stats,
-client_stats, dpi_stats) because Phase 2's AST captured the lookup method,
-not the stats fetch method. The parallel manager-refactor will eventually
-re-register the 3 DETAIL ones as TIMESERIES; the dual-kind handler below
-makes Phase 5A robust to whichever state is current at request time.
-
-For the 3 currently-DETAIL stats tools, we call the manager method that the
-AST-derived dispatch table currently routes to (verified at module import
-time): device_manager.get_device_details, client_manager.get_client_details,
-stats_manager.get_dpi_stats. When the parallel refactor lands, both the
-serializer kind and the dispatch table will update together — the route
-inherits both via the registry/dispatch.
+Stats endpoints span TIMESERIES and DETAIL kinds. After PR4:
+- TIMESERIES (7): dashboard, network, gateway, site_dpi_traffic,
+  client_dpi_traffic, **device_stats** (newly), **client_stats** (newly).
+  ``device_stats`` and ``client_stats`` now call ``stats_manager.get_X_stats``
+  directly (was ``device_manager.get_device_details`` /
+  ``client_manager.get_client_details`` pre-PR4); the dispatch override and
+  serializer kind both flipped together.
+- DETAIL (1): dpi_stats — shape is ``{applications: [], categories: []}``,
+  not a per-point timeseries.
 """
 
 from __future__ import annotations
@@ -261,22 +257,20 @@ async def get_device_stats(
     limit: int = Query(50, ge=1, le=500),
     cursor: str | None = Query(None),
 ) -> dict:
-    """DETAIL kind currently; dispatch routes to device_manager.get_device_details."""
+    """TIMESERIES; calls stats_manager.get_device_stats (PR4)."""
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
     try:
         async with sm() as session:
             mgr = await factory.get_domain_manager(
-                session, controller.id, "network", "device_manager",
+                session, controller.id, "network", "stats_manager",
             )
             cm = await factory.get_connection_manager(session, controller.id, "network")
             await _maybe_set_site(cm, site_id)
-            payload = await mgr.get_device_details(mac)
+            payload = await mgr.get_device_stats(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
-    if payload is None:
-        raise HTTPException(status_code=404, detail=f"device {mac} not found")
     return _stats_response(
         request, payload, "unifi_get_device_stats", limit=limit, cursor=cursor,
     )
@@ -294,22 +288,20 @@ async def get_client_stats(
     limit: int = Query(50, ge=1, le=500),
     cursor: str | None = Query(None),
 ) -> dict:
-    """DETAIL kind currently; dispatch routes to client_manager.get_client_details."""
+    """TIMESERIES; calls stats_manager.get_client_stats (PR4)."""
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
     try:
         async with sm() as session:
             mgr = await factory.get_domain_manager(
-                session, controller.id, "network", "client_manager",
+                session, controller.id, "network", "stats_manager",
             )
             cm = await factory.get_connection_manager(session, controller.id, "network")
             await _maybe_set_site(cm, site_id)
-            payload = await mgr.get_client_details(mac)
+            payload = await mgr.get_client_stats(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
-    if payload is None:
-        raise HTTPException(status_code=404, detail=f"client {mac} not found")
     return _stats_response(
         request, payload, "unifi_get_client_stats", limit=limit, cursor=cursor,
     )

--- a/apps/api/src/unifi_api/serializers/network/stats.py
+++ b/apps/api/src/unifi_api/serializers/network/stats.py
@@ -1,20 +1,17 @@
-"""Stats serializers (Phase 4A PR1 Cluster 6).
+"""Stats serializers (Phase 4A PR1 Cluster 6, amended PR4 of mgr-existence-refactor).
 
 TIMESERIES tools share a per-point shape — `{ts: <ms>, ...metrics}` — locked
 in spec §5 (amended April 29, 2026). Window/step metadata moves to
 `render_hint`, not `data`, to fit Phase 3's `serialize_action` contract
 (TIMESERIES iterates `serialize` per item, same as EVENT_LOG).
 
-A handful of nominally-stats tools are registered as DETAIL because the
-AST-captured manager method returns a single dict rather than a list:
-
-- ``unifi_get_device_stats`` → ``device_manager.get_device_details`` (dict)
-- ``unifi_get_client_stats`` → ``client_manager.get_client_details`` (dict)
-- ``unifi_get_dpi_stats`` → ``stats_manager.get_dpi_stats`` (Dict[str, List])
-
-For these, fields are passed through and curated to the keys most relevant
-for stats consumption. Phase 5 (which fixes the AST limitation) can revisit
-whether dedicated stats endpoints exist.
+After PR4 of the manager-owned-existence-checks refactor, the dispatch
+overrides for ``unifi_get_device_stats`` and ``unifi_get_client_stats`` now
+correctly point at ``stats_manager.get_device_stats`` and
+``stats_manager.get_client_stats`` (which return list[point] timeseries),
+so both re-register here as TIMESERIES. ``unifi_get_dpi_stats`` stays as a
+custom serializer because its shape is ``{applications: [], categories: []}``,
+not a per-point timeseries.
 """
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
@@ -34,6 +31,11 @@ def _normalize_ts(point: dict) -> int:
         "unifi_get_gateway_stats": {"kind": RenderKind.TIMESERIES},
         "unifi_get_client_dpi_traffic": {"kind": RenderKind.TIMESERIES},
         "unifi_get_site_dpi_traffic": {"kind": RenderKind.TIMESERIES},
+        # Re-registered as TIMESERIES after PR4 dispatch override fixed the
+        # AST-captured method from ``get_X_details`` (single dict) to
+        # ``stats_manager.get_X_stats`` (list[point]).
+        "unifi_get_device_stats": {"kind": RenderKind.TIMESERIES},
+        "unifi_get_client_stats": {"kind": RenderKind.TIMESERIES},
     },
 )
 class TimeseriesSerializer(Serializer):
@@ -54,28 +56,6 @@ class TimeseriesSerializer(Serializer):
             "ts": ts,
             **{k: v for k, v in point.items() if k not in ("time", "timestamp", "ts")},
         }
-
-
-@register_serializer(
-    tools={
-        "unifi_get_device_stats": {"kind": RenderKind.DETAIL},
-        "unifi_get_client_stats": {"kind": RenderKind.DETAIL},
-    },
-)
-class StatsDetailSerializer(Serializer):
-    """Detail serializer for stats tools whose AST-captured manager method
-    returns a single dict (e.g. ``get_device_details``)."""
-
-    @staticmethod
-    def serialize(obj) -> dict:
-        if obj is None:
-            return {}
-        if isinstance(obj, dict):
-            return dict(obj)
-        raw = getattr(obj, "raw", None)
-        if isinstance(raw, dict):
-            return dict(raw)
-        return {"value": str(obj)}
 
 
 @register_serializer(

--- a/apps/api/src/unifi_api/services/actions.py
+++ b/apps/api/src/unifi_api/services/actions.py
@@ -43,6 +43,7 @@ from typing import Any, Iterable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from unifi_api.services.dispatch_overrides import DISPATCH_OVERRIDES
 from unifi_api.services.managers import ManagerFactory
 from unifi_api.services.manifest import ManifestRegistry, ToolEntry
 
@@ -203,6 +204,14 @@ def build_dispatch_table(
             if call is None:
                 continue
             table[tool_name] = DispatchEntry(manager_attr=call[0], method=call[1])
+
+    # Apply static overrides AFTER the AST walk. Tools whose body has 2+ awaits
+    # by design (preview/execute split, lookup-then-act with state-dependent
+    # preview, multi-manager compose) need explicit dispatch targets — see
+    # ``dispatch_overrides.DISPATCH_OVERRIDES`` for the list and rationale.
+    for tool_name, (manager_attr, method) in DISPATCH_OVERRIDES.items():
+        table[tool_name] = DispatchEntry(manager_attr=manager_attr, method=method)
+
     return table
 
 

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -1,0 +1,98 @@
+"""Static dispatch overrides for tools the AST walker can't resolve correctly.
+
+The Phase 2 dispatch builder in :mod:`unifi_api.services.actions` AST-walks
+tool modules and records the **first** ``await <singleton>.<method>(...)``
+call inside each ``@server.tool`` body. That works for ~95% of tools, but
+fails for two structural patterns:
+
+1. **Lookup-then-act with state-dependent preview** (network/clients): the
+   tool body genuinely needs the current resource state to render a useful
+   preview (current device name before reboot, the old WLAN config before
+   update, the toggle's current enabled flag to compute new state). Refactor
+   would strip a real preview-UX feature, so the tool keeps its 2-call body
+   and we override dispatch to point at the mutation method.
+
+2. **Preview/execute split** (protect/access): managers expose two methods —
+   ``X(id)`` returns preview state, ``apply_X(id)`` executes the mutation.
+   Both are awaited from the tool body depending on ``confirm``. AST captures
+   the first one (typically ``X``); we override to point at ``apply_X``.
+
+Each entry is ``tool_name → (manager_attr, method)`` exactly matching the
+:class:`DispatchEntry` shape the dispatcher consumes. Overrides are applied
+*after* the AST walk in :func:`build_dispatch_table`, so adding an entry
+here always wins over the AST-derived one.
+
+PR4 of the manager-owned-existence-checks refactor (siblings #172 #173 #175).
+"""
+
+from __future__ import annotations
+
+# Format: tool_name -> (manager_attr, method_name)
+DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
+    # =========================================================================
+    # Network — lookup-then-act tools whose preview needs current state
+    # =========================================================================
+    # Client mutations: tool pre-fetches via get_client_details for preview
+    # enrichment (name, current state). Manager already validates existence
+    # internally per PR1.
+    "unifi_block_client": ("client_manager", "block_client"),
+    "unifi_unblock_client": ("client_manager", "unblock_client"),
+    "unifi_rename_client": ("client_manager", "rename_client"),
+    "unifi_force_reconnect_client": ("client_manager", "force_reconnect_client"),
+    "unifi_authorize_guest": ("client_manager", "authorize_guest"),
+    "unifi_unauthorize_guest": ("client_manager", "unauthorize_guest"),
+    "unifi_set_client_ip_settings": ("client_manager", "set_client_ip_settings"),
+    "unifi_forget_client": ("client_manager", "forget_client"),
+    # list_clients branches between get_all_clients (offline+history) and
+    # get_clients (online only) on the include_offline parameter. Default path
+    # is the online list.
+    "unifi_list_clients": ("client_manager", "get_clients"),
+    # Network/WLAN/AP-group mutations: preview pre-fetches for current config.
+    "unifi_update_network": ("network_manager", "update_network"),
+    "unifi_update_wlan": ("network_manager", "update_wlan"),
+    "unifi_toggle_wlan": ("network_manager", "toggle_wlan"),
+    "unifi_delete_wlan": ("network_manager", "delete_wlan"),
+    "unifi_update_ap_group": ("network_manager", "update_ap_group"),
+    "unifi_delete_ap_group": ("network_manager", "delete_ap_group"),
+    # Firewall: tool layer pre-fetches list to find policy by id.
+    "unifi_toggle_firewall_policy": ("firewall_manager", "toggle_firewall_policy"),
+    "unifi_update_firewall_policy": ("firewall_manager", "update_firewall_policy"),
+    # Genuine multi-manager compose: reads networks then creates firewall policy.
+    "unifi_create_simple_firewall_policy": ("firewall_manager", "create_firewall_policy"),
+    # Toggle tools: tool body needs current enabled flag to compute new state.
+    "unifi_toggle_port_forward": ("firewall_manager", "toggle_port_forward"),
+    "unifi_toggle_qos_rule_enabled": ("qos_manager", "update_qos_rule"),
+    "unifi_toggle_oon_policy": ("oon_manager", "toggle_oon_policy"),
+    "unifi_toggle_traffic_route": ("traffic_route_manager", "toggle_traffic_route"),
+    # update_device_radio: tool needs current radio_table to identify target band.
+    "unifi_update_device_radio": ("device_manager", "update_device_radio"),
+    # Stats: tool combines existence check on client/device with stats fetch.
+    "unifi_get_device_stats": ("stats_manager", "get_device_stats"),
+    "unifi_get_client_stats": ("stats_manager", "get_client_stats"),
+    "unifi_get_top_clients": ("stats_manager", "get_top_clients"),
+    # =========================================================================
+    # Protect — preview/execute split (preview_X + X, X + apply_X patterns)
+    # =========================================================================
+    "protect_alarm_arm": ("alarm_manager", "arm"),
+    "protect_alarm_disarm": ("alarm_manager", "disarm"),
+    "protect_ptz_move": ("camera_manager", "ptz_move"),
+    "protect_ptz_preset": ("camera_manager", "ptz_goto_preset"),
+    "protect_ptz_zoom": ("camera_manager", "ptz_zoom"),
+    "protect_reboot_camera": ("camera_manager", "apply_reboot_camera"),
+    "protect_toggle_recording": ("camera_manager", "apply_toggle_recording"),
+    "protect_update_camera_settings": ("camera_manager", "update_camera_settings"),
+    "protect_update_chime": ("chime_manager", "apply_chime_settings"),
+    "protect_update_light": ("light_manager", "apply_light_settings"),
+    "protect_acknowledge_event": ("event_manager", "apply_acknowledge_event"),
+    # =========================================================================
+    # Access — preview/execute split (X + apply_X)
+    # =========================================================================
+    "access_create_credential": ("credential_manager", "apply_create_credential"),
+    "access_revoke_credential": ("credential_manager", "apply_revoke_credential"),
+    "access_reboot_device": ("device_manager", "apply_reboot_device"),
+    "access_lock_door": ("door_manager", "apply_lock_door"),
+    "access_unlock_door": ("door_manager", "apply_unlock_door"),
+    "access_update_policy": ("policy_manager", "apply_update_policy"),
+    "access_create_visitor": ("visitor_manager", "apply_create_visitor"),
+    "access_delete_visitor": ("visitor_manager", "apply_delete_visitor"),
+}

--- a/apps/api/tests/routes/resources/test_network_stats_events_system.py
+++ b/apps/api/tests/routes/resources/test_network_stats_events_system.py
@@ -182,22 +182,26 @@ async def test_get_client_dpi_traffic_with_mac(tmp_path, monkeypatch) -> None:
     assert r.json()["render_hint"]["kind"] == "timeseries"
 
 
-# ---------- DETAIL stats (3 mis-classified) ----------
+# ---------- TIMESERIES stats (PR4 dispatch override now points at
+# stats_manager.get_X_stats which returns list[point]) ----------
 
 
 @pytest.mark.asyncio
-async def test_get_device_stats_with_mac_detail(tmp_path, monkeypatch) -> None:
-    """device-stats currently DETAIL kind; dispatch routes to device_manager.get_device_details."""
+async def test_get_device_stats_with_mac_timeseries(tmp_path, monkeypatch) -> None:
+    """device-stats now TIMESERIES; dispatch override routes to stats_manager.get_device_stats."""
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)
     _stub_connection(app, cid)
 
-    async def fake_get(self, mac):
+    async def fake_stats(self, mac, *args, **kwargs):
         assert mac == "11:22:33:44:55:66"
-        return {"mac": mac, "name": "ap1", "model": "U6-LR", "type": "uap"}
+        return [
+            {"time": 1_700_000_000, "rx_bytes": 1, "tx_bytes": 2},
+            {"time": 1_700_000_300, "rx_bytes": 3, "tx_bytes": 4},
+        ]
 
-    from unifi_core.network.managers.device_manager import DeviceManager
-    monkeypatch.setattr(DeviceManager, "get_device_details", fake_get)
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_device_stats", fake_stats)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(
@@ -206,23 +210,23 @@ async def test_get_device_stats_with_mac_detail(tmp_path, monkeypatch) -> None:
         )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["render_hint"]["kind"] == "detail"
-    assert "data" in body
+    assert body["render_hint"]["kind"] == "timeseries"
+    assert isinstance(body["items"], list) and len(body["items"]) == 2
 
 
 @pytest.mark.asyncio
-async def test_get_client_stats_with_mac_detail(tmp_path, monkeypatch) -> None:
-    """client-stats currently DETAIL; dispatch routes to client_manager.get_client_details."""
+async def test_get_client_stats_with_mac_timeseries(tmp_path, monkeypatch) -> None:
+    """client-stats now TIMESERIES; dispatch override routes to stats_manager.get_client_stats."""
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)
     _stub_connection(app, cid)
 
-    async def fake_get(self, mac):
+    async def fake_stats(self, mac, *args, **kwargs):
         assert mac == "aa:bb:cc:dd:ee:ff"
-        return {"mac": mac, "hostname": "alice"}
+        return [{"timestamp": 1_700_000_000_000, "tx_bytes": 100}]
 
-    from unifi_core.network.managers.client_manager import ClientManager
-    monkeypatch.setattr(ClientManager, "get_client_details", fake_get)
+    from unifi_core.network.managers.stats_manager import StatsManager
+    monkeypatch.setattr(StatsManager, "get_client_stats", fake_stats)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(
@@ -231,7 +235,8 @@ async def test_get_client_stats_with_mac_detail(tmp_path, monkeypatch) -> None:
         )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["render_hint"]["kind"] == "detail"
+    assert body["render_hint"]["kind"] == "timeseries"
+    assert isinstance(body["items"], list)
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/serializers/test_network_stats.py
+++ b/apps/api/tests/serializers/test_network_stats.py
@@ -59,28 +59,32 @@ def test_timeseries_dispatches_for_all_list_returning_stats_tools() -> None:
         assert out["render_hint"]["kind"] == "timeseries"
 
 
-# ---- DETAIL stats (dict-returning AST capture) ----
+# ---- TIMESERIES stats (PR4 dispatch override now points at list-returning
+# stats_manager.get_device_stats / get_client_stats) ----
 
 
-def test_device_stats_detail_serializer_shape() -> None:
-    """get_device_details (AST capture) returns a single device dict."""
+def test_device_stats_timeseries_serializer_shape() -> None:
     reg = _registry()
     s = reg.serializer_for_tool("unifi_get_device_stats")
-    sample = {"mac": "aa:bb:cc:dd:ee:ff", "name": "AP-1", "uptime": 3600, "rx_bytes": 1, "tx_bytes": 2}
+    sample = [
+        {"time": 1_700_000_000, "rx_bytes": 1, "tx_bytes": 2},
+        {"time": 1_700_000_300, "rx_bytes": 3, "tx_bytes": 4},
+    ]
     out = s.serialize_action(sample, tool_name="unifi_get_device_stats")
     assert out["success"] is True
-    assert out["render_hint"]["kind"] == "detail"
-    assert out["data"]["mac"] == "aa:bb:cc:dd:ee:ff"
-    assert out["data"]["uptime"] == 3600
+    assert out["render_hint"]["kind"] == "timeseries"
+    assert isinstance(out["data"], list) and len(out["data"]) == 2
+    assert out["data"][0]["ts"] == 1_700_000_000_000  # seconds → ms
 
 
-def test_client_stats_detail_serializer_shape() -> None:
+def test_client_stats_timeseries_serializer_shape() -> None:
     reg = _registry()
     s = reg.serializer_for_tool("unifi_get_client_stats")
-    sample = {"mac": "11:22:33:44:55:66", "hostname": "laptop", "tx_bytes": 100}
+    sample = [{"timestamp": 1_700_000_000_000, "tx_bytes": 100}]
     out = s.serialize_action(sample, tool_name="unifi_get_client_stats")
-    assert out["render_hint"]["kind"] == "detail"
-    assert out["data"]["mac"] == "11:22:33:44:55:66"
+    assert out["render_hint"]["kind"] == "timeseries"
+    assert out["data"][0]["ts"] == 1_700_000_000_000
+    assert out["data"][0]["tx_bytes"] == 100
 
 
 def test_dpi_stats_detail_serializer_shape() -> None:

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -199,12 +199,12 @@ def test_build_dispatch_table_finds_real_tools() -> None:
     dispatch table to contain at least one well-known tool from each.
     """
     table = build_dispatch_table()
-    # unifi_list_clients -> client_manager.get_clients (matches tools/clients.py)
+    # unifi_list_clients -> client_manager.get_clients (PR4 override pins the
+    # default-path branch where include_offline=False).
     network_entry = table.get("unifi_list_clients") or table.get("list_clients")
     assert network_entry is not None
     assert network_entry.manager_attr == "client_manager"
-    # The first awaited call in list_clients is get_all_clients() OR get_clients()
-    assert network_entry.method in {"get_clients", "get_all_clients"}
+    assert network_entry.method == "get_clients"
 
     # protect_list_cameras -> camera_manager.list_cameras
     protect_entry = table.get("protect_list_cameras")
@@ -217,3 +217,53 @@ def test_build_dispatch_table_finds_real_tools() -> None:
     assert access_entry is not None
     assert access_entry.manager_attr == "door_manager"
     assert access_entry.method == "list_doors"
+
+
+def test_dispatch_overrides_redirect_compose_tools_to_mutation() -> None:
+    """PR4: tools whose body has 2+ awaits by design route to the mutation
+    method via the static DISPATCH_OVERRIDES table — not the AST-captured
+    first-await (typically a lookup or preview)."""
+    from unifi_api.services.dispatch_overrides import DISPATCH_OVERRIDES
+
+    table = build_dispatch_table()
+
+    # Every override must be present in the resolved table and match.
+    for tool_name, (manager_attr, method) in DISPATCH_OVERRIDES.items():
+        entry = table.get(tool_name)
+        assert entry is not None, f"override missing from dispatch table: {tool_name}"
+        assert entry.manager_attr == manager_attr, (
+            f"{tool_name} manager: got {entry.manager_attr!r}, want {manager_attr!r}"
+        )
+        assert entry.method == method, (
+            f"{tool_name} method: got {entry.method!r}, want {method!r}"
+        )
+
+
+def test_dispatch_overrides_specific_targets() -> None:
+    """Spot-check: previously-broken dispatch for a representative sample
+    of each override category now resolves to the mutation method."""
+    table = build_dispatch_table()
+
+    # Network lookup-then-act with state-dependent preview
+    assert table["unifi_block_client"].method == "block_client"
+    assert table["unifi_update_network"].method == "update_network"
+    assert table["unifi_toggle_wlan"].method == "toggle_wlan"
+    # Toggle that needs current state
+    assert table["unifi_toggle_firewall_policy"].method == "toggle_firewall_policy"
+    # Multi-manager compose
+    assert table["unifi_create_simple_firewall_policy"].manager_attr == "firewall_manager"
+    assert table["unifi_create_simple_firewall_policy"].method == "create_firewall_policy"
+    # Stats: list-returning method (was AST-captured as get_X_details, a dict)
+    assert table["unifi_get_device_stats"].manager_attr == "stats_manager"
+    assert table["unifi_get_device_stats"].method == "get_device_stats"
+    assert table["unifi_get_client_stats"].method == "get_client_stats"
+
+    # Protect preview/execute split
+    assert table["protect_reboot_camera"].method == "apply_reboot_camera"
+    assert table["protect_alarm_arm"].method == "arm"
+    assert table["protect_acknowledge_event"].method == "apply_acknowledge_event"
+
+    # Access preview/execute split
+    assert table["access_lock_door"].method == "apply_lock_door"
+    assert table["access_create_credential"].method == "apply_create_credential"
+    assert table["access_update_policy"].method == "apply_update_policy"


### PR DESCRIPTION
## Summary

**Finale of the manager-owned-existence-checks refactor.** Siblings: #172 (network managers), #173 (protect), #175 (access).

After PR1–PR3, manager existence checks raise `UniFiNotFoundError` consistently, and ~19 simple lookup-then-act tools resolved through pure refactor. The remaining ~45 compose-case tools have legitimate two-method bodies and need the **dispatch override pattern** from spec §4.4 — that's what this PR lands.

## What this PR does

### 1. New `DISPATCH_OVERRIDES` static table

`apps/api/src/unifi_api/services/dispatch_overrides.py` — maps 45 tool names to `(manager_attr, method)` tuples. Covers two structural patterns:

- **Lookup-then-act with state-dependent preview** (network/clients): tool body genuinely needs current resource state to render a useful preview (current device name before reboot, old WLAN config before update, toggle's current enabled flag). Refactoring would strip a real UX feature.
- **Preview/execute split** (protect/access): managers expose `X(id)` for preview state and `apply_X(id)` for execution; both awaited conditionally on `confirm`.

### 2. Wires overrides into `build_dispatch_table`

`apps/api/src/unifi_api/services/actions.py` — AST walk runs first, overrides applied after, so override entries always win.

### 3. Re-registers `unifi_get_device_stats` and `unifi_get_client_stats` as TIMESERIES

`apps/api/src/unifi_api/serializers/network/stats.py` — pre-PR4 these were DETAIL because AST captured `get_X_details` (a single dict). PR4's override redirects dispatch at `stats_manager.get_X_stats` (list of points), so TIMESERIES is now correct.

- `unifi_get_top_clients` stays LIST (per-client aggregates, not per-point series).
- `unifi_get_dpi_stats` stays DETAIL (`{applications: [], categories: []}` shape).

### 4. Updates resource routes for the new shape

`apps/api/src/unifi_api/routes/resources/network/stats.py` — `/v1/sites/{site}/stats/devices/{mac}` and `/v1/sites/{site}/stats/clients/{mac}` now call `stats_manager.get_X_stats` directly instead of `*_details`, so route output matches the new TIMESERIES serializer kind.

### 5. Tests

- `test_dispatch_overrides_redirect_compose_tools_to_mutation` — every override entry resolves correctly (asserts on the full DISPATCH_OVERRIDES table).
- `test_dispatch_overrides_specific_targets` — spot-check representative samples across all three override categories.
- Updated stats serializer/route tests for the TIMESERIES shape (was DETAIL).

## Override breakdown (45 tools)

- **Network (26)**: 8 client mutations (`block`/`unblock`/`rename`/`force_reconnect`/`authorize_guest`/`unauthorize_guest`/`set_ip_settings`/`forget`), `list_clients`, 6 network/wlan/ap-group mutations, 3 firewall mutations (incl. `create_simple_firewall_policy` multi-manager compose), 4 toggle tools (`port_forward`/`qos_rule_enabled`/`oon_policy`/`traffic_route`), `update_device_radio`, 3 stats compose tools.
- **Protect (11)**: `alarm_arm`/`alarm_disarm`, 6 camera tools (`ptz_*`/`reboot`/`toggle_recording`/`update_camera_settings`), 2 device tools (`update_chime`/`update_light`), `acknowledge_event`.
- **Access (8)**: 2 credential mutations, `reboot_device`, 2 door mutations, `update_policy`, 2 visitor mutations.

## Test deltas

| Package | Before | After | Δ |
|---|---|---|---|
| unifi-core | 69 | 69 | 0 |
| unifi-mcp-shared | 205 | 205 | 0 |
| unifi-network-mcp | 630 | 630 | 0 |
| unifi-protect-mcp | 336 | 336 | 0 |
| unifi-access-mcp | 157 | 157 | 0 |
| unifi-api | 388 | **390** | +2 (override coverage tests) |

## After this PR merges

The Phase 2 AST-based dispatch table now resolves correctly for **every** mutation tool across network/protect/access. The Phase 5A "AST introspection fix" item from the original Phase 5A scope is no longer needed — the static-override pattern is the architecturally cleaner solution.

## Test plan

- [x] All 6 package suites pass
- [x] New dispatch_overrides coverage test asserts all 45 entries resolve
- [x] Existing `test_serializer_coverage` Phase 4A gate stays green
- [x] Live smoke recommendable but not strictly required (no behavior change at the controller layer; only dispatch routing within unifi-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)