### PR TITLE
Phase 5B PR3: admin audit + logs + settings finale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ENV/
 # Logs
 *.log
 logs/
+!apps/api/src/unifi_api/templates/admin/logs/
 
 # Docker
 .dockerignore

--- a/apps/api/src/unifi_api/routes/admin/audit.py
+++ b/apps/api/src/unifi_api/routes/admin/audit.py
@@ -1,0 +1,257 @@
+"""Admin UI: /admin/audit page (filters + pagination + live-tail + CSV export).
+
+Page route is unauthenticated and returns the HTMX shell. The rows
+fragment, the SSE live-tail, and the CSV export are admin-scoped (the
+shell loads first and HTMX fetches data with the localStorage Bearer
+attached by admin.js).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.db.models import AuditLog
+from unifi_api.routes.admin._common import render
+from unifi_api.services.audit import add_audit_subscriber
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+
+
+router = APIRouter()
+
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[2] / "templates" / "admin"
+_templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+def _row_view(r: AuditLog) -> dict[str, Any]:
+    return {
+        "id": r.id,
+        "ts": r.ts.isoformat(),
+        "key_id_prefix": r.key_id_prefix,
+        "controller": r.controller,
+        "target": r.target,
+        "outcome": r.outcome,
+        "error_kind": r.error_kind,
+        "detail": r.detail,
+    }
+
+
+def _audit_key(r: AuditLog) -> tuple:
+    return (int(r.ts.timestamp() * 1000), str(r.id))
+
+
+def _build_filtered_query(
+    *,
+    controller: str | None,
+    outcome: str | None,
+    since: str | None,
+    until: str | None,
+    q: str | None,
+):
+    stmt = select(AuditLog)
+    if controller:
+        stmt = stmt.where(AuditLog.controller == controller)
+    if outcome:
+        stmt = stmt.where(AuditLog.outcome == outcome)
+    if since:
+        try:
+            stmt = stmt.where(AuditLog.ts >= datetime.fromisoformat(since))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid 'since' timestamp")
+    if until:
+        try:
+            stmt = stmt.where(AuditLog.ts <= datetime.fromisoformat(until))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid 'until' timestamp")
+    if q:
+        stmt = stmt.where(AuditLog.target.ilike(f"%{q}%"))
+    return stmt.order_by(AuditLog.ts.desc())
+
+
+@router.get("/admin/audit", include_in_schema=False)
+async def audit_page(request: Request):
+    """Unauth HTMX shell — filters live in the page, rows arrive via _rows."""
+    return render(request, "audit/list.html")
+
+
+@router.get(
+    "/admin/audit/_rows",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def audit_rows(
+    request: Request,
+    controller: str | None = Query(None),
+    outcome: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    q: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(None),
+):
+    sm = request.app.state.sessionmaker
+    stmt = _build_filtered_query(
+        controller=controller, outcome=outcome, since=since, until=until, q=q,
+    )
+    async with sm() as session:
+        rows = (await session.execute(stmt)).scalars().all()
+
+    cursor_obj = None
+    if cursor:
+        try:
+            cursor_obj = Cursor.decode(cursor)
+        except InvalidCursor:
+            raise HTTPException(status_code=400, detail="invalid cursor")
+
+    page, next_cursor = paginate(
+        list(rows), limit=limit, cursor=cursor_obj, key_fn=_audit_key,
+    )
+
+    # Carry filter values forward in the "Load more" hx-get URL.
+    filter_qs = "&".join(
+        f"{k}={v}" for k, v in (
+            ("controller", controller), ("outcome", outcome),
+            ("since", since), ("until", until), ("q", q),
+        ) if v
+    )
+
+    return render(
+        request,
+        "audit/_rows.html",
+        {
+            "rows": [_row_view(r) for r in page],
+            "next_cursor": next_cursor.encode() if next_cursor else None,
+            "filter_qs": filter_qs,
+            "limit": limit,
+        },
+    )
+
+
+async def _admin_audit_event_stream(filter_fn):
+    """SSE generator that emits server-rendered _row.html fragments per audit row.
+
+    Module-level so tests can monkeypatch with a finite version. The HTML in
+    each frame's data: must be on a single line — newlines in SSE data
+    confuse parsers; we collapse whitespace before yielding.
+    """
+    queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=256)
+
+    def _on_row(row: dict) -> None:
+        if filter_fn is not None and not filter_fn(row):
+            return
+        try:
+            queue.put_nowait(row)
+        except asyncio.QueueFull:
+            pass
+
+    unsub = add_audit_subscriber(_on_row)
+    try:
+        while True:
+            try:
+                row = await asyncio.wait_for(queue.get(), timeout=30.0)
+                html = _templates.get_template("audit/_row.html").render({"r": row})
+                # Replace any newlines/whitespace with a single space so SSE
+                # 'data:' line framing parses correctly.
+                single = " ".join(html.split())
+                yield (
+                    f"event: audit.row\nid: {row['id']}\ndata: {single}\n\n"
+                ).encode()
+            except asyncio.TimeoutError:
+                yield b": keepalive\n\n"
+    finally:
+        unsub()
+
+
+def _make_filter_fn(*, outcome, q):
+    """Build a filter_fn closure for the live-tail subscriber."""
+    if not outcome and not q:
+        return None
+
+    def _fn(row: dict) -> bool:
+        if outcome and row.get("outcome") != outcome:
+            return False
+        if q and q.lower() not in str(row.get("target", "")).lower():
+            return False
+        return True
+    return _fn
+
+
+@router.get(
+    "/admin/audit/_stream",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def audit_stream(
+    request: Request,
+    outcome: str | None = Query(None),
+    q: str | None = Query(None),
+):
+    return StreamingResponse(
+        _admin_audit_event_stream(_make_filter_fn(outcome=outcome, q=q)),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@router.get(
+    "/admin/audit/export.csv",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def audit_export_csv(
+    request: Request,
+    controller: str | None = Query(None),
+    outcome: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    q: str | None = Query(None),
+):
+    sm = request.app.state.sessionmaker
+    stmt = _build_filtered_query(
+        controller=controller, outcome=outcome, since=since, until=until, q=q,
+    )
+    async with sm() as session:
+        rows = (await session.execute(stmt)).scalars().all()
+
+    def _generate():
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow([
+            "id", "ts", "key_id_prefix", "controller",
+            "target", "outcome", "error_kind", "detail",
+        ])
+        yield buf.getvalue()
+        for r in rows:
+            buf.seek(0)
+            buf.truncate()
+            writer.writerow([
+                r.id, r.ts.isoformat(), r.key_id_prefix,
+                r.controller or "", r.target, r.outcome,
+                r.error_kind or "", r.detail or "",
+            ])
+            yield buf.getvalue()
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/csv",
+        headers={
+            "Cache-Control": "no-store",
+            "Content-Disposition": 'attachment; filename="audit.csv"',
+        },
+    )

--- a/apps/api/src/unifi_api/routes/admin/logs.py
+++ b/apps/api/src/unifi_api/routes/admin/logs.py
@@ -1,0 +1,172 @@
+"""Admin UI: /admin/logs page (filters + pagination + live-tail SSE).
+
+Page route is unauthenticated and returns the HTMX shell. The rows fragment
+and the SSE live-tail are admin-scoped (the shell loads first and HTMX
+fetches data with the localStorage Bearer attached by admin.js).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import StreamingResponse
+from fastapi.templating import Jinja2Templates
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.admin._common import render
+
+
+router = APIRouter()
+
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[2] / "templates" / "admin"
+_templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+@router.get("/admin/logs", include_in_schema=False)
+async def logs_page(request: Request):
+    """Unauth HTMX shell — filters live in the page, rows arrive via _rows."""
+    return render(request, "logs/list.html")
+
+
+@router.get(
+    "/admin/logs/_rows",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def logs_rows(
+    request: Request,
+    level: str | None = Query(None),
+    logger: str | None = Query(None),
+    q: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    reader = request.app.state.log_reader
+    # `tail` returns most-recent-first; over-fetch by `offset+limit`, then slice.
+    rows = reader.tail(
+        limit=offset + limit,
+        level=level or None,
+        logger=logger or None,
+        q=q or None,
+    )
+    page = rows[offset:offset + limit]
+    has_more = len(rows) > offset + limit
+
+    filter_qs = "&".join(
+        f"{k}={v}" for k, v in (
+            ("level", level), ("logger", logger), ("q", q),
+        ) if v
+    )
+
+    return render(
+        request,
+        "logs/_rows.html",
+        {
+            "rows": page,
+            "next_offset": offset + limit if has_more else None,
+            "filter_qs": filter_qs,
+            "limit": limit,
+        },
+    )
+
+
+async def _admin_logs_event_stream(log_path: Path, filter_fn):
+    """SSE generator that emits server-rendered _row.html fragments per new
+    log line as the file grows. Module-level so tests can monkeypatch.
+
+    Implementation: poll os.stat().st_size every 1s; on growth, read new bytes,
+    parse JSON-per-line, apply filter_fn, render server-side, emit. On rotation
+    (size shrinks below previous offset), reset the offset to 0.
+    """
+    log_path = Path(log_path)
+
+    # Start at end-of-file so we don't replay history.
+    try:
+        offset = log_path.stat().st_size
+    except FileNotFoundError:
+        offset = 0
+
+    while True:
+        try:
+            size = log_path.stat().st_size
+        except FileNotFoundError:
+            size = 0
+
+        if size < offset:
+            # File rotated — start from beginning.
+            offset = 0
+
+        if size > offset:
+            try:
+                with log_path.open("rb") as f:
+                    f.seek(offset)
+                    new_bytes = f.read(size - offset)
+                offset = size
+            except FileNotFoundError:
+                offset = 0
+                await asyncio.sleep(1.0)
+                continue
+
+            for raw_line in new_bytes.split(b"\n"):
+                if not raw_line.strip():
+                    continue
+                try:
+                    payload = json.loads(raw_line.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                if filter_fn is not None and not filter_fn(payload):
+                    continue
+                html = _templates.get_template("logs/_row.html").render({"r": payload})
+                single = " ".join(html.split())
+                yield f"event: log.row\ndata: {single}\n\n".encode()
+
+        # Heartbeat keepalive every iteration so proxies don't kill the connection.
+        yield b": keepalive\n\n"
+        await asyncio.sleep(1.0)
+
+
+def _make_filter_fn(*, level, logger, q):
+    """Build a filter_fn closure for the live-tail line filter."""
+    if not (level or logger or q):
+        return None
+    level_norm = level.upper() if level else None
+
+    def _fn(payload: dict) -> bool:
+        if level_norm and str(payload.get("level", "")).upper() != level_norm:
+            return False
+        if logger and payload.get("logger") != logger:
+            return False
+        if q and q.lower() not in str(payload).lower():
+            return False
+        return True
+    return _fn
+
+
+@router.get(
+    "/admin/logs/_stream",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def logs_stream(
+    request: Request,
+    level: str | None = Query(None),
+    logger: str | None = Query(None),
+    q: str | None = Query(None),
+):
+    log_path = request.app.state.log_file_path or Path("/dev/null")
+    return StreamingResponse(
+        _admin_logs_event_stream(
+            log_path, _make_filter_fn(level=level, logger=logger, q=q),
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/apps/api/src/unifi_api/routes/admin/settings.py
+++ b/apps/api/src/unifi_api/routes/admin/settings.py
@@ -1,0 +1,124 @@
+"""Admin UI: /admin/settings — audit retention + log file config + manual prune."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Form, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.routes.admin._common import render
+from unifi_api.services.audit_pruner import prune_audit
+
+
+router = APIRouter()
+
+
+# Defaults match the migration seed data so a fresh DB without seeded rows
+# (e.g. test DBs that use Base.metadata.create_all instead of running migrations)
+# still renders sensible values.
+_AUDIT_DEFAULTS = {
+    "max_age_days": 90,
+    "max_rows": 1_000_000,
+    "enabled": True,
+    "prune_interval_hours": 6,
+}
+_LOGS_DEFAULTS = {
+    "enabled": True,
+    "path": "state/api.log",
+    "max_bytes": 10 * 1024 * 1024,
+    "backup_count": 5,
+    "level": "INFO",
+}
+
+
+async def _read_settings(svc) -> dict:
+    """Materialize the typed settings dict the form needs."""
+    return {
+        "audit": {
+            "max_age_days": await svc.get_int("audit.retention.max_age_days", default=_AUDIT_DEFAULTS["max_age_days"]),
+            "max_rows": await svc.get_int("audit.retention.max_rows", default=_AUDIT_DEFAULTS["max_rows"]),
+            "enabled": await svc.get_bool("audit.retention.enabled", default=_AUDIT_DEFAULTS["enabled"]),
+            "prune_interval_hours": await svc.get_int("audit.retention.prune_interval_hours", default=_AUDIT_DEFAULTS["prune_interval_hours"]),
+        },
+        "logs": {
+            "enabled": await svc.get_bool("logs.file.enabled", default=_LOGS_DEFAULTS["enabled"]),
+            "path": await svc.get_str("logs.file.path", default=_LOGS_DEFAULTS["path"]),
+            "max_bytes": await svc.get_int("logs.file.max_bytes", default=_LOGS_DEFAULTS["max_bytes"]),
+            "backup_count": await svc.get_int("logs.file.backup_count", default=_LOGS_DEFAULTS["backup_count"]),
+            "level": await svc.get_str("logs.file.level", default=_LOGS_DEFAULTS["level"]),
+        },
+    }
+
+
+@router.get("/admin/settings", include_in_schema=False)
+async def settings_page(request: Request):
+    """Unauth HTMX shell — the form fragment is admin-scoped and pre-populated."""
+    return render(request, "settings/page.html")
+
+
+@router.get(
+    "/admin/settings/_form",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def settings_form(request: Request):
+    svc = request.app.state.settings_service
+    return render(request, "settings/_form.html", {"s": await _read_settings(svc), "saved": False})
+
+
+def _coerce_checkbox(value: str) -> bool:
+    return (value or "").strip().lower() in ("on", "true", "1", "yes")
+
+
+@router.post(
+    "/admin/settings/save",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def settings_save(
+    request: Request,
+    audit_max_age_days: int = Form(...),
+    audit_max_rows: int = Form(...),
+    audit_enabled: str = Form(""),
+    audit_prune_interval_hours: int = Form(...),
+    logs_enabled: str = Form(""),
+    logs_max_bytes: int = Form(...),
+    logs_backup_count: int = Form(...),
+    logs_level: str = Form(...),
+):
+    """Persist the changed settings and re-render the form with a 'Saved' indicator.
+
+    Note: `logs.file.path` is intentionally NOT writable here — changing the
+    path requires a service restart anyway, so the field is rendered readonly
+    and excluded from the form post.
+    """
+    svc = request.app.state.settings_service
+    await svc.set_int("audit.retention.max_age_days", audit_max_age_days)
+    await svc.set_int("audit.retention.max_rows", audit_max_rows)
+    await svc.set_bool("audit.retention.enabled", _coerce_checkbox(audit_enabled))
+    await svc.set_int("audit.retention.prune_interval_hours", audit_prune_interval_hours)
+    await svc.set_bool("logs.file.enabled", _coerce_checkbox(logs_enabled))
+    await svc.set_int("logs.file.max_bytes", logs_max_bytes)
+    await svc.set_int("logs.file.backup_count", logs_backup_count)
+    await svc.set_str("logs.file.level", logs_level)
+    return render(
+        request,
+        "settings/_form.html",
+        {"s": await _read_settings(svc), "saved": True},
+    )
+
+
+@router.post(
+    "/admin/settings/_prune",
+    include_in_schema=False,
+    dependencies=[Depends(require_scope(Scope.ADMIN))],
+)
+async def settings_prune(request: Request):
+    """Manual 'Prune now' button. Runs prune_audit using the current settings
+    values and renders the result fragment."""
+    svc = request.app.state.settings_service
+    sm = request.app.state.sessionmaker
+    max_age = await svc.get_int("audit.retention.max_age_days", default=_AUDIT_DEFAULTS["max_age_days"])
+    max_rows = await svc.get_int("audit.retention.max_rows", default=_AUDIT_DEFAULTS["max_rows"])
+    result = await prune_audit(sm, max_age_days=max_age, max_rows=max_rows)
+    return render(request, "settings/_prune_result.html", {"result": result})

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -28,6 +28,7 @@ from unifi_api.routes.admin import controllers as admin_controllers_routes
 from unifi_api.routes.admin import dashboard as admin_dashboard_routes
 from unifi_api.routes.admin import keys as admin_keys_routes
 from unifi_api.routes.admin import logs as admin_logs_routes
+from unifi_api.routes.admin import settings as admin_settings_routes
 from unifi_api.routes import audit as audit_routes
 from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
@@ -366,5 +367,6 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(admin_controllers_routes.router)
     app.include_router(admin_audit_routes.router)
     app.include_router(admin_logs_routes.router)
+    app.include_router(admin_settings_routes.router)
 
     return app

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -27,6 +27,7 @@ from unifi_api.routes.admin import auth as admin_auth_routes
 from unifi_api.routes.admin import controllers as admin_controllers_routes
 from unifi_api.routes.admin import dashboard as admin_dashboard_routes
 from unifi_api.routes.admin import keys as admin_keys_routes
+from unifi_api.routes.admin import logs as admin_logs_routes
 from unifi_api.routes import audit as audit_routes
 from unifi_api.routes import catalog as catalog_routes
 from unifi_api.routes import controllers as controllers_routes
@@ -364,5 +365,6 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(admin_keys_routes.router)
     app.include_router(admin_controllers_routes.router)
     app.include_router(admin_audit_routes.router)
+    app.include_router(admin_logs_routes.router)
 
     return app

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -22,6 +22,7 @@ from unifi_api.db.session import get_sessionmaker
 from unifi_api.logging import attach_rotating_file_handler, request_id_ctx
 from unifi_api.routes import actions as actions_routes
 from unifi_api.routes import admin_data as admin_data_routes
+from unifi_api.routes.admin import audit as admin_audit_routes
 from unifi_api.routes.admin import auth as admin_auth_routes
 from unifi_api.routes.admin import controllers as admin_controllers_routes
 from unifi_api.routes.admin import dashboard as admin_dashboard_routes
@@ -362,5 +363,6 @@ def create_app(config: ApiConfig) -> FastAPI:
     app.include_router(admin_dashboard_routes.router)
     app.include_router(admin_keys_routes.router)
     app.include_router(admin_controllers_routes.router)
+    app.include_router(admin_audit_routes.router)
 
     return app

--- a/apps/api/src/unifi_api/templates/admin/audit/_filters.html
+++ b/apps/api/src/unifi_api/templates/admin/audit/_filters.html
@@ -1,0 +1,48 @@
+<form id="audit-filters"
+      hx-on::change="htmx.trigger('body', 'audit-filter-changed');"
+      style="margin-bottom: 1rem;">
+  <div class="grid">
+    <label>Controller <input type="text" name="controller" placeholder="(any)" /></label>
+    <label>Outcome
+      <select name="outcome">
+        <option value="">(any)</option>
+        <option value="success">success</option>
+        <option value="error">error</option>
+        <option value="denied">denied</option>
+      </select>
+    </label>
+    <label>Target contains <input type="text" name="q" placeholder="(any)" /></label>
+    <label>Limit
+      <select name="limit">
+        <option value="50" selected>50</option>
+        <option value="200">200</option>
+        <option value="500">500</option>
+      </select>
+    </label>
+  </div>
+  <fieldset>
+    <label><input type="checkbox" id="live-tail-toggle"
+      hx-on::click="toggleAuditLive(this);" /> Live-tail</label>
+    <a href="/admin/audit/export.csv" class="secondary outline" role="button">Export CSV</a>
+  </fieldset>
+</form>
+
+<script>
+  function toggleAuditLive(cb) {
+    const slot = document.getElementById('audit-live');
+    while (slot.firstChild) slot.removeChild(slot.firstChild);
+    if (!cb.checked) return;
+    const params = new URLSearchParams();
+    const form = document.getElementById('audit-filters');
+    const outcome = form.querySelector('[name=outcome]').value;
+    const q = form.querySelector('[name=q]').value;
+    if (outcome) params.set('outcome', outcome);
+    if (q) params.set('q', q);
+    const url = '/admin/audit/_stream' + (params.toString() ? '?' + params.toString() : '');
+    slot.setAttribute('sse-connect', url);
+    slot.setAttribute('sse-swap', 'audit.row');
+    slot.setAttribute('hx-target', '#audit-tbody');
+    slot.setAttribute('hx-swap', 'afterbegin');
+    htmx.process(slot);
+  }
+</script>

--- a/apps/api/src/unifi_api/templates/admin/audit/_row.html
+++ b/apps/api/src/unifi_api/templates/admin/audit/_row.html
@@ -1,0 +1,8 @@
+<tr {% if r.outcome != "success" %}class="row-error"{% endif %}>
+  <td><small>{{ r.ts[:19] }}</small></td>
+  <td><code class="compact">{{ r.key_id_prefix }}</code></td>
+  <td><code class="compact">{{ r.controller or "" }}</code></td>
+  <td>{{ r.target }}</td>
+  <td>{{ r.outcome }}</td>
+  <td><small>{{ r.error_kind or "" }}</small></td>
+</tr>

--- a/apps/api/src/unifi_api/templates/admin/audit/_rows.html
+++ b/apps/api/src/unifi_api/templates/admin/audit/_rows.html
@@ -1,0 +1,14 @@
+{% for r in rows %}
+  {% include "audit/_row.html" %}
+{% endfor %}
+{% if next_cursor %}
+<tr id="audit-load-more-row">
+  <td colspan="6" style="text-align: center;">
+    <button class="secondary outline"
+      hx-get="/admin/audit/_rows?{{ filter_qs }}{% if filter_qs %}&{% endif %}cursor={{ next_cursor }}&limit={{ limit }}"
+      hx-target="#audit-load-more-row"
+      hx-swap="outerHTML"
+      hx-include="#audit-filters">Load more</button>
+  </td>
+</tr>
+{% endif %}

--- a/apps/api/src/unifi_api/templates/admin/audit/list.html
+++ b/apps/api/src/unifi_api/templates/admin/audit/list.html
@@ -1,0 +1,29 @@
+{% extends "_layout.html" %}
+{% block title %}Audit log — unifi-api admin{% endblock %}
+{% block content %}
+<h1>Audit log</h1>
+
+{% include "audit/_filters.html" %}
+
+<div hx-ext="sse" id="audit-live"></div>
+
+<table>
+  <thead>
+    <tr>
+      <th>Time</th>
+      <th>Key</th>
+      <th>Controller</th>
+      <th>Target</th>
+      <th>Outcome</th>
+      <th>Error</th>
+    </tr>
+  </thead>
+  <tbody id="audit-tbody"
+         hx-get="/admin/audit/_rows"
+         hx-trigger="load, audit-filter-changed from:body"
+         hx-swap="innerHTML"
+         hx-include="#audit-filters">
+    <tr><td colspan="6"><em>Loading…</em></td></tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/apps/api/src/unifi_api/templates/admin/logs/_filters.html
+++ b/apps/api/src/unifi_api/templates/admin/logs/_filters.html
@@ -1,0 +1,51 @@
+<form id="logs-filters"
+      hx-on::change="htmx.trigger('body', 'logs-filter-changed');"
+      style="margin-bottom: 1rem;">
+  <div class="grid">
+    <label>Level
+      <select name="level">
+        <option value="">(any)</option>
+        <option value="DEBUG">DEBUG</option>
+        <option value="INFO">INFO</option>
+        <option value="WARNING">WARNING</option>
+        <option value="ERROR">ERROR</option>
+        <option value="CRITICAL">CRITICAL</option>
+      </select>
+    </label>
+    <label>Logger <input type="text" name="logger" placeholder="(any)" /></label>
+    <label>Substring (q) <input type="text" name="q" placeholder="(any)" /></label>
+    <label>Limit
+      <select name="limit">
+        <option value="50" selected>50</option>
+        <option value="200">200</option>
+        <option value="500">500</option>
+      </select>
+    </label>
+  </div>
+  <fieldset>
+    <label><input type="checkbox" id="logs-live-toggle"
+      hx-on::click="toggleLogsLive(this);" /> Live-tail</label>
+  </fieldset>
+</form>
+
+<script>
+  function toggleLogsLive(cb) {
+    const slot = document.getElementById('logs-live');
+    while (slot.firstChild) slot.removeChild(slot.firstChild);
+    if (!cb.checked) return;
+    const params = new URLSearchParams();
+    const form = document.getElementById('logs-filters');
+    const level = form.querySelector('[name=level]').value;
+    const logger = form.querySelector('[name=logger]').value;
+    const q = form.querySelector('[name=q]').value;
+    if (level) params.set('level', level);
+    if (logger) params.set('logger', logger);
+    if (q) params.set('q', q);
+    const url = '/admin/logs/_stream' + (params.toString() ? '?' + params.toString() : '');
+    slot.setAttribute('sse-connect', url);
+    slot.setAttribute('sse-swap', 'log.row');
+    slot.setAttribute('hx-target', '#logs-tbody');
+    slot.setAttribute('hx-swap', 'afterbegin');
+    htmx.process(slot);
+  }
+</script>

--- a/apps/api/src/unifi_api/templates/admin/logs/_row.html
+++ b/apps/api/src/unifi_api/templates/admin/logs/_row.html
@@ -1,0 +1,11 @@
+<tr {% if r.get("level") in ("ERROR", "CRITICAL") %}class="row-error"{% elif r.get("level") == "WARNING" %}{% endif %}>
+  <td><small>{{ r.get("ts", "")[:23] }}</small></td>
+  <td>
+    {% set lvl = r.get("level", "") %}
+    {% if lvl in ("ERROR", "CRITICAL") %}<span class="status-error">{{ lvl }}</span>
+    {% elif lvl == "WARNING" %}<span class="status-warn">{{ lvl }}</span>
+    {% else %}{{ lvl }}{% endif %}
+  </td>
+  <td><code class="compact">{{ r.get("logger", "") }}</code></td>
+  <td>{{ r.get("event", "") }}</td>
+</tr>

--- a/apps/api/src/unifi_api/templates/admin/logs/_rows.html
+++ b/apps/api/src/unifi_api/templates/admin/logs/_rows.html
@@ -1,0 +1,14 @@
+{% for r in rows %}
+  {% include "logs/_row.html" %}
+{% endfor %}
+{% if next_offset %}
+<tr id="logs-load-more-row">
+  <td colspan="4" style="text-align: center;">
+    <button class="secondary outline"
+      hx-get="/admin/logs/_rows?{{ filter_qs }}{% if filter_qs %}&{% endif %}offset={{ next_offset }}&limit={{ limit }}"
+      hx-target="#logs-load-more-row"
+      hx-swap="outerHTML"
+      hx-include="#logs-filters">Load more</button>
+  </td>
+</tr>
+{% endif %}

--- a/apps/api/src/unifi_api/templates/admin/logs/list.html
+++ b/apps/api/src/unifi_api/templates/admin/logs/list.html
@@ -1,0 +1,27 @@
+{% extends "_layout.html" %}
+{% block title %}Logs — unifi-api admin{% endblock %}
+{% block content %}
+<h1>Application logs</h1>
+
+{% include "logs/_filters.html" %}
+
+<div hx-ext="sse" id="logs-live"></div>
+
+<table>
+  <thead>
+    <tr>
+      <th>Time</th>
+      <th>Level</th>
+      <th>Logger</th>
+      <th>Event</th>
+    </tr>
+  </thead>
+  <tbody id="logs-tbody"
+         hx-get="/admin/logs/_rows"
+         hx-trigger="load, logs-filter-changed from:body"
+         hx-swap="innerHTML"
+         hx-include="#logs-filters">
+    <tr><td colspan="4"><em>Loading…</em></td></tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/apps/api/src/unifi_api/templates/admin/settings/_form.html
+++ b/apps/api/src/unifi_api/templates/admin/settings/_form.html
@@ -1,0 +1,56 @@
+<form
+  hx-post="/admin/settings/save"
+  hx-target="#settings-form-slot"
+  hx-swap="innerHTML">
+
+  {% if saved %}
+  <p class="status-ok">● Saved.</p>
+  {% endif %}
+
+  <article>
+    <header><strong>Audit log retention</strong></header>
+    <div class="grid">
+      <label>Max age (days)
+        <input type="number" name="audit_max_age_days" value="{{ s.audit.max_age_days }}" min="0" required />
+      </label>
+      <label>Max rows
+        <input type="number" name="audit_max_rows" value="{{ s.audit.max_rows }}" min="0" required />
+      </label>
+    </div>
+    <div class="grid">
+      <label>Prune interval (hours)
+        <input type="number" name="audit_prune_interval_hours" value="{{ s.audit.prune_interval_hours }}" min="1" required />
+      </label>
+      <label><input type="checkbox" name="audit_enabled"
+        {% if s.audit.enabled %}checked{% endif %} /> Background pruner enabled</label>
+    </div>
+  </article>
+
+  <article>
+    <header><strong>Log file</strong></header>
+    <label><input type="checkbox" name="logs_enabled"
+      {% if s.logs.enabled %}checked{% endif %} /> File logging enabled</label>
+    <label>Path <small>(restart required to change)</small>
+      <input type="text" name="logs_path" value="{{ s.logs.path }}" readonly />
+    </label>
+    <div class="grid">
+      <label>Max bytes per file
+        <input type="number" name="logs_max_bytes" value="{{ s.logs.max_bytes }}" min="1024" required />
+      </label>
+      <label>Backup count
+        <input type="number" name="logs_backup_count" value="{{ s.logs.backup_count }}" min="0" required />
+      </label>
+    </div>
+    <label>Level
+      <select name="logs_level">
+        <option value="DEBUG" {% if s.logs.level == "DEBUG" %}selected{% endif %}>DEBUG</option>
+        <option value="INFO" {% if s.logs.level == "INFO" %}selected{% endif %}>INFO</option>
+        <option value="WARNING" {% if s.logs.level == "WARNING" %}selected{% endif %}>WARNING</option>
+        <option value="ERROR" {% if s.logs.level == "ERROR" %}selected{% endif %}>ERROR</option>
+        <option value="CRITICAL" {% if s.logs.level == "CRITICAL" %}selected{% endif %}>CRITICAL</option>
+      </select>
+    </label>
+  </article>
+
+  <button type="submit">Save</button>
+</form>

--- a/apps/api/src/unifi_api/templates/admin/settings/_prune_result.html
+++ b/apps/api/src/unifi_api/templates/admin/settings/_prune_result.html
@@ -1,0 +1,5 @@
+<p>
+  <span class="status-ok">●</span>
+  Pruned <strong>{{ result.pruned }}</strong> rows ·
+  audit log now has <strong>{{ result.current_count }}</strong> rows.
+</p>

--- a/apps/api/src/unifi_api/templates/admin/settings/page.html
+++ b/apps/api/src/unifi_api/templates/admin/settings/page.html
@@ -1,0 +1,22 @@
+{% extends "_layout.html" %}
+{% block title %}Settings — unifi-api admin{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+
+<div id="settings-form-slot"
+     hx-get="/admin/settings/_form"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+  <p><em>Loading…</em></p>
+</div>
+
+<article>
+  <header><strong>Audit log retention</strong></header>
+  <p>Manually prune now using the current retention thresholds.</p>
+  <button class="secondary"
+    hx-post="/admin/settings/_prune"
+    hx-target="#prune-result"
+    hx-swap="innerHTML">Prune now</button>
+  <div id="prune-result"></div>
+</article>
+{% endblock %}

--- a/apps/api/tests/test_admin_audit.py
+++ b/apps/api/tests/test_admin_audit.py
@@ -1,0 +1,185 @@
+"""Phase 5B PR3 Task 20 — admin /admin/audit page (filters + pagination + live-tail SSE + CSV)."""
+
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, AuditLog, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app_with_admin_key(tmp_path: Path):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="admin",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+async def _seed_audit(app, rows: list[dict]) -> None:
+    sm = app.state.sessionmaker
+    async with sm() as session:
+        for r in rows:
+            session.add(AuditLog(**r))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_audit_page_shell_renders_unauth(tmp_path: Path, monkeypatch) -> None:
+    """Page shell is unauth + HTMX-driven; rows are NOT inlined."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, _ = await _bootstrap_app_with_admin_key(tmp_path)
+    # Seed a row whose target should NOT appear in the page shell
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base, "key_id_prefix": "p1", "controller": "c1",
+         "target": "should-not-be-inlined", "outcome": "success"},
+    ])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/audit")
+        assert r.status_code == 200
+        body = r.text
+        assert "Audit log" in body
+        assert 'hx-get="/admin/audit/_rows"' in body
+        # Filters form is present
+        assert 'id="audit-filters"' in body
+        assert "should-not-be-inlined" not in body  # rows arrive via fragment
+        assert r.headers.get("cache-control") == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_audit_rows_fragment_returns_rows_and_pagination(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Seed 60 rows, fetch page 1 (50), then page 2 (10) via cursor."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base + timedelta(seconds=i * 10), "key_id_prefix": "p1",
+         "controller": "c1", "target": f"t{i:02d}", "outcome": "success"}
+        for i in range(60)
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        # Page 1: 50 rows + Load more button with a cursor
+        r = await c.get("/admin/audit/_rows?limit=50", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.text
+        # Count <tr ... > occurrences that are real data rows (skip the load-more row).
+        # The load-more row carries id="audit-load-more-row".
+        data_rows = re.findall(r"<tr(?![^>]*id=\"audit-load-more-row\")[^>]*>", body)
+        assert len(data_rows) == 50, f"expected 50 data rows, got {len(data_rows)}"
+        assert "Load more" in body
+        match = re.search(r'cursor=([^&"]+)', body)
+        assert match is not None, "expected cursor query param in Load more URL"
+        cursor = match.group(1)
+
+        # Page 2: 10 remaining rows + no Load more
+        r = await c.get(
+            f"/admin/audit/_rows?limit=50&cursor={cursor}", headers=headers,
+        )
+        assert r.status_code == 200, r.text
+        body = r.text
+        data_rows = re.findall(r"<tr(?![^>]*id=\"audit-load-more-row\")[^>]*>", body)
+        assert len(data_rows) == 10, f"expected 10 data rows on page 2, got {len(data_rows)}"
+        assert "Load more" not in body
+
+
+@pytest.mark.asyncio
+async def test_audit_rows_filter_by_outcome(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base, "key_id_prefix": "p1", "controller": "c1",
+         "target": "target-success-1", "outcome": "success"},
+        {"ts": base + timedelta(seconds=10), "key_id_prefix": "p1",
+         "controller": "c1", "target": "target-success-2", "outcome": "success"},
+        {"ts": base + timedelta(seconds=20), "key_id_prefix": "p1",
+         "controller": "c1", "target": "target-error-1", "outcome": "error"},
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/audit/_rows?outcome=error", headers=headers)
+        assert r.status_code == 200, r.text
+        body = r.text
+        assert "target-error-1" in body
+        assert "target-success-1" not in body
+        assert "target-success-2" not in body
+
+
+@pytest.mark.asyncio
+async def test_audit_export_csv_returns_csv(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    base = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    await _seed_audit(app, [
+        {"ts": base, "key_id_prefix": "p1", "controller": "c1",
+         "target": "csv-row-a", "outcome": "success"},
+        {"ts": base + timedelta(seconds=10), "key_id_prefix": "p1",
+         "controller": "c1", "target": "csv-row-b", "outcome": "success"},
+        {"ts": base + timedelta(seconds=20), "key_id_prefix": "p1",
+         "controller": "c1", "target": "csv-row-c", "outcome": "error"},
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/audit/export.csv", headers=headers)
+        assert r.status_code == 200, r.text
+        assert "text/csv" in r.headers["content-type"].lower()
+        body = r.text
+        lines = [ln for ln in body.splitlines() if ln.strip()]
+        assert lines[0].startswith(
+            "id,ts,key_id_prefix,controller,target,outcome,error_kind,detail"
+        )
+        # 3 data rows after the header
+        assert len(lines) == 1 + 3
+        assert "csv-row-a" in body
+        assert "csv-row-b" in body
+        assert "csv-row-c" in body
+
+
+@pytest.mark.asyncio
+async def test_audit_stream_returns_event_stream_content_type(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """SSE headers-only test — stub the infinite generator with a finite version."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+
+    from unifi_api.routes.admin import audit as admin_audit_routes
+
+    async def _finite_gen(filter_fn):
+        yield b": keepalive\n\n"
+
+    monkeypatch.setattr(
+        admin_audit_routes, "_admin_audit_event_stream", _finite_gen,
+    )
+
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        async with c.stream("GET", "/admin/audit/_stream", headers=headers) as resp:
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/event-stream")

--- a/apps/api/tests/test_admin_logs.py
+++ b/apps/api/tests/test_admin_logs.py
@@ -1,0 +1,115 @@
+"""Phase 5B PR3 Task 21 — /admin/logs page."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, Base
+from unifi_api.server import create_app
+from unifi_api.services.log_reader import LogReader
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app_with_log_reader(tmp_path: Path):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="admin",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+
+    # Replace the default LogReader (/dev/null) with one pointing at a real file.
+    log_path = tmp_path / "app.log"
+    log_path.write_text("", encoding="utf-8")
+    app.state.log_file_path = log_path
+    app.state.log_reader = LogReader(log_path)
+    return app, material.plaintext, log_path
+
+
+def _write_log(path: Path, entries: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_logs_page_shell_renders_unauth(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, _, _ = await _bootstrap_app_with_log_reader(tmp_path)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/logs")
+        assert r.status_code == 200
+        assert "Application logs" in r.text
+        assert 'hx-get="/admin/logs/_rows"' in r.text
+        assert r.headers.get("cache-control") == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_logs_rows_filter_by_level(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, log_path = await _bootstrap_app_with_log_reader(tmp_path)
+    _write_log(log_path, [
+        {"ts": "2026-05-01T00:00:00.000Z", "level": "INFO", "logger": "a", "event": "hello"},
+        {"ts": "2026-05-01T00:00:01.000Z", "level": "ERROR", "logger": "a", "event": "boom"},
+        {"ts": "2026-05-01T00:00:02.000Z", "level": "INFO", "logger": "b", "event": "hi"},
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/logs/_rows?level=ERROR", headers=headers)
+        assert r.status_code == 200
+        assert "boom" in r.text
+        assert "hello" not in r.text
+        assert "hi" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_logs_rows_filter_by_logger(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, log_path = await _bootstrap_app_with_log_reader(tmp_path)
+    _write_log(log_path, [
+        {"ts": "2026-05-01T00:00:00.000Z", "level": "INFO", "logger": "alpha", "event": "from-alpha"},
+        {"ts": "2026-05-01T00:00:01.000Z", "level": "INFO", "logger": "beta", "event": "from-beta"},
+        {"ts": "2026-05-01T00:00:02.000Z", "level": "INFO", "logger": "alpha", "event": "alpha-2"},
+    ])
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/logs/_rows?logger=alpha", headers=headers)
+        assert r.status_code == 200
+        assert "from-alpha" in r.text
+        assert "alpha-2" in r.text
+        assert "from-beta" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_logs_stream_returns_event_stream_content_type(tmp_path: Path, monkeypatch) -> None:
+    """Headers-only check; the infinite generator is replaced by a finite one to avoid hanging."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, _ = await _bootstrap_app_with_log_reader(tmp_path)
+
+    async def _finite_gen(*args, **kwargs):
+        yield b": keepalive\n\n"
+
+    monkeypatch.setattr("unifi_api.routes.admin.logs._admin_logs_event_stream", _finite_gen)
+
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        async with c.stream("GET", "/admin/logs/_stream", headers=headers) as resp:
+            assert resp.status_code == 200
+            assert resp.headers.get("content-type", "").startswith("text/event-stream")

--- a/apps/api/tests/test_admin_settings.py
+++ b/apps/api/tests/test_admin_settings.py
@@ -1,0 +1,115 @@
+"""Phase 5B PR3 Task 22 — /admin/settings page."""
+
+import uuid
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.models import ApiKey, AuditLog, Base
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap_app_with_admin_key(tmp_path: Path):
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="admin",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext
+
+
+@pytest.mark.asyncio
+async def test_settings_form_renders_with_current_values(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    # Pre-seed a non-default value so we can confirm the form pre-fills it.
+    await app.state.settings_service.set_int("audit.retention.max_age_days", 30)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/admin/settings/_form", headers=headers)
+        assert r.status_code == 200
+        # max_age_days = 30 (not the 90 default)
+        assert 'name="audit_max_age_days" value="30"' in r.text
+        # File logging level select with INFO option present
+        assert "INFO" in r.text
+        assert "DEBUG" in r.text
+        assert r.headers.get("cache-control") == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_settings_save_round_trips_through_settings_service(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/admin/settings/save", headers=headers, data={
+            "audit_max_age_days": "45",
+            "audit_max_rows": "500000",
+            "audit_enabled": "on",
+            "audit_prune_interval_hours": "12",
+            "logs_enabled": "",  # disabled
+            "logs_max_bytes": "5242880",
+            "logs_backup_count": "3",
+            "logs_level": "WARNING",
+        })
+        assert r.status_code == 200
+        assert "Saved" in r.text  # the saved indicator
+        # Form re-renders with the new values
+        assert 'value="45"' in r.text
+        assert 'value="500000"' in r.text
+    # Confirm via SettingsService directly
+    svc = app.state.settings_service
+    assert await svc.get_int("audit.retention.max_age_days") == 45
+    assert await svc.get_int("audit.retention.max_rows") == 500_000
+    assert await svc.get_bool("audit.retention.enabled") is True
+    assert await svc.get_int("audit.retention.prune_interval_hours") == 12
+    assert await svc.get_bool("logs.file.enabled") is False
+    assert await svc.get_int("logs.file.max_bytes") == 5_242_880
+    assert await svc.get_int("logs.file.backup_count") == 3
+    assert await svc.get_str("logs.file.level") == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_settings_prune_button_returns_counts(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key = await _bootstrap_app_with_admin_key(tmp_path)
+    headers = {"Authorization": f"Bearer {key}"}
+    # Seed 3 audit rows with old timestamps so prune deletes them.
+    sm = app.state.sessionmaker
+    now = datetime.now(timezone.utc)
+    async with sm() as session:
+        for i in range(3):
+            session.add(AuditLog(
+                ts=now - timedelta(days=200),
+                key_id_prefix="p", controller=None,
+                target=f"t{i}", outcome="ok",
+            ))
+        await session.commit()
+    # Pin retention so the prune actually removes rows.
+    await app.state.settings_service.set_int("audit.retention.max_age_days", 30)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/admin/settings/_prune", headers=headers)
+        assert r.status_code == 200
+        # The fragment renders pruned + current_count
+        assert "Pruned" in r.text
+        assert "3" in r.text  # 3 rows removed
+        assert "0" in r.text  # current_count = 0


### PR DESCRIPTION
## Summary

Phase 5B PR3 — final piece of the operational admin UI: audit log viewer, application logs viewer, and settings page. Three commits, all TDD-driven, no fixups needed (the page-shell + HX-Trigger pattern from PR2 generalized cleanly).

This PR ships:
- **`/admin/audit`** — paginated audit-log viewer with filters (controller, outcome, target substring), live-tail SSE that prepends new rows as they're written via `add_audit_subscriber`, "Load more" cursor-based pagination, CSV export with `Content-Disposition: attachment`
- **`/admin/logs`** — paginated tail-of-file viewer over the rotating JSON log; filters (level, logger, q substring), live-tail SSE that polls `os.stat().st_size` every 1s and emits new lines as server-rendered row fragments; rotation-aware (resets offset on shrink)
- **`/admin/settings`** — pre-populated form for audit retention thresholds + log file config; "Save" button persists to `SettingsService` with a "Saved" indicator on success; "Prune now" button runs `prune_audit(...)` against the current thresholds and renders `Pruned N rows · current N` result fragment

### Architecture pattern (carried forward from PR2)

Every admin page follows the same shape:
- **Page route**: unauthenticated, returns the HTMX shell
- **Data fragment** (`_rows`, `_form`, `_table`): admin-scoped, server-rendered HTML
- **Mutation** (`save`, `_prune`): admin-scoped, returns either a confirmation fragment (settings) or empty + `HX-Trigger: <name>-changed` (audit/keys/controllers)
- **SSE generators**: module-level so tests can monkeypatch with finite versions
- **Cache-Control: no-store** on every `/admin/*` HTML response
- **`include_in_schema=False`** on every admin route

### Test deltas

| Package | Before | After | Δ |
|---|---|---|---|
| unifi-core | 69 | 69 | 0 |
| unifi-mcp-shared | 205 | 205 | 0 |
| unifi-network-mcp | 630 | 630 | 0 |
| unifi-protect-mcp | 157 | 157 | 0 |
| unifi-access-mcp | 336 | 336 | 0 |
| **unifi-api** | **496** | **508** | **+12** |

Phase 4A `test_serializer_coverage` and Phase 5A `test_resource_route_coverage` gates remain green — admin endpoints don't add MCP tools or read tools.

## Test plan

- [x] All 6 packages green per-package via `uv run --package <pkg> pytest`
- [x] Live browser smoke against the real network controller (UDM SE) using `.env` credentials, full end-to-end walkthrough of the §12 manual smoke checklist:
  - Boot service → `unifi-api migrate` bootstraps admin key → `unifi-api serve` → log file at `state/api.log` is created and growing
  - Login (paste admin Bearer → client-side `/v1/health/ready` validation → server bootstrap script → localStorage set → redirect to `/admin/`)
  - Dashboard renders diagnostics
  - Add controller via UI; live probe returns ok against the real UDM SE
  - Trigger 5 read actions via `/v1/actions/unifi_list_clients` to populate audit
  - **Audit page**: shows all 5 rows correctly (timestamp, key prefix, controller ID, target, outcome=success), filters render, CSV export returns `text/csv` with proper header row + 5 data rows
  - **Logs page**: shows live request stream from the rotating file (uvicorn.access entries for every page load), filters render
  - **Settings page**: pre-populated with seeded defaults (max_age_days=90, max_rows=1000000, prune_interval_hours=6, file logging enabled, level=INFO, etc.); changed `audit.retention.max_age_days` to 0, clicked Save → "Saved" indicator appears; clicked "Prune now" → result fragment shows `Pruned 5 rows · audit log now has 0 rows` (full save + prune cycle works end-to-end)
- [x] No console errors during the full walkthrough; theme toggle persists across reloads

## Phase 5B is complete

This is the final PR of Phase 5B. The full admin UI is operational:

- 7 pages: Dashboard / Keys / Controllers / Audit / Logs / Settings + API docs nav-link
- 18 backend admin routes (page shells + data fragments + mutations + SSE streams + CSV)
- 1 background audit pruner task (PR1)
- 1 migration adding `app_settings` (PR1)
- Rolling-file logger (PR1)
- Vendored Pico CSS / HTMX / HTMX-SSE (PR2)

Total Phase 5B test growth: **446 → 508** unifi-api tests (+62), exactly matching the spec.

## What's next

Per the roadmap:

1. **Phase 6 — GraphQL overlay** (committed; we are definitely doing this)
2. **Phase 7 — Codegen / client SDKs** (conditional on real consumer need at decision time)
3. **Phase 8 — Release** (`api/v0.1.0` tag, pure quality / live smoke testing across all surfaces)

Once this merges, the next session opens the Phase 6 brainstorm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)