### PR TITLE
Phase 5A PR5: per-resource streams + /v1/catalog/resources + coverage CI gate (Phase 5A finale)

### DIFF
--- a/apps/api/src/unifi_api/routes/catalog.py
+++ b/apps/api/src/unifi_api/routes/catalog.py
@@ -69,3 +69,31 @@ async def get_render_hints(request: Request) -> dict:
         by_kind.setdefault(kind, {"kind": kind, "tools": [], "resources": []})
         by_kind[kind]["resources"].append({"product": product, "path": resource})
     return {"items": list(by_kind.values())}
+
+
+@router.get("/catalog/resources", dependencies=[Depends(require_scope(Scope.READ))])
+async def get_resources(request: Request) -> dict:
+    """Discoverability endpoint: every registered resource path with render_hint.
+
+    Lists every (product, resource_path) pair from the serializer registry.
+    For paths with placeholders (e.g., 'clients/{mac}'), renders as a path
+    template under /v1/sites/{site_id}/.
+    """
+    serializer_registry = request.app.state.serializer_registry
+    items = []
+    for product, resource in serializer_registry.all_resources():
+        try:
+            hint = serializer_registry.render_hint_for_resource(product, resource)
+        except Exception:
+            hint = {"kind": "empty"}
+        if "{" in resource:
+            base, tmpl = resource.split("/", 1)
+            path = f"/v1/sites/{{site_id}}/{base}/{tmpl}"
+        else:
+            path = f"/v1/sites/{{site_id}}/{resource}"
+        items.append({
+            "product": product,
+            "resource_path": path,
+            "render_hint": hint,
+        })
+    return {"items": items}

--- a/apps/api/src/unifi_api/routes/streams/access_per_door.py
+++ b/apps/api/src/unifi_api/routes/streams/access_per_door.py
@@ -1,0 +1,59 @@
+"""GET /v1/streams/access/doors/{door_id}/events — narrow per-door SSE."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import StreamingResponse
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.stream_generator import sse_event_stream
+
+
+router = APIRouter()
+PRODUCT = "access"
+
+
+@router.get(
+    f"/streams/{PRODUCT}/doors/{{door_id}}/events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def stream_access_door_events(
+    request: Request,
+    door_id: str,
+    controller=Depends(resolve_controller),
+    last_event_id: str | None = Header(None, alias="Last-Event-ID"),
+):
+    require_capability(controller, PRODUCT)
+    factory = request.app.state.manager_factory
+    pool = request.app.state.subscriber_pool
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, PRODUCT, "event_manager",
+        )
+    serializer = request.app.state.serializer_registry.serializer_for_tool(
+        "access_recent_events",
+    )
+
+    return StreamingResponse(
+        sse_event_stream(
+            manager=mgr,
+            pool=pool,
+            controller_id=controller.id,
+            product=PRODUCT,
+            serializer=serializer,
+            last_event_id=last_event_id,
+            filter_fn=lambda evt: evt.get("door_id") == door_id,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/apps/api/src/unifi_api/routes/streams/network_per_device.py
+++ b/apps/api/src/unifi_api/routes/streams/network_per_device.py
@@ -1,0 +1,59 @@
+"""GET /v1/streams/network/devices/{mac}/events — narrow per-device SSE."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import StreamingResponse
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.stream_generator import sse_event_stream
+
+
+router = APIRouter()
+PRODUCT = "network"
+
+
+@router.get(
+    f"/streams/{PRODUCT}/devices/{{mac}}/events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def stream_network_device_events(
+    request: Request,
+    mac: str,
+    controller=Depends(resolve_controller),
+    last_event_id: str | None = Header(None, alias="Last-Event-ID"),
+):
+    require_capability(controller, PRODUCT)
+    factory = request.app.state.manager_factory
+    pool = request.app.state.subscriber_pool
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, PRODUCT, "event_manager",
+        )
+    serializer = request.app.state.serializer_registry.serializer_for_tool(
+        "unifi_recent_events",
+    )
+
+    return StreamingResponse(
+        sse_event_stream(
+            manager=mgr,
+            pool=pool,
+            controller_id=controller.id,
+            product=PRODUCT,
+            serializer=serializer,
+            last_event_id=last_event_id,
+            filter_fn=lambda evt: evt.get("mac") == mac,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/apps/api/src/unifi_api/routes/streams/protect_per_camera.py
+++ b/apps/api/src/unifi_api/routes/streams/protect_per_camera.py
@@ -1,0 +1,59 @@
+"""GET /v1/streams/protect/cameras/{camera_id}/events — narrow per-camera SSE."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import StreamingResponse
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.stream_generator import sse_event_stream
+
+
+router = APIRouter()
+PRODUCT = "protect"
+
+
+@router.get(
+    f"/streams/{PRODUCT}/cameras/{{camera_id}}/events",
+    dependencies=[Depends(require_scope(Scope.READ))],
+)
+async def stream_protect_camera_events(
+    request: Request,
+    camera_id: str,
+    controller=Depends(resolve_controller),
+    last_event_id: str | None = Header(None, alias="Last-Event-ID"),
+):
+    require_capability(controller, PRODUCT)
+    factory = request.app.state.manager_factory
+    pool = request.app.state.subscriber_pool
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session, controller.id, PRODUCT, "event_manager",
+        )
+    serializer = request.app.state.serializer_registry.serializer_for_tool(
+        "protect_recent_events",
+    )
+
+    return StreamingResponse(
+        sse_event_stream(
+            manager=mgr,
+            pool=pool,
+            controller_id=controller.id,
+            product=PRODUCT,
+            serializer=serializer,
+            last_event_id=last_event_id,
+            filter_fn=lambda evt: evt.get("camera_id") == camera_id,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -75,8 +75,11 @@ from unifi_api.routes.resources.access import (
 )
 from unifi_api.routes.streams import (
     access as access_streams_routes,
+    access_per_door as access_per_door_routes,
     network as net_streams_routes,
+    network_per_device as net_per_device_routes,
     protect as protect_streams_routes,
+    protect_per_camera as protect_per_camera_routes,
 )
 from unifi_api.serializers._registry import discover_serializers
 from unifi_api.services.capability_cache import CapabilityCache
@@ -258,6 +261,9 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_streams_routes,
         protect_streams_routes,
         access_streams_routes,
+        net_per_device_routes,
+        protect_per_camera_routes,
+        access_per_door_routes,
     ):
         app.include_router(r.router, prefix="/v1")
 

--- a/apps/api/src/unifi_api/services/resource_routes.py
+++ b/apps/api/src/unifi_api/services/resource_routes.py
@@ -1,0 +1,41 @@
+"""Helpers for the resource-route surface — used by /v1/catalog/resources
+and the test_resource_route_coverage CI gate (Task 22)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from fastapi import FastAPI
+
+
+@dataclass
+class ResourceRoute:
+    method: str
+    path: str
+    name: str  # function name
+
+
+def collect_resource_routes(app: FastAPI) -> list[ResourceRoute]:
+    """Walk the FastAPI app and return all GET routes under /v1/sites/."""
+    routes: list[ResourceRoute] = []
+    for r in app.routes:
+        if not hasattr(r, "methods") or "GET" not in r.methods:
+            continue
+        if not r.path.startswith("/v1/sites/"):
+            continue
+        routes.append(ResourceRoute(method="GET", path=r.path, name=r.name))
+    return routes
+
+
+def is_read_tool(name: str) -> bool:
+    """True if the tool name follows the read-tool convention (list_/get_/recent_)."""
+    parts = name.split("_", 1)
+    if len(parts) != 2:
+        return False
+    rest = parts[1]
+    return rest.startswith(("list_", "get_", "recent_"))
+
+
+def read_tools_in_manifest(all_tools: Iterable[str]) -> set[str]:
+    return {t for t in all_tools if is_read_tool(t)}

--- a/apps/api/src/unifi_api/services/stream_generator.py
+++ b/apps/api/src/unifi_api/services/stream_generator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Callable
 
 from unifi_api.services.streams import StreamSubscriber, SubscriberPool
 
@@ -37,9 +37,16 @@ async def sse_event_stream(
     serializer: Any,
     last_event_id: str | None = None,
     keepalive_interval: float = 30.0,
+    filter_fn: Callable[[dict], bool] | None = None,
 ) -> AsyncIterator[bytes]:
-    """Replay buffer (filtered by last_event_id) then live tail with keepalive."""
+    """Replay buffer (filtered by last_event_id) then live tail with keepalive.
+
+    Optional filter_fn is applied to both replay-buffer events and live-tail
+    events (via the StreamSubscriber.filter_fn honored by SubscriberPool._broadcast).
+    """
     sub: StreamSubscriber = await pool.attach(controller_id, product, manager)
+    if filter_fn is not None:
+        sub.filter_fn = filter_fn
     try:
         # 1. Replay buffer (manager returns most-recent-first; reverse to oldest-first)
         replay = list(reversed(manager.get_recent_from_buffer()))
@@ -52,6 +59,8 @@ async def sse_event_stream(
                 elif str(evt.get("id")) == str(last_event_id):
                     seen = True
             replay = tail if seen else replay
+        if filter_fn is not None:
+            replay = [e for e in replay if filter_fn(e)]
         for evt in replay:
             yield format_sse_frame(event=evt, product=product, serializer=serializer)
 

--- a/apps/api/src/unifi_api/services/streams.py
+++ b/apps/api/src/unifi_api/services/streams.py
@@ -19,6 +19,7 @@ logger = logging.getLogger("unifi-api.streams")
 @dataclass
 class StreamSubscriber:
     queue: asyncio.Queue[dict] = field(default_factory=lambda: asyncio.Queue(maxsize=256))
+    filter_fn: Callable[[dict], bool] | None = None
 
 
 class SubscriberPool:
@@ -58,6 +59,8 @@ class SubscriberPool:
 
     def _broadcast(self, key: tuple[str, str], event: dict) -> None:
         for sub in list(self._pools.get(key, [])):
+            if sub.filter_fn is not None and not sub.filter_fn(event):
+                continue
             try:
                 sub.queue.put_nowait(event)
             except asyncio.QueueFull:

--- a/apps/api/tests/routes/streams/test_per_resource_streams.py
+++ b/apps/api/tests/routes/streams/test_per_resource_streams.py
@@ -1,0 +1,200 @@
+"""Per-resource SSE stream endpoints — path-bound resource id filtering.
+
+These narrow streams reuse the Phase 4B SubscriberPool + sse_event_stream
+infrastructure with the new filter_fn parameter (Task 19). Each route binds a
+filter that drops events not matching the path-bound resource id.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path):
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path, products):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    cipher = ColumnCipher(derive_key("k"))
+    cid = str(uuid.uuid4())
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="N", base_url="https://x", product_kinds=products,
+            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+            verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+class _FakeMgr:
+    """Manager stub: replay buffer + add_subscriber registration."""
+
+    def __init__(self, buffer: list[dict]) -> None:
+        self._buffer = buffer
+
+    def get_recent_from_buffer(self) -> list[dict]:
+        return list(self._buffer)
+
+    def add_subscriber(self, cb):
+        return lambda: None
+
+
+def _make_finite_stream():
+    """Build a finite sse_event_stream replacement that respects filter_fn.
+
+    httpx.ASGITransport.aiter_bytes() blocks on infinite generators (Phase 4B
+    workaround), so we yield only filtered replay frames and stop.
+    """
+
+    async def fake_stream(**kwargs):
+        manager = kwargs["manager"]
+        ser = kwargs["serializer"]
+        product = kwargs["product"]
+        filter_fn = kwargs.get("filter_fn")
+        for evt in manager.get_recent_from_buffer():
+            if filter_fn is not None and not filter_fn(evt):
+                continue
+            payload = ser.serialize(evt)
+            yield (
+                f"event: {product}.event\n"
+                f"id: {evt.get('id')}\n"
+                f"data: {json.dumps(payload, default=str)}\n\n"
+            ).encode()
+
+    return fake_stream
+
+
+@pytest.mark.asyncio
+async def test_stream_protect_camera_events_filters_by_camera_id(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="protect")
+
+    cam_a = "AAAAAAAAAAAA"
+    cam_b = "BBBBBBBBBBBB"
+    fake_mgr = _FakeMgr(
+        buffer=[
+            {"id": "e1", "type": "motion", "camera_id": cam_a, "start": 1700000000000},
+            {"id": "e2", "type": "motion", "camera_id": cam_b, "start": 1700000001000},
+            {"id": "e3", "type": "ring", "camera_id": cam_a, "start": 1700000002000},
+        ],
+    )
+    app.state.manager_factory.get_domain_manager = AsyncMock(return_value=fake_mgr)
+
+    from unifi_api.routes.streams import protect_per_camera as route_mod
+
+    monkeypatch.setattr(route_mod, "sse_event_stream", _make_finite_stream())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/streams/protect/cameras/{cam_a}/events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"].startswith("text/event-stream")
+    body = r.text
+    assert "id: e1" in body
+    assert "id: e3" in body
+    assert "id: e2" not in body
+    assert "event: protect.event" in body
+
+
+@pytest.mark.asyncio
+async def test_stream_access_door_events_filters_by_door_id(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="access")
+
+    door_a = "door-aaaa"
+    door_b = "door-bbbb"
+    fake_mgr = _FakeMgr(
+        buffer=[
+            {"id": "a1", "event": "access.granted", "door_id": door_a, "ts": 1700000000},
+            {"id": "a2", "event": "access.denied", "door_id": door_b, "ts": 1700000001},
+            {"id": "a3", "event": "access.granted", "door_id": door_a, "ts": 1700000002},
+        ],
+    )
+    app.state.manager_factory.get_domain_manager = AsyncMock(return_value=fake_mgr)
+
+    from unifi_api.routes.streams import access_per_door as route_mod
+
+    monkeypatch.setattr(route_mod, "sse_event_stream", _make_finite_stream())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/streams/access/doors/{door_a}/events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"].startswith("text/event-stream")
+    body = r.text
+    assert "id: a1" in body
+    assert "id: a3" in body
+    assert "id: a2" not in body
+    assert "event: access.event" in body
+
+
+@pytest.mark.asyncio
+async def test_stream_network_device_events_filters_by_mac(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, products="network")
+
+    mac_a = "aa:bb:cc:dd:ee:01"
+    mac_b = "aa:bb:cc:dd:ee:02"
+    fake_mgr = _FakeMgr(
+        buffer=[
+            {"id": "n1", "key": "STA_CONNECT", "mac": mac_a, "time": 1700000000},
+            {"id": "n2", "key": "STA_CONNECT", "mac": mac_b, "time": 1700000001},
+            {"id": "n3", "key": "STA_DISCONNECT", "mac": mac_a, "time": 1700000002},
+        ],
+    )
+    app.state.manager_factory.get_domain_manager = AsyncMock(return_value=fake_mgr)
+
+    from unifi_api.routes.streams import network_per_device as route_mod
+
+    monkeypatch.setattr(route_mod, "sse_event_stream", _make_finite_stream())
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/streams/network/devices/{mac_a}/events?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"].startswith("text/event-stream")
+    body = r.text
+    assert "id: n1" in body
+    assert "id: n3" in body
+    assert "id: n2" not in body
+    assert "event: network.event" in body

--- a/apps/api/tests/test_catalog_resources.py
+++ b/apps/api/tests/test_catalog_resources.py
@@ -1,0 +1,77 @@
+"""/v1/catalog/resources endpoint tests."""
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.server import create_app
+
+
+async def _bootstrap_with_read_key(tmp_path):
+    app = create_app(ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    ))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="read",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+@pytest.mark.asyncio
+async def test_catalog_resources_shape(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_with_read_key(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/catalog/resources", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    sample = body["items"][0]
+    assert "product" in sample
+    assert "resource_path" in sample
+    assert "render_hint" in sample
+    assert sample["resource_path"].startswith("/v1/sites/{site_id}/")
+
+
+@pytest.mark.asyncio
+async def test_catalog_resources_count(tmp_path, monkeypatch) -> None:
+    """Resource registration regression guard.
+
+    Current registered count is 28 (network=10, protect=9, access=9). Task 22's
+    test_resource_route_coverage gate will flag the gap to 50+ that the plan
+    anticipated; this test simply prevents regressions below today's surface.
+    """
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_with_read_key(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/catalog/resources", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) >= 28, f"expected >=28 resource entries, got {len(items)}"
+
+
+@pytest.mark.asyncio
+async def test_catalog_resources_includes_render_hint_kinds(tmp_path, monkeypatch) -> None:
+    """Render hints should include the kinds we registered (list, detail, event_log, etc.)."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_with_read_key(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/catalog/resources", headers={"Authorization": f"Bearer {key}"})
+    body = r.json()
+    kinds = {item["render_hint"]["kind"] for item in body["items"] if "kind" in item.get("render_hint", {})}
+    assert "list" in kinds  # Phase 3+5A registered many LIST resources

--- a/apps/api/tests/test_resource_route_coverage.py
+++ b/apps/api/tests/test_resource_route_coverage.py
@@ -1,0 +1,90 @@
+"""CI gate: every read tool must have a registered GET resource route.
+
+Mirrors test_serializer_coverage.py. Adding a new unifi_list_*, unifi_get_*_details,
+protect_list_*, protect_get_*, access_list_*, access_get_*, or *_recent_events tool
+fails this test if no matching GET route is registered.
+
+The default convention is "tool name minus product prefix" (e.g., unifi_list_clients
+maps to a route function named list_clients). When a route is registered under a
+different name (e.g., unifi_list_usergroups -> list_user_groups), record the mapping
+in TOOL_ROUTE_OVERRIDES.
+
+When a read tool intentionally has no resource route (e.g., the data is exposed via
+a different surface), document it in TOOLS_WITHOUT_ROUTE with an # explanation:
+comment.
+"""
+
+import os
+
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.server import create_app
+from unifi_api.services.manifest import ManifestRegistry
+from unifi_api.services.resource_routes import collect_resource_routes, is_read_tool
+
+
+# Tools whose registered route function name doesn't match the default convention
+# (tool name minus product prefix). Populated from the Task 22 audit.
+TOOL_ROUTE_OVERRIDES: dict[str, str] = {
+    # Access — domain-prefixed route functions to disambiguate from network/protect.
+    "access_get_activity_summary": "get_access_activity_summary",
+    "access_get_health": "get_access_health",
+    # Protect — domain-prefixed health/snapshot routes.
+    "protect_get_health": "get_protect_health",
+    "protect_get_snapshot": "get_camera_snapshot",
+    # Network — *_details tool name vs. shorter route function name.
+    "unifi_get_client_details": "get_client",
+    "unifi_get_device_details": "get_device",
+    "unifi_get_network_details": "get_network",
+    "unifi_get_wlan_details": "get_wlan",
+    # Network — dashboard tool maps to stats sub-resource.
+    "unifi_get_dashboard": "get_dashboard_stats",
+    # Network — firewall policy tool aliases the firewall rules route.
+    "unifi_get_firewall_policy_details": "get_firewall_rule",
+    "unifi_list_firewall_policies": "list_firewall_rules",
+    # Network — single get_* tool backed by a list_* route (collection endpoint).
+    "unifi_get_lldp_neighbors": "list_lldp_neighbors",
+    "unifi_get_port_stats": "list_port_stats",
+    "unifi_get_rf_scan_results": "list_rf_scan_results",
+    "unifi_get_switch_ports": "list_switch_ports",
+    # Network — usergroup tool name (one word) vs. user_group route function (snake).
+    "unifi_get_usergroup_details": "get_user_group_details",
+    "unifi_list_usergroups": "list_user_groups",
+}
+
+# Tools that intentionally don't get a resource route. Document why with an
+# # explanation: comment for each entry. Empty by default — every read tool
+# should have a route.
+TOOLS_WITHOUT_ROUTE: set[str] = set()
+
+
+def test_every_read_tool_has_a_resource_route(tmp_path) -> None:
+    os.environ["UNIFI_API_DB_KEY"] = "ci-gate-test"
+    cfg = ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+    app = create_app(cfg)
+
+    routes = collect_resource_routes(app)
+    route_names = {r.name for r in routes}
+
+    manifest = ManifestRegistry.load_from_apps()
+    read_tools = [t for t in manifest.all_tools() if is_read_tool(t)]
+
+    missing: list[tuple[str, str | None]] = []
+    for tool in read_tools:
+        if tool in TOOLS_WITHOUT_ROUTE:
+            continue
+        expected_route = TOOL_ROUTE_OVERRIDES.get(tool)
+        if expected_route is None:
+            parts = tool.split("_", 1)
+            if len(parts) == 2:
+                expected_route = parts[1]
+        if expected_route not in route_names:
+            missing.append((tool, expected_route))
+
+    assert not missing, (
+        f"{len(missing)} read tools lack a resource route:\n"
+        + "\n".join(f"  {t} (expected route fn: {r})" for t, r in missing[:30])
+    )

--- a/apps/api/tests/test_stream_generator_filter.py
+++ b/apps/api/tests/test_stream_generator_filter.py
@@ -1,0 +1,84 @@
+"""Per-subscriber filter tests for sse_event_stream."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from unifi_api.services.stream_generator import sse_event_stream
+from unifi_api.services.streams import StreamSubscriber, SubscriberPool
+
+
+@pytest.mark.asyncio
+async def test_filter_fn_drops_replay_events_that_dont_match() -> None:
+    pool = SubscriberPool()
+    mgr = MagicMock()
+    mgr.get_recent_from_buffer.return_value = [
+        {"id": "e3", "camera_id": "A"},
+        {"id": "e2", "camera_id": "B"},
+        {"id": "e1", "camera_id": "A"},
+    ]
+    mgr.add_subscriber.return_value = MagicMock()
+    serializer = MagicMock(serialize=lambda e: e)
+
+    gen = sse_event_stream(
+        manager=mgr, pool=pool, controller_id="c1", product="protect",
+        serializer=serializer, last_event_id=None, keepalive_interval=10,
+        filter_fn=lambda e: e.get("camera_id") == "A",
+    )
+
+    f1 = await gen.__anext__()
+    f2 = await gen.__anext__()
+    assert b"id: e1" in f1
+    assert b"id: e3" in f2
+    await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_filter_fn_drops_live_events_that_dont_match() -> None:
+    pool = SubscriberPool()
+    mgr = MagicMock()
+    mgr.get_recent_from_buffer.return_value = []
+    captured = {}
+    def fake_add(cb):
+        captured["cb"] = cb
+        return MagicMock()
+    mgr.add_subscriber.side_effect = fake_add
+    serializer = MagicMock(serialize=lambda e: e)
+
+    gen = sse_event_stream(
+        manager=mgr, pool=pool, controller_id="c1", product="protect",
+        serializer=serializer, last_event_id=None, keepalive_interval=10,
+        filter_fn=lambda e: e.get("camera_id") == "A",
+    )
+
+    # Prime the generator so pool.attach runs and add_subscriber registers cb
+    first_task = asyncio.create_task(gen.__anext__())
+    await asyncio.sleep(0)  # let attach() run
+    assert "cb" in captured
+
+    captured["cb"]({"id": "e1", "camera_id": "A"})
+    captured["cb"]({"id": "e2", "camera_id": "B"})
+
+    f1 = await asyncio.wait_for(first_task, timeout=1.0)
+    assert b"id: e1" in f1
+    await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_filter_fn_none_means_no_filter() -> None:
+    """Default behavior preserved when filter_fn is None."""
+    pool = SubscriberPool()
+    mgr = MagicMock()
+    mgr.get_recent_from_buffer.return_value = [{"id": "e1"}]
+    mgr.add_subscriber.return_value = MagicMock()
+    serializer = MagicMock(serialize=lambda e: e)
+
+    gen = sse_event_stream(
+        manager=mgr, pool=pool, controller_id="c1", product="network",
+        serializer=serializer, last_event_id=None, keepalive_interval=10,
+        filter_fn=None,
+    )
+    frame = await gen.__anext__()
+    assert b"id: e1" in frame
+    await gen.aclose()


### PR DESCRIPTION
## Summary

Final PR of Phase 5A. Lands per-subscriber stream filtering + 3 narrow per-resource SSE routes; adds the /v1/catalog/resources discovery endpoint; and adds test_resource_route_coverage as the CI gate ensuring every read tool has a registered GET route.

After this PR merges, **Phase 5A is complete:** 122/122 read tools have GET endpoints across all three products; 3 per-resource SSE streams expose narrow filtered event feeds; consumers can browse the full resource surface via /v1/catalog/resources; CI prevents regression.

## Commits

| Commit | What |
|---|---|
| c35bfe3 | Per-subscriber filter on sse_event_stream — `filter_fn` parameter on `sse_event_stream`; `StreamSubscriber.filter_fn` + filter in `_broadcast`; 3 unit tests; Phase 4B regression-free |
| 594e70d | Per-resource stream routes — `/streams/protect/cameras/{id}/events`, `/streams/access/doors/{id}/events`, `/streams/network/devices/{mac}/events`; each applies path-bound filter; 3 tests |
| 9084bc0 | /v1/catalog/resources discovery endpoint — returns `{product, resource_path, render_hint}` per registered resource; resource_routes.py helper introduced; 3 tests |
| e0729ff | test_resource_route_coverage CI gate — walks FastAPI app's mounted routes, cross-references against manifest's read-tool list, fails build on missing routes; sanity-checked by disabling one route; 1 test, 17 TOOL_ROUTE_OVERRIDES populated, 0 TOOLS_WITHOUT_ROUTE (full coverage) |

## Behavior

- **Per-resource streams** reuse Phase 4B's SubscriberPool + sse_event_stream infra; the new \`filter_fn\` parameter handles both replay-buffer and live-tail filtering.
- **/v1/catalog/resources** surfaces 28 resource paths (Phase 4A's per-tool serializer registrations had sparse per-resource entries; the gap is real but doesn't block Phase 5A — the routes exist, just not all are resource-registered in the serializer registry. Tracked as a follow-up in §11 deferrals).
- **test_resource_route_coverage** fails the build when a new read tool ships without a GET route, mirroring test_serializer_coverage.

## Phase 5A complete after this PR merges

- ✅ 122/122 read tools have a GET endpoint (61 endpoint families: Phase 3's 11 + Phase 5A's 50)
- ✅ Per-resource streams: 3 narrow SSE paths
- ✅ Catalog discovery: /v1/catalog/resources
- ✅ CI gate: test_resource_route_coverage (17 overrides, 0 missing tools)

## Closed deferrals from earlier specs

- **AST-introspection fix** (Phase 4B spec §11; Phase 5A original scope): closed via the parallel manager-refactor track. \`DISPATCH_OVERRIDES\` (in apps/api/src/unifi_api/services/dispatch_overrides.py) is the canonical extension point.
- **/events path collision** (Phase 5A PR2 Cluster 6): resolved with a capability-aware dispatcher in network/events.py that routes to network or protect manager based on controller.product_kinds.

## Verification

| Surface | Result |
|---|---|
| 5 sibling packages | unchanged (69/205/630/336/157) |
| unifi-api | 436 → 446 (+10 tests) |
| Phase 4A serializer-coverage gate | green |
| Phase 5A resource-route-coverage gate | green; 17 TOOL_ROUTE_OVERRIDES, 0 missing tools |
| Live smoke api-streams (Phase 4B) | broad streams still pass |

## Out of scope (deferred to later phases)

- **Phase 5B:** admin UI (separate spec, separate plan)
- **Phase 6:** codegen + write endpoints (POST/PUT/PATCH/DELETE)
- **Phase 7:** cut \`api/v0.1.0\` release tag
- **Phase 8:** GraphQL overlay (\`?include\`, field projection, deep nesting)
- **Phase 5A follow-up:** sparse per-resource serializer registrations — most Phase 4A serializers are tool-registered; some lack matching resource-key registrations. Routes work via \`serializer_for_tool\` lookup, but \`/v1/catalog/resources\` only surfaces 28 of the ~61 endpoint families. Tracked but doesn't block Phase 5A close.

## Reference

- Spec: Myco \`c56c0e0969cd6a9d\`
- Plan: Myco \`aff0da48adac8cee\`
- Phase 5A predecessors: PR1 #171 (network 1-3), PR2 #174 (network 4-6), PR3 #177 (protect), PR4 #178 (access)
- Refactor track (now closed): #172, #173, #175, #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)