### PR TITLE
Phase 5B PR1: backend foundations for admin UI

### DIFF
--- a/apps/api/alembic/versions/0002_add_app_settings.py
+++ b/apps/api/alembic/versions/0002_add_app_settings.py
@@ -1,0 +1,52 @@
+"""add app_settings table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-30
+"""
+
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_settings",
+        sa.Column("key", sa.String(128), primary_key=True),
+        sa.Column("value", sa.Text, nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    defaults = [
+        ("audit.retention.max_age_days", "90"),
+        ("audit.retention.max_rows", "1000000"),
+        ("audit.retention.enabled", "true"),
+        ("audit.retention.prune_interval_hours", "6"),
+        ("logs.file.enabled", "true"),
+        ("logs.file.path", "state/api.log"),
+        ("logs.file.max_bytes", "10485760"),
+        ("logs.file.backup_count", "5"),
+        ("logs.file.level", "INFO"),
+        ("theme.default", "auto"),
+    ]
+    op.bulk_insert(
+        sa.table(
+            "app_settings",
+            sa.column("key", sa.String),
+            sa.column("value", sa.Text),
+            sa.column("updated_at", sa.DateTime(timezone=True)),
+        ),
+        [{"key": k, "value": v, "updated_at": datetime.now(timezone.utc)} for k, v in defaults],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_settings")

--- a/apps/api/src/unifi_api/db/models.py
+++ b/apps/api/src/unifi_api/db/models.py
@@ -65,3 +65,12 @@ class AuditLog(Base):
     outcome: Mapped[str] = mapped_column(String(32), nullable=False)
     error_kind: Mapped[Optional[str]] = mapped_column(String(64))
     detail: Mapped[Optional[str]] = mapped_column(Text)
+
+
+class AppSetting(Base):
+    """Single-row-per-setting key/value store for runtime configuration."""
+
+    __tablename__ = "app_settings"
+    key: Mapped[str] = mapped_column(String(128), primary_key=True)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/apps/api/src/unifi_api/logging.py
+++ b/apps/api/src/unifi_api/logging.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import contextvars
 import json
 import logging
+import logging.handlers
 import sys
 import time
+from pathlib import Path
 
 request_id_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar("request_id", default=None)
 key_id_prefix_ctx: contextvars.ContextVar[str | None] = contextvars.ContextVar("key_id_prefix", default=None)
@@ -24,6 +26,7 @@ class JsonFormatter(logging.Formatter):
             "level": record.levelname,
             "event": record.getMessage(),
         }
+        payload["logger"] = record.name
         rid = request_id_ctx.get()
         if rid is not None:
             payload["request_id"] = rid
@@ -58,3 +61,29 @@ def configure_logging(level: str = "INFO") -> None:
 
 def get_logger(name: str) -> logging.Logger:
     return logging.getLogger(name)
+
+
+def attach_rotating_file_handler(
+    *,
+    path: Path,
+    max_bytes: int,
+    backup_count: int,
+    level: str = "INFO",
+) -> logging.handlers.RotatingFileHandler:
+    """Attach a RotatingFileHandler to the root logger using JsonFormatter.
+
+    Creates the parent directory if it doesn't exist. Returns the handler so
+    callers can hold a reference for shutdown / testing.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = logging.handlers.RotatingFileHandler(
+        path,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setLevel(level)
+    handler.setFormatter(JsonFormatter())
+    logging.getLogger().addHandler(handler)
+    return handler

--- a/apps/api/src/unifi_api/routes/admin_data.py
+++ b/apps/api/src/unifi_api/routes/admin_data.py
@@ -1,0 +1,73 @@
+"""Admin-scoped data endpoints: diagnostics, logs, settings.
+
+These power the /admin/ UI but are also useful for programmatic access.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.services.diagnostics import collect_diagnostics
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/diagnostics",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def get_diagnostics(request: Request) -> dict:
+    return await collect_diagnostics(
+        sessionmaker=request.app.state.sessionmaker,
+        db_path=request.app.state.db_path,
+        capability_cache=request.app.state.capability_cache,
+        log_path=request.app.state.log_file_path,
+        version=request.app.state.api_version,
+        started_at=request.app.state.started_at,
+    )
+
+
+@router.get(
+    "/logs",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def get_logs(
+    request: Request,
+    level: str | None = Query(None),
+    logger: str | None = Query(None),
+    q: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+) -> dict:
+    reader = request.app.state.log_reader
+    return {
+        "items": reader.tail(limit=limit, level=level, logger=logger, q=q),
+        "file_size_bytes": reader.size_bytes,
+    }
+
+
+class SettingsBody(BaseModel):
+    settings: dict[str, str]
+
+
+@router.get(
+    "/settings",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def get_settings(request: Request) -> dict:
+    svc = request.app.state.settings_service
+    return {"settings": await svc.get_all()}
+
+
+@router.put(
+    "/settings",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def put_settings(request: Request, body: SettingsBody) -> dict:
+    svc = request.app.state.settings_service
+    for k, v in body.settings.items():
+        await svc.set_str(k, v)
+    return {"settings": await svc.get_all()}

--- a/apps/api/src/unifi_api/routes/audit.py
+++ b/apps/api/src/unifi_api/routes/audit.py
@@ -1,0 +1,88 @@
+"""Audit log query route — admin-scoped, paginated, filterable."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import select
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.db.models import AuditLog
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+def _row_to_dict(r: AuditLog) -> dict:
+    return {
+        "id": r.id,
+        "ts": r.ts.isoformat(),
+        "key_id_prefix": r.key_id_prefix,
+        "controller": r.controller,
+        "target": r.target,
+        "outcome": r.outcome,
+        "error_kind": r.error_kind,
+        "detail": r.detail,
+    }
+
+
+def _audit_key(r: AuditLog) -> tuple:
+    return (int(r.ts.timestamp() * 1000), str(r.id))
+
+
+@router.get(
+    "/audit",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def list_audit(
+    request: Request,
+    controller: str | None = Query(None),
+    outcome: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    q: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+) -> dict:
+    sm = request.app.state.sessionmaker
+
+    stmt = select(AuditLog)
+    if controller is not None:
+        stmt = stmt.where(AuditLog.controller == controller)
+    if outcome is not None:
+        stmt = stmt.where(AuditLog.outcome == outcome)
+    if since is not None:
+        try:
+            stmt = stmt.where(AuditLog.ts >= datetime.fromisoformat(since))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid 'since' timestamp")
+    if until is not None:
+        try:
+            stmt = stmt.where(AuditLog.ts <= datetime.fromisoformat(until))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid 'until' timestamp")
+    if q is not None:
+        stmt = stmt.where(AuditLog.target.ilike(f"%{q}%"))
+    stmt = stmt.order_by(AuditLog.ts.desc())
+
+    async with sm() as session:
+        rows = (await session.execute(stmt)).scalars().all()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(rows), limit=limit, cursor=cursor_obj, key_fn=_audit_key,
+    )
+
+    return {
+        "items": [_row_to_dict(r) for r in page],
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+    }

--- a/apps/api/src/unifi_api/routes/audit.py
+++ b/apps/api/src/unifi_api/routes/audit.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.db.models import AuditLog
+from unifi_api.services.audit import add_audit_subscriber
+from unifi_api.services.audit_pruner import prune_audit
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
 
@@ -86,3 +91,62 @@ async def list_audit(
         "items": [_row_to_dict(r) for r in page],
         "next_cursor": next_cursor.encode() if next_cursor else None,
     }
+
+
+@router.post(
+    "/audit/prune",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def prune_endpoint(request: Request) -> dict:
+    sm = request.app.state.sessionmaker
+    svc = request.app.state.settings_service
+    max_age = await svc.get_int("audit.retention.max_age_days", default=90)
+    max_rows = await svc.get_int("audit.retention.max_rows", default=1_000_000)
+    return await prune_audit(sm, max_age_days=max_age, max_rows=max_rows)
+
+
+async def _audit_event_stream():
+    """Async generator that yields SSE frames for audit rows.
+
+    Module-level (not nested inside the route) so tests can monkeypatch it
+    with a finite version that doesn't loop forever.
+    """
+    queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)
+
+    def _on_row(row: dict) -> None:
+        try:
+            queue.put_nowait(row)
+        except asyncio.QueueFull:
+            pass  # drop newest if backpressured
+
+    unsub = add_audit_subscriber(_on_row)
+    try:
+        while True:
+            try:
+                row = await asyncio.wait_for(queue.get(), timeout=30.0)
+                yield (
+                    f"event: audit.row\n"
+                    f"id: {row['id']}\n"
+                    f"data: {json.dumps(row, default=str)}\n\n"
+                ).encode()
+            except asyncio.TimeoutError:
+                yield b": keepalive\n\n"
+    finally:
+        unsub()
+
+
+@router.get(
+    "/streams/audit",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def stream_audit(request: Request) -> StreamingResponse:
+    """SSE stream of audit rows. One frame per row inserted via write_audit."""
+    return StreamingResponse(
+        _audit_event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/apps/api/src/unifi_api/routes/controllers.py
+++ b/apps/api/src/unifi_api/routes/controllers.py
@@ -170,3 +170,17 @@ async def capabilities_endpoint(request: Request, cid: str, refresh: bool = Fals
     payload = await probe_capabilities(controller)
     cache.put(cid, payload)
     return payload
+
+
+@router.post(
+    "/controllers/{cid}/probe",
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def probe_endpoint(request: Request, cid: str) -> dict:
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        try:
+            await get_controller(session, cid)
+        except ControllerNotFound:
+            raise HTTPException(status_code=404, detail="controller not found")
+    return await request.app.state.manager_factory.probe_controller(cid)

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from contextlib import asynccontextmanager
@@ -17,7 +18,7 @@ from unifi_api.config import ApiConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
 from unifi_api.db.engine import create_engine
 from unifi_api.db.session import get_sessionmaker
-from unifi_api.logging import request_id_ctx
+from unifi_api.logging import attach_rotating_file_handler, request_id_ctx
 from unifi_api.routes import actions as actions_routes
 from unifi_api.routes import admin_data as admin_data_routes
 from unifi_api.routes import audit as audit_routes
@@ -87,6 +88,7 @@ from unifi_api.routes.streams import (
     protect_per_camera as protect_per_camera_routes,
 )
 from unifi_api.serializers._registry import discover_serializers
+from unifi_api.services.audit_pruner import prune_audit
 from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.controllers import list_controllers
 from unifi_api.services.managers import ManagerFactory
@@ -140,7 +142,69 @@ def create_app(config: ApiConfig) -> FastAPI:
                         controller.id, product, exc_info=True,
                     )
 
+        # Phase 5B: file logging (optional) + background audit pruner
+        settings_svc = app.state.settings_service
+        log_enabled = await settings_svc.get_bool("logs.file.enabled", default=True)
+        log_path = None
+        if log_enabled:
+            log_path_str = await settings_svc.get_str("logs.file.path", default="state/api.log")
+            db_dir = Path(config.db.path).parent
+            log_path = (
+                Path(log_path_str)
+                if Path(log_path_str).is_absolute()
+                else (db_dir / log_path_str).resolve()
+            )
+            max_bytes = await settings_svc.get_int("logs.file.max_bytes", default=10 * 1024 * 1024)
+            backup_count = await settings_svc.get_int("logs.file.backup_count", default=5)
+            level = await settings_svc.get_str("logs.file.level", default="INFO")
+            attach_rotating_file_handler(
+                path=log_path, max_bytes=max_bytes, backup_count=backup_count, level=level,
+            )
+            app.state.log_file_path = log_path
+            app.state.log_reader = LogReader(log_path)
+
+        # Background audit pruner — periodic prune based on settings
+        async def _prune_loop():
+            while True:
+                try:
+                    interval_h = await settings_svc.get_int(
+                        "audit.retention.prune_interval_hours", default=6,
+                    )
+                    enabled = await settings_svc.get_bool(
+                        "audit.retention.enabled", default=True,
+                    )
+                    if enabled:
+                        max_age = await settings_svc.get_int(
+                            "audit.retention.max_age_days", default=90,
+                        )
+                        max_rows = await settings_svc.get_int(
+                            "audit.retention.max_rows", default=1_000_000,
+                        )
+                        result = await prune_audit(
+                            app.state.sessionmaker,
+                            max_age_days=max_age,
+                            max_rows=max_rows,
+                        )
+                        _streams_log.info(
+                            "[audit-pruner] pruned %s rows; current count %s",
+                            result["pruned"], result["current_count"],
+                        )
+                except Exception:
+                    _streams_log.warning("[audit-pruner] error", exc_info=True)
+                await asyncio.sleep(interval_h * 3600)
+
+        app.state._audit_pruner_task = asyncio.create_task(_prune_loop())
+
         yield
+        # Cancel background pruner task
+        task = getattr(app.state, "_audit_pruner_task", None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
         # Shutdown — drop manager caches first, then engine
         factory = app.state.manager_factory
         cached_ids = list({k[0] for k in factory._connection_cache.keys()})

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import logging
 import uuid
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
 from starlette.middleware.cors import CORSMiddleware
 
+from unifi_api._version import __version__ as _api_version
 from unifi_api.auth.cache import ArgonVerifyCache
 from unifi_api.config import ApiConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
@@ -16,6 +19,7 @@ from unifi_api.db.engine import create_engine
 from unifi_api.db.session import get_sessionmaker
 from unifi_api.logging import request_id_ctx
 from unifi_api.routes import actions as actions_routes
+from unifi_api.routes import admin_data as admin_data_routes
 from unifi_api.routes import audit as audit_routes
 from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
@@ -87,6 +91,7 @@ from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.controllers import list_controllers
 from unifi_api.services.managers import ManagerFactory
 from unifi_api.services.manifest import ManifestRegistry
+from unifi_api.services.log_reader import LogReader
 from unifi_api.services.settings import SettingsService
 from unifi_api.services.streams import SubscriberPool
 
@@ -185,6 +190,11 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.state.argon_cache = ArgonVerifyCache()
     app.state.capability_cache = CapabilityCache()
     app.state.settings_service = SettingsService(app.state.sessionmaker)
+    app.state.db_path = config.db.path
+    app.state.api_version = _api_version
+    app.state.started_at = datetime.now(timezone.utc)
+    app.state.log_file_path = None  # Task 11 may override this if log file is enabled
+    app.state.log_reader = LogReader(Path("/dev/null"))  # Task 11 may override
     app.state.manifest_registry = ManifestRegistry.load_from_apps()
     # Discover and register every serializer module, then validate against the
     # full manifest. Phase 4A landed coverage for all 235 manifest tools, so
@@ -200,6 +210,7 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(actions_routes.router, prefix="/v1")
     app.include_router(catalog_routes.router, prefix="/v1")
     app.include_router(audit_routes.router, prefix="/v1")
+    app.include_router(admin_data_routes.router, prefix="/v1")
     for r in (
         net_clients_routes,
         net_devices_routes,

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -87,6 +87,7 @@ from unifi_api.services.capability_cache import CapabilityCache
 from unifi_api.services.controllers import list_controllers
 from unifi_api.services.managers import ManagerFactory
 from unifi_api.services.manifest import ManifestRegistry
+from unifi_api.services.settings import SettingsService
 from unifi_api.services.streams import SubscriberPool
 
 
@@ -183,6 +184,7 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.state.subscriber_pool = SubscriberPool()
     app.state.argon_cache = ArgonVerifyCache()
     app.state.capability_cache = CapabilityCache()
+    app.state.settings_service = SettingsService(app.state.sessionmaker)
     app.state.manifest_registry = ManifestRegistry.load_from_apps()
     # Discover and register every serializer module, then validate against the
     # full manifest. Phase 4A landed coverage for all 235 manifest tools, so

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -16,6 +16,7 @@ from unifi_api.db.engine import create_engine
 from unifi_api.db.session import get_sessionmaker
 from unifi_api.logging import request_id_ctx
 from unifi_api.routes import actions as actions_routes
+from unifi_api.routes import audit as audit_routes
 from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
 from unifi_api.routes import health
@@ -196,6 +197,7 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(controllers_routes.router, prefix="/v1")
     app.include_router(actions_routes.router, prefix="/v1")
     app.include_router(catalog_routes.router, prefix="/v1")
+    app.include_router(audit_routes.router, prefix="/v1")
     for r in (
         net_clients_routes,
         net_devices_routes,

--- a/apps/api/src/unifi_api/services/audit.py
+++ b/apps/api/src/unifi_api/services/audit.py
@@ -1,16 +1,52 @@
-"""Audit log writer.
+"""Audit log writer + subscriber fan-out.
 
 Synchronous insert in the request transaction. Failures of the audit insert
 itself propagate to the caller (we don't silently drop audit records).
+
+After a successful insert, fan out the row dict to any registered subscribers
+(SSE streams). Subscriber callbacks must not raise — exceptions are caught
+per-callback so one failing subscriber doesn't break others.
 """
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
+from typing import Callable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from unifi_api.db.models import AuditLog
+
+
+_log = logging.getLogger("unifi-api.audit")
+_audit_subscribers: list[Callable[[dict], None]] = []
+
+
+def add_audit_subscriber(cb: Callable[[dict], None]) -> Callable[[], None]:
+    """Register a subscriber callback. Returns an unsubscribe callable."""
+    _audit_subscribers.append(cb)
+
+    def _unsub() -> None:
+        try:
+            _audit_subscribers.remove(cb)
+        except ValueError:
+            pass
+
+    return _unsub
+
+
+def _row_to_dict(row: AuditLog) -> dict:
+    return {
+        "id": row.id,
+        "ts": row.ts.isoformat(),
+        "key_id_prefix": row.key_id_prefix,
+        "controller": row.controller,
+        "target": row.target,
+        "outcome": row.outcome,
+        "error_kind": row.error_kind,
+        "detail": row.detail,
+    }
 
 
 async def write_audit(
@@ -23,7 +59,7 @@ async def write_audit(
     error_kind: str | None = None,
     detail: str | None = None,
 ) -> None:
-    session.add(AuditLog(
+    row = AuditLog(
         ts=datetime.now(timezone.utc),
         key_id_prefix=key_id_prefix,
         controller=controller,
@@ -31,5 +67,14 @@ async def write_audit(
         outcome=outcome,
         error_kind=error_kind,
         detail=detail,
-    ))
-    await session.flush()
+    )
+    session.add(row)
+    await session.flush()  # populate row.id
+
+    # Fan out to subscribers — protect each callback with try/except.
+    payload = _row_to_dict(row)
+    for cb in list(_audit_subscribers):
+        try:
+            cb(payload)
+        except Exception:
+            _log.warning("audit subscriber raised", exc_info=True)

--- a/apps/api/src/unifi_api/services/audit_pruner.py
+++ b/apps/api/src/unifi_api/services/audit_pruner.py
@@ -1,0 +1,60 @@
+"""Audit log pruning — by age and/or by row count."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from unifi_api.db.models import AuditLog
+
+
+async def prune_audit(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    max_age_days: int,
+    max_rows: int,
+) -> dict:
+    """Delete audit_log rows older than ``max_age_days``; then enforce ``max_rows``
+    by deleting the oldest-first remaining rows beyond the cap.
+
+    Returns:
+        ``{"pruned": <int>, "current_count": <int>}`` — total rows deleted in this
+        invocation (age + row-cap combined), and the row count after pruning.
+    """
+
+    pruned = 0
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+
+    async with sessionmaker() as session:
+        # Phase 1 — age-based prune
+        age_result = await session.execute(
+            delete(AuditLog).where(AuditLog.ts < cutoff)
+        )
+        pruned += age_result.rowcount or 0
+
+        # Phase 2 — row-cap prune (oldest-first)
+        current = (
+            await session.execute(select(func.count(AuditLog.id)))
+        ).scalar_one()
+        if current > max_rows:
+            excess = current - max_rows
+            ids_to_delete = (
+                await session.execute(
+                    select(AuditLog.id).order_by(AuditLog.ts.asc()).limit(excess)
+                )
+            ).scalars().all()
+            if ids_to_delete:
+                cap_result = await session.execute(
+                    delete(AuditLog).where(AuditLog.id.in_(ids_to_delete))
+                )
+                pruned += cap_result.rowcount or 0
+
+        await session.commit()
+
+        current_count = (
+            await session.execute(select(func.count(AuditLog.id)))
+        ).scalar_one()
+
+    return {"pruned": pruned, "current_count": current_count}

--- a/apps/api/src/unifi_api/services/capability_cache.py
+++ b/apps/api/src/unifi_api/services/capability_cache.py
@@ -17,14 +17,32 @@ class CapabilityCache:
     def __init__(self, ttl_seconds: int = 300) -> None:
         self._ttl = ttl_seconds
         self._data: dict[str, _Entry] = {}
+        self._hits = 0
+        self._misses = 0
+
+    @property
+    def size(self) -> int:
+        return len(self._data)
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl
+
+    @property
+    def hit_rate(self) -> float:
+        total = self._hits + self._misses
+        return (self._hits / total) if total else 0.0
 
     def get(self, controller_id: str) -> Any | None:
         e = self._data.get(controller_id)
         if e is None:
+            self._misses += 1
             return None
         if time.time() - e.fetched_at > self._ttl:
             del self._data[controller_id]
+            self._misses += 1
             return None
+        self._hits += 1
         return e.payload
 
     def put(self, controller_id: str, payload: Any) -> None:

--- a/apps/api/src/unifi_api/services/diagnostics.py
+++ b/apps/api/src/unifi_api/services/diagnostics.py
@@ -1,0 +1,96 @@
+"""Diagnostics aggregator for /admin/ and GET /v1/diagnostics."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from unifi_api.db.models import ApiKey, AuditLog, Controller
+
+
+async def collect_diagnostics(
+    *,
+    sessionmaker: async_sessionmaker[AsyncSession],
+    db_path: Path | str,
+    capability_cache: Any,
+    log_path: Path | str | None,
+    version: str,
+    started_at: datetime,
+) -> dict:
+    """Build the diagnostics snapshot for dashboard / API consumption."""
+
+    db_path = Path(db_path)
+    log_path_obj = Path(log_path) if log_path else None
+
+    # Service section
+    now = datetime.now(timezone.utc)
+    uptime_seconds = int((now - started_at).total_seconds())
+    service = {
+        "version": version,
+        "uptime_seconds": uptime_seconds,
+        "python_version": sys.version.split()[0],
+    }
+
+    # Database section
+    db_reachable = True
+    db_size = 0
+    api_keys_count = 0
+    controllers_count = 0
+    audit_rows_count = 0
+    try:
+        db_size = db_path.stat().st_size
+    except FileNotFoundError:
+        db_size = 0
+
+    try:
+        async with sessionmaker() as session:
+            api_keys_count = (await session.execute(select(func.count(ApiKey.id)))).scalar_one()
+            controllers_count = (await session.execute(select(func.count(Controller.id)))).scalar_one()
+            audit_rows_count = (await session.execute(select(func.count(AuditLog.id)))).scalar_one()
+    except Exception:
+        db_reachable = False
+
+    database = {
+        "reachable": db_reachable,
+        "path": str(db_path),
+        "size_bytes": db_size,
+    }
+
+    # Capability cache section
+    cap_cache = {
+        "size": capability_cache.size,
+        "hit_rate": capability_cache.hit_rate,
+        "ttl_seconds": capability_cache.ttl_seconds,
+    }
+
+    # Logs section
+    log_size = 0
+    if log_path_obj is not None:
+        try:
+            log_size = log_path_obj.stat().st_size
+        except FileNotFoundError:
+            log_size = 0
+    logs = {
+        "file_path": str(log_path_obj) if log_path_obj else None,
+        "file_size_bytes": log_size,
+    }
+
+    # Counts section
+    counts = {
+        "api_keys": api_keys_count,
+        "controllers": controllers_count,
+        "audit_rows": audit_rows_count,
+    }
+
+    return {
+        "service": service,
+        "database": database,
+        "capability_cache": cap_cache,
+        "logs": logs,
+        "counts": counts,
+    }

--- a/apps/api/src/unifi_api/services/log_reader.py
+++ b/apps/api/src/unifi_api/services/log_reader.py
@@ -1,0 +1,66 @@
+"""Tail-of-file reader for the rotating JSON application log."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class LogReader:
+    """Read recent JSON-per-line log entries from a single file (no rotation
+    awareness — RotatingFileHandler keeps the active file ≤ maxBytes).
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+
+    @property
+    def size_bytes(self) -> int:
+        try:
+            return self._path.stat().st_size
+        except FileNotFoundError:
+            return 0
+
+    def tail(
+        self,
+        *,
+        limit: int = 50,
+        level: str | None = None,
+        logger: str | None = None,
+        q: str | None = None,
+    ) -> list[dict]:
+        """Return up to ``limit`` recent log entries, most-recent-first.
+
+        Filters:
+          * ``level`` — exact match on ``payload["level"]`` (case-insensitive).
+          * ``logger`` — exact match on ``payload["logger"]``.
+          * ``q`` — case-insensitive substring match against the raw line.
+
+        Malformed (non-JSON) lines are skipped silently.
+        Missing file → ``[]``.
+        """
+        try:
+            text = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return []
+
+        out: list[dict] = []
+        level_norm = level.upper() if level else None
+
+        for line in reversed(text.splitlines()):
+            if not line.strip():
+                continue
+            if q is not None and q.lower() not in line.lower():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if level_norm is not None and str(payload.get("level", "")).upper() != level_norm:
+                continue
+            if logger is not None and payload.get("logger") != logger:
+                continue
+            out.append(payload)
+            if len(out) >= limit:
+                break
+        return out

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any, Callable
 from urllib.parse import urlparse
 
@@ -298,6 +300,70 @@ class ManagerFactory:
         instance = builder(cm)
         self._domain_cache[key] = instance
         return instance
+
+    async def probe_controller(self, controller_id: str) -> dict:
+        """Live connectivity probe across all products the controller advertises.
+
+        Invalidates any cached connection for the controller, then reconstructs
+        each product's ConnectionManager (which calls initialize() — the network
+        round-trip). Per-product latency + success/failure.
+
+        Returns:
+            {
+              "ok": <bool — all products succeeded>,
+              "products": {<product>: {"ok": bool, "latency_ms": int, "error": <str|None>}, ...},
+              "latency_ms": <int — sum of per-product latencies>,
+              "error_kind": <"not_found" | None>,
+              "last_probed_at": <iso8601 utc str>,
+            }
+
+        If the controller does not exist, returns:
+            {"ok": False, "error_kind": "not_found", "products": {},
+             "latency_ms": 0, "last_probed_at": iso8601}
+
+        This method does NOT cache the constructed connection. After the probe,
+        the controller's connection cache is empty. The next normal request
+        will reconstruct cleanly. This is intentional (probe = fresh handshake).
+        """
+        async with self._sm() as session:
+            controller = await session.get(Controller, controller_id)
+            if controller is None:
+                return {
+                    "ok": False,
+                    "error_kind": "not_found",
+                    "products": {},
+                    "latency_ms": 0,
+                    "last_probed_at": datetime.now(timezone.utc).isoformat(),
+                }
+            products = [p for p in controller.product_kinds.split(",") if p]
+
+        # Drop cached connections so we exercise the slow path.
+        await self.invalidate_controller(controller_id)
+
+        per_product: dict[str, dict] = {}
+        total_latency = 0
+        all_ok = True
+        for product in products:
+            start = time.perf_counter()
+            try:
+                async with self._sm() as session:
+                    await self._construct_connection_manager(session, controller_id, product)
+                latency = int((time.perf_counter() - start) * 1000)
+                per_product[product] = {"ok": True, "latency_ms": latency, "error": None}
+                total_latency += latency
+            except Exception as exc:
+                latency = int((time.perf_counter() - start) * 1000)
+                per_product[product] = {"ok": False, "latency_ms": latency, "error": str(exc)}
+                total_latency += latency
+                all_ok = False
+
+        return {
+            "ok": all_ok,
+            "products": per_product,
+            "latency_ms": total_latency,
+            "error_kind": None,
+            "last_probed_at": datetime.now(timezone.utc).isoformat(),
+        }
 
     async def invalidate_controller(self, controller_id: str) -> None:
         """Drop all cached managers for a controller and dispose their sessions."""

--- a/apps/api/src/unifi_api/services/settings.py
+++ b/apps/api/src/unifi_api/services/settings.py
@@ -1,0 +1,82 @@
+"""Typed accessors over the app_settings key/value table."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from unifi_api.db.models import AppSetting
+
+_SENTINEL: Any = object()
+
+
+class UnknownSettingKey(KeyError):
+    """Raised when a setting key is missing AND no default was provided."""
+
+
+class SettingsService:
+    """Async UPSERT-based key/value access to the app_settings table.
+
+    All ``get_*``/``set_*`` methods are async — they open a session per call so
+    the service can be held on ``app.state`` without dragging an open session
+    around with it.
+    """
+
+    def __init__(self, sessionmaker: async_sessionmaker[AsyncSession]) -> None:
+        self._sm = sessionmaker
+
+    async def get_str(self, key: str, default: Any = _SENTINEL) -> str:
+        async with self._sm() as session:
+            row = await session.get(AppSetting, key)
+        if row is not None:
+            return row.value
+        if default is _SENTINEL:
+            raise UnknownSettingKey(key)
+        return default
+
+    async def get_int(self, key: str, default: Any = _SENTINEL) -> int:
+        try:
+            return int(await self.get_str(key))
+        except UnknownSettingKey:
+            if default is _SENTINEL:
+                raise
+            return default
+
+    async def get_bool(self, key: str, default: Any = _SENTINEL) -> bool:
+        try:
+            raw = await self.get_str(key)
+        except UnknownSettingKey:
+            if default is _SENTINEL:
+                raise
+            return default
+        return raw.lower() in ("true", "1", "yes")
+
+    async def set_str(self, key: str, value: str) -> None:
+        async with self._sm() as session:
+            row = await session.get(AppSetting, key)
+            if row is None:
+                session.add(
+                    AppSetting(
+                        key=key,
+                        value=value,
+                        updated_at=datetime.now(timezone.utc),
+                    )
+                )
+            else:
+                row.value = value
+                row.updated_at = datetime.now(timezone.utc)
+            await session.commit()
+
+    async def set_int(self, key: str, value: int) -> None:
+        await self.set_str(key, str(value))
+
+    async def set_bool(self, key: str, value: bool) -> None:
+        await self.set_str(key, "true" if value else "false")
+
+    async def get_all(self) -> dict[str, str]:
+        async with self._sm() as session:
+            rows = (await session.execute(select(AppSetting))).scalars().all()
+        return {r.key: r.value for r in rows}

--- a/apps/api/tests/test_admin_data.py
+++ b/apps/api/tests/test_admin_data.py
@@ -1,0 +1,115 @@
+"""Admin-scoped data endpoints: /v1/diagnostics, /v1/logs, /v1/settings."""
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app(tmp_path: Path, scopes: str = "admin"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes=scopes,
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_returns_shape(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/diagnostics", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert set(body.keys()) >= {"service", "database", "capability_cache", "logs", "counts"}
+        assert isinstance(body["service"]["version"], str)
+        assert body["service"]["version"]
+        assert body["counts"]["api_keys"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_logs_returns_empty_when_no_log_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/logs", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["items"] == []
+        assert body["file_size_bytes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_settings_get_returns_dict(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    await app.state.settings_service.set_str("foo", "1")
+    await app.state.settings_service.set_str("bar", "two")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/settings", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["settings"]["foo"] == "1"
+        assert body["settings"]["bar"] == "two"
+
+
+@pytest.mark.asyncio
+async def test_settings_put_round_trip(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    payload = {"settings": {"theme.default": "dark", "audit.retention.max_age_days": "30"}}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.put("/v1/settings", headers=headers, json=payload)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["settings"]["theme.default"] == "dark"
+        assert body["settings"]["audit.retention.max_age_days"] == "30"
+    assert await app.state.settings_service.get_str("theme.default") == "dark"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_requires_admin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path, scopes="read")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/diagnostics", headers=headers)
+        assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_settings_put_requires_admin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path, scopes="read")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.put("/v1/settings", headers=headers, json={"settings": {"k": "v"}})
+        assert r.status_code == 403

--- a/apps/api/tests/test_app_settings_model.py
+++ b/apps/api/tests/test_app_settings_model.py
@@ -1,0 +1,32 @@
+"""AppSetting model creation + insert/query smoke tests."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from unifi_api.db.engine import create_engine
+from unifi_api.db.models import AppSetting, Base
+from unifi_api.db.session import get_sessionmaker
+
+
+@pytest.mark.asyncio
+async def test_app_setting_insert_and_query(tmp_path: Path) -> None:
+    engine = create_engine(tmp_path / "state.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = get_sessionmaker(engine)
+    async with sm() as session:
+        setting = AppSetting(
+            key="theme.default",
+            value="auto",
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(setting)
+        await session.commit()
+        rows = (await session.execute(select(AppSetting))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].key == "theme.default"
+        assert rows[0].value == "auto"
+    await engine.dispose()

--- a/apps/api/tests/test_audit_pruner.py
+++ b/apps/api/tests/test_audit_pruner.py
@@ -1,0 +1,98 @@
+"""Tests for audit_log pruning service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from unifi_api.db.engine import create_engine
+from unifi_api.db.models import AuditLog, Base
+from unifi_api.db.session import get_sessionmaker
+from unifi_api.services.audit_pruner import prune_audit
+
+
+async def _seed(sm, ts_offsets_days: list[int]) -> None:
+    """Insert one AuditLog row per offset (negative = past)."""
+    now = datetime.now(timezone.utc)
+    async with sm() as session:
+        for offset in ts_offsets_days:
+            session.add(
+                AuditLog(
+                    ts=now + timedelta(days=offset),
+                    key_id_prefix="test",
+                    controller=None,
+                    target="test.tool",
+                    outcome="ok",
+                )
+            )
+        await session.commit()
+
+
+async def _make_sm(tmp_path: Path):
+    engine = create_engine(tmp_path / "state.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, get_sessionmaker(engine)
+
+
+@pytest.mark.asyncio
+async def test_prune_by_age_removes_old_rows(tmp_path: Path) -> None:
+    engine, sm = await _make_sm(tmp_path)
+    try:
+        await _seed(sm, [-100, -10])
+        result = await prune_audit(sm, max_age_days=30, max_rows=1_000_000)
+        assert result == {"pruned": 1, "current_count": 1}
+
+        # Surviving row should be the 10-day-old one.
+        async with sm() as session:
+            rows = (await session.execute(select(AuditLog))).scalars().all()
+        assert len(rows) == 1
+        ts = rows[0].ts
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - ts).total_seconds() / 86400
+        assert 9 < age_days < 11
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_prune_by_max_rows_keeps_newest(tmp_path: Path) -> None:
+    engine, sm = await _make_sm(tmp_path)
+    try:
+        # 10 rows: now-9, now-8, ..., now
+        await _seed(sm, list(range(-9, 1)))
+        result = await prune_audit(sm, max_age_days=365, max_rows=5)
+        assert result == {"pruned": 5, "current_count": 5}
+
+        # The 5 surviving rows must be the newest ones (offsets -4..0).
+        async with sm() as session:
+            rows = (
+                await session.execute(select(AuditLog).order_by(AuditLog.ts.desc()))
+            ).scalars().all()
+        assert len(rows) == 5
+        now = datetime.now(timezone.utc)
+
+        def _aware(ts: datetime) -> datetime:
+            return ts.replace(tzinfo=timezone.utc) if ts.tzinfo is None else ts
+
+        ages = sorted((now - _aware(r.ts)).total_seconds() / 86400 for r in rows)
+        # Surviving offsets should be roughly 0, 1, 2, 3, 4 days old.
+        for expected, actual in zip([0, 1, 2, 3, 4], ages):
+            assert abs(actual - expected) < 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_prune_noop_when_under_limits(tmp_path: Path) -> None:
+    engine, sm = await _make_sm(tmp_path)
+    try:
+        await _seed(sm, [-1, -2, -3])
+        result = await prune_audit(sm, max_age_days=90, max_rows=100)
+        assert result == {"pruned": 0, "current_count": 3}
+    finally:
+        await engine.dispose()

--- a/apps/api/tests/test_audit_query.py
+++ b/apps/api/tests/test_audit_query.py
@@ -1,0 +1,132 @@
+"""GET /v1/audit — paginated audit log query route."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, AuditLog, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app(tmp_path: Path, scopes: str = "admin"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes=scopes,
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+async def _seed_audit(app, rows: list[dict]) -> None:
+    sm = app.state.sessionmaker
+    async with sm() as session:
+        for r in rows:
+            session.add(AuditLog(**r))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_default_returns_all_rows_newest_first(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base, "key_id_prefix": "p1", "controller": "c1",
+         "target": "t1", "outcome": "ok"},
+        {"ts": base + timedelta(seconds=10), "key_id_prefix": "p1", "controller": "c1",
+         "target": "t2", "outcome": "ok"},
+        {"ts": base + timedelta(seconds=20), "key_id_prefix": "p1", "controller": "c1",
+         "target": "t3", "outcome": "ok"},
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/audit", headers=headers)
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert len(data["items"]) == 3
+        targets = [item["target"] for item in data["items"]]
+        assert targets == ["t3", "t2", "t1"]
+
+
+@pytest.mark.asyncio
+async def test_filter_by_outcome(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base, "key_id_prefix": "p1", "controller": "c1",
+         "target": "t1", "outcome": "ok"},
+        {"ts": base + timedelta(seconds=10), "key_id_prefix": "p1", "controller": "c1",
+         "target": "t2", "outcome": "ok"},
+        {"ts": base + timedelta(seconds=20), "key_id_prefix": "p1", "controller": "c1",
+         "target": "t3", "outcome": "error"},
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/audit?outcome=error", headers=headers)
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["outcome"] == "error"
+        assert data["items"][0]["target"] == "t3"
+
+
+@pytest.mark.asyncio
+async def test_pagination_with_cursor(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base + timedelta(seconds=i * 10), "key_id_prefix": "p1",
+         "controller": "c1", "target": f"t{i}", "outcome": "ok"}
+        for i in range(5)
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/audit?limit=2", headers=headers)
+        assert r.status_code == 200, r.text
+        page1 = r.json()
+        assert len(page1["items"]) == 2
+        assert page1["next_cursor"] is not None
+        seen_ids = {item["id"] for item in page1["items"]}
+
+        r = await c.get(
+            f"/v1/audit?limit=2&cursor={page1['next_cursor']}",
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        page2 = r.json()
+        assert len(page2["items"]) == 2
+        # No overlap between page 1 and page 2.
+        for item in page2["items"]:
+            assert item["id"] not in seen_ids
+
+
+@pytest.mark.asyncio
+async def test_admin_scope_required(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path, scopes="read")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/audit", headers=headers)
+        assert r.status_code == 403

--- a/apps/api/tests/test_audit_streams.py
+++ b/apps/api/tests/test_audit_streams.py
@@ -1,0 +1,110 @@
+"""POST /v1/audit/prune + GET /v1/streams/audit — Phase 5B PR1 Task 9."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, AuditLog, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app(tmp_path: Path, scopes: str = "admin"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes=scopes,
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+@pytest.mark.asyncio
+async def test_prune_endpoint_returns_counts(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    sm = app.state.sessionmaker
+    old_ts = datetime.now(timezone.utc) - timedelta(days=100)
+    async with sm() as session:
+        for i in range(2):
+            session.add(AuditLog(
+                ts=old_ts,
+                key_id_prefix="p1",
+                controller="c1",
+                target=f"t{i}",
+                outcome="ok",
+            ))
+        await session.commit()
+
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/audit/prune", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["pruned"] == 2
+        assert body["current_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_requires_admin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path, scopes="read")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/audit/prune", headers=headers)
+        assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stream_returns_event_stream_content_type(tmp_path: Path, monkeypatch) -> None:
+    """Verify SSE route headers without consuming the infinite body.
+
+    The real route's generator runs forever, so we monkeypatch
+    ``_audit_event_stream`` with a finite stub that yields one keepalive frame
+    and returns. This still exercises route registration, the admin-scope
+    dependency, and the SSE response media type / headers — the parts that
+    matter for this PR.
+    """
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+
+    from unifi_api.routes import audit as audit_routes
+
+    async def _finite_gen():
+        yield b": keepalive\n\n"
+
+    monkeypatch.setattr(audit_routes, "_audit_event_stream", _finite_gen)
+
+    app, key = await _bootstrap_app(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        async with c.stream("GET", "/v1/streams/audit", headers=headers) as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/event-stream")
+
+
+@pytest.mark.asyncio
+async def test_stream_requires_admin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path, scopes="read")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/v1/streams/audit", headers=headers)
+        assert r.status_code == 403

--- a/apps/api/tests/test_controllers_probe.py
+++ b/apps/api/tests/test_controllers_probe.py
@@ -1,0 +1,110 @@
+"""POST /v1/controllers/{id}/probe — live connectivity test."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app(tmp_path: Path, scopes: str = "admin"):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes=scopes,
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+async def _create_controller(client, headers, product_kinds: list[str]) -> str:
+    r = await client.post("/v1/controllers", headers=headers, json={
+        "name": "Home", "base_url": "https://10.0.0.1",
+        "username": "root", "password": "hunter2",
+        "product_kinds": product_kinds, "verify_tls": False, "is_default": True,
+    })
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_probe_happy_path(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    # Stub _construct_connection_manager to avoid network round-trip.
+    async def _stub_construct(self, session, controller_id, product):
+        return object()
+    monkeypatch.setattr(
+        "unifi_api.services.managers.ManagerFactory._construct_connection_manager",
+        _stub_construct,
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        cid = await _create_controller(c, headers, ["network", "protect"])
+        r = await c.post(f"/v1/controllers/{cid}/probe", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert set(body["products"].keys()) == {"network", "protect"}
+        assert body["products"]["network"]["ok"] is True
+        assert body["products"]["protect"]["ok"] is True
+        assert body["error_kind"] is None
+        assert "last_probed_at" in body
+
+
+@pytest.mark.asyncio
+async def test_probe_requires_admin_scope(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path, scopes="read")
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        # We can't create the controller with read scope, so fabricate a row directly.
+        cipher = ColumnCipher(derive_key("k"))
+        cred_blob = cipher.encrypt(
+            json.dumps({"username": "u", "password": "p", "api_token": None}).encode("utf-8")
+        )
+        async with app.state.sessionmaker() as session:
+            session.add(Controller(
+                id="c1", name="x", base_url="https://x",
+                product_kinds="network", credentials_blob=cred_blob,
+                verify_tls=True, is_default=False,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ))
+            await session.commit()
+        r = await c.post("/v1/controllers/c1/probe", headers=headers)
+        assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_probe_unknown_controller_404(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/controllers/nonexistent/probe", headers=headers)
+        assert r.status_code == 404

--- a/apps/api/tests/test_diagnostics.py
+++ b/apps/api/tests/test_diagnostics.py
@@ -1,0 +1,92 @@
+"""Diagnostics aggregator tests — Phase 5B PR1 Task 6."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_collect_diagnostics_shape_and_counts(tmp_path: Path) -> None:
+    from datetime import datetime, timezone, timedelta
+    from unifi_api.db.engine import create_engine
+    from unifi_api.db.models import ApiKey, AuditLog, Base, Controller
+    from unifi_api.db.session import get_sessionmaker
+    from unifi_api.services.capability_cache import CapabilityCache
+    from unifi_api.services.diagnostics import collect_diagnostics
+
+    db_path = tmp_path / "state.db"
+    engine = create_engine(db_path)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = get_sessionmaker(engine)
+
+    # Seed: 2 keys, 1 controller, 3 audit rows
+    async with sm() as session:
+        for i in range(2):
+            session.add(ApiKey(
+                id=f"k{i}", prefix=f"p{i}", hash="h", scopes="read",
+                name=f"n{i}", created_at=datetime.now(timezone.utc),
+            ))
+        session.add(Controller(
+            id="c1", name="c", base_url="http://c", product_kinds="network",
+            credentials_blob=b"x", verify_tls=True, is_default=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ))
+        for _ in range(3):
+            session.add(AuditLog(
+                ts=datetime.now(timezone.utc),
+                key_id_prefix="p", controller=None, target="t", outcome="ok",
+            ))
+        await session.commit()
+
+    cache = CapabilityCache(ttl_seconds=300)
+    cache.put("c1", {"x": 1})
+    cache.get("c1")  # hit
+    cache.get("missing")  # miss
+
+    log_file = tmp_path / "app.log"
+    log_file.write_bytes(b"some log content\n")
+
+    started = datetime.now(timezone.utc) - timedelta(seconds=42)
+
+    snap = await collect_diagnostics(
+        sessionmaker=sm,
+        db_path=db_path,
+        capability_cache=cache,
+        log_path=log_file,
+        version="0.1.0",
+        started_at=started,
+    )
+
+    # Shape assertions
+    assert set(snap.keys()) == {"service", "database", "capability_cache", "logs", "counts"}
+
+    # Service
+    assert snap["service"]["version"] == "0.1.0"
+    assert snap["service"]["uptime_seconds"] >= 42
+    assert "." in snap["service"]["python_version"]
+
+    # Database
+    assert snap["database"]["reachable"] is True
+    assert snap["database"]["path"] == str(db_path)
+    assert snap["database"]["size_bytes"] > 0
+
+    # Capability cache
+    assert snap["capability_cache"]["size"] == 1
+    assert snap["capability_cache"]["ttl_seconds"] == 300
+    assert 0.0 <= snap["capability_cache"]["hit_rate"] <= 1.0
+    assert snap["capability_cache"]["hit_rate"] == 0.5  # 1 hit, 1 miss
+
+    # Logs
+    assert snap["logs"]["file_path"] == str(log_file)
+    assert snap["logs"]["file_size_bytes"] > 0
+
+    # Counts
+    assert snap["counts"]["api_keys"] == 2
+    assert snap["counts"]["controllers"] == 1
+    assert snap["counts"]["audit_rows"] == 3
+
+    await engine.dispose()

--- a/apps/api/tests/test_lifespan_admin.py
+++ b/apps/api/tests/test_lifespan_admin.py
@@ -1,0 +1,58 @@
+"""Phase 5B lifespan integration: rotating file handler + audit pruner."""
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+import uuid
+
+import pytest
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifespan_wires_file_logging_and_pruner(tmp_path: Path, monkeypatch) -> None:
+    """Lifespan startup attaches the rotating file handler and starts the pruner task."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app = create_app(_cfg(tmp_path))
+
+    # Materialize tables (lifespan doesn't run migrations — schema must exist).
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    # Seed a settings row pinning the log file under tmp_path so we can verify it gets attached.
+    log_target = tmp_path / "state" / "phase5b.log"
+    svc = app.state.settings_service
+    await svc.set_str("logs.file.enabled", "true")
+    await svc.set_str("logs.file.path", str(log_target))
+    # Quick prune interval so the loop doesn't dominate tests; we don't wait for it to fire.
+    await svc.set_int("audit.retention.prune_interval_hours", 1)
+
+    # Use FastAPI's lifespan_context — the same async cm used at runtime.
+    async with app.router.lifespan_context(app):
+        # Inside lifespan startup window:
+        assert app.state.log_file_path == log_target, (
+            f"expected log_file_path={log_target}, got {app.state.log_file_path}"
+        )
+        # log_reader rebound to the real file
+        assert app.state.log_reader._path == log_target  # noqa: SLF001
+        # background pruner task scheduled
+        task = app.state._audit_pruner_task
+        assert isinstance(task, asyncio.Task)
+        assert not task.done()
+        # settings_service reachable (already wired pre-lifespan)
+        assert app.state.settings_service is svc
+
+    # After lifespan shutdown, the pruner task should be cancelled / done.
+    assert task.done()

--- a/apps/api/tests/test_log_reader.py
+++ b/apps/api/tests/test_log_reader.py
@@ -1,0 +1,111 @@
+"""Tests for the tail-of-file log reader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from unifi_api.services.log_reader import LogReader
+
+
+def _write_lines(path: Path, entries: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+def test_tail_returns_most_recent_first(tmp_path: Path) -> None:
+    log = tmp_path / "app.log"
+    _write_lines(
+        log,
+        [
+            {"ts": "2026-04-30T00:00:01Z", "level": "INFO", "logger": "a", "event": "first"},
+            {"ts": "2026-04-30T00:00:02Z", "level": "INFO", "logger": "a", "event": "second"},
+            {"ts": "2026-04-30T00:00:03Z", "level": "INFO", "logger": "a", "event": "third"},
+        ],
+    )
+
+    entries = LogReader(log).tail(limit=10)
+
+    assert len(entries) == 3
+    assert [e["event"] for e in entries] == ["third", "second", "first"]
+
+
+def test_tail_respects_limit(tmp_path: Path) -> None:
+    log = tmp_path / "app.log"
+    _write_lines(
+        log,
+        [
+            {"ts": f"2026-04-30T00:00:{i:02d}Z", "level": "INFO", "logger": "a", "event": f"e{i}"}
+            for i in range(10)
+        ],
+    )
+
+    entries = LogReader(log).tail(limit=3)
+
+    assert len(entries) == 3
+    assert [e["event"] for e in entries] == ["e9", "e8", "e7"]
+
+
+def test_filter_by_level(tmp_path: Path) -> None:
+    log = tmp_path / "app.log"
+    _write_lines(
+        log,
+        [
+            {"ts": "2026-04-30T00:00:01Z", "level": "INFO", "logger": "a", "event": "i1"},
+            {"ts": "2026-04-30T00:00:02Z", "level": "WARNING", "logger": "a", "event": "w1"},
+            {"ts": "2026-04-30T00:00:03Z", "level": "INFO", "logger": "a", "event": "i2"},
+        ],
+    )
+
+    reader = LogReader(log)
+
+    upper = reader.tail(level="WARNING")
+    assert len(upper) == 1
+    assert upper[0]["level"] == "WARNING"
+    assert upper[0]["event"] == "w1"
+
+    # Case-insensitive
+    lower = reader.tail(level="warning")
+    assert len(lower) == 1
+    assert lower[0]["event"] == "w1"
+
+
+def test_filter_by_logger(tmp_path: Path) -> None:
+    log = tmp_path / "app.log"
+    _write_lines(
+        log,
+        [
+            {"ts": "2026-04-30T00:00:01Z", "level": "INFO", "logger": "a", "event": "a1"},
+            {"ts": "2026-04-30T00:00:02Z", "level": "INFO", "logger": "b", "event": "b1"},
+            {"ts": "2026-04-30T00:00:03Z", "level": "INFO", "logger": "a", "event": "a2"},
+        ],
+    )
+
+    entries = LogReader(log).tail(logger="a")
+
+    assert len(entries) == 2
+    assert all(e["logger"] == "a" for e in entries)
+    assert [e["event"] for e in entries] == ["a2", "a1"]
+
+
+def test_filter_by_q_substring(tmp_path: Path) -> None:
+    log = tmp_path / "app.log"
+    _write_lines(
+        log,
+        [
+            {"ts": "2026-04-30T00:00:01Z", "level": "INFO", "logger": "a", "event": "haystack"},
+            {"ts": "2026-04-30T00:00:02Z", "level": "INFO", "logger": "a", "event": "find the needle here"},
+            {"ts": "2026-04-30T00:00:03Z", "level": "INFO", "logger": "a", "event": "another"},
+        ],
+    )
+
+    entries = LogReader(log).tail(q="needle")
+
+    assert len(entries) == 1
+    assert entries[0]["event"] == "find the needle here"
+
+
+def test_missing_file_returns_empty(tmp_path: Path) -> None:
+    reader = LogReader(tmp_path / "no_such.log")
+
+    assert reader.tail() == []
+    assert reader.size_bytes == 0

--- a/apps/api/tests/test_logging_rotating_file.py
+++ b/apps/api/tests/test_logging_rotating_file.py
@@ -1,0 +1,60 @@
+"""Tests for the rotating file handler and `logger` field in JsonFormatter."""
+
+import json
+import logging
+
+from unifi_api.logging import (
+    attach_rotating_file_handler,
+    configure_logging,
+    get_logger,
+)
+
+
+def test_attaches_handler_and_writes_json(tmp_path) -> None:
+    log_path = tmp_path / "app.log"
+    configure_logging(level="INFO")
+    handler = attach_rotating_file_handler(
+        path=log_path,
+        max_bytes=10_485_760,
+        backup_count=2,
+    )
+    log = get_logger("test_logger")
+    log.info("rotating_event")
+    handler.flush()
+    handler.close()
+
+    contents = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert contents, "expected at least one JSON line written to the rotating file"
+    payload = json.loads(contents[-1])
+    assert payload["event"] == "rotating_event"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "test_logger"
+
+
+def test_creates_parent_directories(tmp_path) -> None:
+    log_path = tmp_path / "nested" / "subdir" / "app.log"
+    assert not log_path.parent.exists()
+    configure_logging(level="INFO")
+    handler = attach_rotating_file_handler(
+        path=log_path,
+        max_bytes=10_485_760,
+        backup_count=2,
+    )
+    assert log_path.parent.exists()
+    assert log_path.parent.is_dir()
+
+    log = get_logger("nested_logger")
+    log.info("nested_event")
+    handler.flush()
+    handler.close()
+    assert log_path.exists()
+
+
+def test_logger_field_in_stderr_json(capsys) -> None:
+    configure_logging(level="INFO")
+    log = get_logger("my.module")
+    log.info("foo")
+    captured = capsys.readouterr().err.strip().splitlines()
+    assert captured, "expected one JSON log line on stderr"
+    payload = json.loads(captured[-1])
+    assert payload["logger"] == "my.module"

--- a/apps/api/tests/test_settings_service.py
+++ b/apps/api/tests/test_settings_service.py
@@ -1,0 +1,120 @@
+"""Tests for SettingsService typed accessors over app_settings."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from unifi_api.db.engine import create_engine
+from unifi_api.db.models import AppSetting, Base
+from unifi_api.db.session import get_sessionmaker
+from unifi_api.services.settings import SettingsService, UnknownSettingKey
+
+
+async def _build_service(tmp_path: Path, seeds: list[tuple[str, str]] | None = None):
+    engine = create_engine(tmp_path / "state.db")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = get_sessionmaker(engine)
+    if seeds:
+        async with sm() as session:
+            for key, value in seeds:
+                session.add(
+                    AppSetting(key=key, value=value, updated_at=datetime.now(timezone.utc))
+                )
+            await session.commit()
+    return SettingsService(sm), engine
+
+
+@pytest.mark.asyncio
+async def test_get_int_returns_seeded_default(tmp_path: Path) -> None:
+    svc, engine = await _build_service(
+        tmp_path, [("audit.retention.max_age_days", "90")]
+    )
+    try:
+        assert await svc.get_int("audit.retention.max_age_days") == 90
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_get_bool_returns_true(tmp_path: Path) -> None:
+    svc, engine = await _build_service(
+        tmp_path,
+        [
+            ("audit.retention.enabled", "true"),
+            ("flag.yes", "yes"),
+            ("flag.one", "1"),
+            ("flag.off", "false"),
+        ],
+    )
+    try:
+        assert await svc.get_bool("audit.retention.enabled") is True
+        assert await svc.get_bool("flag.yes") is True
+        assert await svc.get_bool("flag.one") is True
+        assert await svc.get_bool("flag.off") is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_set_str_then_get_str_round_trip(tmp_path: Path) -> None:
+    svc, engine = await _build_service(tmp_path)
+    try:
+        await svc.set_str("foo", "bar")
+        assert await svc.get_str("foo") == "bar"
+        # Update path: overwrite the existing row.
+        await svc.set_str("foo", "baz")
+        assert await svc.get_str("foo") == "baz"
+        # Numeric and bool setters round-trip through the same column.
+        await svc.set_int("count", 42)
+        assert await svc.get_int("count") == 42
+        await svc.set_bool("enabled", True)
+        assert await svc.get_bool("enabled") is True
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_get_all_returns_dict(tmp_path: Path) -> None:
+    svc, engine = await _build_service(
+        tmp_path,
+        [
+            ("alpha", "1"),
+            ("beta", "two"),
+        ],
+    )
+    try:
+        result = await svc.get_all()
+        assert result == {"alpha": "1", "beta": "two"}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_default_fallback_when_key_missing(tmp_path: Path) -> None:
+    svc, engine = await _build_service(tmp_path)
+    try:
+        assert await svc.get_int("missing.key", default=42) == 42
+        assert await svc.get_bool("missing.key", default=False) is False
+        assert await svc.get_str("missing.key", default="x") == "x"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_raises_unknown_setting_key_when_missing_and_no_default(
+    tmp_path: Path,
+) -> None:
+    svc, engine = await _build_service(tmp_path)
+    try:
+        with pytest.raises(UnknownSettingKey):
+            await svc.get_str("nope")
+        with pytest.raises(UnknownSettingKey):
+            await svc.get_int("nope")
+        with pytest.raises(UnknownSettingKey):
+            await svc.get_bool("nope")
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary

Phase 5B PR1 — backend foundations for the upcoming admin UI. All 11 tasks delivered as separate commits, each TDD-driven, no UI yet.

This PR ships:
- **`app_settings` table** + `SettingsService` (typed get/set, UPSERT) + 10 seeded defaults via migration `0002_add_app_settings.py`
- **Audit retention** — `prune_audit(sm, max_age_days, max_rows)` + a periodic background pruner started in lifespan, configurable via `audit.retention.*` settings
- **Rotating file logging** — `attach_rotating_file_handler` + `logger` field added to `JsonFormatter` + `LogReader.tail()` with level/logger/q filters; conditionally enabled at lifespan startup based on `logs.file.*` settings
- **Diagnostics aggregator** — `collect_diagnostics()` returning service/database/capability_cache/logs/counts; powers the upcoming dashboard
- **Capability cache instrumentation** — additive `size`/`ttl_seconds`/`hit_rate` properties + hit/miss counters
- **Eleven new endpoints** under `/v1/`:
  - `POST /v1/controllers/{id}/probe` (admin) — live connectivity probe across all advertised products
  - `GET /v1/audit` (admin) — paginated, filterable audit log query
  - `POST /v1/audit/prune` (admin) — manual prune using settings-driven thresholds
  - `GET /v1/streams/audit` (admin) — SSE live-tail of audit rows via subscriber pattern
  - `GET /v1/diagnostics` (admin) — full diagnostics snapshot
  - `GET /v1/logs` (admin) — paginated tail-of-file
  - `GET /v1/settings` (admin) — full settings dict
  - `PUT /v1/settings` (admin) — bulk set
- **Audit subscriber pattern** — `add_audit_subscriber` with try/except per-callback fan-out from `write_audit`

### Test deltas

| Package | Before | After | Δ |
|---|---|---|---|
| unifi-core | 69 | 69 | 0 |
| unifi-mcp-shared | 205 | 205 | 0 |
| unifi-network-mcp | 630 | 630 | 0 |
| unifi-protect-mcp | 157 | 157 | 0 |
| unifi-access-mcp | 336 | 336 | 0 |
| **unifi-api** | **446** | **484** | **+38** |

Phase 4A `test_serializer_coverage` and Phase 5A `test_resource_route_coverage` gates remain green — admin endpoints don't add MCP tools or read tools, so they're orthogonal to the catalog/serializer registries.

## Test plan

- [x] All 6 packages green per-package via `uv run --package <pkg> pytest`
- [x] `test_serializer_coverage` green
- [x] `test_resource_route_coverage` green
- [x] Lifespan startup wires file logging + pruner task (verified via `app.router.lifespan_context`)
- [x] Subscriber pattern is fan-out + try/except per callback (existing audit tests still pass with subscriber registry empty)
- [x] Cursor pagination on `GET /v1/audit` round-trips without overlap
- [ ] Manual smoke pending PR2 UI (no UI exists in this PR)

## Architecture notes

- **Eager wiring vs lifespan:** `app.state.settings_service`, `db_path`, `api_version`, `started_at`, and a `LogReader(/dev/null)` placeholder are wired in `create_app()` so ASGITransport-based tests work without entering lifespan. Lifespan startup *replaces* `log_file_path` and `log_reader` with real values when `logs.file.enabled=true` and starts the background pruner task. This split was intentional — non-lifespan tests need stable defaults, while production-style startup gets the real handler attached.
- **SSE generator extracted to module level** in `routes/audit.py` (`_audit_event_stream`) so the streams test can monkeypatch a finite generator (Phase 4B PR3 lesson applied).
- **Sensitive data:** the new `GET /v1/settings` returns plaintext setting values. None of the seeded keys carry secrets (audit retention thresholds, log path, theme). When credential-bearing settings are added in future, redact at the API layer per Phase 5B spec §10.

## What's next

PR2 (UI shell + dashboard + keys + controllers pages) cuts from main after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)