### PR TITLE
Phase 5A PR3: protect resource routes (15 endpoint families)

### DIFF
--- a/apps/api/src/unifi_api/routes/resources/protect/cameras.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/cameras.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -115,4 +117,128 @@ async def get_camera(
     return {
         "data": serializer.serialize(camera),
         "render_hint": registry.render_hint_for_resource("protect", "cameras/{id}"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-camera nested reads (Phase 5A PR3 Cluster 1).
+#
+# Camera analytics/streams/snapshot are intentionally nested under
+# /cameras/{id}/* — the spec's only flat-layout exception, since these
+# resources are intrinsically per-camera. The serializers live alongside
+# the LIST/DETAIL serializer in unifi_api.serializers.protect.cameras.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/sites/{site_id}/cameras/{camera_id}/analytics",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_camera_analytics(
+    request: Request,
+    site_id: str,
+    camera_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "camera_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            analytics = await mgr.get_camera_analytics(camera_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if analytics is None:
+        raise HTTPException(
+            status_code=404, detail=f"camera analytics for {camera_id} not found",
+        )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_camera_analytics")
+    return {
+        "data": serializer.serialize(analytics),
+        "render_hint": registry.render_hint_for_tool("protect_get_camera_analytics"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/cameras/{camera_id}/streams",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_camera_streams(
+    request: Request,
+    site_id: str,
+    camera_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "camera_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            streams = await mgr.get_camera_streams(camera_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if streams is None:
+        raise HTTPException(
+            status_code=404, detail=f"camera streams for {camera_id} not found",
+        )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_camera_streams")
+    return {
+        "data": serializer.serialize(streams),
+        "render_hint": registry.render_hint_for_tool("protect_get_camera_streams"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/cameras/{camera_id}/snapshot",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_camera_snapshot(
+    request: Request,
+    site_id: str,
+    camera_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """Return snapshot metadata (size_bytes / content_type / captured_at).
+
+    The manager returns raw JPEG bytes; the SnapshotSerializer surfaces
+    metadata only. A future ``/snapshot/raw`` endpoint that returns the
+    binary body is deferred to Phase 5B if a UI consumer needs it.
+    """
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "camera_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            snapshot = await mgr.get_snapshot(camera_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if snapshot is None:
+        raise HTTPException(
+            status_code=404, detail=f"snapshot for {camera_id} not found",
+        )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_snapshot")
+    return {
+        "data": serializer.serialize(snapshot),
+        "render_hint": registry.render_hint_for_tool("protect_get_snapshot"),
     }

--- a/apps/api/src/unifi_api/routes/resources/protect/chimes.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/chimes.py
@@ -1,0 +1,71 @@
+"""GET /v1/sites/{site_id}/chimes — protect chimes.
+
+The protect ``ChimeManager`` exposes ``list_chimes``; there is no dedicated
+``protect_get_chime`` tool in the manifest, so this module only ships LIST
+(mirrors network firewall_zones, which is also LIST-only).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.protect.cameras import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/chimes",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_chimes(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "chime_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_chimes()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_chimes")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("protect_list_chimes"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/events.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/events.py
@@ -1,12 +1,21 @@
-"""GET /v1/sites/{site_id}/events — protect event log.
+"""GET /v1/sites/{site_id}/events[/{id}] + thumbnails + smart-detections + recent-events.
 
-LIST only (EVENT_LOG render kind). The protect manifest does not expose
-a ``protect_get_event`` tool, so we don't expose a detail endpoint.
+Phase 3 landed the LIST endpoint. Phase 5A PR3 Cluster 2 extends with:
+
+- ``GET /events/{event_id}``           → ``protect_get_event``
+- ``GET /event-thumbnails/{event_id}`` → ``protect_get_event_thumbnail``
+- ``GET /smart-detections``            → ``protect_list_smart_detections`` (EVENT_LOG)
+- ``GET /recent-events``               → ``protect_recent_events`` (buffer snapshot)
+
+The path ``/events/{id}`` does not collide with PR2's network/events.py
+capability-aware dispatcher — that one only owns the bare ``/events`` path.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
@@ -83,4 +92,173 @@ async def list_events(
         "items": items,
         "next_cursor": next_cursor.encode() if next_cursor else None,
         "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/events/{event_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_event(
+    request: Request,
+    site_id: str,
+    event_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "event_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            event = await mgr.get_event(event_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_event")
+    return {
+        "data": serializer.serialize(event),
+        "render_hint": registry.render_hint_for_tool("protect_get_event"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/event-thumbnails/{event_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_event_thumbnail(
+    request: Request,
+    site_id: str,
+    event_id: str,
+    controller=Depends(resolve_controller),
+    width: int | None = Query(None, ge=1, le=4096),
+    height: int | None = Query(None, ge=1, le=4096),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "event_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_event_thumbnail(event_id, width=width, height=height)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_event_thumbnail")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_get_event_thumbnail"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/smart-detections",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_smart_detections(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    camera_id: str | None = Query(None),
+    detection_type: str | None = Query(None),
+    min_confidence: int | None = Query(None, ge=0, le=100),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        all_events = await mgr.list_smart_detections(
+            camera_id=camera_id,
+            detection_type=detection_type,
+            min_confidence=min_confidence,
+            limit=max(limit, 100),
+        )
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_events), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_smart_detections")
+    return {
+        "items": [serializer.serialize(e) for e in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("protect_list_smart_detections"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/recent-events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def recent_events(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    event_type: str | None = Query(None),
+    camera_id: str | None = Query(None),
+    min_confidence: int | None = Query(None, ge=0, le=100),
+    limit: int | None = Query(None, ge=1, le=500),
+) -> dict:
+    """Return a snapshot of the websocket ring buffer.
+
+    Differs from the SSE stream at ``/v1/streams/protect/events``: this is
+    a buffer-snapshot REST surface, not a tailing stream. ``DETAIL`` render
+    kind — the manager's wrapper dict (events / count / source / buffer_size)
+    is itself the payload.
+    """
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        # get_recent_from_buffer is synchronous (in-memory ring buffer read)
+        events = mgr.get_recent_from_buffer(
+            event_type=event_type,
+            camera_id=camera_id,
+            min_confidence=min_confidence,
+            limit=limit,
+        )
+
+    buffer_size = getattr(mgr, "buffer_size", len(events) if isinstance(events, list) else 0)
+    payload = {
+        "events": list(events) if events is not None else [],
+        "count": len(events) if events is not None else 0,
+        "source": "buffer",
+        "buffer_size": buffer_size,
+    }
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_recent_events")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_recent_events"),
     }

--- a/apps/api/src/unifi_api/routes/resources/protect/lights.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/lights.py
@@ -1,0 +1,130 @@
+"""GET /v1/sites/{site_id}/lights[/{light_id}] — protect lights.
+
+The protect ``LightManager`` exposes only ``list_lights``; there is no
+dedicated ``get_light`` summary helper, and the manifest does not register
+a ``protect_get_light`` tool. The DETAIL endpoint therefore filters from
+the LIST response (mirrors the network firewall_rules pattern).
+
+Protect is a single-controller, no-site product: the protect connection
+manager has no ``set_site`` method, so we guard the call via ``getattr``
+through the shared ``_maybe_set_site`` helper.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.protect.cameras import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/lights",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_lights(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "light_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_lights()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_lights")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("protect_list_lights"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/lights/{light_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_light_details(
+    request: Request,
+    site_id: str,
+    light_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """No native ``protect_get_light`` tool exists — filter from LIST.
+
+    LightManager._get_light raises UniFiNotFoundError, but list_lights
+    does not invoke that helper. We wrap the manager call defensively
+    so any future refactor that surfaces UniFiNotFoundError keeps mapping
+    cleanly to a 404.
+    """
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "light_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            all_lights = await mgr.list_lights()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    found = None
+    for light in all_lights:
+        raw = light if isinstance(light, dict) else getattr(light, "raw", {}) or {}
+        if raw.get("id") == light_id:
+            found = light
+            break
+    if found is None:
+        raise HTTPException(status_code=404, detail=f"light {light_id} not found")
+
+    registry = request.app.state.serializer_registry
+    # No protect_get_light tool exists; reuse the LIST serializer + emit a
+    # detail render hint so consumers can render a single-row detail card.
+    serializer = registry.serializer_for_tool("protect_list_lights")
+    list_hint = registry.render_hint_for_tool("protect_list_lights")
+    detail_hint = {**list_hint, "kind": "detail"}
+    return {
+        "data": serializer.serialize(found),
+        "render_hint": detail_hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/liveviews.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/liveviews.py
@@ -1,0 +1,117 @@
+"""GET /v1/sites/{site_id}/liveviews[/{liveview_id}] — protect liveviews.
+
+LiveviewManager exposes ``list_liveviews`` only as a read surface; there
+is no ``protect_get_liveview`` tool in the manifest. The DETAIL endpoint
+filters from the LIST response (mirrors the lights/sensors pattern).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.protect.cameras import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/liveviews",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_liveviews(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "liveview_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_liveviews()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_liveviews")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("protect_list_liveviews"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/liveviews/{liveview_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_liveview(
+    request: Request,
+    site_id: str,
+    liveview_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """No native ``protect_get_liveview`` tool — filter from LIST."""
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "liveview_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            all_lvs = await mgr.list_liveviews()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    found = None
+    for lv in all_lvs:
+        raw = lv if isinstance(lv, dict) else getattr(lv, "raw", {}) or {}
+        if raw.get("id") == liveview_id:
+            found = lv
+            break
+    if found is None:
+        raise HTTPException(status_code=404, detail=f"liveview {liveview_id} not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_liveviews")
+    list_hint = registry.render_hint_for_tool("protect_list_liveviews")
+    detail_hint = {**list_hint, "kind": "detail"}
+    return {
+        "data": serializer.serialize(found),
+        "render_hint": detail_hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/recordings.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recordings.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -140,4 +142,44 @@ async def get_recording(
     return {
         "data": serializer.serialize(match),
         "render_hint": registry.render_hint_for_resource("protect", "recordings/{id}"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/recording-status",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_recording_status(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    camera_id: str | None = Query(
+        None, description="Optional — limit to a single camera",
+    ),
+) -> dict:
+    """Return current recording state for one or all cameras.
+
+    The ``camera_id`` query is optional: omitting it returns the
+    aggregate (all cameras), supplying it scopes to one camera and
+    raises 404 via UniFiNotFoundError if the camera is unknown.
+    """
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "recording_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_recording_status(camera_id=camera_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_recording_status")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_get_recording_status"),
     }

--- a/apps/api/src/unifi_api/routes/resources/protect/sensors.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/sensors.py
@@ -1,0 +1,118 @@
+"""GET /v1/sites/{site_id}/sensors[/{sensor_id}] — protect sensors.
+
+The protect ``SensorManager`` exposes only ``list_sensors``; there is no
+dedicated ``get_sensor`` summary helper, and the manifest does not register
+a ``protect_get_sensor`` tool. The DETAIL endpoint therefore filters from
+the LIST response (mirrors lights.py / network firewall_rules).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.protect.cameras import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/sensors",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_sensors(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "sensor_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_sensors()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_sensors")
+    return {
+        "items": [serializer.serialize(i) for i in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("protect_list_sensors"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/sensors/{sensor_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_sensor_details(
+    request: Request,
+    site_id: str,
+    sensor_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """No native ``protect_get_sensor`` tool exists — filter from LIST."""
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "sensor_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            all_sensors = await mgr.list_sensors()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    found = None
+    for sensor in all_sensors:
+        raw = sensor if isinstance(sensor, dict) else getattr(sensor, "raw", {}) or {}
+        if raw.get("id") == sensor_id:
+            found = sensor
+            break
+    if found is None:
+        raise HTTPException(status_code=404, detail=f"sensor {sensor_id} not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_sensors")
+    list_hint = registry.render_hint_for_tool("protect_list_sensors")
+    detail_hint = {**list_hint, "kind": "detail"}
+    return {
+        "data": serializer.serialize(found),
+        "render_hint": detail_hint,
+    }

--- a/apps/api/src/unifi_api/routes/resources/protect/system.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/system.py
@@ -1,0 +1,267 @@
+"""Protect system + alarm read endpoints.
+
+Six endpoint families collected here:
+
+- ``GET /firmware-status``           → ``protect_get_firmware_status``
+- ``GET /alarm-status``              → ``protect_alarm_get_status``
+- ``GET /alarm-profiles``            → ``protect_alarm_list_profiles``
+- ``GET /protect/health``            → ``protect_get_health`` (product-prefixed
+  to disambiguate from ``/network/health`` and ``/access/health``)
+- ``GET /protect/system-info``       → ``protect_get_system_info`` (likewise)
+- ``GET /viewers``                   → ``protect_list_viewers``
+
+The ``/protect/...`` prefix is in the URL path — not a router prefix.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.protect.cameras import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+# ---------------------------------------------------------------------------
+# Firmware status
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/sites/{site_id}/firmware-status",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_firmware_status(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "system_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_firmware_status()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_firmware_status")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_get_firmware_status"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Alarm status + profiles (alarm_manager)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/sites/{site_id}/alarm-status",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def alarm_get_status(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "alarm_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_arm_state()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_alarm_get_status")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_alarm_get_status"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/alarm-profiles",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def alarm_list_profiles(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "alarm_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_arm_profiles()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_alarm_list_profiles")
+    return {
+        "items": [serializer.serialize(p) for p in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("protect_alarm_list_profiles"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Protect-prefixed health + system info (disambiguated paths)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/sites/{site_id}/protect/health",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_protect_health(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "system_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_health()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_health")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_get_health"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/protect/system-info",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_protect_system_info(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "protect", "system_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "protect")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_system_info()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_get_system_info")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("protect_get_system_info"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Viewers — LIST
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/sites/{site_id}/viewers",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_viewers(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "protect", "system_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "protect")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_viewers()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("protect_list_viewers")
+    # ViewerSerializer hint kind is "detail" but the surface is a LIST —
+    # override to "list" so consumers render rows. Mirror the chimes
+    # approach if the registry exposes a list-render hint; here we just
+    # set kind explicitly.
+    list_hint = {**registry.render_hint_for_tool("protect_list_viewers"), "kind": "list"}
+    return {
+        "items": [serializer.serialize(v) for v in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": list_hint,
+    }

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -57,8 +57,10 @@ from unifi_api.routes.resources.protect import (
     chimes as protect_chimes_routes,
     events as protect_events_routes,
     lights as protect_lights_routes,
+    liveviews as protect_liveviews_routes,
     recordings as protect_recordings_routes,
     sensors as protect_sensors_routes,
+    system as protect_system_routes,
 )
 from unifi_api.routes.resources.access import (
     credentials as access_credentials_routes,
@@ -230,6 +232,8 @@ def create_app(config: ApiConfig) -> FastAPI:
         protect_lights_routes,
         protect_sensors_routes,
         protect_chimes_routes,
+        protect_liveviews_routes,
+        protect_system_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -54,8 +54,11 @@ from unifi_api.routes.resources.network import (
 )
 from unifi_api.routes.resources.protect import (
     cameras as protect_cameras_routes,
+    chimes as protect_chimes_routes,
     events as protect_events_routes,
+    lights as protect_lights_routes,
     recordings as protect_recordings_routes,
+    sensors as protect_sensors_routes,
 )
 from unifi_api.routes.resources.access import (
     credentials as access_credentials_routes,
@@ -224,6 +227,9 @@ def create_app(config: ApiConfig) -> FastAPI:
         protect_cameras_routes,
         protect_events_routes,
         protect_recordings_routes,
+        protect_lights_routes,
+        protect_sensors_routes,
+        protect_chimes_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/tests/routes/resources/test_protect_cameras_lights_sensors.py
+++ b/apps/api/tests/routes/resources/test_protect_cameras_lights_sensors.py
@@ -1,0 +1,408 @@
+"""Phase 5A PR3 Cluster 1 — protect cameras (extension) + lights + sensors + chimes.
+
+Per-camera analytics/streams/snapshot are nested under /cameras/{id}/* (the one
+intentional flat-layout exception). Lights and sensors expose LIST + DETAIL
+(filter-from-list since the protect managers don't expose dedicated get_*
+methods for these device families). Chimes expose LIST only.
+"""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="protect"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="P", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeProtectCM:
+    """Stub protect connection manager — no set_site (single-controller-no-site)."""
+
+    async def initialize(self) -> None:
+        return None
+
+
+def _stub_connection(app, cid: str) -> _FakeProtectCM:
+    fake = _FakeProtectCM()
+    app.state.manager_factory._connection_cache[(cid, "protect")] = fake
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Cameras — nested analytics / streams / snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_camera_analytics_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "camera_id": "cam-1",
+        "camera_name": "Door",
+        "detections": {"is_motion_detected": False},
+        "smart_detects": {},
+        "smart_audio_detects": {},
+        "currently_detected": {},
+        "motion_zone_count": 2,
+        "smart_detect_zone_count": 1,
+        "stats": {},
+    }
+
+    async def fake(self, camera_id):
+        assert camera_id == "cam-1"
+        return payload
+
+    from unifi_core.protect.managers.camera_manager import CameraManager
+    monkeypatch.setattr(CameraManager, "get_camera_analytics", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/cameras/cam-1/analytics?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["camera_id"] == "cam-1"
+    assert body["data"]["motion_zone_count"] == 2
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_camera_streams_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "camera_id": "cam-1",
+        "camera_name": "Door",
+        "channels": {"high": {"channel_id": 0}},
+        "rtsps_streams": {"high": "rtsps://x/abc"},
+    }
+
+    async def fake(self, camera_id):
+        return payload
+
+    from unifi_core.protect.managers.camera_manager import CameraManager
+    monkeypatch.setattr(CameraManager, "get_camera_streams", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/cameras/cam-1/streams?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["camera_id"] == "cam-1"
+    assert body["data"]["rtsps_streams"]["high"] == "rtsps://x/abc"
+
+
+@pytest.mark.asyncio
+async def test_get_camera_snapshot_returns_metadata(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_jpeg = b"\xff\xd8" + b"\x00" * 1024 + b"\xff\xd9"
+
+    async def fake(self, camera_id, width=None, height=None):
+        return fake_jpeg
+
+    from unifi_core.protect.managers.camera_manager import CameraManager
+    monkeypatch.setattr(CameraManager, "get_snapshot", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/cameras/cam-1/snapshot?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # SnapshotSerializer surfaces metadata, not raw bytes.
+    assert body["data"]["size_bytes"] == len(fake_jpeg)
+    assert body["data"]["content_type"] == "image/jpeg"
+    assert body["data"]["captured_at"] is not None
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_camera_analytics_404_via_unifi_not_found(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake(self, camera_id):
+        raise UniFiNotFoundError("camera", camera_id)
+
+    from unifi_core.protect.managers.camera_manager import CameraManager
+    monkeypatch.setattr(CameraManager, "get_camera_analytics", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/cameras/missing/analytics?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404, r.text
+
+
+# ---------------------------------------------------------------------------
+# Lights — LIST + DETAIL (filter-from-list)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_lights_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_lights = [
+        {
+            "id": f"light-{i}",
+            "mac": f"aa:bb:cc:00:00:0{i}",
+            "name": f"Light {i}",
+            "model": "FloodLight",
+            "state": "CONNECTED",
+            "is_pir_motion_detected": False,
+            "is_light_on": (i % 2 == 0),
+        }
+        for i in range(3)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_lights
+
+    from unifi_core.protect.managers.light_manager import LightManager
+    monkeypatch.setattr(LightManager, "list_lights", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/lights?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+    assert {item["id"] for item in body["items"]} == {"light-0", "light-1", "light-2"}
+
+
+@pytest.mark.asyncio
+async def test_list_lights_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")  # no protect
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/lights?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "protect"
+
+
+@pytest.mark.asyncio
+async def test_get_light_filter_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_lights = [
+        {
+            "id": "light-1",
+            "mac": "aa:bb:cc:00:00:01",
+            "name": "Garage",
+            "model": "FloodLight",
+            "state": "CONNECTED",
+            "is_pir_motion_detected": False,
+            "is_light_on": True,
+        },
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_lights
+
+    from unifi_core.protect.managers.light_manager import LightManager
+    monkeypatch.setattr(LightManager, "list_lights", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/lights/light-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/lights/light-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["data"]["id"] == "light-1"
+    assert ok.json()["render_hint"]["kind"] == "detail"
+    assert miss.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Sensors — LIST + DETAIL (filter-from-list)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sensors_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_sensors = [
+        {
+            "id": f"sen-{i}",
+            "mac": f"dd:ee:ff:00:00:0{i}",
+            "name": f"Sensor {i}",
+            "type": "ups",
+            "battery": {"status": "normal"},
+            "stats": {"humidity": {"status": "normal"}, "light": {"status": "normal"}},
+            "motion_detected_at": None,
+        }
+        for i in range(2)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_sensors
+
+    from unifi_core.protect.managers.sensor_manager import SensorManager
+    monkeypatch.setattr(SensorManager, "list_sensors", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/sensors?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_sensor_filter_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_sensors = [
+        {
+            "id": "sen-1",
+            "mac": "dd:ee:ff:00:00:01",
+            "name": "Closet",
+            "type": "ups",
+            "battery": {"status": "normal"},
+            "stats": {},
+            "motion_detected_at": None,
+        }
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_sensors
+
+    from unifi_core.protect.managers.sensor_manager import SensorManager
+    monkeypatch.setattr(SensorManager, "list_sensors", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/sensors/sen-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/sensors/sen-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["data"]["id"] == "sen-1"
+    assert miss.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Chimes — LIST only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_chimes_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_chimes = [
+        {
+            "id": "chime-1",
+            "mac": "11:22:33:44:55:66",
+            "name": "Front Chime",
+            "model": "Chime",
+            "type": "chime",
+            "state": "CONNECTED",
+            "is_connected": True,
+            "firmware_version": "1.0.0",
+            "volume": 80,
+            "camera_ids": ["cam-1"],
+            "ring_settings": [],
+            "available_tracks": [],
+        }
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return fake_chimes
+
+    from unifi_core.protect.managers.chime_manager import ChimeManager
+    monkeypatch.setattr(ChimeManager, "list_chimes", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/chimes?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["paired_cameras"] == ["cam-1"]
+    assert body["render_hint"]["kind"] == "list"

--- a/apps/api/tests/routes/resources/test_protect_events_system.py
+++ b/apps/api/tests/routes/resources/test_protect_events_system.py
@@ -1,0 +1,591 @@
+"""Phase 5A PR3 Cluster 2 — protect events + recordings + liveviews + system.
+
+Covers 9 endpoint families across 4 route modules:
+- events.py extends with detail/thumbnail/recent-events/smart-detections
+- recordings.py extends with /recording-status
+- liveviews.py (new) — LIST + filter-from-list DETAIL
+- system.py (new) — /firmware-status, /alarm-status, /alarm-profiles,
+  /protect/health, /protect/system-info, /viewers
+"""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="protect"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="P", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeProtectCM:
+    """Stub protect connection manager — no set_site (single-controller-no-site)."""
+
+    async def initialize(self) -> None:
+        return None
+
+
+def _stub_connection(app, cid: str) -> _FakeProtectCM:
+    fake = _FakeProtectCM()
+    app.state.manager_factory._connection_cache[(cid, "protect")] = fake
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Smart detections — EVENT_LOG list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_smart_detections_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_events = [
+        {
+            "id": f"sd-{i}",
+            "type": "smartDetectZone",
+            "start": 1700000000 + i,
+            "score": 90,
+            "smart_detect_types": ["person"],
+            "camera_id": "cam-1",
+        }
+        for i in range(3)
+    ]
+
+    async def fake(self, *a, **kw):
+        return fake_events
+
+    from unifi_core.protect.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "list_smart_detections", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/smart-detections?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "event_log"
+
+
+# ---------------------------------------------------------------------------
+# Recent events — DETAIL pass-through (buffer wrapper)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_events_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    def fake_buffer(self, *a, **kw):
+        return [{"id": "ev-1", "type": "motion"}, {"id": "ev-2", "type": "ring"}]
+
+    from unifi_core.protect.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_recent_from_buffer", fake_buffer)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/recent-events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["count"] == 2
+    assert len(body["data"]["events"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Event detail + thumbnail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_event_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "id": "ev-1",
+        "type": "motion",
+        "start": 1700000000,
+        "end": 1700000010,
+        "camera_id": "cam-1",
+        "score": 88,
+    }
+
+    async def fake(self, event_id):
+        assert event_id == "ev-1"
+        return payload
+
+    from unifi_core.protect.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_event", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/events/ev-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["id"] == "ev-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_event_404_via_unifi_not_found(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake(self, event_id):
+        raise UniFiNotFoundError("event", event_id)
+
+    from unifi_core.protect.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_event", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/events/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_event_thumbnail_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "event_id": "ev-1",
+        "thumbnail_id": "thumb-abc",
+        "thumbnail_available": True,
+        "image_base64": "Zm9v",
+        "content_type": "image/jpeg",
+    }
+
+    async def fake(self, event_id, width=None, height=None):
+        return payload
+
+    from unifi_core.protect.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_event_thumbnail", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/event-thumbnails/ev-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["event_id"] == "ev-1"
+    assert body["data"]["thumbnail_available"] is True
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------------------------------------------------------------------------
+# Recording status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_recording_status_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "cameras": [
+            {
+                "camera_id": "cam-1",
+                "name": "Door",
+                "recording_mode": "always",
+                "is_recording": True,
+            }
+        ],
+        "count": 1,
+    }
+
+    async def fake(self, camera_id=None):
+        return payload
+
+    from unifi_core.protect.managers.recording_manager import RecordingManager
+    monkeypatch.setattr(RecordingManager, "get_recording_status", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/recording-status?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["count"] == 1
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------------------------------------------------------------------------
+# Liveviews — LIST + filter-from-list DETAIL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_liveviews_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_lvs = [
+        {
+            "id": "lv-1",
+            "name": "Main",
+            "is_default": True,
+            "is_global": False,
+            "layout": 4,
+            "owner_id": "u-1",
+            "slots": [],
+            "slot_count": 0,
+            "camera_count": 0,
+        },
+        {
+            "id": "lv-2",
+            "name": "Outdoor",
+            "is_default": False,
+            "is_global": True,
+            "layout": 9,
+            "owner_id": "u-1",
+            "slots": [],
+            "slot_count": 0,
+            "camera_count": 0,
+        },
+    ]
+
+    async def fake(self):
+        return fake_lvs
+
+    from unifi_core.protect.managers.liveview_manager import LiveviewManager
+    monkeypatch.setattr(LiveviewManager, "list_liveviews", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/liveviews?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_liveview_filter_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_lvs = [
+        {
+            "id": "lv-1",
+            "name": "Main",
+            "is_default": True,
+            "is_global": False,
+            "layout": 4,
+            "owner_id": "u-1",
+            "slots": [],
+            "slot_count": 0,
+            "camera_count": 0,
+        }
+    ]
+
+    async def fake(self):
+        return fake_lvs
+
+    from unifi_core.protect.managers.liveview_manager import LiveviewManager
+    monkeypatch.setattr(LiveviewManager, "list_liveviews", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/liveviews/lv-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/liveviews/lv-999?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert ok.status_code == 200
+    assert ok.json()["data"]["id"] == "lv-1"
+    assert ok.json()["render_hint"]["kind"] == "detail"
+    assert miss.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# System: firmware-status / alarm-status / alarm-profiles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_firmware_status_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "nvr": {"id": "nvr-1", "name": "Studio", "current_firmware": "3.0", "version": "3.0", "is_updating": False},
+        "devices": [],
+        "total_devices": 0,
+        "devices_with_updates": 0,
+    }
+
+    async def fake(self):
+        return payload
+
+    from unifi_core.protect.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_firmware_status", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/firmware-status?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["nvr"]["id"] == "nvr-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_alarm_get_status_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "armed": False,
+        "status": "disabled",
+        "active_profile_id": "p-1",
+        "active_profile_name": "Home",
+        "armed_at": None,
+        "will_be_armed_at": None,
+        "breach_detected_at": None,
+        "breach_event_count": 0,
+        "profiles": [],
+    }
+
+    async def fake(self):
+        return payload
+
+    from unifi_core.protect.managers.alarm_manager import AlarmManager
+    monkeypatch.setattr(AlarmManager, "get_arm_state", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/alarm-status?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["status"] == "disabled"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_alarm_list_profiles_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_profiles = [
+        {"id": "p-1", "name": "Home"},
+        {"id": "p-2", "name": "Away"},
+    ]
+
+    async def fake(self):
+        return fake_profiles
+
+    from unifi_core.protect.managers.alarm_manager import AlarmManager
+    monkeypatch.setattr(AlarmManager, "list_arm_profiles", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/alarm-profiles?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Protect health + system-info (product-prefixed paths)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_protect_health_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "cpu": {"average_load": 12.5, "temperature_c": 50.0},
+        "memory": {"available_bytes": 1, "free_bytes": 2, "total_bytes": 3},
+        "storage": {
+            "available_bytes": 1, "size_bytes": 2, "used_bytes": 3,
+            "is_recycling": False, "type": "hdd",
+        },
+        "is_updating": False,
+        "uptime_seconds": 3600,
+    }
+
+    async def fake(self):
+        return payload
+
+    from unifi_core.protect.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_health", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/protect/health?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["cpu"]["average_load"] == 12.5
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_protect_system_info_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "id": "nvr-1",
+        "name": "Studio",
+        "model": "UDM-Pro",
+        "firmware_version": "3.0",
+        "version": "3.0",
+        "uptime_seconds": 3600,
+        "camera_count": 4,
+    }
+
+    async def fake(self):
+        return payload
+
+    from unifi_core.protect.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_system_info", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/protect/system-info?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["id"] == "nvr-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------------------------------------------------------------------------
+# Viewers — LIST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_viewers_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_viewers = [
+        {
+            "id": "v-1",
+            "name": "Lobby",
+            "type": "viewer",
+            "mac": "ff:ee:dd:cc:bb:aa",
+            "host": "10.0.0.5",
+            "firmware_version": "1.0",
+            "is_connected": True,
+            "is_updating": False,
+            "uptime_seconds": 100,
+            "state": "CONNECTED",
+            "software_version": "1.0",
+            "liveview_id": "lv-1",
+        }
+    ]
+
+    async def fake(self):
+        return fake_viewers
+
+    from unifi_core.protect.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "list_viewers", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/viewers?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["id"] == "v-1"
+
+
+@pytest.mark.asyncio
+async def test_list_viewers_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")  # no protect
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/viewers?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["kind"] == "capability_mismatch"
+    assert body["detail"]["missing_product"] == "protect"


### PR DESCRIPTION
## Summary

Phase 5A PR3: read-only resource routes for the protect product. Adds 15 endpoint families across 2 cluster commits, completing the protect read surface.

## Cluster commits

| Cluster | Commit | Families | Notes |
|---|---|---|---|
| 1 — cameras (extend) + lights + sensors + chimes | 2687b44 | 6 | Per-camera analytics/streams/snapshot **nested** under \`/cameras/{id}/*\` (the one intentional flat-layout exception). Lights/sensors LIST + filter-from-list DETAIL (\`protect_get_light\`/\`protect_get_sensor\` tools don't exist). Chimes LIST-only. UniFiNotFoundError → 404 throughout. |
| 2 — events + recordings + liveviews + system | cf859ab | 9 | Protect events detail/thumbnails/smart-detections/recent-events; recording-status; liveviews LIST + filter-from-list DETAIL; firmware-status, alarm-status, alarm-profiles, /protect/health, /protect/system-info (product-prefixed paths), viewers. |

Total: 15 endpoint families. Protect read coverage now complete.

## Mid-execution adaptations

1. **\`protect_get_light\`, \`protect_get_sensor\`, \`protect_get_chime\` don't exist as tools** — used filter-from-list for light/sensor details; chimes ship LIST-only. Detail render hint synthesised inline with kind override since no detail tool means no \`serializer_for_tool\` lookup.
2. **Snapshot returns metadata, not raw bytes** — \`SnapshotSerializer\` from Phase 4A emits \`{size_bytes, content_type, captured_at}\`. A future \`/snapshot/raw\` endpoint for actual image bytes is deferred to Phase 5B if needed.
3. **Manager-method-name deviations:** \`AlarmManager.get_arm_state\` (not \`alarm_get_status\`), \`AlarmManager.list_arm_profiles\` (not \`alarm_list_profiles\`), \`EventManager.get_recent_from_buffer\` is **sync** (returns in-memory ring buffer; route reads it without \`await\`).
4. **Path-disambiguation paths:** \`/protect/health\` and \`/protect/system-info\` use \`protect/\` prefix per spec §5 to disambiguate from network and access equivalents.
5. **No path-collision with network's capability-aware /events dispatcher** — that owns the bare \`/events\` path; \`/events/{event_id}\` is uniquely served by protect.
6. **UniFiNotFoundError handling baked in from the start** — refactor PRs #172/#173/#175 are all on main as of this branch's baseline; protect detail routes wrap manager calls in \`try/except UniFiNotFoundError → 404\` with \`if item is None\` defensive fallback.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (69/205/630/336/157) |
| unifi-api | 388 → 413 (+25 tests) |
| Phase 4A serializer-coverage gate | green |

## Out of scope (later PRs)

- Access routes — PR4
- Per-resource streams + /v1/catalog/resources + CI gate — PR5
- Write endpoints — Phase 6
- GraphQL overlay — Phase 8

## Reference

- Spec: Myco \`c56c0e0969cd6a9d\`
- Plan: Myco \`aff0da48adac8cee\`
- PR1 (network waves 1-3): merged in #171
- PR2 (network waves 4-6): merged in #174
- Refactor PRs (manager-owned existence checks): #172, #173, #175 — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)