### PR TITLE
Phase 5A PR4: access resource routes (14 endpoint families)

### DIFF
--- a/apps/api/src/unifi_api/routes/resources/access/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/access/devices.py
@@ -1,0 +1,108 @@
+"""GET /v1/sites/{site_id}/access-devices[/{device_id}] — access devices.
+
+Path uses ``/access-devices`` (product-prefixed) to disambiguate from the
+network ``/devices`` endpoint at /v1/sites/{id}/devices. Same controller
+can serve both products on the same site path; the prefix prevents
+ambiguity.
+
+DeviceManager.get_device raises UniFiNotFoundError on miss → 404.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.access.doors import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or raw.get("_id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/access-devices",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_access_devices(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "device_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_devices()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_list_devices")
+    return {
+        "items": [serializer.serialize(d) for d in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("access_list_devices"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/access-devices/{device_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_access_device(
+    request: Request,
+    site_id: str,
+    device_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "device_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            device = await mgr.get_device(device_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_device")
+    return {
+        "data": serializer.serialize(device),
+        "render_hint": registry.render_hint_for_tool("access_get_device"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/doors.py
+++ b/apps/api/src/unifi_api/routes/resources/access/doors.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from unifi_core.exceptions import UniFiNotFoundError
+
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.routes.resources._common import (
@@ -115,4 +117,85 @@ async def get_door(
     return {
         "data": serializer.serialize(door),
         "render_hint": registry.render_hint_for_resource("access", "doors/{id}"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/doors/{door_id}/status",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_door_status(
+    request: Request,
+    site_id: str,
+    door_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    """Per-door status (nested under /doors/{door_id}/status).
+
+    Mirrors the protect /cameras/{id}/analytics nested-detail pattern.
+    DoorManager.get_door_status raises UniFiNotFoundError on miss → 404.
+    """
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "door_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            status = await mgr.get_door_status(door_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if status is None:
+        raise HTTPException(status_code=404, detail=f"door {door_id} not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_door_status")
+    return {
+        "data": serializer.serialize(status),
+        "render_hint": registry.render_hint_for_tool("access_get_door_status"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/door-groups",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_door_groups(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "door_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        all_groups = await mgr.list_door_groups()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_groups), limit=limit, cursor=cursor_obj, key_fn=_door_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_list_door_groups")
+    return {
+        "items": [serializer.serialize(g) for g in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("access_list_door_groups"),
     }

--- a/apps/api/src/unifi_api/routes/resources/access/events.py
+++ b/apps/api/src/unifi_api/routes/resources/access/events.py
@@ -1,0 +1,216 @@
+"""Access events + activity-summary read endpoints.
+
+Four endpoint families collected here:
+
+- ``GET /access/events``               → ``access_list_events`` (EVENT_LOG)
+- ``GET /access/events/{event_id}``    → ``access_get_event`` (DETAIL)
+- ``GET /access/recent-events``        → ``access_recent_events`` (buffer
+  snapshot — wraps the manager's in-memory ring buffer in the same shape
+  as protect's ``/recent-events``)
+- ``GET /access/activity-summary``     → ``access_get_activity_summary``
+  (DETAIL — passes the histogram payload through ``ActivitySummarySerializer``)
+
+The ``/access/...`` prefix is in the URL path, not a router prefix — so each
+@router.get registers the full path. This disambiguates from network's
+capability-aware ``/events`` dispatcher (PR2) and protect's ``/events``
+(PR3 Cluster 2).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _event_key(obj) -> tuple:
+    """Sort by (timestamp, id) — newest first via the manifest's
+    ``sort_default = "timestamp:desc"``. paginate() sorts ascending; the
+    user-facing direction is captured in the serializer metadata.
+    """
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (raw.get("timestamp") or raw.get("time") or 0, raw.get("id") or "")
+
+
+async def _maybe_set_site(cm, site_id: str) -> None:
+    """Access is single-controller-no-site; set_site is a no-op when absent."""
+    set_site = getattr(cm, "set_site", None)
+    if set_site is None:
+        return
+    if getattr(cm, "site", None) != site_id:
+        await set_site(site_id)
+
+
+@router.get(
+    "/sites/{site_id}/access/events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_access_events(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        all_events = await mgr.list_events(limit=max(limit, 100))
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(all_events), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+    )
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_list_events")
+    return {
+        "items": [serializer.serialize(e) for e in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("access_list_events"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/access/events/{event_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_access_event(
+    request: Request,
+    site_id: str,
+    event_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "event_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            event = await mgr.get_event(event_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_event")
+    return {
+        "data": serializer.serialize(event),
+        "render_hint": registry.render_hint_for_tool("access_get_event"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/access/recent-events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def recent_access_events(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    event_type: str | None = Query(None),
+    door_id: str | None = Query(None),
+    limit: int | None = Query(None, ge=1, le=500),
+) -> dict:
+    """Return a snapshot of the websocket ring buffer.
+
+    Differs from the SSE stream at ``/v1/streams/access/events``: this is
+    a buffer-snapshot REST surface, not a tailing stream. Mirrors PR3's
+    protect ``/recent-events`` shape: ``{events, count, source, buffer_size}``.
+    ``EventManager.get_recent_from_buffer`` is synchronous (in-memory ring
+    buffer read).
+    """
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "event_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        # synchronous (in-memory ring buffer read)
+        events = mgr.get_recent_from_buffer(
+            event_type=event_type,
+            door_id=door_id,
+            limit=limit,
+        )
+
+    buffer_size = getattr(mgr, "buffer_size", len(events) if isinstance(events, list) else 0)
+    payload = {
+        "events": list(events) if events is not None else [],
+        "count": len(events) if events is not None else 0,
+        "source": "buffer",
+        "buffer_size": buffer_size,
+    }
+
+    # access_recent_events is registered as EVENT_LOG but the route surface
+    # is a wrapper dict (matches protect's recent-events convention).
+    # Return DETAIL kind in the render_hint so consumers render the wrapper
+    # rather than treating it as a list.
+    registry = request.app.state.serializer_registry
+    list_hint = registry.render_hint_for_tool("access_recent_events")
+    detail_hint = {**list_hint, "kind": "detail"}
+    return {
+        "data": payload,
+        "render_hint": detail_hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/access/activity-summary",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_access_activity_summary(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    door_id: str | None = Query(None),
+    days: int = Query(7, ge=1, le=90),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "event_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_activity_summary(door_id=door_id, days=days)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_activity_summary")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("access_get_activity_summary"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/policies.py
+++ b/apps/api/src/unifi_api/routes/resources/access/policies.py
@@ -1,0 +1,107 @@
+"""GET /v1/sites/{site_id}/policies[/{policy_id}] — access policies.
+
+Access is a single-controller, no-site product. ``site_id`` is accepted for
+URL symmetry but no-ops on access. PolicyManager.get_policy may raise
+UniFiNotFoundError post-#175 when proxy returns a miss.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.access.doors import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or raw.get("_id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/policies",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_policies(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "policy_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_policies()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_list_policies")
+    return {
+        "items": [serializer.serialize(p) for p in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("access_list_policies"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/policies/{policy_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_policy(
+    request: Request,
+    site_id: str,
+    policy_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "policy_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            policy = await mgr.get_policy(policy_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if not policy:
+        raise HTTPException(status_code=404, detail=f"policy {policy_id} not found")
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_policy")
+    return {
+        "data": serializer.serialize(policy),
+        "render_hint": registry.render_hint_for_tool("access_get_policy"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/schedules.py
+++ b/apps/api/src/unifi_api/routes/resources/access/schedules.py
@@ -1,0 +1,67 @@
+"""GET /v1/sites/{site_id}/schedules — access schedules (LIST only).
+
+PolicyManager owns ``list_schedules`` (no separate schedule manager). Access
+is single-controller-no-site; ``site_id`` is accepted for URL symmetry.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.access.doors import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or raw.get("_id") or "")
+
+
+@router.get(
+    "/sites/{site_id}/schedules",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_schedules(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "policy_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_schedules()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_list_schedules")
+    return {
+        "items": [serializer.serialize(s) for s in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("access_list_schedules"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/system.py
+++ b/apps/api/src/unifi_api/routes/resources/access/system.py
@@ -1,0 +1,90 @@
+"""Access health + system-info read endpoints (product-prefixed paths).
+
+Two endpoint families:
+
+- ``GET /access/health``        → ``access_get_health`` (DETAIL)
+- ``GET /access/system-info``   → ``access_get_system_info`` (DETAIL)
+
+The ``/access/...`` prefix is in the URL path — not a router prefix — to
+disambiguate from network's ``/network/...`` and protect's ``/protect/...``
+equivalents (PR3 Cluster 2).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.access.events import _maybe_set_site
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/sites/{site_id}/access/health",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_access_health(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "system_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_health()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_health")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("access_get_health"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/access/system-info",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_access_system_info(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "system_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            payload = await mgr.get_system_info()
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_system_info")
+    return {
+        "data": serializer.serialize(payload),
+        "render_hint": registry.render_hint_for_tool("access_get_system_info"),
+    }

--- a/apps/api/src/unifi_api/routes/resources/access/visitors.py
+++ b/apps/api/src/unifi_api/routes/resources/access/visitors.py
@@ -1,0 +1,104 @@
+"""GET /v1/sites/{site_id}/visitors[/{visitor_id}] — access visitors.
+
+VisitorManager.get_visitor raises UniFiNotFoundError on miss → 404.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.routes.resources.access.doors import _maybe_set_site
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _visitor_key(obj) -> tuple:
+    """Sort by (created_at, id) — visitor lists are time-oriented."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (raw.get("created_at") or 0, raw.get("id") or raw.get("_id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/visitors",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def list_visitors(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, "access", "visitor_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "access")
+        await _maybe_set_site(cm, site_id)
+        items = await mgr.list_visitors()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items), limit=limit, cursor=cursor_obj, key_fn=_visitor_key,
+    )
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_list_visitors")
+    return {
+        "items": [serializer.serialize(v) for v in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": registry.render_hint_for_tool("access_list_visitors"),
+    }
+
+
+@router.get(
+    "/sites/{site_id}/visitors/{visitor_id}",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def get_visitor(
+    request: Request,
+    site_id: str,
+    visitor_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "access", "visitor_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            visitor = await mgr.get_visitor(visitor_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    registry = request.app.state.serializer_registry
+    serializer = registry.serializer_for_tool("access_get_visitor")
+    return {
+        "data": serializer.serialize(visitor),
+        "render_hint": registry.render_hint_for_tool("access_get_visitor"),
+    }

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -66,8 +66,10 @@ from unifi_api.routes.resources.access import (
     credentials as access_credentials_routes,
     devices as access_devices_routes,
     doors as access_doors_routes,
+    events as access_events_routes,
     policies as access_policies_routes,
     schedules as access_schedules_routes,
+    system as access_system_routes,
     users as access_users_routes,
     visitors as access_visitors_routes,
 )
@@ -248,6 +250,8 @@ def create_app(config: ApiConfig) -> FastAPI:
         access_schedules_routes,
         access_devices_routes,
         access_visitors_routes,
+        access_events_routes,
+        access_system_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -64,8 +64,12 @@ from unifi_api.routes.resources.protect import (
 )
 from unifi_api.routes.resources.access import (
     credentials as access_credentials_routes,
+    devices as access_devices_routes,
     doors as access_doors_routes,
+    policies as access_policies_routes,
+    schedules as access_schedules_routes,
     users as access_users_routes,
+    visitors as access_visitors_routes,
 )
 from unifi_api.routes.streams import (
     access as access_streams_routes,
@@ -240,6 +244,10 @@ def create_app(config: ApiConfig) -> FastAPI:
         access_doors_routes,
         access_users_routes,
         access_credentials_routes,
+        access_policies_routes,
+        access_schedules_routes,
+        access_devices_routes,
+        access_visitors_routes,
     ):
         app.include_router(r.router, prefix="/v1")
     for r in (

--- a/apps/api/tests/routes/resources/test_access_doors_policies.py
+++ b/apps/api/tests/routes/resources/test_access_doors_policies.py
@@ -1,0 +1,437 @@
+"""Phase 5A PR4 Cluster 1 — access doors+policies+schedules+devices+visitors.
+
+Covers 8 endpoint families:
+- doors/{id}/status (nested)        — access_get_door_status
+- door-groups (LIST)                — access_list_door_groups
+- policies LIST + DETAIL            — access_list_policies, access_get_policy
+- schedules LIST                    — access_list_schedules
+- access-devices LIST + DETAIL      — access_list_devices, access_get_device
+- visitors LIST + DETAIL            — access_list_visitors, access_get_visitor
+"""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="access"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="A", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeAccessCM:
+    """Stub access connection manager — no set_site (single-controller-no-site)."""
+
+    async def initialize(self) -> None:
+        return None
+
+
+def _stub_connection(app, cid: str) -> _FakeAccessCM:
+    fake = _FakeAccessCM()
+    app.state.manager_factory._connection_cache[(cid, "access")] = fake
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# door status (nested)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_door_status_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    status = {
+        "id": "door-1",
+        "name": "Lobby",
+        "door_position_status": "open",
+        "lock_relay_status": "unlocked",
+    }
+
+    async def fake_status(self, door_id):
+        if door_id == "door-1":
+            return status
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("door", door_id)
+
+    from unifi_core.access.managers.door_manager import DoorManager
+    monkeypatch.setattr(DoorManager, "get_door_status", fake_status)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/doors/door-1/status?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["door_id"] == "door-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_door_status_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_status(self, door_id):
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("door", door_id)
+
+    from unifi_core.access.managers.door_manager import DoorManager
+    monkeypatch.setattr(DoorManager, "get_door_status", fake_status)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/doors/missing/status?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# door-groups (LIST only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_door_groups_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    groups = [
+        {"id": f"grp-{i}", "name": f"Group {i}", "type": "door"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self):
+        return groups
+
+    from unifi_core.access.managers.door_manager import DoorManager
+    monkeypatch.setattr(DoorManager, "list_door_groups", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/door-groups?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+
+
+# ---------------------------------------------------------------------------
+# policies LIST + DETAIL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_policies_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    policies = [
+        {"id": f"pol-{i}", "name": f"Policy {i}", "resource_type": "door"}
+        for i in range(4)
+    ]
+
+    async def fake_list(self):
+        return policies
+
+    from unifi_core.access.managers.policy_manager import PolicyManager
+    monkeypatch.setattr(PolicyManager, "list_policies", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/policies?controller={cid}&limit=2",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert body["next_cursor"] is not None
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_policies_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")  # no access
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/policies?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409
+    assert r.json()["detail"]["missing_product"] == "access"
+
+
+@pytest.mark.asyncio
+async def test_get_policy_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"id": "pol-1", "name": "Front Door", "resource_type": "door"}
+
+    async def fake_get(self, policy_id):
+        if policy_id == "pol-1":
+            return target
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("policy", policy_id)
+
+    from unifi_core.access.managers.policy_manager import PolicyManager
+    monkeypatch.setattr(PolicyManager, "get_policy", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/policies/pol-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["id"] == "pol-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_policy_404_via_unifi_not_found(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, policy_id):
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("policy", policy_id)
+
+    from unifi_core.access.managers.policy_manager import PolicyManager
+    monkeypatch.setattr(PolicyManager, "get_policy", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/policies/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# schedules LIST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_schedules_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    schedules = [
+        {"id": f"sch-{i}", "name": f"Sched {i}", "type": "weekly"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self):
+        return schedules
+
+    from unifi_core.access.managers.policy_manager import PolicyManager
+    monkeypatch.setattr(PolicyManager, "list_schedules", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/schedules?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+
+
+# ---------------------------------------------------------------------------
+# access-devices LIST + DETAIL (product-prefixed path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_access_devices_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    devices = [
+        {"id": f"dev-{i}", "name": f"Reader {i}", "device_type": "UA-Hub"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return devices
+
+    from unifi_core.access.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "list_devices", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access-devices?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_access_device_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"id": "dev-1", "name": "Reader 1", "device_type": "UA-Hub"}
+
+    async def fake_get(self, device_id):
+        if device_id == "dev-1":
+            return target
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("device", device_id)
+
+    from unifi_core.access.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "get_device", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access-devices/dev-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["id"] == "dev-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_access_device_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, device_id):
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("device", device_id)
+
+    from unifi_core.access.managers.device_manager import DeviceManager
+    monkeypatch.setattr(DeviceManager, "get_device", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access-devices/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# visitors LIST + DETAIL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_visitors_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    visitors = [
+        {"id": f"vis-{i}", "name": f"Visitor {i}", "status": "active"}
+        for i in range(3)
+    ]
+
+    async def fake_list(self):
+        return visitors
+
+    from unifi_core.access.managers.visitor_manager import VisitorManager
+    monkeypatch.setattr(VisitorManager, "list_visitors", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/visitors?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_get_visitor_happy_and_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    target = {"id": "vis-1", "name": "Alice", "status": "active"}
+
+    async def fake_get(self, visitor_id):
+        if visitor_id == "vis-1":
+            return target
+        from unifi_core.exceptions import UniFiNotFoundError
+        raise UniFiNotFoundError("visitor", visitor_id)
+
+    from unifi_core.access.managers.visitor_manager import VisitorManager
+    monkeypatch.setattr(VisitorManager, "get_visitor", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        ok = await c.get(
+            f"/v1/sites/default/visitors/vis-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        miss = await c.get(
+            f"/v1/sites/default/visitors/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["data"]["id"] == "vis-1"
+    assert ok.json()["render_hint"]["kind"] == "detail"
+    assert miss.status_code == 404

--- a/apps/api/tests/routes/resources/test_access_events_system.py
+++ b/apps/api/tests/routes/resources/test_access_events_system.py
@@ -1,0 +1,327 @@
+"""Phase 5A PR4 Cluster 2 — access events + system.
+
+Covers 6 endpoint families across 2 route modules:
+
+- events.py (new) — /access/events LIST + DETAIL,
+  /access/recent-events buffer-snapshot, /access/activity-summary
+- system.py (new) — /access/health, /access/system-info
+  (product-prefixed paths to disambiguate from network/protect)
+"""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products="access"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="A", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeAccessCM:
+    """Stub access connection manager — no set_site (single-controller-no-site)."""
+
+    async def initialize(self) -> None:
+        return None
+
+
+def _stub_connection(app, cid: str) -> _FakeAccessCM:
+    fake = _FakeAccessCM()
+    app.state.manager_factory._connection_cache[(cid, "access")] = fake
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# /access/events — LIST (EVENT_LOG)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_access_events_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_events = [
+        {
+            "id": f"ev-{i}",
+            "type": "access_granted",
+            "timestamp": 1700000000 + i,
+            "door_id": "door-1",
+            "user_id": "u-1",
+            "result": "granted",
+        }
+        for i in range(3)
+    ]
+
+    async def fake(self, *a, **kw):
+        return fake_events
+
+    from unifi_core.access.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "list_events", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 3
+    assert body["render_hint"]["kind"] == "event_log"
+
+
+# ---------------------------------------------------------------------------
+# /access/events/{event_id} — DETAIL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_access_event_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "id": "ev-1",
+        "type": "access_granted",
+        "timestamp": 1700000000,
+        "door_id": "door-1",
+        "user_id": "u-1",
+        "result": "granted",
+    }
+
+    async def fake(self, event_id):
+        assert event_id == "ev-1"
+        return payload
+
+    from unifi_core.access.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_event", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/events/ev-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["id"] == "ev-1"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_get_access_event_404_via_unifi_not_found(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake(self, event_id):
+        raise UniFiNotFoundError("event", event_id)
+
+    from unifi_core.access.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_event", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/events/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /access/recent-events — buffer snapshot (DETAIL pass-through)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recent_access_events_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    def fake_buffer(self, *a, **kw):
+        return [
+            {"id": "ev-1", "type": "access_granted", "door_id": "door-1"},
+            {"id": "ev-2", "type": "access_denied", "door_id": "door-1"},
+        ]
+
+    from unifi_core.access.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_recent_from_buffer", fake_buffer)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/recent-events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # AccessEventSerializer is registered for access_recent_events as
+    # EVENT_LOG, but we render the manager's wrapper dict so the route
+    # returns DETAIL kind here. Mirror protect's recent-events convention.
+    assert body["data"]["count"] == 2
+    assert len(body["data"]["events"]) == 2
+    assert body["data"]["source"] == "buffer"
+
+
+# ---------------------------------------------------------------------------
+# /access/activity-summary — DETAIL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_activity_summary_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "since": 1700000000,
+        "until": 1700086400,
+        "total": 42,
+        "granted_count": 30,
+        "denied_count": 12,
+        "histogram": [{"bucket": 1700000000, "count": 5}],
+    }
+
+    async def fake(self, door_id=None, days=7):
+        return payload
+
+    from unifi_core.access.managers.event_manager import EventManager
+    monkeypatch.setattr(EventManager, "get_activity_summary", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/activity-summary?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["total_events"] == 42
+    assert body["data"]["granted_count"] == 30
+    assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------------------------------------------------------------------------
+# /access/health — DETAIL (product-prefixed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_health_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "host": "1.2.3.4",
+        "is_connected": True,
+        "api_client_available": True,
+        "proxy_available": True,
+        "api_client_healthy": True,
+        "proxy_healthy": True,
+    }
+
+    async def fake(self):
+        return payload
+
+    from unifi_core.access.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_health", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/health?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["status"] == "healthy"
+    assert body["render_hint"]["kind"] == "detail"
+
+
+@pytest.mark.asyncio
+async def test_access_health_capability_mismatch(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")  # no access
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/health?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 409, r.text
+    body = r.json()
+    assert body["detail"]["missing_product"] == "access"
+
+
+# ---------------------------------------------------------------------------
+# /access/system-info — DETAIL (product-prefixed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_system_info_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "name": "Access Hub",
+        "version": "2.5.0",
+        "hostname": "access.local",
+        "uptime": 12345,
+    }
+
+    async def fake(self):
+        return payload
+
+    from unifi_core.access.managers.system_manager import SystemManager
+    monkeypatch.setattr(SystemManager, "get_system_info", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access/system-info?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["name"] == "Access Hub"
+    assert body["data"]["version"] == "2.5.0"
+    assert body["render_hint"]["kind"] == "detail"


### PR DESCRIPTION
## Summary

Phase 5A PR4: read-only resource routes for the access product. Adds 14 endpoint families across 2 cluster commits, completing the access read surface and bringing all three products to exhaustive list/detail coverage.

## Cluster commits

| Cluster | Commit | Families | Notes |
|---|---|---|---|
| 1 — doors+policies+schedules+access-devices+visitors | 0bed5a7 | 8 | Per-door /doors/{id}/status nested; door-groups; policies LIST+DETAIL; schedules LIST (lives on policy_manager — no separate schedule_manager); access-devices LIST+DETAIL (path disambiguated from network /devices); visitors LIST+DETAIL. UniFiNotFoundError → 404 throughout. |
| 2 — events+system | d89c147 | 6 | /access/events LIST+DETAIL+recent-events (sync ring-buffer, mirrors protect)+activity-summary; /access/health and /access/system-info (product-prefixed paths). |

Total: 14 endpoint families. **Access read coverage now complete (20/20 tools)** and the entire Phase 5A read surface (network 32 + protect 15 + access 14 = 61 endpoint families) is in place.

## Mid-execution adaptations

1. **Schedules live on \`policy_manager\`** — no separate \`schedule_manager\` exists; \`list_schedules\` is a method on PolicyManager.
2. **Access uses \`device_manager\` (DeviceManager class)**, not \`access_device_manager\` — same name as network's manager but in the access subpackage. Path disambiguated as \`/access-devices\` per spec.
3. **\`access_recent_events\` uses sync \`get_recent_from_buffer\`** — same pattern as protect (in-memory ring buffer); route reads without await and wraps with \`{events, count, source, buffer_size}\`.
4. **\`policy_manager.get_policy\` not yet refactored to raise UniFiNotFoundError** — wrapped routes with try/except for forward compatibility plus a falsy-check fallback.
5. **DoorStatusSerializer outputs door_id (not id)** — test assertions adjusted accordingly.
6. **Refactor track fully complete on main** — all detail routes use try/except UniFiNotFoundError → 404 from the start. No retroactive fix commits needed.

## Closed deferred items from earlier specs

- **AST-introspection fix** (Phase 4B spec §11 deferral; Phase 5A original scope): closed by the parallel manager-refactor track. \`DISPATCH_OVERRIDES\` (in \`apps/api/src/unifi_api/services/dispatch_overrides.py\`) is the canonical extension point for any future compose-case tools.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (69/205/630/336/157) |
| unifi-api | 415 → 436 (+21 tests) |
| Phase 4A serializer-coverage gate | green |
| Access read tools coverage | 20/20 (100%) |
| Total Phase 5A endpoint families | 61 (Phase 3's 11 + Phase 5A's 50) |

## Out of scope (final PR coming)

- Per-resource streams (3 narrow paths) + /v1/catalog/resources + test_resource_route_coverage CI gate — PR5
- Write endpoints — Phase 6
- GraphQL overlay — Phase 8

## Reference

- Spec: Myco \`c56c0e0969cd6a9d\`
- Plan: Myco \`aff0da48adac8cee\`
- PR1 (network 1-3): merged in #171
- PR2 (network 4-6): merged in #174
- PR3 (protect): merged in #177
- Refactor track: closed via #172/#173/#175/#176

🤖 Generated with [Claude Code](https://claude.com/claude-code)