### PR TITLE
Phase 6 PR2.5: NetworkQuery resolvers + relationship edges + e2e tests

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -6,6 +6,20 @@
 ## Schema (SDL)
 
 ```graphql
+"""An active kernel routing-table entry on a gateway."""
+type ActiveRoute {
+  targetSubnet: String
+  gateway: String
+  interface: String
+  distance: Int
+}
+
+"""Paginated page of active kernel routes."""
+type ActiveRoutePage {
+  items: [ActiveRoute!]!
+  nextCursor: String
+}
+
 """A wireless channel allowed by the regulatory domain."""
 type AvailableChannel {
   channel: Int
@@ -82,6 +96,22 @@ type DeviceRadio {
   name: String
   model: String
   radios: [RadioEntry!]!
+}
+
+"""A static DNS record served by the controller."""
+type DnsRecord {
+  id: ID
+  hostname: String
+  ip: String
+  type: String
+  ttl: Int
+  enabled: Boolean!
+}
+
+"""Paginated page of DNS records."""
+type DnsRecordPage {
+  items: [DnsRecord!]!
+  nextCursor: String
 }
 
 """Service health snapshot — smoke field for the GraphQL endpoint."""
@@ -208,6 +238,47 @@ type NetworkQuery {
 
   """Get the controller's network-health subsystems list."""
   networkHealth(controller: ID!, site: String! = "default"): [NetworkHealth!]!
+
+  """
+  List WLAN/SSID configurations on the given controller/site (paginated).
+  """
+  wlans(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): WlanPage!
+
+  """Look up a single WLAN/SSID by id."""
+  wlan(controller: ID!, id: ID!, site: String! = "default"): Wlan
+
+  """List configured VPN clients (outbound tunnels) (paginated)."""
+  vpnClients(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): VpnClientPage!
+
+  """Look up a single VPN client by id."""
+  vpnClient(controller: ID!, id: ID!, site: String! = "default"): VpnClient
+
+  """List configured VPN servers (inbound tunnels) (paginated)."""
+  vpnServers(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): VpnServerPage!
+
+  """Look up a single VPN server by id."""
+  vpnServer(controller: ID!, id: ID!, site: String! = "default"): VpnServer
+
+  """List static DNS records on the given controller/site (paginated)."""
+  dnsRecords(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DnsRecordPage!
+
+  """Look up a single DNS record by id."""
+  dnsRecord(controller: ID!, id: ID!, site: String! = "default"): DnsRecord
+
+  """List configured static routes (paginated)."""
+  routes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): RoutePage!
+
+  """Look up a single static route by id."""
+  route(controller: ID!, id: ID!, site: String! = "default"): Route
+
+  """List the gateway's active kernel routing-table entries (paginated)."""
+  activeRoutes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ActiveRoutePage!
+
+  """List traffic-route policies (V2 /trafficroutes) (paginated)."""
+  trafficRoutes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): TrafficRoutePage!
+
+  """Look up a single traffic-route policy by id."""
+  trafficRoute(controller: ID!, id: ID!, site: String! = "default"): TrafficRoute
 }
 
 type Query {
@@ -256,6 +327,22 @@ type RogueApPage {
   nextCursor: String
 }
 
+"""A static route configured on the gateway."""
+type Route {
+  id: ID
+  name: String
+  targetSubnet: String
+  gateway: String
+  distance: Int
+  enabled: Boolean!
+}
+
+"""Paginated page of static routes."""
+type RoutePage {
+  items: [Route!]!
+  nextCursor: String
+}
+
 """Speedtest status reported by a UniFi gateway."""
 type SpeedtestStatus {
   status: String
@@ -263,5 +350,71 @@ type SpeedtestStatus {
   uploadMbps: Float
   latencyMs: Int
   lastRun: Int
+}
+
+"""A traffic-route policy (V2 /trafficroutes entry)."""
+type TrafficRoute {
+  id: ID
+  name: String
+  matchingTarget: String
+  sourceTargets: JSON
+  destinationTargets: JSON
+  nextHop: String
+  enabled: Boolean!
+}
+
+"""Paginated page of traffic-route policies."""
+type TrafficRoutePage {
+  items: [TrafficRoute!]!
+  nextCursor: String
+}
+
+"""A configured VPN client (outbound tunnel)."""
+type VpnClient {
+  id: ID
+  name: String
+  type: String
+  enabled: Boolean!
+  serverAddress: String
+  lastHandshake: Int
+}
+
+"""Paginated page of VPN clients."""
+type VpnClientPage {
+  items: [VpnClient!]!
+  nextCursor: String
+}
+
+"""A configured VPN server (inbound tunnel)."""
+type VpnServer {
+  id: ID
+  name: String
+  type: String
+  enabled: Boolean!
+  listenPort: Int
+  allowedSubnets: [String!]
+}
+
+"""Paginated page of VPN servers."""
+type VpnServerPage {
+  items: [VpnServer!]!
+  nextCursor: String
+}
+
+"""A UniFi WLAN/SSID configuration."""
+type Wlan {
+  id: ID
+  name: String
+  enabled: Boolean!
+  security: String
+  networkId: String
+  hideSsid: Boolean!
+  vlanId: Int
+}
+
+"""Paginated page of WLAN/SSID configurations."""
+type WlanPage {
+  items: [Wlan!]!
+  nextCursor: String
 }
 ```

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -36,12 +36,48 @@ type ActiveRoutePage {
   nextCursor: String
 }
 
+"""A controller alarm (V1 /list/alarm entry)."""
+type Alarm {
+  id: ID
+  key: String
+  msg: String
+  archived: Boolean!
+  time: Int
+}
+
+"""Paginated page of controller alarms."""
+type AlarmPage {
+  items: [Alarm!]!
+  nextCursor: String
+}
+
+"""Auto-backup schedule + retention settings."""
+type AutoBackupSettings {
+  enabled: Boolean!
+  schedule: String
+  maxCount: Int
+}
+
 """A wireless channel allowed by the regulatory domain."""
 type AvailableChannel {
   channel: Int
   frequencyMhz: Int
   widthMhz: Int
   allowed: Boolean!
+}
+
+"""A controller backup file metadata record."""
+type Backup {
+  id: ID
+  filename: String
+  size: Int
+  createdAt: Int
+}
+
+"""Paginated page of controller backup descriptors."""
+type BackupPage {
+  items: [Backup!]!
+  nextCursor: String
 }
 
 """A client currently blocked on the UniFi Network controller."""
@@ -85,6 +121,34 @@ type ClientLookup {
 type ClientPage {
   items: [Client!]!
   nextCursor: String
+}
+
+"""A client association session entry."""
+type ClientSession {
+  mac: String
+  hostname: String
+  ap: String
+  ssid: String
+  connectedAt: Int
+  disconnectedAt: Int
+  duration: Int
+}
+
+"""Paginated page of client association sessions."""
+type ClientSessionPage {
+  items: [ClientSession!]!
+  nextCursor: String
+}
+
+"""Current WiFi parameters for a client."""
+type ClientWifiDetails {
+  mac: String
+  ssid: String
+  ap: String
+  signal: Int
+  txRate: Int
+  rxRate: Int
+  channel: Int
 }
 
 """A content-filtering profile (V2 /content-filtering entry)."""
@@ -168,6 +232,34 @@ type DpiCategory {
 type DpiCategoryPage {
   items: [DpiCategory!]!
   nextCursor: String
+}
+
+"""DPI stats wrapper: applications + categories arrays."""
+type DpiStats {
+  applications: JSON!
+  categories: JSON!
+}
+
+"""A curated event-log entry."""
+type EventLog {
+  id: ID
+  key: String
+  msg: String
+  time: Int
+  mac: String
+  ip: String
+  severity: String
+}
+
+"""Paginated page of event-log entries."""
+type EventLogPage {
+  items: [EventLog!]!
+  nextCursor: String
+}
+
+"""Wrapper for event-type prefix descriptors."""
+type EventTypes {
+  eventTypes: JSON!
 }
 
 """A firewall address/port group (V1 /rest/firewallgroup)."""
@@ -425,6 +517,81 @@ type NetworkQuery {
 
   """Look up a single port forward by id."""
   portForward(controller: ID!, id: ID!, site: String! = "default"): PortForward
+
+  """Site dashboard timeseries (all-points)."""
+  dashboardStats(controller: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Network-wide stats timeseries."""
+  networkStats(controller: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Gateway stats timeseries."""
+  gatewayStats(controller: ID!, site: String! = "default", durationHours: Int! = 24): [StatPoint!]!
+
+  """Per-client stats timeseries (by MAC)."""
+  clientStats(controller: ID!, mac: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Per-device stats timeseries (by MAC)."""
+  deviceStats(controller: ID!, mac: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Per-client DPI traffic breakdown."""
+  clientDpiTraffic(controller: ID!, mac: ID!, site: String! = "default"): [StatPoint!]!
+
+  """Site-wide DPI traffic breakdown."""
+  siteDpiTraffic(controller: ID!, site: String! = "default"): [StatPoint!]!
+
+  """DPI stats catalog (applications + categories)."""
+  dpiStats(controller: ID!, site: String! = "default"): DpiStats
+
+  """List recent controller events (paginated)."""
+  eventLog(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List active alerts (paginated)."""
+  alerts(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List recent anomalies (paginated)."""
+  anomalies(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List recent IPS/IDS events (paginated)."""
+  ipsEvents(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List controller alarms (paginated)."""
+  alarms(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): AlarmPage!
+
+  """Get controller system info (build, uptime, hardware)."""
+  systemInfo(controller: ID!, site: String! = "default"): SystemInfo
+
+  """Get site-level settings (locale, timezone, advanced)."""
+  siteSettings(controller: ID!, site: String! = "default"): SiteSettings
+
+  """Get SNMP settings."""
+  snmpSettings(controller: ID!, site: String! = "default"): SnmpSettings
+
+  """Get the controller's event-type prefix catalog."""
+  eventTypes(controller: ID!, site: String! = "default"): EventTypes
+
+  """Get auto-backup schedule + retention settings."""
+  autobackupSettings(controller: ID!, site: String! = "default"): AutoBackupSettings
+
+  """List controller backups (paginated)."""
+  backups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): BackupPage!
+
+  """List recent speedtest results (paginated)."""
+  speedtestResults(controller: ID!, site: String! = "default", durationHours: Int! = 24, limit: Int! = 50, cursor: String = null): SpeedtestResultPage!
+
+  """List top-traffic clients within a window."""
+  topClients(controller: ID!, site: String! = "default", withinHours: Int! = 24): [TopClient!]!
+
+  """List hotspot vouchers on the given controller/site (paginated)."""
+  vouchers(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): VoucherPage!
+
+  """Look up a single hotspot voucher by id."""
+  voucher(controller: ID!, id: ID!, site: String! = "default"): Voucher
+
+  """List a client's association sessions (paginated)."""
+  clientSessions(controller: ID!, site: String! = "default", mac: String = null, durationHours: Int! = 24, limit: Int! = 50, cursor: String = null): ClientSessionPage!
+
+  """Get a client's current WiFi parameters (signal, rates)."""
+  clientWifiDetails(controller: ID!, mac: ID!, site: String! = "default"): ClientWifiDetails
 }
 
 """An out-of-network (OON) policy entry."""
@@ -538,6 +705,36 @@ type RoutePage {
   nextCursor: String
 }
 
+"""Controller site settings."""
+type SiteSettings {
+  siteId: String
+  name: String
+  role: String
+  country: Int
+}
+
+"""Controller SNMP settings."""
+type SnmpSettings {
+  enabled: Boolean!
+  community: String
+  port: Int
+  version: String
+}
+
+"""A speedtest result entry."""
+type SpeedtestResult {
+  timestamp: Int
+  downloadMbps: Float
+  uploadMbps: Float
+  latencyMs: Float
+}
+
+"""Paginated page of speedtest result entries."""
+type SpeedtestResultPage {
+  items: [SpeedtestResult!]!
+  nextCursor: String
+}
+
 """Speedtest status reported by a UniFi gateway."""
 type SpeedtestStatus {
   status: String
@@ -545,6 +742,30 @@ type SpeedtestStatus {
   uploadMbps: Float
   latencyMs: Int
   lastRun: Int
+}
+
+"""A single timeseries point: {ts: <ms>, ...metrics}."""
+type StatPoint {
+  ts: Int!
+}
+
+"""Controller system information."""
+type SystemInfo {
+  name: String
+  version: String
+  hostname: String
+  uptime: Int
+  numDevices: Int
+  numClients: Int
+}
+
+"""A top-traffic client entry."""
+type TopClient {
+  mac: String
+  hostname: String
+  txBytes: Int
+  rxBytes: Int
+  totalBytes: Int
 }
 
 """A traffic-route policy (V2 /trafficroutes entry)."""
@@ -561,6 +782,23 @@ type TrafficRoute {
 """Paginated page of traffic-route policies."""
 type TrafficRoutePage {
   items: [TrafficRoute!]!
+  nextCursor: String
+}
+
+"""A hotspot voucher (V1 /stat/voucher entry)."""
+type Voucher {
+  id: ID
+  code: String
+  status: String
+  duration: Int
+  qosOverwrite: Boolean!
+  createdAt: Int
+  usedAt: Int
+}
+
+"""Paginated page of hotspot vouchers."""
+type VoucherPage {
+  items: [Voucher!]!
   nextCursor: String
 }
 

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -6,6 +6,28 @@
 ## Schema (SDL)
 
 ```graphql
+"""A wireless channel allowed by the regulatory domain."""
+type AvailableChannel {
+  channel: Int
+  frequencyMhz: Int
+  widthMhz: Int
+  allowed: Boolean!
+}
+
+"""A client currently blocked on the UniFi Network controller."""
+type BlockedClient {
+  mac: ID
+  hostname: String
+  lastSeen: String
+  blocked: Boolean!
+}
+
+"""Paginated page of blocked clients."""
+type BlockedClientPage {
+  items: [BlockedClient!]!
+  nextCursor: String
+}
+
 """A client device on the UniFi Network controller."""
 type Client {
   mac: ID
@@ -18,6 +40,15 @@ type Client {
   firstSeen: String
   note: String
   usergroupId: String
+}
+
+"""Result of a by-IP client lookup — online presence + last seen."""
+type ClientLookup {
+  mac: ID
+  ip: String
+  hostname: String
+  isOnline: Boolean!
+  lastSeen: String
 }
 
 """Paginated page of clients."""
@@ -45,6 +76,14 @@ type DevicePage {
   nextCursor: String
 }
 
+"""Wrapper dict containing the radio table for a device."""
+type DeviceRadio {
+  mac: ID
+  name: String
+  model: String
+  radios: [RadioEntry!]!
+}
+
 """Service health snapshot — smoke field for the GraphQL endpoint."""
 type HealthSnapshot {
   ok: Boolean!
@@ -57,6 +96,38 @@ The `JSON` scalar type represents JSON values as specified by [ECMA-404](https:/
 """
 scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
 
+"""A known rogue AP (allowlisted by the operator)."""
+type KnownRogueAp {
+  bssid: ID
+  ssid: String
+  channel: Int
+  signalDbm: Int
+  lastSeen: Int
+  isKnown: Boolean!
+}
+
+"""Paginated page of known (allowlisted) rogue APs."""
+type KnownRogueApPage {
+  items: [KnownRogueAp!]!
+  nextCursor: String
+}
+
+"""Wrapper dict containing LLDP neighbors for a switch."""
+type LldpNeighbors {
+  name: String
+  model: String
+  lldpTable: [LldpRow!]!
+}
+
+"""A single LLDP neighbor row reported by a switch."""
+type LldpRow {
+  localPortIdx: Int
+  chassisId: String
+  portId: String
+  systemName: String
+  capabilities: [String!]!
+}
+
 """A UniFi LAN/VLAN network configuration."""
 type Network {
   id: ID
@@ -65,6 +136,17 @@ type Network {
   enabled: Boolean!
   vlan: Int
   subnet: String
+}
+
+"""A network-health subsystem entry."""
+type NetworkHealth {
+  subsystem: String
+  status: String
+  numUser: Int
+  numGuest: Int
+  numIot: Int
+  rxBytes: Int
+  txBytes: Int
 }
 
 """Paginated page of network configurations."""
@@ -78,13 +160,54 @@ type NetworkQuery {
   """List clients on the given controller/site (paginated)."""
   clients(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ClientPage!
 
+  """Look up a single client by MAC address."""
+  client(controller: ID!, mac: ID!, site: String! = "default"): Client
+
+  """List clients currently blocked from the network (paginated)."""
+  blockedClients(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): BlockedClientPage!
+
+  """Look up a client by IP address (online-presence check)."""
+  clientByIp(controller: ID!, ip: String!, site: String! = "default"): ClientLookup
+
   """List devices on the given controller/site (paginated)."""
   devices(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DevicePage!
+
+  """Look up a single device by MAC address."""
+  device(controller: ID!, mac: ID!, site: String! = "default"): Device
+
+  """Get the radio configuration for a UniFi access point."""
+  deviceRadio(controller: ID!, mac: ID!, site: String! = "default"): DeviceRadio
+
+  """Get LLDP neighbors reported by a switch."""
+  lldpNeighbors(controller: ID!, deviceMac: ID!, site: String! = "default"): LldpNeighbors
+
+  """List rogue (unknown) APs detected within a window (paginated)."""
+  rogueAps(controller: ID!, site: String! = "default", withinHours: Int! = 24, limit: Int! = 50, cursor: String = null): RogueApPage!
+
+  """List known (allowlisted) rogue APs (paginated)."""
+  knownRogueAps(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): KnownRogueApPage!
+
+  """List RF-scan results for a specific access point."""
+  rfScanResults(controller: ID!, apMac: ID!, site: String! = "default"): [RfScanResult!]!
+
+  """List wireless channels allowed by the regulatory domain."""
+  availableChannels(controller: ID!, site: String! = "default"): [AvailableChannel!]!
+
+  """Get the gateway speedtest status (idle/running + last results)."""
+  speedtestStatus(controller: ID!, gatewayMac: ID!, site: String! = "default"): SpeedtestStatus
 
   """
   List configured LAN/VLAN networks on the given controller/site (paginated).
   """
   networks(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): NetworkPage!
+
+  """
+  Look up a single LAN/VLAN network by id. (Named ``networkDetail`` because ``network`` is reserved for the namespace.)
+  """
+  networkDetail(controller: ID!, id: ID!, site: String! = "default"): Network
+
+  """Get the controller's network-health subsystems list."""
+  networkHealth(controller: ID!, site: String! = "default"): [NetworkHealth!]!
 }
 
 type Query {
@@ -93,5 +216,52 @@ type Query {
 
   """Read-only access to UniFi Network resources."""
   network: NetworkQuery!
+}
+
+"""Radio configuration entry on a UniFi access point."""
+type RadioEntry {
+  name: String
+  radio: String
+  channel: Int
+  ht: Int
+  txPower: Int
+  txPowerMode: String
+  currentChannel: Int
+  currentTxPower: Int
+  numSta: Int
+}
+
+"""A single RF-scan result row reported by an AP."""
+type RfScanResult {
+  bssid: ID
+  ssid: String
+  channel: Int
+  signalDbm: Int
+  capturedAt: Int
+}
+
+"""A rogue (unknown) AP detected by the controller."""
+type RogueAp {
+  bssid: ID
+  ssid: String
+  channel: Int
+  signalDbm: Int
+  lastSeen: Int
+  isKnown: Boolean!
+}
+
+"""Paginated page of detected rogue APs."""
+type RogueApPage {
+  items: [RogueAp!]!
+  nextCursor: String
+}
+
+"""Speedtest status reported by a UniFi gateway."""
+type SpeedtestStatus {
+  status: String
+  downloadMbps: Float
+  uploadMbps: Float
+  latencyMs: Int
+  lastRun: Int
 }
 ```

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -120,6 +120,9 @@ type Client {
   firstSeen: String
   note: String
   usergroupId: String
+
+  """The AP or switch this client connects through."""
+  device: Device
 }
 
 """A network member client group (V2 /network-members-group entry)."""
@@ -205,6 +208,9 @@ type Device {
   state: String
   ip: String
   ports: JSON
+
+  """Clients currently connected through this AP/switch."""
+  portClients: [Client!]!
 }
 
 """Paginated page of devices."""
@@ -381,6 +387,9 @@ type Network {
   enabled: Boolean!
   vlan: Int
   subnet: String
+
+  """Clients on this network."""
+  clients: [Client!]!
 }
 
 """A network-health subsystem entry."""

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -51,6 +51,20 @@ type AlarmPage {
   nextCursor: String
 }
 
+"""A UniFi AP group (collection of AP MAC addresses)."""
+type ApGroup {
+  id: ID
+  name: String
+  apCount: Int!
+  deviceMacs: [String!]!
+}
+
+"""Paginated page of AP groups."""
+type ApGroupPage {
+  items: [ApGroup!]!
+  nextCursor: String
+}
+
 """Auto-backup schedule + retention settings."""
 type AutoBackupSettings {
   enabled: Boolean!
@@ -106,6 +120,20 @@ type Client {
   firstSeen: String
   note: String
   usergroupId: String
+}
+
+"""A network member client group (V2 /network-members-group entry)."""
+type ClientGroup {
+  id: ID
+  name: String
+  qosRateMaxDown: Int
+  qosRateMaxUp: Int
+}
+
+"""Paginated page of network member client groups."""
+type ClientGroupPage {
+  items: [ClientGroup!]!
+  nextCursor: String
 }
 
 """Result of a by-IP client lookup — online presence + last seen."""
@@ -592,6 +620,45 @@ type NetworkQuery {
 
   """Get a client's current WiFi parameters (signal, rates)."""
   clientWifiDetails(controller: ID!, mac: ID!, site: String! = "default"): ClientWifiDetails
+
+  """List switch port profiles on the given controller/site (paginated)."""
+  portProfiles(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortProfilePage!
+
+  """Look up a single switch port profile by id."""
+  portProfile(controller: ID!, id: ID!, site: String! = "default"): PortProfile
+
+  """
+  Get the port-override wrapper for a switch (name/model + per-port overrides).
+  """
+  switchPorts(controller: ID!, deviceMac: ID!, site: String! = "default"): SwitchPorts
+
+  """Get the per-port stats wrapper for a switch (name/model + port_table)."""
+  portStats(controller: ID!, deviceMac: ID!, site: String! = "default"): PortStats
+
+  """Get switch capabilities (caps dict + STP / dot1x flags)."""
+  switchCapabilities(controller: ID!, deviceMac: ID!, site: String! = "default"): SwitchCapabilities
+
+  """List AP groups on the given controller/site (paginated)."""
+  apGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ApGroupPage!
+
+  """Look up a single AP group by id."""
+  apGroup(controller: ID!, id: ID!, site: String! = "default"): ApGroup
+
+  """
+  List network member client groups on the given controller/site (paginated).
+  """
+  clientGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ClientGroupPage!
+
+  """Look up a single network member client group by id."""
+  clientGroup(controller: ID!, id: ID!, site: String! = "default"): ClientGroup
+
+  """
+  List QoS user groups (V1 /rest/usergroup) on the given controller/site (paginated).
+  """
+  userGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): UserGroupPage!
+
+  """Look up a single QoS user group by id."""
+  userGroup(controller: ID!, id: ID!, site: String! = "default"): UserGroup
 }
 
 """An out-of-network (OON) policy entry."""
@@ -625,6 +692,56 @@ type PortForward {
 type PortForwardPage {
   items: [PortForward!]!
   nextCursor: String
+}
+
+"""A single port-override row on a switch."""
+type PortOverrideRow {
+  portIdx: Int
+  name: String
+  portconfId: String
+  poeMode: String
+  opMode: String
+}
+
+"""A switch port profile (PoE / VLAN tagging template)."""
+type PortProfile {
+  id: ID
+  name: String
+  nativeNetworkconfId: String
+  taggedNetworkconfIds: [String!]!
+  poeMode: String
+  isolation: Boolean
+}
+
+"""Paginated page of switch port profiles."""
+type PortProfilePage {
+  items: [PortProfile!]!
+  nextCursor: String
+}
+
+"""A single port-table row reporting per-port stats."""
+type PortStatRow {
+  portIdx: Int
+  name: String
+  enable: Boolean!
+  speed: Int
+  duplex: Boolean
+  txBytes: Int!
+  rxBytes: Int!
+  txPackets: Int!
+  rxPackets: Int!
+  txDropped: Int!
+  rxDropped: Int!
+  poeEnable: Boolean!
+  poeMode: String
+  poePower: Float
+}
+
+"""Wrapper dict containing the per-port stats table for a switch."""
+type PortStats {
+  name: String
+  model: String
+  portTable: [PortStatRow!]!
 }
 
 """A QoS rate-limit rule (V2 /qos-rules entry)."""
@@ -749,6 +866,24 @@ type StatPoint {
   ts: Int!
 }
 
+"""Switch capabilities (caps dict + STP / dot1x flags)."""
+type SwitchCapabilities {
+  name: String
+  model: String
+  switchCaps: JSON
+  stpVersion: String
+  stpPriority: String
+  jumboframeEnabled: Boolean
+  dot1xPortctrlEnabled: Boolean
+}
+
+"""Wrapper dict containing port-override rows for a switch."""
+type SwitchPorts {
+  name: String
+  model: String
+  portOverrides: [PortOverrideRow!]!
+}
+
 """Controller system information."""
 type SystemInfo {
   name: String
@@ -782,6 +917,20 @@ type TrafficRoute {
 """Paginated page of traffic-route policies."""
 type TrafficRoutePage {
   items: [TrafficRoute!]!
+  nextCursor: String
+}
+
+"""A QoS user group (V1 /rest/usergroup entry)."""
+type UserGroup {
+  id: ID
+  name: String
+  qosRateMaxDown: Int
+  qosRateMaxUp: Int
+}
+
+"""Paginated page of QoS user groups."""
+type UserGroupPage {
+  items: [UserGroup!]!
   nextCursor: String
 }
 

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -6,6 +6,22 @@
 ## Schema (SDL)
 
 ```graphql
+"""A MAC ACL rule (V2 /acl-rules entry)."""
+type AclRule {
+  id: ID
+  name: String
+  enabled: Boolean!
+  action: String
+  source: JSON
+  destination: JSON
+}
+
+"""Paginated page of ACL rules."""
+type AclRulePage {
+  items: [AclRule!]!
+  nextCursor: String
+}
+
 """An active kernel routing-table entry on a gateway."""
 type ActiveRoute {
   targetSubnet: String
@@ -71,6 +87,21 @@ type ClientPage {
   nextCursor: String
 }
 
+"""A content-filtering profile (V2 /content-filtering entry)."""
+type ContentFilter {
+  id: ID
+  name: String
+  enabled: Boolean!
+  profile: String
+  appliesTo: JSON!
+}
+
+"""Paginated page of content filters."""
+type ContentFilterPage {
+  items: [ContentFilter!]!
+  nextCursor: String
+}
+
 """A UniFi network device (AP, switch, gateway)."""
 type Device {
   mac: ID
@@ -112,6 +143,70 @@ type DnsRecord {
 type DnsRecordPage {
   items: [DnsRecord!]!
   nextCursor: String
+}
+
+"""A DPI application classification entry."""
+type DpiApplication {
+  id: Int
+  name: String
+  categoryId: Int
+}
+
+"""Paginated page of DPI applications."""
+type DpiApplicationPage {
+  items: [DpiApplication!]!
+  nextCursor: String
+}
+
+"""A DPI application category."""
+type DpiCategory {
+  id: Int
+  name: String
+}
+
+"""Paginated page of DPI categories."""
+type DpiCategoryPage {
+  items: [DpiCategory!]!
+  nextCursor: String
+}
+
+"""A firewall address/port group (V1 /rest/firewallgroup)."""
+type FirewallGroup {
+  id: ID
+  name: String
+  groupType: String
+  members: JSON!
+}
+
+"""Paginated page of firewall groups."""
+type FirewallGroupPage {
+  items: [FirewallGroup!]!
+  nextCursor: String
+}
+
+"""A firewall policy rule."""
+type FirewallRule {
+  id: ID
+  name: String
+  action: String
+  enabled: Boolean!
+  predefined: Boolean!
+  source: JSON
+  destination: JSON
+}
+
+"""Paginated page of firewall policies/rules."""
+type FirewallRulePage {
+  items: [FirewallRule!]!
+  nextCursor: String
+}
+
+"""A firewall zone (V2 /firewall/zone-matrix entry)."""
+type FirewallZone {
+  id: ID
+  name: String
+  networks: JSON!
+  defaultPolicy: String
 }
 
 """Service health snapshot — smoke field for the GraphQL endpoint."""
@@ -279,6 +374,106 @@ type NetworkQuery {
 
   """Look up a single traffic-route policy by id."""
   trafficRoute(controller: ID!, id: ID!, site: String! = "default"): TrafficRoute
+
+  """List firewall policies/rules on the given controller/site (paginated)."""
+  firewallPolicies(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): FirewallRulePage!
+
+  """Look up a single firewall policy/rule by id."""
+  firewallPolicy(controller: ID!, id: ID!, site: String! = "default"): FirewallRule
+
+  """List firewall address/port groups (paginated)."""
+  firewallGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): FirewallGroupPage!
+
+  """Look up a single firewall group by id."""
+  firewallGroup(controller: ID!, id: ID!, site: String! = "default"): FirewallGroup
+
+  """List firewall zones (typically a small flat list — no pagination)."""
+  firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
+
+  """List QoS rules on the given controller/site (paginated)."""
+  qosRules(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): QosRulePage!
+
+  """Look up a single QoS rule by id."""
+  qosRule(controller: ID!, id: ID!, site: String! = "default"): QosRule
+
+  """List DPI applications (paginated)."""
+  dpiApplications(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DpiApplicationPage!
+
+  """List DPI categories (paginated)."""
+  dpiCategories(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DpiCategoryPage!
+
+  """List content filters on the given controller/site (paginated)."""
+  contentFilters(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ContentFilterPage!
+
+  """Look up a single content filter by id."""
+  contentFilter(controller: ID!, id: ID!, site: String! = "default"): ContentFilter
+
+  """List ACL rules on the given controller/site (paginated)."""
+  aclRules(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): AclRulePage!
+
+  """Look up a single ACL rule by id."""
+  aclRule(controller: ID!, id: ID!, site: String! = "default"): AclRule
+
+  """List OON (out-of-network) policies (paginated)."""
+  oonPolicies(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): OonPolicyPage!
+
+  """Look up a single OON policy by id."""
+  oonPolicy(controller: ID!, id: ID!, site: String! = "default"): OonPolicy
+
+  """List port forwards on the given controller/site (paginated)."""
+  portForwards(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortForwardPage!
+
+  """Look up a single port forward by id."""
+  portForward(controller: ID!, id: ID!, site: String! = "default"): PortForward
+}
+
+"""An out-of-network (OON) policy entry."""
+type OonPolicy {
+  id: ID
+  name: String
+  enabled: Boolean!
+  appliesTo: JSON!
+  restrictionLevel: String
+}
+
+"""Paginated page of OON (out-of-network) policies."""
+type OonPolicyPage {
+  items: [OonPolicy!]!
+  nextCursor: String
+}
+
+"""A port-forward rule (V1 /rest/portforward entry)."""
+type PortForward {
+  id: ID
+  name: String
+  enabled: Boolean!
+  fwdProtocol: String
+  dstPort: String
+  fwdPort: String
+  src: String
+  log: Boolean!
+}
+
+"""Paginated page of port forwards."""
+type PortForwardPage {
+  items: [PortForward!]!
+  nextCursor: String
+}
+
+"""A QoS rate-limit rule (V2 /qos-rules entry)."""
+type QosRule {
+  id: ID
+  name: String
+  enabled: Boolean!
+  rateMaxDown: Int
+  rateMaxUp: Int
+  priority: Int
+}
+
+"""Paginated page of QoS rules."""
+type QosRulePage {
+  items: [QosRule!]!
+  nextCursor: String
 }
 
 type Query {

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -40,8 +40,19 @@ from unifi_api.graphql.types.network.device import (
     RogueAp,
     SpeedtestStatus,
 )
+from unifi_api.graphql.types.network.acl import AclRule
+from unifi_api.graphql.types.network.content_filter import ContentFilter
 from unifi_api.graphql.types.network.dns import DnsRecord
+from unifi_api.graphql.types.network.dpi import DpiApplication, DpiCategory
+from unifi_api.graphql.types.network.firewall import (
+    FirewallGroup,
+    FirewallRule,
+    FirewallZone,
+)
 from unifi_api.graphql.types.network.network import Network
+from unifi_api.graphql.types.network.oon import OonPolicy
+from unifi_api.graphql.types.network.port_forward import PortForward
+from unifi_api.graphql.types.network.qos import QosRule
 from unifi_api.graphql.types.network.route import (
     ActiveRoute,
     Route,
@@ -451,6 +462,221 @@ async def _fetch_traffic_routes(
     return await ctx.cache.get_or_fetch(key, _do)
 
 
+# ---- Cluster C fetch helpers (firewall / qos / dpi / cf / acl / oon / pf) -
+
+
+async def _fetch_firewall_policies(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/firewall-policies/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "firewall_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_firewall_policies(include_predefined=True))
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_firewall_groups(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/firewall-groups/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "firewall_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_firewall_groups())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_firewall_zones(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/firewall-zones/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "firewall_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_firewall_zones())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_qos_rules(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/qos-rules/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "qos_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_qos_rules())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+def _unwrap_dpi(result: Any) -> list:
+    """Extract bare list from a paginated DPI wrapper or pass through."""
+    if isinstance(result, dict) and "data" in result:
+        data = result.get("data") or []
+        return list(data) if isinstance(data, list) else []
+    if isinstance(result, list):
+        return result
+    return []
+
+
+async def _fetch_dpi_applications(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/dpi-applications/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "dpi_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            result = await mgr.get_dpi_applications(limit=2500, offset=0)
+            return _unwrap_dpi(result)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_dpi_categories(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/dpi-categories/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "dpi_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            result = await mgr.get_dpi_categories(limit=500, offset=0)
+            return _unwrap_dpi(result)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_content_filters(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/content-filters/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "content_filter_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_content_filters())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_acl_rules(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/acl-rules/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "acl_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_acl_rules())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_oon_policies(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/oon-policies/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "oon_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_oon_policies())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_port_forwards(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/port-forwards/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "firewall_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_port_forwards())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
 # ---------------------------------------------------------------------------
 # Page wrappers
 # ---------------------------------------------------------------------------
@@ -531,6 +757,60 @@ class ActiveRoutePage:
 @strawberry.type(description="Paginated page of traffic-route policies.")
 class TrafficRoutePage:
     items: list[TrafficRoute]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of firewall policies/rules.")
+class FirewallRulePage:
+    items: list[FirewallRule]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of firewall groups.")
+class FirewallGroupPage:
+    items: list[FirewallGroup]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of QoS rules.")
+class QosRulePage:
+    items: list[QosRule]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of DPI applications.")
+class DpiApplicationPage:
+    items: list[DpiApplication]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of DPI categories.")
+class DpiCategoryPage:
+    items: list[DpiCategory]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of content filters.")
+class ContentFilterPage:
+    items: list[ContentFilter]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of ACL rules.")
+class AclRulePage:
+    items: list[AclRule]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of OON (out-of-network) policies.")
+class OonPolicyPage:
+    items: list[OonPolicy]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of port forwards.")
+class PortForwardPage:
+    items: list[PortForward]
     next_cursor: str | None
 
 
@@ -1311,4 +1591,427 @@ class NetworkQuery:
                 tid = getattr(rr, "_id", None) or getattr(rr, "id", None)
             if tid == id:
                 return TrafficRoute.from_manager_output(t)
+        return None
+
+    # ---- Firewall domain -------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List firewall policies/rules on the given controller/site (paginated).",
+    )
+    async def firewall_policies(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> FirewallRulePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_firewall_policies(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return FirewallRulePage(
+            items=[FirewallRule.from_manager_output(r) for r in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single firewall policy/rule by id.",
+    )
+    async def firewall_policy(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> FirewallRule | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_firewall_policies(ctx, controller, site)
+        for r in raw:
+            rr = _raw(r)
+            if isinstance(rr, dict):
+                rid = rr.get("_id") or rr.get("id")
+            else:
+                rid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if rid == id:
+                return FirewallRule.from_manager_output(r)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List firewall address/port groups (paginated).",
+    )
+    async def firewall_groups(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> FirewallGroupPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_firewall_groups(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return FirewallGroupPage(
+            items=[FirewallGroup.from_manager_output(g) for g in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single firewall group by id.",
+    )
+    async def firewall_group(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> FirewallGroup | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_firewall_groups(ctx, controller, site)
+        for g in raw:
+            rr = _raw(g)
+            if isinstance(rr, dict):
+                gid = rr.get("_id") or rr.get("id")
+            else:
+                gid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if gid == id:
+                return FirewallGroup.from_manager_output(g)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List firewall zones (typically a small flat list — no pagination).",
+    )
+    async def firewall_zones(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> list[FirewallZone]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_firewall_zones(ctx, controller, site)
+        return [FirewallZone.from_manager_output(z) for z in raw]
+
+    # ---- QoS domain ------------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List QoS rules on the given controller/site (paginated).",
+    )
+    async def qos_rules(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> QosRulePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_qos_rules(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return QosRulePage(
+            items=[QosRule.from_manager_output(q) for q in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single QoS rule by id.",
+    )
+    async def qos_rule(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> QosRule | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_qos_rules(ctx, controller, site)
+        for q in raw:
+            rr = _raw(q)
+            if isinstance(rr, dict):
+                qid = rr.get("_id") or rr.get("id")
+            else:
+                qid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if qid == id:
+                return QosRule.from_manager_output(q)
+        return None
+
+    # ---- DPI domain ------------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List DPI applications (paginated).",
+    )
+    async def dpi_applications(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> DpiApplicationPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dpi_applications(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return DpiApplicationPage(
+            items=[DpiApplication.from_manager_output(a) for a in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List DPI categories (paginated).",
+    )
+    async def dpi_categories(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> DpiCategoryPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dpi_categories(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return DpiCategoryPage(
+            items=[DpiCategory.from_manager_output(c) for c in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    # ---- Content filter domain ------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List content filters on the given controller/site (paginated).",
+    )
+    async def content_filters(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ContentFilterPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_content_filters(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return ContentFilterPage(
+            items=[ContentFilter.from_manager_output(f) for f in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single content filter by id.",
+    )
+    async def content_filter(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> ContentFilter | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_content_filters(ctx, controller, site)
+        for f in raw:
+            rr = _raw(f)
+            if isinstance(rr, dict):
+                fid = rr.get("_id") or rr.get("id")
+            else:
+                fid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if fid == id:
+                return ContentFilter.from_manager_output(f)
+        return None
+
+    # ---- ACL domain ------------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List ACL rules on the given controller/site (paginated).",
+    )
+    async def acl_rules(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> AclRulePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_acl_rules(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return AclRulePage(
+            items=[AclRule.from_manager_output(a) for a in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single ACL rule by id.",
+    )
+    async def acl_rule(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> AclRule | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_acl_rules(ctx, controller, site)
+        for a in raw:
+            rr = _raw(a)
+            if isinstance(rr, dict):
+                aid = rr.get("_id") or rr.get("id")
+            else:
+                aid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if aid == id:
+                return AclRule.from_manager_output(a)
+        return None
+
+    # ---- OON domain ------------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List OON (out-of-network) policies (paginated).",
+    )
+    async def oon_policies(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> OonPolicyPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_oon_policies(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return OonPolicyPage(
+            items=[OonPolicy.from_manager_output(p) for p in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single OON policy by id.",
+    )
+    async def oon_policy(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> OonPolicy | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_oon_policies(ctx, controller, site)
+        for p in raw:
+            rr = _raw(p)
+            if isinstance(rr, dict):
+                pid = rr.get("_id") or rr.get("id")
+            else:
+                pid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if pid == id:
+                return OonPolicy.from_manager_output(p)
+        return None
+
+    # ---- Port forward domain --------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List port forwards on the given controller/site (paginated).",
+    )
+    async def port_forwards(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> PortForwardPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_port_forwards(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return PortForwardPage(
+            items=[PortForward.from_manager_output(p) for p in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single port forward by id.",
+    )
+    async def port_forward(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> PortForward | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_port_forwards(ctx, controller, site)
+        for p in raw:
+            rr = _raw(p)
+            if isinstance(rr, dict):
+                pid = rr.get("_id") or rr.get("id")
+            else:
+                pid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if pid == id:
+                return PortForward.from_manager_output(p)
         return None

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -1,12 +1,19 @@
 """NetworkQuery — read-only GraphQL resolvers for the UniFi Network product.
 
-Phase 6 PR2 Task 25a — foundation only:
-- Three fetch helpers (clients, devices, networks) routed through the
-  request-scoped ``RequestCache`` so multi-resolver queries dedupe.
-- Three Page wrappers (`ClientPage`, `DevicePage`, `NetworkPage`).
-- ``NetworkQuery`` with the three resolvers (``clients``/``devices``/
-  ``networks``). Subsequent dispatches add the remaining ~27 resolvers
-  and relationship edges; this file establishes the canonical pattern.
+Phase 6 PR2.5 Cluster A — adds DETAIL counterparts and remaining LIST
+resolvers for the client / device / network type domains. Builds on the
+foundation laid by Task 25a (PR2):
+
+- Fetch helpers route through the request-scoped ``RequestCache`` so
+  multi-resolver queries dedupe.
+- Page wrappers carry pagination cursors per LIST resolver.
+- DETAIL resolvers reuse the cached LIST snapshots where the manager
+  exposes a snapshot method; per-id manager calls (``get_device_radio``,
+  ``get_lldp_neighbors``, ``get_speedtest_status``) get their own keyed
+  cache entries so distinct macs don't collide.
+
+Cluster B+ (vpn/dns/routes/firewall/etc.) and relationship edges land in
+follow-up dispatches.
 """
 
 from __future__ import annotations
@@ -18,9 +25,23 @@ from strawberry.types import Info
 
 from unifi_api.graphql.context import GraphQLContext
 from unifi_api.graphql.permissions import IsRead
-from unifi_api.graphql.types.network.client import Client
-from unifi_api.graphql.types.network.device import Device
+from unifi_api.graphql.types.network.client import (
+    BlockedClient,
+    Client,
+    ClientLookup,
+)
+from unifi_api.graphql.types.network.device import (
+    AvailableChannel,
+    Device,
+    DeviceRadio,
+    KnownRogueAp,
+    LldpNeighbors,
+    RfScanResult,
+    RogueAp,
+    SpeedtestStatus,
+)
 from unifi_api.graphql.types.network.network import Network
+from unifi_api.graphql.types.network.system import NetworkHealth
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +104,206 @@ async def _fetch_networks(ctx: GraphQLContext, controller: str, site: str) -> li
     return await ctx.cache.get_or_fetch(key, _do)
 
 
+async def _fetch_blocked_clients(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/blocked-clients/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "client_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_blocked_clients())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_client_by_ip(
+    ctx: GraphQLContext, controller: str, site: str, ip: str,
+) -> Any:
+    key = f"network/client-by-ip/{controller}/{site}/{ip}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "client_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_client_by_ip(ip)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_device_radio(
+    ctx: GraphQLContext, controller: str, site: str, mac: str,
+) -> Any:
+    key = f"network/device-radio/{controller}/{site}/{mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_device_radio(mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_lldp_neighbors(
+    ctx: GraphQLContext, controller: str, site: str, device_mac: str,
+) -> Any:
+    key = f"network/lldp-neighbors/{controller}/{site}/{device_mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "switch_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_lldp_neighbors(device_mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_rogue_aps(
+    ctx: GraphQLContext, controller: str, site: str, within_hours: int = 24,
+) -> list:
+    key = f"network/rogue-aps/{controller}/{site}/{within_hours}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.list_rogue_aps(within_hours))
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_known_rogue_aps(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/known-rogue-aps/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.list_known_rogue_aps())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_rf_scan_results(
+    ctx: GraphQLContext, controller: str, site: str, ap_mac: str,
+) -> list:
+    key = f"network/rf-scan-results/{controller}/{site}/{ap_mac}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_rf_scan_results(ap_mac) or [])
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_available_channels(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/available-channels/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.list_available_channels() or [])
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_speedtest_status(
+    ctx: GraphQLContext, controller: str, site: str, gateway_mac: str,
+) -> Any:
+    key = f"network/speedtest-status/{controller}/{site}/{gateway_mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_speedtest_status(gateway_mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_network_health(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/network-health/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "system_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_network_health() or [])
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
 # ---------------------------------------------------------------------------
 # Page wrappers
 # ---------------------------------------------------------------------------
@@ -103,6 +324,24 @@ class DevicePage:
 @strawberry.type(description="Paginated page of network configurations.")
 class NetworkPage:
     items: list[Network]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of blocked clients.")
+class BlockedClientPage:
+    items: list[BlockedClient]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of detected rogue APs.")
+class RogueApPage:
+    items: list[RogueAp]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of known (allowlisted) rogue APs.")
+class KnownRogueApPage:
+    items: list[KnownRogueAp]
     next_cursor: str | None
 
 
@@ -156,13 +395,49 @@ def _network_key(n: Any) -> tuple:
     return (0, f"{name or ''}|{nid or ''}")
 
 
+def _blocked_key(c: Any) -> tuple:
+    raw = _raw(c)
+    if isinstance(raw, dict):
+        ts = raw.get("last_seen")
+        mac = raw.get("mac")
+    else:
+        ts = getattr(raw, "last_seen", None)
+        mac = getattr(raw, "mac", None)
+    return (int(ts or 0), str(mac or ""))
+
+
+def _bssid_key(row: Any) -> tuple:
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        ts = raw.get("last_seen")
+        bssid = raw.get("bssid")
+    else:
+        ts = getattr(raw, "last_seen", None)
+        bssid = getattr(raw, "bssid", None)
+    return (int(ts or 0), str(bssid or ""))
+
+
 # ---------------------------------------------------------------------------
 # NetworkQuery
 # ---------------------------------------------------------------------------
 
 
+def _decode_cursor(cursor: str | None):
+    """Translate an opaque cursor string to a Cursor (or raise ValueError)."""
+    from unifi_api.services.pagination import Cursor, InvalidCursor
+
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise ValueError("invalid cursor")
+
+
 @strawberry.type(description="Read-only access to UniFi Network resources.")
 class NetworkQuery:
+    # ---- Client domain ---------------------------------------------------
+
     @strawberry.field(
         permission_classes=[IsRead],
         description="List clients on the given controller/site (paginated).",
@@ -178,15 +453,9 @@ class NetworkQuery:
         ctx: GraphQLContext = info.context
         raw = await _fetch_clients(ctx, controller, site)
 
-        from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+        from unifi_api.services.pagination import paginate
 
-        cursor_obj = None
-        if cursor:
-            try:
-                cursor_obj = Cursor.decode(cursor)
-            except InvalidCursor:
-                raise ValueError("invalid cursor")
-
+        cursor_obj = _decode_cursor(cursor)
         page, next_cursor = paginate(
             list(raw), limit=limit, cursor=cursor_obj, key_fn=_client_key,
         )
@@ -194,6 +463,71 @@ class NetworkQuery:
             items=[Client.from_manager_output(c) for c in page],
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single client by MAC address.",
+    )
+    async def client(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+    ) -> Client | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_clients(ctx, controller, site)
+        for c in raw:
+            r = _raw(c)
+            c_mac = r.get("mac") if isinstance(r, dict) else getattr(r, "mac", None)
+            if c_mac == mac:
+                return Client.from_manager_output(c)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List clients currently blocked from the network (paginated).",
+    )
+    async def blocked_clients(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> BlockedClientPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_blocked_clients(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_blocked_key,
+        )
+        return BlockedClientPage(
+            items=[BlockedClient.from_manager_output(c) for c in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a client by IP address (online-presence check).",
+    )
+    async def client_by_ip(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        ip: str,
+        site: str = "default",
+    ) -> ClientLookup | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_by_ip(ctx, controller, site, ip)
+        if raw is None:
+            return None
+        return ClientLookup.from_manager_output(raw)
+
+    # ---- Device domain ---------------------------------------------------
 
     @strawberry.field(
         permission_classes=[IsRead],
@@ -210,15 +544,9 @@ class NetworkQuery:
         ctx: GraphQLContext = info.context
         raw = await _fetch_devices(ctx, controller, site)
 
-        from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+        from unifi_api.services.pagination import paginate
 
-        cursor_obj = None
-        if cursor:
-            try:
-                cursor_obj = Cursor.decode(cursor)
-            except InvalidCursor:
-                raise ValueError("invalid cursor")
-
+        cursor_obj = _decode_cursor(cursor)
         page, next_cursor = paginate(
             list(raw), limit=limit, cursor=cursor_obj, key_fn=_device_key,
         )
@@ -226,6 +554,161 @@ class NetworkQuery:
             items=[Device.from_manager_output(d) for d in page],
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single device by MAC address.",
+    )
+    async def device(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+    ) -> Device | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_devices(ctx, controller, site)
+        for d in raw:
+            r = _raw(d)
+            d_mac = r.get("mac") if isinstance(r, dict) else getattr(r, "mac", None)
+            if d_mac == mac:
+                return Device.from_manager_output(d)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get the radio configuration for a UniFi access point.",
+    )
+    async def device_radio(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+    ) -> DeviceRadio | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_device_radio(ctx, controller, site, mac)
+        if raw is None:
+            return None
+        return DeviceRadio.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get LLDP neighbors reported by a switch.",
+    )
+    async def lldp_neighbors(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        device_mac: strawberry.ID,
+        site: str = "default",
+    ) -> LldpNeighbors | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_lldp_neighbors(ctx, controller, site, device_mac)
+        if raw is None:
+            return None
+        return LldpNeighbors.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List rogue (unknown) APs detected within a window (paginated).",
+    )
+    async def rogue_aps(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        within_hours: int = 24,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> RogueApPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_rogue_aps(ctx, controller, site, within_hours)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_bssid_key,
+        )
+        return RogueApPage(
+            items=[RogueAp.from_manager_output(r) for r in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List known (allowlisted) rogue APs (paginated).",
+    )
+    async def known_rogue_aps(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> KnownRogueApPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_known_rogue_aps(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_bssid_key,
+        )
+        return KnownRogueApPage(
+            items=[KnownRogueAp.from_manager_output(r) for r in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List RF-scan results for a specific access point.",
+    )
+    async def rf_scan_results(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        ap_mac: strawberry.ID,
+        site: str = "default",
+    ) -> list[RfScanResult]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_rf_scan_results(ctx, controller, site, ap_mac)
+        return [RfScanResult.from_manager_output(r) for r in raw]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List wireless channels allowed by the regulatory domain.",
+    )
+    async def available_channels(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> list[AvailableChannel]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_available_channels(ctx, controller, site)
+        return [AvailableChannel.from_manager_output(r) for r in raw]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get the gateway speedtest status (idle/running + last results).",
+    )
+    async def speedtest_status(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        gateway_mac: strawberry.ID,
+        site: str = "default",
+    ) -> SpeedtestStatus | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_speedtest_status(ctx, controller, site, gateway_mac)
+        if raw is None:
+            return None
+        return SpeedtestStatus.from_manager_output(raw)
+
+    # ---- Network domain --------------------------------------------------
 
     @strawberry.field(
         permission_classes=[IsRead],
@@ -242,15 +725,9 @@ class NetworkQuery:
         ctx: GraphQLContext = info.context
         raw = await _fetch_networks(ctx, controller, site)
 
-        from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+        from unifi_api.services.pagination import paginate
 
-        cursor_obj = None
-        if cursor:
-            try:
-                cursor_obj = Cursor.decode(cursor)
-            except InvalidCursor:
-                raise ValueError("invalid cursor")
-
+        cursor_obj = _decode_cursor(cursor)
         page, next_cursor = paginate(
             list(raw), limit=limit, cursor=cursor_obj, key_fn=_network_key,
         )
@@ -258,3 +735,41 @@ class NetworkQuery:
             items=[Network.from_manager_output(n) for n in page],
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single LAN/VLAN network by id. (Named "
+        "``networkDetail`` because ``network`` is reserved for the namespace.)",
+    )
+    async def network_detail(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> Network | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_networks(ctx, controller, site)
+        for n in raw:
+            r = _raw(n)
+            if isinstance(r, dict):
+                nid = r.get("_id") or r.get("id")
+            else:
+                nid = getattr(r, "_id", None) or getattr(r, "id", None)
+            if nid == id:
+                return Network.from_manager_output(n)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get the controller's network-health subsystems list.",
+    )
+    async def network_health(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> list[NetworkHealth]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_network_health(ctx, controller, site)
+        return [NetworkHealth.from_manager_output(r) for r in raw]

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -40,8 +40,16 @@ from unifi_api.graphql.types.network.device import (
     RogueAp,
     SpeedtestStatus,
 )
+from unifi_api.graphql.types.network.dns import DnsRecord
 from unifi_api.graphql.types.network.network import Network
+from unifi_api.graphql.types.network.route import (
+    ActiveRoute,
+    Route,
+    TrafficRoute,
+)
 from unifi_api.graphql.types.network.system import NetworkHealth
+from unifi_api.graphql.types.network.vpn import VpnClient, VpnServer
+from unifi_api.graphql.types.network.wlan import Wlan
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +312,145 @@ async def _fetch_network_health(
     return await ctx.cache.get_or_fetch(key, _do)
 
 
+# ---- Cluster B fetch helpers (wlan / vpn / dns / routes) -----------------
+
+
+async def _fetch_wlans(ctx: GraphQLContext, controller: str, site: str) -> list:
+    key = f"network/wlans/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "network_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_wlans())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_vpn_clients(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/vpn-clients/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "vpn_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_vpn_clients())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_vpn_servers(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/vpn-servers/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "vpn_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_vpn_servers())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_dns_records(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/dns-records/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "dns_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.list_dns_records())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_routes(ctx: GraphQLContext, controller: str, site: str) -> list:
+    key = f"network/routes/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "routing_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_routes())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_active_routes(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/active-routes/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "routing_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_active_routes())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_traffic_routes(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/traffic-routes/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "traffic_route_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_traffic_routes())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
 # ---------------------------------------------------------------------------
 # Page wrappers
 # ---------------------------------------------------------------------------
@@ -342,6 +489,48 @@ class RogueApPage:
 @strawberry.type(description="Paginated page of known (allowlisted) rogue APs.")
 class KnownRogueApPage:
     items: list[KnownRogueAp]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of WLAN/SSID configurations.")
+class WlanPage:
+    items: list[Wlan]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of VPN clients.")
+class VpnClientPage:
+    items: list[VpnClient]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of VPN servers.")
+class VpnServerPage:
+    items: list[VpnServer]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of DNS records.")
+class DnsRecordPage:
+    items: list[DnsRecord]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of static routes.")
+class RoutePage:
+    items: list[Route]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of active kernel routes.")
+class ActiveRoutePage:
+    items: list[ActiveRoute]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of traffic-route policies.")
+class TrafficRoutePage:
+    items: list[TrafficRoute]
     next_cursor: str | None
 
 
@@ -404,6 +593,28 @@ def _blocked_key(c: Any) -> tuple:
         ts = getattr(raw, "last_seen", None)
         mac = getattr(raw, "mac", None)
     return (int(ts or 0), str(mac or ""))
+
+
+def _id_key(obj: Any) -> tuple:
+    raw = _raw(obj)
+    if isinstance(raw, dict):
+        oid = raw.get("_id") or raw.get("id")
+    else:
+        oid = getattr(raw, "_id", None) or getattr(raw, "id", None)
+    return (0, str(oid or ""))
+
+
+def _active_route_key(row: Any) -> tuple:
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        pfx = raw.get("pfx") or raw.get("target_subnet") or raw.get("network")
+    else:
+        pfx = (
+            getattr(raw, "pfx", None)
+            or getattr(raw, "target_subnet", None)
+            or getattr(raw, "network", None)
+        )
+    return (0, str(pfx or ""))
 
 
 def _bssid_key(row: Any) -> tuple:
@@ -773,3 +984,331 @@ class NetworkQuery:
         ctx: GraphQLContext = info.context
         raw = await _fetch_network_health(ctx, controller, site)
         return [NetworkHealth.from_manager_output(r) for r in raw]
+
+    # ---- WLAN domain -----------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List WLAN/SSID configurations on the given controller/site (paginated).",
+    )
+    async def wlans(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> WlanPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_wlans(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return WlanPage(
+            items=[Wlan.from_manager_output(w) for w in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single WLAN/SSID by id.",
+    )
+    async def wlan(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> Wlan | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_wlans(ctx, controller, site)
+        for w in raw:
+            r = _raw(w)
+            if isinstance(r, dict):
+                wid = r.get("_id") or r.get("id")
+            else:
+                wid = getattr(r, "_id", None) or getattr(r, "id", None)
+            if wid == id:
+                return Wlan.from_manager_output(w)
+        return None
+
+    # ---- VPN domain ------------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List configured VPN clients (outbound tunnels) (paginated).",
+    )
+    async def vpn_clients(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> VpnClientPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_vpn_clients(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return VpnClientPage(
+            items=[VpnClient.from_manager_output(v) for v in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single VPN client by id.",
+    )
+    async def vpn_client(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> VpnClient | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_vpn_clients(ctx, controller, site)
+        for v in raw:
+            r = _raw(v)
+            if isinstance(r, dict):
+                vid = r.get("_id") or r.get("id")
+            else:
+                vid = getattr(r, "_id", None) or getattr(r, "id", None)
+            if vid == id:
+                return VpnClient.from_manager_output(v)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List configured VPN servers (inbound tunnels) (paginated).",
+    )
+    async def vpn_servers(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> VpnServerPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_vpn_servers(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return VpnServerPage(
+            items=[VpnServer.from_manager_output(v) for v in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single VPN server by id.",
+    )
+    async def vpn_server(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> VpnServer | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_vpn_servers(ctx, controller, site)
+        for v in raw:
+            r = _raw(v)
+            if isinstance(r, dict):
+                vid = r.get("_id") or r.get("id")
+            else:
+                vid = getattr(r, "_id", None) or getattr(r, "id", None)
+            if vid == id:
+                return VpnServer.from_manager_output(v)
+        return None
+
+    # ---- DNS domain ------------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List static DNS records on the given controller/site (paginated).",
+    )
+    async def dns_records(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> DnsRecordPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dns_records(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return DnsRecordPage(
+            items=[DnsRecord.from_manager_output(d) for d in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single DNS record by id.",
+    )
+    async def dns_record(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> DnsRecord | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dns_records(ctx, controller, site)
+        for d in raw:
+            r = _raw(d)
+            if isinstance(r, dict):
+                did = r.get("_id") or r.get("id")
+            else:
+                did = getattr(r, "_id", None) or getattr(r, "id", None)
+            if did == id:
+                return DnsRecord.from_manager_output(d)
+        return None
+
+    # ---- Routes domain ---------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List configured static routes (paginated).",
+    )
+    async def routes(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> RoutePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_routes(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return RoutePage(
+            items=[Route.from_manager_output(r) for r in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single static route by id.",
+    )
+    async def route(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> Route | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_routes(ctx, controller, site)
+        for r in raw:
+            rr = _raw(r)
+            if isinstance(rr, dict):
+                rid = rr.get("_id") or rr.get("id")
+            else:
+                rid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if rid == id:
+                return Route.from_manager_output(r)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List the gateway's active kernel routing-table entries (paginated).",
+    )
+    async def active_routes(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ActiveRoutePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_active_routes(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_active_route_key,
+        )
+        return ActiveRoutePage(
+            items=[ActiveRoute.from_manager_output(r) for r in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List traffic-route policies (V2 /trafficroutes) (paginated).",
+    )
+    async def traffic_routes(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> TrafficRoutePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_traffic_routes(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return TrafficRoutePage(
+            items=[TrafficRoute.from_manager_output(t) for t in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single traffic-route policy by id.",
+    )
+    async def traffic_route(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> TrafficRoute | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_traffic_routes(ctx, controller, site)
+        for t in raw:
+            rr = _raw(t)
+            if isinstance(rr, dict):
+                tid = rr.get("_id") or rr.get("id")
+            else:
+                tid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if tid == id:
+                return TrafficRoute.from_manager_output(t)
+        return None

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -41,6 +41,8 @@ from unifi_api.graphql.types.network.device import (
     SpeedtestStatus,
 )
 from unifi_api.graphql.types.network.acl import AclRule
+from unifi_api.graphql.types.network.ap_group import ApGroup
+from unifi_api.graphql.types.network.client_group import ClientGroup, UserGroup
 from unifi_api.graphql.types.network.content_filter import ContentFilter
 from unifi_api.graphql.types.network.dns import DnsRecord
 from unifi_api.graphql.types.network.dpi import DpiApplication, DpiCategory
@@ -64,6 +66,12 @@ from unifi_api.graphql.types.network.session import (
     ClientWifiDetails,
 )
 from unifi_api.graphql.types.network.stat import DpiStats, StatPoint
+from unifi_api.graphql.types.network.switch import (
+    PortProfile,
+    PortStats,
+    SwitchCapabilities,
+    SwitchPorts,
+)
 from unifi_api.graphql.types.network.system import (
     Alarm,
     AutoBackupSettings,
@@ -1040,6 +1048,149 @@ async def _fetch_voucher_details(
     )
 
 
+# ---- Switch / AP groups / Client groups domain (Cluster E) -----------------
+
+
+async def _fetch_port_profiles(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/port-profiles/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "switch_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_port_profiles())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_switch_ports(
+    ctx: GraphQLContext, controller: str, site: str, device_mac: str,
+) -> Any:
+    key = f"network/switch-ports/{controller}/{site}/{device_mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "switch_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_switch_ports(device_mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_port_stats(
+    ctx: GraphQLContext, controller: str, site: str, device_mac: str,
+) -> Any:
+    key = f"network/port-stats/{controller}/{site}/{device_mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "switch_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_port_stats(device_mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_switch_capabilities(
+    ctx: GraphQLContext, controller: str, site: str, device_mac: str,
+) -> Any:
+    key = f"network/switch-capabilities/{controller}/{site}/{device_mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "switch_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_switch_capabilities(device_mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_ap_groups(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/ap-groups/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "network_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.list_ap_groups())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_client_groups(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/client-groups/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "client_group_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_client_groups())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_user_groups(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/user-groups/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "usergroup_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_usergroups())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
 # ---------------------------------------------------------------------------
 # Page wrappers
 # ---------------------------------------------------------------------------
@@ -1210,6 +1361,30 @@ class VoucherPage:
 @strawberry.type(description="Paginated page of client association sessions.")
 class ClientSessionPage:
     items: list[ClientSession]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of switch port profiles.")
+class PortProfilePage:
+    items: list[PortProfile]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of AP groups.")
+class ApGroupPage:
+    items: list[ApGroup]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of network member client groups.")
+class ClientGroupPage:
+    items: list[ClientGroup]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of QoS user groups.")
+class UserGroupPage:
+    items: list[UserGroup]
     next_cursor: str | None
 
 
@@ -2997,3 +3172,268 @@ class NetworkQuery:
         if raw is None:
             return None
         return ClientWifiDetails.from_manager_output(raw)
+
+    # ---- Switch domain ---------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List switch port profiles on the given controller/site (paginated).",
+    )
+    async def port_profiles(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> PortProfilePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_port_profiles(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return PortProfilePage(
+            items=[PortProfile.from_manager_output(p) for p in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single switch port profile by id.",
+    )
+    async def port_profile(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> PortProfile | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_port_profiles(ctx, controller, site)
+        for p in raw:
+            rr = _raw(p)
+            if isinstance(rr, dict):
+                pid = rr.get("_id") or rr.get("id")
+            else:
+                pid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if pid == id:
+                return PortProfile.from_manager_output(p)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "Get the port-override wrapper for a switch "
+            "(name/model + per-port overrides)."
+        ),
+    )
+    async def switch_ports(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        device_mac: strawberry.ID,
+        site: str = "default",
+    ) -> SwitchPorts | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_switch_ports(ctx, controller, site, device_mac)
+        if raw is None:
+            return None
+        return SwitchPorts.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "Get the per-port stats wrapper for a switch "
+            "(name/model + port_table)."
+        ),
+    )
+    async def port_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        device_mac: strawberry.ID,
+        site: str = "default",
+    ) -> PortStats | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_port_stats(ctx, controller, site, device_mac)
+        if raw is None:
+            return None
+        return PortStats.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get switch capabilities (caps dict + STP / dot1x flags).",
+    )
+    async def switch_capabilities(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        device_mac: strawberry.ID,
+        site: str = "default",
+    ) -> SwitchCapabilities | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_switch_capabilities(ctx, controller, site, device_mac)
+        if raw is None:
+            return None
+        return SwitchCapabilities.from_manager_output(raw)
+
+    # ---- AP groups domain ------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List AP groups on the given controller/site (paginated).",
+    )
+    async def ap_groups(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ApGroupPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_ap_groups(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return ApGroupPage(
+            items=[ApGroup.from_manager_output(g) for g in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single AP group by id.",
+    )
+    async def ap_group(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> ApGroup | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_ap_groups(ctx, controller, site)
+        for g in raw:
+            rr = _raw(g)
+            if isinstance(rr, dict):
+                gid = rr.get("_id") or rr.get("id")
+            else:
+                gid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if gid == id:
+                return ApGroup.from_manager_output(g)
+        return None
+
+    # ---- Client groups domain --------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "List network member client groups on the given controller/site "
+            "(paginated)."
+        ),
+    )
+    async def client_groups(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ClientGroupPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_groups(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return ClientGroupPage(
+            items=[ClientGroup.from_manager_output(g) for g in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single network member client group by id.",
+    )
+    async def client_group(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> ClientGroup | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_groups(ctx, controller, site)
+        for g in raw:
+            rr = _raw(g)
+            if isinstance(rr, dict):
+                gid = rr.get("_id") or rr.get("id")
+            else:
+                gid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if gid == id:
+                return ClientGroup.from_manager_output(g)
+        return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "List QoS user groups (V1 /rest/usergroup) on the given "
+            "controller/site (paginated)."
+        ),
+    )
+    async def user_groups(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> UserGroupPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_user_groups(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_id_key,
+        )
+        return UserGroupPage(
+            items=[UserGroup.from_manager_output(g) for g in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single QoS user group by id.",
+    )
+    async def user_group(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> UserGroup | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_user_groups(ctx, controller, site)
+        for g in raw:
+            rr = _raw(g)
+            if isinstance(rr, dict):
+                gid = rr.get("_id") or rr.get("id")
+            else:
+                gid = getattr(rr, "_id", None) or getattr(rr, "id", None)
+            if gid == id:
+                return UserGroup.from_manager_output(g)
+        return None

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -58,7 +58,25 @@ from unifi_api.graphql.types.network.route import (
     Route,
     TrafficRoute,
 )
-from unifi_api.graphql.types.network.system import NetworkHealth
+from unifi_api.graphql.types.network.event import EventLog
+from unifi_api.graphql.types.network.session import (
+    ClientSession,
+    ClientWifiDetails,
+)
+from unifi_api.graphql.types.network.stat import DpiStats, StatPoint
+from unifi_api.graphql.types.network.system import (
+    Alarm,
+    AutoBackupSettings,
+    Backup,
+    EventTypes,
+    NetworkHealth,
+    SiteSettings,
+    SnmpSettings,
+    SpeedtestResult,
+    SystemInfo,
+    TopClient,
+)
+from unifi_api.graphql.types.network.voucher import Voucher
 from unifi_api.graphql.types.network.vpn import VpnClient, VpnServer
 from unifi_api.graphql.types.network.wlan import Wlan
 
@@ -677,6 +695,351 @@ async def _fetch_port_forwards(
     return await ctx.cache.get_or_fetch(key, _do)
 
 
+# ---- Cluster D fetch helpers (stats / events / system / vouchers / sessions) ---
+
+
+async def _stats_mgr_fetch(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    cache_key: str,
+    method: str,
+    *args: Any,
+):
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "stats_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await getattr(mgr, method)(*args)
+
+    return await ctx.cache.get_or_fetch(cache_key, _do)
+
+
+async def _fetch_dashboard_stats(
+    ctx: GraphQLContext, controller: str, site: str, duration_hours: int,
+) -> list:
+    key = f"network/dashboard-stats/{controller}/{site}/{duration_hours}"
+    return await _stats_mgr_fetch(ctx, controller, site, key, "get_dashboard")
+
+
+async def _fetch_network_stats(
+    ctx: GraphQLContext, controller: str, site: str, duration_hours: int,
+) -> list:
+    key = f"network/network-stats/{controller}/{site}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_network_stats", duration_hours,
+    )
+
+
+async def _fetch_gateway_stats(
+    ctx: GraphQLContext, controller: str, site: str, duration_hours: int,
+) -> list:
+    key = f"network/gateway-stats/{controller}/{site}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_gateway_stats", duration_hours,
+    )
+
+
+async def _fetch_client_stats(
+    ctx: GraphQLContext, controller: str, site: str, mac: str, duration_hours: int,
+) -> list:
+    key = f"network/client-stats/{controller}/{site}/{mac}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_client_stats", mac, duration_hours,
+    )
+
+
+async def _fetch_device_stats(
+    ctx: GraphQLContext, controller: str, site: str, mac: str, duration_hours: int,
+) -> list:
+    key = f"network/device-stats/{controller}/{site}/{mac}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_device_stats", mac, duration_hours,
+    )
+
+
+async def _fetch_client_dpi_traffic(
+    ctx: GraphQLContext, controller: str, site: str, mac: str,
+) -> list:
+    key = f"network/client-dpi-traffic/{controller}/{site}/{mac}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_client_dpi_traffic", mac,
+    )
+
+
+async def _fetch_site_dpi_traffic(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/site-dpi-traffic/{controller}/{site}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_site_dpi_traffic",
+    )
+
+
+async def _fetch_dpi_stats(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> Any:
+    key = f"network/dpi-stats/{controller}/{site}"
+    return await _stats_mgr_fetch(ctx, controller, site, key, "get_dpi_stats")
+
+
+async def _fetch_alerts(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/alerts/{controller}/{site}"
+    return await _stats_mgr_fetch(ctx, controller, site, key, "get_alerts")
+
+
+async def _fetch_anomalies(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/anomalies/{controller}/{site}"
+    return await _stats_mgr_fetch(ctx, controller, site, key, "get_anomalies")
+
+
+async def _fetch_ips_events(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/ips-events/{controller}/{site}"
+    return await _stats_mgr_fetch(ctx, controller, site, key, "get_ips_events")
+
+
+async def _fetch_top_clients(
+    ctx: GraphQLContext, controller: str, site: str, duration_hours: int,
+) -> list:
+    key = f"network/top-clients/{controller}/{site}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_top_clients", duration_hours,
+    )
+
+
+async def _fetch_speedtest_results(
+    ctx: GraphQLContext, controller: str, site: str, duration_hours: int,
+) -> list:
+    key = f"network/speedtest-results/{controller}/{site}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_speedtest_results", duration_hours,
+    )
+
+
+async def _fetch_client_sessions(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    mac: str | None,
+    duration_hours: int,
+) -> list:
+    mac_part = mac or "all"
+    key = f"network/client-sessions/{controller}/{site}/{mac_part}/{duration_hours}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_client_sessions", mac, duration_hours,
+    )
+
+
+async def _fetch_client_wifi_details(
+    ctx: GraphQLContext, controller: str, site: str, mac: str,
+) -> Any:
+    key = f"network/client-wifi-details/{controller}/{site}/{mac}"
+    return await _stats_mgr_fetch(
+        ctx, controller, site, key, "get_client_wifi_details", mac,
+    )
+
+
+async def _event_mgr_fetch(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    cache_key: str,
+    method: str,
+    *args: Any,
+):
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "event_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await getattr(mgr, method)(*args)
+
+    return await ctx.cache.get_or_fetch(cache_key, _do)
+
+
+async def _fetch_event_log(
+    ctx: GraphQLContext, controller: str, site: str, fetch_limit: int,
+) -> list:
+    key = f"network/event-log/{controller}/{site}/{fetch_limit}"
+
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "event_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_events(limit=fetch_limit))
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_alarms(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/alarms/{controller}/{site}"
+    return await _event_mgr_fetch(ctx, controller, site, key, "get_alarms")
+
+
+async def _fetch_event_types(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> Any:
+    key = f"network/event-types/{controller}/{site}"
+
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "event_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            import inspect as _inspect
+
+            result = mgr.get_event_type_prefixes()
+            if _inspect.isawaitable(result):
+                result = await result
+            return result
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _system_mgr_fetch(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    cache_key: str,
+    method: str,
+    *args: Any,
+):
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "system_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await getattr(mgr, method)(*args)
+
+    return await ctx.cache.get_or_fetch(cache_key, _do)
+
+
+async def _fetch_system_info(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> Any:
+    key = f"network/system-info/{controller}/{site}"
+    return await _system_mgr_fetch(ctx, controller, site, key, "get_system_info")
+
+
+async def _fetch_site_settings(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> Any:
+    key = f"network/site-settings/{controller}/{site}"
+    return await _system_mgr_fetch(ctx, controller, site, key, "get_site_settings")
+
+
+async def _fetch_snmp_settings(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> Any:
+    key = f"network/snmp-settings/{controller}/{site}"
+    return await _system_mgr_fetch(
+        ctx, controller, site, key, "get_settings", "snmp",
+    )
+
+
+async def _fetch_autobackup_settings(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> Any:
+    key = f"network/autobackup-settings/{controller}/{site}"
+    return await _system_mgr_fetch(
+        ctx, controller, site, key, "get_autobackup_settings",
+    )
+
+
+async def _fetch_backups(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/backups/{controller}/{site}"
+    return await _system_mgr_fetch(ctx, controller, site, key, "list_backups")
+
+
+async def _hotspot_mgr_fetch(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    cache_key: str,
+    method: str,
+    *args: Any,
+):
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "hotspot_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await getattr(mgr, method)(*args)
+
+    return await ctx.cache.get_or_fetch(cache_key, _do)
+
+
+async def _fetch_vouchers(
+    ctx: GraphQLContext, controller: str, site: str,
+) -> list:
+    key = f"network/vouchers/{controller}/{site}"
+
+    async def _do():
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "hotspot_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_vouchers())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_voucher_details(
+    ctx: GraphQLContext, controller: str, site: str, voucher_id: str,
+) -> Any:
+    key = f"network/voucher-details/{controller}/{site}/{voucher_id}"
+    return await _hotspot_mgr_fetch(
+        ctx, controller, site, key, "get_voucher_details", voucher_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Page wrappers
 # ---------------------------------------------------------------------------
@@ -814,6 +1177,42 @@ class PortForwardPage:
     next_cursor: str | None
 
 
+@strawberry.type(description="Paginated page of event-log entries.")
+class EventLogPage:
+    items: list[EventLog]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of controller alarms.")
+class AlarmPage:
+    items: list[Alarm]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of controller backup descriptors.")
+class BackupPage:
+    items: list[Backup]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of speedtest result entries.")
+class SpeedtestResultPage:
+    items: list[SpeedtestResult]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of hotspot vouchers.")
+class VoucherPage:
+    items: list[Voucher]
+    next_cursor: str | None
+
+
+@strawberry.type(description="Paginated page of client association sessions.")
+class ClientSessionPage:
+    items: list[ClientSession]
+    next_cursor: str | None
+
+
 # ---------------------------------------------------------------------------
 # Key extractors — operate on raw manager outputs (objects or dicts).
 # Each returns (timestamp_or_zero, secondary_id) for stable descending sort.
@@ -906,6 +1305,89 @@ def _bssid_key(row: Any) -> tuple:
         ts = getattr(raw, "last_seen", None)
         bssid = getattr(raw, "bssid", None)
     return (int(ts or 0), str(bssid or ""))
+
+
+def _event_key(row: Any) -> tuple:
+    """Sort key for event/alarm rows: time desc, id tiebreaker."""
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        ts = raw.get("time") or raw.get("timestamp")
+        rid = raw.get("_id") or raw.get("id") or raw.get("key") or ""
+    else:
+        ts = getattr(raw, "time", None) or getattr(raw, "timestamp", None)
+        rid = (
+            getattr(raw, "_id", None)
+            or getattr(raw, "id", None)
+            or getattr(raw, "key", None)
+            or ""
+        )
+    return (int(ts or 0), str(rid))
+
+
+def _backup_key(row: Any) -> tuple:
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        ts = raw.get("time") or raw.get("datetime") or raw.get("timestamp")
+        name = raw.get("filename") or raw.get("name") or raw.get("_id") or ""
+    else:
+        ts = (
+            getattr(raw, "time", None)
+            or getattr(raw, "datetime", None)
+            or getattr(raw, "timestamp", None)
+        )
+        name = (
+            getattr(raw, "filename", None)
+            or getattr(raw, "name", None)
+            or getattr(raw, "_id", None)
+            or ""
+        )
+    return (int(ts or 0), str(name))
+
+
+def _voucher_key(row: Any) -> tuple:
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        ts = raw.get("create_time") or raw.get("created_at")
+        vid = raw.get("_id") or raw.get("id") or raw.get("code") or ""
+    else:
+        ts = getattr(raw, "create_time", None) or getattr(raw, "created_at", None)
+        vid = (
+            getattr(raw, "_id", None)
+            or getattr(raw, "id", None)
+            or getattr(raw, "code", None)
+            or ""
+        )
+    return (int(ts or 0), str(vid))
+
+
+def _session_key(row: Any) -> tuple:
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        ts = raw.get("assoc_time") or raw.get("connected_at") or raw.get("first_seen")
+        mac = raw.get("mac") or ""
+    else:
+        ts = (
+            getattr(raw, "assoc_time", None)
+            or getattr(raw, "connected_at", None)
+            or getattr(raw, "first_seen", None)
+        )
+        mac = getattr(raw, "mac", None) or ""
+    return (int(ts or 0), str(mac))
+
+
+def _speedtest_key(row: Any) -> tuple:
+    raw = _raw(row)
+    if isinstance(raw, dict):
+        ts = raw.get("time") or raw.get("timestamp") or raw.get("ts")
+        rid = raw.get("_id") or raw.get("id") or ""
+    else:
+        ts = (
+            getattr(raw, "time", None)
+            or getattr(raw, "timestamp", None)
+            or getattr(raw, "ts", None)
+        )
+        rid = getattr(raw, "_id", None) or getattr(raw, "id", None) or ""
+    return (int(ts or 0), str(rid))
 
 
 # ---------------------------------------------------------------------------
@@ -2015,3 +2497,503 @@ class NetworkQuery:
             if pid == id:
                 return PortForward.from_manager_output(p)
         return None
+
+    # ---- Stats domain ---------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Site dashboard timeseries (all-points).",
+    )
+    async def dashboard_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        duration_hours: int = 1,
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dashboard_stats(ctx, controller, site, duration_hours)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Network-wide stats timeseries.",
+    )
+    async def network_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        duration_hours: int = 1,
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_network_stats(ctx, controller, site, duration_hours)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Gateway stats timeseries.",
+    )
+    async def gateway_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        duration_hours: int = 24,
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_gateway_stats(ctx, controller, site, duration_hours)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Per-client stats timeseries (by MAC).",
+    )
+    async def client_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+        duration_hours: int = 1,
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_stats(ctx, controller, site, mac, duration_hours)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Per-device stats timeseries (by MAC).",
+    )
+    async def device_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+        duration_hours: int = 1,
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_device_stats(ctx, controller, site, mac, duration_hours)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Per-client DPI traffic breakdown.",
+    )
+    async def client_dpi_traffic(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_dpi_traffic(ctx, controller, site, mac)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Site-wide DPI traffic breakdown.",
+    )
+    async def site_dpi_traffic(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> list[StatPoint]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_site_dpi_traffic(ctx, controller, site)
+        return [StatPoint.from_manager_output(p) for p in (raw or [])]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="DPI stats catalog (applications + categories).",
+    )
+    async def dpi_stats(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> DpiStats | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dpi_stats(ctx, controller, site)
+        if raw is None:
+            return None
+        return DpiStats.from_manager_output(raw)
+
+    # ---- Events domain --------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List recent controller events (paginated).",
+    )
+    async def event_log(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> EventLogPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_event_log(ctx, controller, site, max(limit, 100))
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+        )
+        return EventLogPage(
+            items=[EventLog.from_manager_output(e) for e in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List active alerts (paginated).",
+    )
+    async def alerts(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> EventLogPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_alerts(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+        )
+        return EventLogPage(
+            items=[EventLog.from_manager_output(e) for e in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List recent anomalies (paginated).",
+    )
+    async def anomalies(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> EventLogPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_anomalies(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+        )
+        return EventLogPage(
+            items=[EventLog.from_manager_output(e) for e in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List recent IPS/IDS events (paginated).",
+    )
+    async def ips_events(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> EventLogPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_ips_events(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+        )
+        return EventLogPage(
+            items=[EventLog.from_manager_output(e) for e in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List controller alarms (paginated).",
+    )
+    async def alarms(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> AlarmPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_alarms(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_event_key,
+        )
+        return AlarmPage(
+            items=[Alarm.from_manager_output(a) for a in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    # ---- System domain --------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get controller system info (build, uptime, hardware).",
+    )
+    async def system_info(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> SystemInfo | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_system_info(ctx, controller, site)
+        if raw is None:
+            return None
+        return SystemInfo.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get site-level settings (locale, timezone, advanced).",
+    )
+    async def site_settings(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> SiteSettings | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_site_settings(ctx, controller, site)
+        if raw is None:
+            return None
+        return SiteSettings.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get SNMP settings.",
+    )
+    async def snmp_settings(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> SnmpSettings | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_snmp_settings(ctx, controller, site)
+        if raw is None:
+            return None
+        return SnmpSettings.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get the controller's event-type prefix catalog.",
+    )
+    async def event_types(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> EventTypes | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_event_types(ctx, controller, site)
+        if raw is None:
+            return None
+        return EventTypes.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get auto-backup schedule + retention settings.",
+    )
+    async def autobackup_settings(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> AutoBackupSettings | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_autobackup_settings(ctx, controller, site)
+        if raw is None:
+            return None
+        return AutoBackupSettings.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List controller backups (paginated).",
+    )
+    async def backups(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> BackupPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_backups(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_backup_key,
+        )
+        return BackupPage(
+            items=[Backup.from_manager_output(b) for b in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List recent speedtest results (paginated).",
+    )
+    async def speedtest_results(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        duration_hours: int = 24,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> SpeedtestResultPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_speedtest_results(ctx, controller, site, duration_hours)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_speedtest_key,
+        )
+        return SpeedtestResultPage(
+            items=[SpeedtestResult.from_manager_output(s) for s in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List top-traffic clients within a window.",
+    )
+    async def top_clients(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        within_hours: int = 24,
+    ) -> list[TopClient]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_top_clients(ctx, controller, site, within_hours)
+        return [TopClient.from_manager_output(t) for t in (raw or [])]
+
+    # ---- Vouchers domain ------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List hotspot vouchers on the given controller/site (paginated).",
+    )
+    async def vouchers(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> VoucherPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_vouchers(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw), limit=limit, cursor=cursor_obj, key_fn=_voucher_key,
+        )
+        return VoucherPage(
+            items=[Voucher.from_manager_output(v) for v in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single hotspot voucher by id.",
+    )
+    async def voucher(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> Voucher | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_voucher_details(ctx, controller, site, id)
+        if raw is None:
+            return None
+        return Voucher.from_manager_output(raw)
+
+    # ---- Sessions domain ------------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List a client's association sessions (paginated).",
+    )
+    async def client_sessions(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        mac: str | None = None,
+        duration_hours: int = 24,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> ClientSessionPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_sessions(
+            ctx, controller, site, mac, duration_hours,
+        )
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw or []), limit=limit, cursor=cursor_obj, key_fn=_session_key,
+        )
+        return ClientSessionPage(
+            items=[ClientSession.from_manager_output(s) for s in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get a client's current WiFi parameters (signal, rates).",
+    )
+    async def client_wifi_details(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+    ) -> ClientWifiDetails | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_client_wifi_details(ctx, controller, site, mac)
+        if raw is None:
+            return None
+        return ClientWifiDetails.from_manager_output(raw)

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -1607,8 +1607,14 @@ class NetworkQuery:
         page, next_cursor = paginate(
             list(raw), limit=limit, cursor=cursor_obj, key_fn=_client_key,
         )
+        items = []
+        for c in page:
+            inst = Client.from_manager_output(c)
+            inst._controller_id = controller
+            inst._site = site
+            items.append(inst)
         return ClientPage(
-            items=[Client.from_manager_output(c) for c in page],
+            items=items,
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
 
@@ -1629,7 +1635,10 @@ class NetworkQuery:
             r = _raw(c)
             c_mac = r.get("mac") if isinstance(r, dict) else getattr(r, "mac", None)
             if c_mac == mac:
-                return Client.from_manager_output(c)
+                inst = Client.from_manager_output(c)
+                inst._controller_id = controller
+                inst._site = site
+                return inst
         return None
 
     @strawberry.field(
@@ -1698,8 +1707,14 @@ class NetworkQuery:
         page, next_cursor = paginate(
             list(raw), limit=limit, cursor=cursor_obj, key_fn=_device_key,
         )
+        items = []
+        for d in page:
+            inst = Device.from_manager_output(d)
+            inst._controller_id = controller
+            inst._site = site
+            items.append(inst)
         return DevicePage(
-            items=[Device.from_manager_output(d) for d in page],
+            items=items,
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
 
@@ -1720,7 +1735,10 @@ class NetworkQuery:
             r = _raw(d)
             d_mac = r.get("mac") if isinstance(r, dict) else getattr(r, "mac", None)
             if d_mac == mac:
-                return Device.from_manager_output(d)
+                inst = Device.from_manager_output(d)
+                inst._controller_id = controller
+                inst._site = site
+                return inst
         return None
 
     @strawberry.field(
@@ -1879,8 +1897,14 @@ class NetworkQuery:
         page, next_cursor = paginate(
             list(raw), limit=limit, cursor=cursor_obj, key_fn=_network_key,
         )
+        items = []
+        for n in page:
+            inst = Network.from_manager_output(n)
+            inst._controller_id = controller
+            inst._site = site
+            items.append(inst)
         return NetworkPage(
-            items=[Network.from_manager_output(n) for n in page],
+            items=items,
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
 
@@ -1905,7 +1929,10 @@ class NetworkQuery:
             else:
                 nid = getattr(r, "_id", None) or getattr(r, "id", None)
             if nid == id:
-                return Network.from_manager_output(n)
+                inst = Network.from_manager_output(n)
+                inst._controller_id = controller
+                inst._site = site
+                return inst
         return None
 
     @strawberry.field(

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1,3 +1,17 @@
+"""An active kernel routing-table entry on a gateway."""
+type ActiveRoute {
+  targetSubnet: String
+  gateway: String
+  interface: String
+  distance: Int
+}
+
+"""Paginated page of active kernel routes."""
+type ActiveRoutePage {
+  items: [ActiveRoute!]!
+  nextCursor: String
+}
+
 """A wireless channel allowed by the regulatory domain."""
 type AvailableChannel {
   channel: Int
@@ -74,6 +88,22 @@ type DeviceRadio {
   name: String
   model: String
   radios: [RadioEntry!]!
+}
+
+"""A static DNS record served by the controller."""
+type DnsRecord {
+  id: ID
+  hostname: String
+  ip: String
+  type: String
+  ttl: Int
+  enabled: Boolean!
+}
+
+"""Paginated page of DNS records."""
+type DnsRecordPage {
+  items: [DnsRecord!]!
+  nextCursor: String
 }
 
 """Service health snapshot — smoke field for the GraphQL endpoint."""
@@ -200,6 +230,47 @@ type NetworkQuery {
 
   """Get the controller's network-health subsystems list."""
   networkHealth(controller: ID!, site: String! = "default"): [NetworkHealth!]!
+
+  """
+  List WLAN/SSID configurations on the given controller/site (paginated).
+  """
+  wlans(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): WlanPage!
+
+  """Look up a single WLAN/SSID by id."""
+  wlan(controller: ID!, id: ID!, site: String! = "default"): Wlan
+
+  """List configured VPN clients (outbound tunnels) (paginated)."""
+  vpnClients(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): VpnClientPage!
+
+  """Look up a single VPN client by id."""
+  vpnClient(controller: ID!, id: ID!, site: String! = "default"): VpnClient
+
+  """List configured VPN servers (inbound tunnels) (paginated)."""
+  vpnServers(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): VpnServerPage!
+
+  """Look up a single VPN server by id."""
+  vpnServer(controller: ID!, id: ID!, site: String! = "default"): VpnServer
+
+  """List static DNS records on the given controller/site (paginated)."""
+  dnsRecords(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DnsRecordPage!
+
+  """Look up a single DNS record by id."""
+  dnsRecord(controller: ID!, id: ID!, site: String! = "default"): DnsRecord
+
+  """List configured static routes (paginated)."""
+  routes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): RoutePage!
+
+  """Look up a single static route by id."""
+  route(controller: ID!, id: ID!, site: String! = "default"): Route
+
+  """List the gateway's active kernel routing-table entries (paginated)."""
+  activeRoutes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ActiveRoutePage!
+
+  """List traffic-route policies (V2 /trafficroutes) (paginated)."""
+  trafficRoutes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): TrafficRoutePage!
+
+  """Look up a single traffic-route policy by id."""
+  trafficRoute(controller: ID!, id: ID!, site: String! = "default"): TrafficRoute
 }
 
 type Query {
@@ -248,6 +319,22 @@ type RogueApPage {
   nextCursor: String
 }
 
+"""A static route configured on the gateway."""
+type Route {
+  id: ID
+  name: String
+  targetSubnet: String
+  gateway: String
+  distance: Int
+  enabled: Boolean!
+}
+
+"""Paginated page of static routes."""
+type RoutePage {
+  items: [Route!]!
+  nextCursor: String
+}
+
 """Speedtest status reported by a UniFi gateway."""
 type SpeedtestStatus {
   status: String
@@ -255,4 +342,70 @@ type SpeedtestStatus {
   uploadMbps: Float
   latencyMs: Int
   lastRun: Int
+}
+
+"""A traffic-route policy (V2 /trafficroutes entry)."""
+type TrafficRoute {
+  id: ID
+  name: String
+  matchingTarget: String
+  sourceTargets: JSON
+  destinationTargets: JSON
+  nextHop: String
+  enabled: Boolean!
+}
+
+"""Paginated page of traffic-route policies."""
+type TrafficRoutePage {
+  items: [TrafficRoute!]!
+  nextCursor: String
+}
+
+"""A configured VPN client (outbound tunnel)."""
+type VpnClient {
+  id: ID
+  name: String
+  type: String
+  enabled: Boolean!
+  serverAddress: String
+  lastHandshake: Int
+}
+
+"""Paginated page of VPN clients."""
+type VpnClientPage {
+  items: [VpnClient!]!
+  nextCursor: String
+}
+
+"""A configured VPN server (inbound tunnel)."""
+type VpnServer {
+  id: ID
+  name: String
+  type: String
+  enabled: Boolean!
+  listenPort: Int
+  allowedSubnets: [String!]
+}
+
+"""Paginated page of VPN servers."""
+type VpnServerPage {
+  items: [VpnServer!]!
+  nextCursor: String
+}
+
+"""A UniFi WLAN/SSID configuration."""
+type Wlan {
+  id: ID
+  name: String
+  enabled: Boolean!
+  security: String
+  networkId: String
+  hideSsid: Boolean!
+  vlanId: Int
+}
+
+"""Paginated page of WLAN/SSID configurations."""
+type WlanPage {
+  items: [Wlan!]!
+  nextCursor: String
 }

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -28,12 +28,48 @@ type ActiveRoutePage {
   nextCursor: String
 }
 
+"""A controller alarm (V1 /list/alarm entry)."""
+type Alarm {
+  id: ID
+  key: String
+  msg: String
+  archived: Boolean!
+  time: Int
+}
+
+"""Paginated page of controller alarms."""
+type AlarmPage {
+  items: [Alarm!]!
+  nextCursor: String
+}
+
+"""Auto-backup schedule + retention settings."""
+type AutoBackupSettings {
+  enabled: Boolean!
+  schedule: String
+  maxCount: Int
+}
+
 """A wireless channel allowed by the regulatory domain."""
 type AvailableChannel {
   channel: Int
   frequencyMhz: Int
   widthMhz: Int
   allowed: Boolean!
+}
+
+"""A controller backup file metadata record."""
+type Backup {
+  id: ID
+  filename: String
+  size: Int
+  createdAt: Int
+}
+
+"""Paginated page of controller backup descriptors."""
+type BackupPage {
+  items: [Backup!]!
+  nextCursor: String
 }
 
 """A client currently blocked on the UniFi Network controller."""
@@ -77,6 +113,34 @@ type ClientLookup {
 type ClientPage {
   items: [Client!]!
   nextCursor: String
+}
+
+"""A client association session entry."""
+type ClientSession {
+  mac: String
+  hostname: String
+  ap: String
+  ssid: String
+  connectedAt: Int
+  disconnectedAt: Int
+  duration: Int
+}
+
+"""Paginated page of client association sessions."""
+type ClientSessionPage {
+  items: [ClientSession!]!
+  nextCursor: String
+}
+
+"""Current WiFi parameters for a client."""
+type ClientWifiDetails {
+  mac: String
+  ssid: String
+  ap: String
+  signal: Int
+  txRate: Int
+  rxRate: Int
+  channel: Int
 }
 
 """A content-filtering profile (V2 /content-filtering entry)."""
@@ -160,6 +224,34 @@ type DpiCategory {
 type DpiCategoryPage {
   items: [DpiCategory!]!
   nextCursor: String
+}
+
+"""DPI stats wrapper: applications + categories arrays."""
+type DpiStats {
+  applications: JSON!
+  categories: JSON!
+}
+
+"""A curated event-log entry."""
+type EventLog {
+  id: ID
+  key: String
+  msg: String
+  time: Int
+  mac: String
+  ip: String
+  severity: String
+}
+
+"""Paginated page of event-log entries."""
+type EventLogPage {
+  items: [EventLog!]!
+  nextCursor: String
+}
+
+"""Wrapper for event-type prefix descriptors."""
+type EventTypes {
+  eventTypes: JSON!
 }
 
 """A firewall address/port group (V1 /rest/firewallgroup)."""
@@ -417,6 +509,81 @@ type NetworkQuery {
 
   """Look up a single port forward by id."""
   portForward(controller: ID!, id: ID!, site: String! = "default"): PortForward
+
+  """Site dashboard timeseries (all-points)."""
+  dashboardStats(controller: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Network-wide stats timeseries."""
+  networkStats(controller: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Gateway stats timeseries."""
+  gatewayStats(controller: ID!, site: String! = "default", durationHours: Int! = 24): [StatPoint!]!
+
+  """Per-client stats timeseries (by MAC)."""
+  clientStats(controller: ID!, mac: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Per-device stats timeseries (by MAC)."""
+  deviceStats(controller: ID!, mac: ID!, site: String! = "default", durationHours: Int! = 1): [StatPoint!]!
+
+  """Per-client DPI traffic breakdown."""
+  clientDpiTraffic(controller: ID!, mac: ID!, site: String! = "default"): [StatPoint!]!
+
+  """Site-wide DPI traffic breakdown."""
+  siteDpiTraffic(controller: ID!, site: String! = "default"): [StatPoint!]!
+
+  """DPI stats catalog (applications + categories)."""
+  dpiStats(controller: ID!, site: String! = "default"): DpiStats
+
+  """List recent controller events (paginated)."""
+  eventLog(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List active alerts (paginated)."""
+  alerts(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List recent anomalies (paginated)."""
+  anomalies(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List recent IPS/IDS events (paginated)."""
+  ipsEvents(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): EventLogPage!
+
+  """List controller alarms (paginated)."""
+  alarms(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): AlarmPage!
+
+  """Get controller system info (build, uptime, hardware)."""
+  systemInfo(controller: ID!, site: String! = "default"): SystemInfo
+
+  """Get site-level settings (locale, timezone, advanced)."""
+  siteSettings(controller: ID!, site: String! = "default"): SiteSettings
+
+  """Get SNMP settings."""
+  snmpSettings(controller: ID!, site: String! = "default"): SnmpSettings
+
+  """Get the controller's event-type prefix catalog."""
+  eventTypes(controller: ID!, site: String! = "default"): EventTypes
+
+  """Get auto-backup schedule + retention settings."""
+  autobackupSettings(controller: ID!, site: String! = "default"): AutoBackupSettings
+
+  """List controller backups (paginated)."""
+  backups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): BackupPage!
+
+  """List recent speedtest results (paginated)."""
+  speedtestResults(controller: ID!, site: String! = "default", durationHours: Int! = 24, limit: Int! = 50, cursor: String = null): SpeedtestResultPage!
+
+  """List top-traffic clients within a window."""
+  topClients(controller: ID!, site: String! = "default", withinHours: Int! = 24): [TopClient!]!
+
+  """List hotspot vouchers on the given controller/site (paginated)."""
+  vouchers(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): VoucherPage!
+
+  """Look up a single hotspot voucher by id."""
+  voucher(controller: ID!, id: ID!, site: String! = "default"): Voucher
+
+  """List a client's association sessions (paginated)."""
+  clientSessions(controller: ID!, site: String! = "default", mac: String = null, durationHours: Int! = 24, limit: Int! = 50, cursor: String = null): ClientSessionPage!
+
+  """Get a client's current WiFi parameters (signal, rates)."""
+  clientWifiDetails(controller: ID!, mac: ID!, site: String! = "default"): ClientWifiDetails
 }
 
 """An out-of-network (OON) policy entry."""
@@ -530,6 +697,36 @@ type RoutePage {
   nextCursor: String
 }
 
+"""Controller site settings."""
+type SiteSettings {
+  siteId: String
+  name: String
+  role: String
+  country: Int
+}
+
+"""Controller SNMP settings."""
+type SnmpSettings {
+  enabled: Boolean!
+  community: String
+  port: Int
+  version: String
+}
+
+"""A speedtest result entry."""
+type SpeedtestResult {
+  timestamp: Int
+  downloadMbps: Float
+  uploadMbps: Float
+  latencyMs: Float
+}
+
+"""Paginated page of speedtest result entries."""
+type SpeedtestResultPage {
+  items: [SpeedtestResult!]!
+  nextCursor: String
+}
+
 """Speedtest status reported by a UniFi gateway."""
 type SpeedtestStatus {
   status: String
@@ -537,6 +734,30 @@ type SpeedtestStatus {
   uploadMbps: Float
   latencyMs: Int
   lastRun: Int
+}
+
+"""A single timeseries point: {ts: <ms>, ...metrics}."""
+type StatPoint {
+  ts: Int!
+}
+
+"""Controller system information."""
+type SystemInfo {
+  name: String
+  version: String
+  hostname: String
+  uptime: Int
+  numDevices: Int
+  numClients: Int
+}
+
+"""A top-traffic client entry."""
+type TopClient {
+  mac: String
+  hostname: String
+  txBytes: Int
+  rxBytes: Int
+  totalBytes: Int
 }
 
 """A traffic-route policy (V2 /trafficroutes entry)."""
@@ -553,6 +774,23 @@ type TrafficRoute {
 """Paginated page of traffic-route policies."""
 type TrafficRoutePage {
   items: [TrafficRoute!]!
+  nextCursor: String
+}
+
+"""A hotspot voucher (V1 /stat/voucher entry)."""
+type Voucher {
+  id: ID
+  code: String
+  status: String
+  duration: Int
+  qosOverwrite: Boolean!
+  createdAt: Int
+  usedAt: Int
+}
+
+"""Paginated page of hotspot vouchers."""
+type VoucherPage {
+  items: [Voucher!]!
   nextCursor: String
 }
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -43,6 +43,20 @@ type AlarmPage {
   nextCursor: String
 }
 
+"""A UniFi AP group (collection of AP MAC addresses)."""
+type ApGroup {
+  id: ID
+  name: String
+  apCount: Int!
+  deviceMacs: [String!]!
+}
+
+"""Paginated page of AP groups."""
+type ApGroupPage {
+  items: [ApGroup!]!
+  nextCursor: String
+}
+
 """Auto-backup schedule + retention settings."""
 type AutoBackupSettings {
   enabled: Boolean!
@@ -98,6 +112,20 @@ type Client {
   firstSeen: String
   note: String
   usergroupId: String
+}
+
+"""A network member client group (V2 /network-members-group entry)."""
+type ClientGroup {
+  id: ID
+  name: String
+  qosRateMaxDown: Int
+  qosRateMaxUp: Int
+}
+
+"""Paginated page of network member client groups."""
+type ClientGroupPage {
+  items: [ClientGroup!]!
+  nextCursor: String
 }
 
 """Result of a by-IP client lookup — online presence + last seen."""
@@ -584,6 +612,45 @@ type NetworkQuery {
 
   """Get a client's current WiFi parameters (signal, rates)."""
   clientWifiDetails(controller: ID!, mac: ID!, site: String! = "default"): ClientWifiDetails
+
+  """List switch port profiles on the given controller/site (paginated)."""
+  portProfiles(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortProfilePage!
+
+  """Look up a single switch port profile by id."""
+  portProfile(controller: ID!, id: ID!, site: String! = "default"): PortProfile
+
+  """
+  Get the port-override wrapper for a switch (name/model + per-port overrides).
+  """
+  switchPorts(controller: ID!, deviceMac: ID!, site: String! = "default"): SwitchPorts
+
+  """Get the per-port stats wrapper for a switch (name/model + port_table)."""
+  portStats(controller: ID!, deviceMac: ID!, site: String! = "default"): PortStats
+
+  """Get switch capabilities (caps dict + STP / dot1x flags)."""
+  switchCapabilities(controller: ID!, deviceMac: ID!, site: String! = "default"): SwitchCapabilities
+
+  """List AP groups on the given controller/site (paginated)."""
+  apGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ApGroupPage!
+
+  """Look up a single AP group by id."""
+  apGroup(controller: ID!, id: ID!, site: String! = "default"): ApGroup
+
+  """
+  List network member client groups on the given controller/site (paginated).
+  """
+  clientGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ClientGroupPage!
+
+  """Look up a single network member client group by id."""
+  clientGroup(controller: ID!, id: ID!, site: String! = "default"): ClientGroup
+
+  """
+  List QoS user groups (V1 /rest/usergroup) on the given controller/site (paginated).
+  """
+  userGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): UserGroupPage!
+
+  """Look up a single QoS user group by id."""
+  userGroup(controller: ID!, id: ID!, site: String! = "default"): UserGroup
 }
 
 """An out-of-network (OON) policy entry."""
@@ -617,6 +684,56 @@ type PortForward {
 type PortForwardPage {
   items: [PortForward!]!
   nextCursor: String
+}
+
+"""A single port-override row on a switch."""
+type PortOverrideRow {
+  portIdx: Int
+  name: String
+  portconfId: String
+  poeMode: String
+  opMode: String
+}
+
+"""A switch port profile (PoE / VLAN tagging template)."""
+type PortProfile {
+  id: ID
+  name: String
+  nativeNetworkconfId: String
+  taggedNetworkconfIds: [String!]!
+  poeMode: String
+  isolation: Boolean
+}
+
+"""Paginated page of switch port profiles."""
+type PortProfilePage {
+  items: [PortProfile!]!
+  nextCursor: String
+}
+
+"""A single port-table row reporting per-port stats."""
+type PortStatRow {
+  portIdx: Int
+  name: String
+  enable: Boolean!
+  speed: Int
+  duplex: Boolean
+  txBytes: Int!
+  rxBytes: Int!
+  txPackets: Int!
+  rxPackets: Int!
+  txDropped: Int!
+  rxDropped: Int!
+  poeEnable: Boolean!
+  poeMode: String
+  poePower: Float
+}
+
+"""Wrapper dict containing the per-port stats table for a switch."""
+type PortStats {
+  name: String
+  model: String
+  portTable: [PortStatRow!]!
 }
 
 """A QoS rate-limit rule (V2 /qos-rules entry)."""
@@ -741,6 +858,24 @@ type StatPoint {
   ts: Int!
 }
 
+"""Switch capabilities (caps dict + STP / dot1x flags)."""
+type SwitchCapabilities {
+  name: String
+  model: String
+  switchCaps: JSON
+  stpVersion: String
+  stpPriority: String
+  jumboframeEnabled: Boolean
+  dot1xPortctrlEnabled: Boolean
+}
+
+"""Wrapper dict containing port-override rows for a switch."""
+type SwitchPorts {
+  name: String
+  model: String
+  portOverrides: [PortOverrideRow!]!
+}
+
 """Controller system information."""
 type SystemInfo {
   name: String
@@ -774,6 +909,20 @@ type TrafficRoute {
 """Paginated page of traffic-route policies."""
 type TrafficRoutePage {
   items: [TrafficRoute!]!
+  nextCursor: String
+}
+
+"""A QoS user group (V1 /rest/usergroup entry)."""
+type UserGroup {
+  id: ID
+  name: String
+  qosRateMaxDown: Int
+  qosRateMaxUp: Int
+}
+
+"""Paginated page of QoS user groups."""
+type UserGroupPage {
+  items: [UserGroup!]!
   nextCursor: String
 }
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -112,6 +112,9 @@ type Client {
   firstSeen: String
   note: String
   usergroupId: String
+
+  """The AP or switch this client connects through."""
+  device: Device
 }
 
 """A network member client group (V2 /network-members-group entry)."""
@@ -197,6 +200,9 @@ type Device {
   state: String
   ip: String
   ports: JSON
+
+  """Clients currently connected through this AP/switch."""
+  portClients: [Client!]!
 }
 
 """Paginated page of devices."""
@@ -373,6 +379,9 @@ type Network {
   enabled: Boolean!
   vlan: Int
   subnet: String
+
+  """Clients on this network."""
+  clients: [Client!]!
 }
 
 """A network-health subsystem entry."""

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1,3 +1,25 @@
+"""A wireless channel allowed by the regulatory domain."""
+type AvailableChannel {
+  channel: Int
+  frequencyMhz: Int
+  widthMhz: Int
+  allowed: Boolean!
+}
+
+"""A client currently blocked on the UniFi Network controller."""
+type BlockedClient {
+  mac: ID
+  hostname: String
+  lastSeen: String
+  blocked: Boolean!
+}
+
+"""Paginated page of blocked clients."""
+type BlockedClientPage {
+  items: [BlockedClient!]!
+  nextCursor: String
+}
+
 """A client device on the UniFi Network controller."""
 type Client {
   mac: ID
@@ -10,6 +32,15 @@ type Client {
   firstSeen: String
   note: String
   usergroupId: String
+}
+
+"""Result of a by-IP client lookup — online presence + last seen."""
+type ClientLookup {
+  mac: ID
+  ip: String
+  hostname: String
+  isOnline: Boolean!
+  lastSeen: String
 }
 
 """Paginated page of clients."""
@@ -37,6 +68,14 @@ type DevicePage {
   nextCursor: String
 }
 
+"""Wrapper dict containing the radio table for a device."""
+type DeviceRadio {
+  mac: ID
+  name: String
+  model: String
+  radios: [RadioEntry!]!
+}
+
 """Service health snapshot — smoke field for the GraphQL endpoint."""
 type HealthSnapshot {
   ok: Boolean!
@@ -49,6 +88,38 @@ The `JSON` scalar type represents JSON values as specified by [ECMA-404](https:/
 """
 scalar JSON @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
 
+"""A known rogue AP (allowlisted by the operator)."""
+type KnownRogueAp {
+  bssid: ID
+  ssid: String
+  channel: Int
+  signalDbm: Int
+  lastSeen: Int
+  isKnown: Boolean!
+}
+
+"""Paginated page of known (allowlisted) rogue APs."""
+type KnownRogueApPage {
+  items: [KnownRogueAp!]!
+  nextCursor: String
+}
+
+"""Wrapper dict containing LLDP neighbors for a switch."""
+type LldpNeighbors {
+  name: String
+  model: String
+  lldpTable: [LldpRow!]!
+}
+
+"""A single LLDP neighbor row reported by a switch."""
+type LldpRow {
+  localPortIdx: Int
+  chassisId: String
+  portId: String
+  systemName: String
+  capabilities: [String!]!
+}
+
 """A UniFi LAN/VLAN network configuration."""
 type Network {
   id: ID
@@ -57,6 +128,17 @@ type Network {
   enabled: Boolean!
   vlan: Int
   subnet: String
+}
+
+"""A network-health subsystem entry."""
+type NetworkHealth {
+  subsystem: String
+  status: String
+  numUser: Int
+  numGuest: Int
+  numIot: Int
+  rxBytes: Int
+  txBytes: Int
 }
 
 """Paginated page of network configurations."""
@@ -70,13 +152,54 @@ type NetworkQuery {
   """List clients on the given controller/site (paginated)."""
   clients(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ClientPage!
 
+  """Look up a single client by MAC address."""
+  client(controller: ID!, mac: ID!, site: String! = "default"): Client
+
+  """List clients currently blocked from the network (paginated)."""
+  blockedClients(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): BlockedClientPage!
+
+  """Look up a client by IP address (online-presence check)."""
+  clientByIp(controller: ID!, ip: String!, site: String! = "default"): ClientLookup
+
   """List devices on the given controller/site (paginated)."""
   devices(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DevicePage!
+
+  """Look up a single device by MAC address."""
+  device(controller: ID!, mac: ID!, site: String! = "default"): Device
+
+  """Get the radio configuration for a UniFi access point."""
+  deviceRadio(controller: ID!, mac: ID!, site: String! = "default"): DeviceRadio
+
+  """Get LLDP neighbors reported by a switch."""
+  lldpNeighbors(controller: ID!, deviceMac: ID!, site: String! = "default"): LldpNeighbors
+
+  """List rogue (unknown) APs detected within a window (paginated)."""
+  rogueAps(controller: ID!, site: String! = "default", withinHours: Int! = 24, limit: Int! = 50, cursor: String = null): RogueApPage!
+
+  """List known (allowlisted) rogue APs (paginated)."""
+  knownRogueAps(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): KnownRogueApPage!
+
+  """List RF-scan results for a specific access point."""
+  rfScanResults(controller: ID!, apMac: ID!, site: String! = "default"): [RfScanResult!]!
+
+  """List wireless channels allowed by the regulatory domain."""
+  availableChannels(controller: ID!, site: String! = "default"): [AvailableChannel!]!
+
+  """Get the gateway speedtest status (idle/running + last results)."""
+  speedtestStatus(controller: ID!, gatewayMac: ID!, site: String! = "default"): SpeedtestStatus
 
   """
   List configured LAN/VLAN networks on the given controller/site (paginated).
   """
   networks(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): NetworkPage!
+
+  """
+  Look up a single LAN/VLAN network by id. (Named ``networkDetail`` because ``network`` is reserved for the namespace.)
+  """
+  networkDetail(controller: ID!, id: ID!, site: String! = "default"): Network
+
+  """Get the controller's network-health subsystems list."""
+  networkHealth(controller: ID!, site: String! = "default"): [NetworkHealth!]!
 }
 
 type Query {
@@ -85,4 +208,51 @@ type Query {
 
   """Read-only access to UniFi Network resources."""
   network: NetworkQuery!
+}
+
+"""Radio configuration entry on a UniFi access point."""
+type RadioEntry {
+  name: String
+  radio: String
+  channel: Int
+  ht: Int
+  txPower: Int
+  txPowerMode: String
+  currentChannel: Int
+  currentTxPower: Int
+  numSta: Int
+}
+
+"""A single RF-scan result row reported by an AP."""
+type RfScanResult {
+  bssid: ID
+  ssid: String
+  channel: Int
+  signalDbm: Int
+  capturedAt: Int
+}
+
+"""A rogue (unknown) AP detected by the controller."""
+type RogueAp {
+  bssid: ID
+  ssid: String
+  channel: Int
+  signalDbm: Int
+  lastSeen: Int
+  isKnown: Boolean!
+}
+
+"""Paginated page of detected rogue APs."""
+type RogueApPage {
+  items: [RogueAp!]!
+  nextCursor: String
+}
+
+"""Speedtest status reported by a UniFi gateway."""
+type SpeedtestStatus {
+  status: String
+  downloadMbps: Float
+  uploadMbps: Float
+  latencyMs: Int
+  lastRun: Int
 }

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1,3 +1,19 @@
+"""A MAC ACL rule (V2 /acl-rules entry)."""
+type AclRule {
+  id: ID
+  name: String
+  enabled: Boolean!
+  action: String
+  source: JSON
+  destination: JSON
+}
+
+"""Paginated page of ACL rules."""
+type AclRulePage {
+  items: [AclRule!]!
+  nextCursor: String
+}
+
 """An active kernel routing-table entry on a gateway."""
 type ActiveRoute {
   targetSubnet: String
@@ -63,6 +79,21 @@ type ClientPage {
   nextCursor: String
 }
 
+"""A content-filtering profile (V2 /content-filtering entry)."""
+type ContentFilter {
+  id: ID
+  name: String
+  enabled: Boolean!
+  profile: String
+  appliesTo: JSON!
+}
+
+"""Paginated page of content filters."""
+type ContentFilterPage {
+  items: [ContentFilter!]!
+  nextCursor: String
+}
+
 """A UniFi network device (AP, switch, gateway)."""
 type Device {
   mac: ID
@@ -104,6 +135,70 @@ type DnsRecord {
 type DnsRecordPage {
   items: [DnsRecord!]!
   nextCursor: String
+}
+
+"""A DPI application classification entry."""
+type DpiApplication {
+  id: Int
+  name: String
+  categoryId: Int
+}
+
+"""Paginated page of DPI applications."""
+type DpiApplicationPage {
+  items: [DpiApplication!]!
+  nextCursor: String
+}
+
+"""A DPI application category."""
+type DpiCategory {
+  id: Int
+  name: String
+}
+
+"""Paginated page of DPI categories."""
+type DpiCategoryPage {
+  items: [DpiCategory!]!
+  nextCursor: String
+}
+
+"""A firewall address/port group (V1 /rest/firewallgroup)."""
+type FirewallGroup {
+  id: ID
+  name: String
+  groupType: String
+  members: JSON!
+}
+
+"""Paginated page of firewall groups."""
+type FirewallGroupPage {
+  items: [FirewallGroup!]!
+  nextCursor: String
+}
+
+"""A firewall policy rule."""
+type FirewallRule {
+  id: ID
+  name: String
+  action: String
+  enabled: Boolean!
+  predefined: Boolean!
+  source: JSON
+  destination: JSON
+}
+
+"""Paginated page of firewall policies/rules."""
+type FirewallRulePage {
+  items: [FirewallRule!]!
+  nextCursor: String
+}
+
+"""A firewall zone (V2 /firewall/zone-matrix entry)."""
+type FirewallZone {
+  id: ID
+  name: String
+  networks: JSON!
+  defaultPolicy: String
 }
 
 """Service health snapshot — smoke field for the GraphQL endpoint."""
@@ -271,6 +366,106 @@ type NetworkQuery {
 
   """Look up a single traffic-route policy by id."""
   trafficRoute(controller: ID!, id: ID!, site: String! = "default"): TrafficRoute
+
+  """List firewall policies/rules on the given controller/site (paginated)."""
+  firewallPolicies(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): FirewallRulePage!
+
+  """Look up a single firewall policy/rule by id."""
+  firewallPolicy(controller: ID!, id: ID!, site: String! = "default"): FirewallRule
+
+  """List firewall address/port groups (paginated)."""
+  firewallGroups(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): FirewallGroupPage!
+
+  """Look up a single firewall group by id."""
+  firewallGroup(controller: ID!, id: ID!, site: String! = "default"): FirewallGroup
+
+  """List firewall zones (typically a small flat list — no pagination)."""
+  firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
+
+  """List QoS rules on the given controller/site (paginated)."""
+  qosRules(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): QosRulePage!
+
+  """Look up a single QoS rule by id."""
+  qosRule(controller: ID!, id: ID!, site: String! = "default"): QosRule
+
+  """List DPI applications (paginated)."""
+  dpiApplications(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DpiApplicationPage!
+
+  """List DPI categories (paginated)."""
+  dpiCategories(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DpiCategoryPage!
+
+  """List content filters on the given controller/site (paginated)."""
+  contentFilters(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): ContentFilterPage!
+
+  """Look up a single content filter by id."""
+  contentFilter(controller: ID!, id: ID!, site: String! = "default"): ContentFilter
+
+  """List ACL rules on the given controller/site (paginated)."""
+  aclRules(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): AclRulePage!
+
+  """Look up a single ACL rule by id."""
+  aclRule(controller: ID!, id: ID!, site: String! = "default"): AclRule
+
+  """List OON (out-of-network) policies (paginated)."""
+  oonPolicies(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): OonPolicyPage!
+
+  """Look up a single OON policy by id."""
+  oonPolicy(controller: ID!, id: ID!, site: String! = "default"): OonPolicy
+
+  """List port forwards on the given controller/site (paginated)."""
+  portForwards(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortForwardPage!
+
+  """Look up a single port forward by id."""
+  portForward(controller: ID!, id: ID!, site: String! = "default"): PortForward
+}
+
+"""An out-of-network (OON) policy entry."""
+type OonPolicy {
+  id: ID
+  name: String
+  enabled: Boolean!
+  appliesTo: JSON!
+  restrictionLevel: String
+}
+
+"""Paginated page of OON (out-of-network) policies."""
+type OonPolicyPage {
+  items: [OonPolicy!]!
+  nextCursor: String
+}
+
+"""A port-forward rule (V1 /rest/portforward entry)."""
+type PortForward {
+  id: ID
+  name: String
+  enabled: Boolean!
+  fwdProtocol: String
+  dstPort: String
+  fwdPort: String
+  src: String
+  log: Boolean!
+}
+
+"""Paginated page of port forwards."""
+type PortForwardPage {
+  items: [PortForward!]!
+  nextCursor: String
+}
+
+"""A QoS rate-limit rule (V2 /qos-rules entry)."""
+type QosRule {
+  id: ID
+  name: String
+  enabled: Boolean!
+  rateMaxDown: Int
+  rateMaxUp: Int
+  priority: Int
+}
+
+"""Paginated page of QoS rules."""
+type QosRulePage {
+  items: [QosRule!]!
+  nextCursor: String
 }
 
 type Query {

--- a/apps/api/src/unifi_api/graphql/types/network/client.py
+++ b/apps/api/src/unifi_api/graphql/types/network/client.py
@@ -14,9 +14,13 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
+from strawberry.types import Info
+
+if TYPE_CHECKING:
+    from unifi_api.graphql.types.network.device import Device
 
 
 def _iso(ts: int | None) -> str | None:
@@ -47,6 +51,13 @@ class Client:
     note: str | None
     usergroup_id: str | None
 
+    # Context for relationship edges — NOT in SDL, NOT in to_dict().
+    # Set by the resolver after construction so edge resolvers can look up
+    # related resources via the request cache.
+    _controller_id: strawberry.Private[str | None] = None
+    _site: strawberry.Private[str | None] = None
+    _ap_mac: strawberry.Private[str | None] = None
+
     @classmethod
     def render_hint(cls, kind: str) -> dict:
         return {
@@ -70,10 +81,38 @@ class Client:
             first_seen=_iso(raw.get("first_seen")),
             note=raw.get("note") or None,
             usergroup_id=raw.get("usergroup_id") or None,
+            _ap_mac=raw.get("ap_mac"),
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        out = asdict(self)
+        return {k: v for k, v in out.items() if not k.startswith("_") and not callable(v)}
+
+    @strawberry.field(description="The AP or switch this client connects through.")
+    async def device(
+        self, info: Info,
+    ) -> Annotated["Device", strawberry.lazy("unifi_api.graphql.types.network.device")] | None:
+        """Resolves to the parent AP/switch — uses the request cache to avoid N+1."""
+        # Forward references to avoid circular imports.
+        from unifi_api.graphql.resolvers.network import _fetch_devices
+        from unifi_api.graphql.types.network.device import Device
+
+        if not self._controller_id or not self._ap_mac:
+            return None
+        site = self._site or "default"
+        raw_devices = await _fetch_devices(info.context, self._controller_id, site)
+        for d in raw_devices:
+            if isinstance(d, dict):
+                d_mac = d.get("mac")
+            else:
+                raw = getattr(d, "raw", None)
+                d_mac = raw.get("mac") if isinstance(raw, dict) else getattr(d, "mac", None)
+            if d_mac == self._ap_mac:
+                instance = Device.from_manager_output(d)
+                instance._controller_id = self._controller_id
+                instance._site = site
+                return instance
+        return None
 
 
 @strawberry.type(description="A client currently blocked on the UniFi Network controller.")
@@ -102,7 +141,8 @@ class BlockedClient:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        out = asdict(self)
+        return {k: v for k, v in out.items() if not k.startswith("_") and not callable(v)}
 
 
 @strawberry.type(description="Result of a by-IP client lookup — online presence + last seen.")
@@ -128,4 +168,5 @@ class ClientLookup:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        out = asdict(self)
+        return {k: v for k, v in out.items() if not k.startswith("_") and not callable(v)}

--- a/apps/api/src/unifi_api/graphql/types/network/device.py
+++ b/apps/api/src/unifi_api/graphql/types/network/device.py
@@ -20,9 +20,13 @@ exposes the same dict contract the REST routes return today.
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
+from strawberry.types import Info
+
+if TYPE_CHECKING:
+    from unifi_api.graphql.types.network.client import Client
 
 
 _STATE_MAP = {
@@ -59,6 +63,10 @@ class Device:
     ip: str | None
     ports: strawberry.scalars.JSON | None  # type: ignore[name-defined]
 
+    # Context for relationship edges — NOT in SDL, NOT in to_dict().
+    _controller_id: strawberry.Private[str | None] = None
+    _site: strawberry.Private[str | None] = None
+
     @classmethod
     def render_hint(cls, kind: str) -> dict:
         return {
@@ -85,7 +93,34 @@ class Device:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        out = asdict(self)
+        return {k: v for k, v in out.items() if not k.startswith("_") and not callable(v)}
+
+    @strawberry.field(description="Clients currently connected through this AP/switch.")
+    async def port_clients(
+        self, info: Info,
+    ) -> list[Annotated["Client", strawberry.lazy("unifi_api.graphql.types.network.client")]]:
+        """Resolves to clients whose ap_mac matches this device's mac."""
+        from unifi_api.graphql.resolvers.network import _fetch_clients
+        from unifi_api.graphql.types.network.client import Client
+
+        if not self._controller_id:
+            return []
+        site = self._site or "default"
+        raw_clients = await _fetch_clients(info.context, self._controller_id, site)
+        out: list[Client] = []
+        for c in raw_clients:
+            if isinstance(c, dict):
+                ap_mac = c.get("ap_mac")
+            else:
+                raw = getattr(c, "raw", None)
+                ap_mac = raw.get("ap_mac") if isinstance(raw, dict) else getattr(c, "ap_mac", None)
+            if ap_mac == self.mac:
+                inst = Client.from_manager_output(c)
+                inst._controller_id = self._controller_id
+                inst._site = site
+                out.append(inst)
+        return out
 
 
 @strawberry.type(description="Radio configuration entry on a UniFi access point.")

--- a/apps/api/src/unifi_api/graphql/types/network/network.py
+++ b/apps/api/src/unifi_api/graphql/types/network/network.py
@@ -13,9 +13,13 @@ exposes the same dict contract the REST routes return today.
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
+from strawberry.types import Info
+
+if TYPE_CHECKING:
+    from unifi_api.graphql.types.network.client import Client
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -35,6 +39,10 @@ class Network:
     enabled: bool
     vlan: int | None
     subnet: str | None
+
+    # Context for relationship edges — NOT in SDL, NOT in to_dict().
+    _controller_id: strawberry.Private[str | None] = None
+    _site: strawberry.Private[str | None] = None
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
@@ -58,4 +66,34 @@ class Network:
         )
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        out = asdict(self)
+        return {k: v for k, v in out.items() if not k.startswith("_") and not callable(v)}
+
+    @strawberry.field(description="Clients on this network.")
+    async def clients(
+        self, info: Info,
+    ) -> list[Annotated["Client", strawberry.lazy("unifi_api.graphql.types.network.client")]]:
+        """Resolves to clients whose network_id matches this network's id."""
+        from unifi_api.graphql.resolvers.network import _fetch_clients
+        from unifi_api.graphql.types.network.client import Client
+
+        if not self._controller_id:
+            return []
+        site = self._site or "default"
+        raw_clients = await _fetch_clients(info.context, self._controller_id, site)
+        out: list[Client] = []
+        for c in raw_clients:
+            if isinstance(c, dict):
+                net_id = c.get("network_id")
+            else:
+                raw = getattr(c, "raw", None)
+                net_id = (
+                    raw.get("network_id") if isinstance(raw, dict)
+                    else getattr(c, "network_id", None)
+                )
+            if net_id == self.id:
+                inst = Client.from_manager_output(c)
+                inst._controller_id = self._controller_id
+                inst._site = site
+                out.append(inst)
+        return out

--- a/apps/api/src/unifi_api/graphql/types/network/stat.py
+++ b/apps/api/src/unifi_api/graphql/types/network/stat.py
@@ -70,9 +70,10 @@ class StatPoint:
 class DpiStats:
     # Wrapper-dict shape; each sub-row is a passthrough dict (unstructured —
     # the controller's DPI catalogs vary by firmware so we don't tighten the
-    # schema here).
-    _applications: strawberry.Private[list[dict]]
-    _categories: strawberry.Private[list[dict]]
+    # schema here). Exposed as ``JSON`` scalars on the GraphQL surface so the
+    # heterogeneous payload survives without an enumerated sub-type.
+    applications: strawberry.scalars.JSON  # type: ignore[name-defined]
+    categories: strawberry.scalars.JSON  # type: ignore[name-defined]
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
@@ -81,7 +82,7 @@ class DpiStats:
     @classmethod
     def from_manager_output(cls, obj: Any) -> "DpiStats":
         if not isinstance(obj, dict):
-            return cls(_applications=[], _categories=[])
+            return cls(applications=[], categories=[])
 
         def _itemize(items):
             out = []
@@ -95,12 +96,12 @@ class DpiStats:
             return out
 
         return cls(
-            _applications=_itemize(obj.get("applications")),
-            _categories=_itemize(obj.get("categories")),
+            applications=_itemize(obj.get("applications")),
+            categories=_itemize(obj.get("categories")),
         )
 
     def to_dict(self) -> dict:
         return {
-            "applications": list(self._applications),
-            "categories": list(self._categories),
+            "applications": list(self.applications),
+            "categories": list(self.categories),
         }

--- a/apps/api/src/unifi_api/graphql/types/network/system.py
+++ b/apps/api/src/unifi_api/graphql/types/network/system.py
@@ -284,7 +284,9 @@ class SnmpSettings:
 class EventTypes:
     # The catalog of event-type prefixes is unstructured (varies by
     # firmware), so each descriptor passes through as a plain dict.
-    _event_types: strawberry.Private[list[dict]]
+    # Exposed as a ``JSON`` scalar on the GraphQL surface so the
+    # heterogeneous payload survives without an enumerated sub-type.
+    event_types: strawberry.scalars.JSON  # type: ignore[name-defined]
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
@@ -294,17 +296,17 @@ class EventTypes:
     def from_manager_output(cls, obj: Any) -> "EventTypes":
         if isinstance(obj, list):
             return cls(
-                _event_types=[e for e in obj if isinstance(e, dict)],
+                event_types=[e for e in obj if isinstance(e, dict)],
             )
         if isinstance(obj, dict):
             inner = obj.get("event_types")
             if isinstance(inner, list):
-                return cls(_event_types=list(inner))
-            return cls(_event_types=[obj])
-        return cls(_event_types=[])
+                return cls(event_types=list(inner))
+            return cls(event_types=[obj])
+        return cls(event_types=[])
 
     def to_dict(self) -> dict:
-        return {"event_types": list(self._event_types)}
+        return {"event_types": list(self.event_types)}
 
 
 @strawberry.type(description="Auto-backup schedule + retention settings.")

--- a/apps/api/tests/graphql/test_graphql_coverage.py
+++ b/apps/api/tests/graphql/test_graphql_coverage.py
@@ -49,11 +49,18 @@ def _read_tools_by_product() -> dict[str, list[str]]:
 def _query_field_names() -> set[str]:
     """Walk the schema's Query type and any nested namespaces for field names."""
     names: set[str] = set()
+    seen: set[int] = set()
     gql_schema = graphql_schema._schema  # underlying graphql-core GraphQLSchema
 
     def _walk(type_obj) -> None:
         if not hasattr(type_obj, "fields"):
             return
+        # Cycle protection — relationship edges (e.g. Client.device -> Device,
+        # Device.portClients -> [Client]) form cycles in the type graph.
+        type_id = id(type_obj)
+        if type_id in seen:
+            return
+        seen.add(type_id)
         for field_name, field in type_obj.fields.items():
             names.add(field_name)
             # If the field's return type is itself a typed object with subfields

--- a/apps/api/tests/graphql/test_graphql_coverage.py
+++ b/apps/api/tests/graphql/test_graphql_coverage.py
@@ -20,17 +20,27 @@ from unifi_api.serializers._registry import (
 from unifi_api.services.manifest import ManifestRegistry
 
 
-# PR1 baseline: every product is exempt (no resolvers yet, just the smoke
-# `health` field). PR2 will remove "network" from this set; PR3 "protect"; PR4 "access".
-EXEMPT_PRODUCTS: set[str] = {"network", "protect", "access"}
+# PR2.5 close: network is now covered by ~80 NetworkQuery resolvers. The
+# gate enforces every network read tool maps to a Query field. PR3 will
+# remove "protect"; PR4 "access". PR4 close has the set empty.
+EXEMPT_PRODUCTS: set[str] = {"protect", "access"}
 
 
 def _read_tools_by_product() -> dict[str, list[str]]:
-    """Group read tools (LIST + DETAIL kinds) by product."""
+    """Group read tools (LIST + DETAIL kinds, `unifi_list_*` / `unifi_get_*` prefix) by product.
+
+    Mutation tools (`unifi_update_*`, `unifi_block_*`, `unifi_configure_*`, etc.)
+    are also registered with DETAIL render kind because the action endpoint
+    returns a single result — but they are out of scope for Phase 6's read-only
+    GraphQL surface. Filter by prefix in addition to kind.
+    """
     reg = ManifestRegistry.load_from_apps()
     serializer_reg = serializer_registry_singleton()
     out: dict[str, list[str]] = {"network": [], "protect": [], "access": []}
     for tool_name in reg.all_tools():
+        # Read-tool prefix filter — Phase 6 scope is unifi_list_* / unifi_get_* only.
+        if not (tool_name.startswith("unifi_list_") or tool_name.startswith("unifi_get_")):
+            continue
         try:
             entry = reg.resolve(tool_name)
         except Exception:

--- a/apps/api/tests/graphql/test_n1_regression.py
+++ b/apps/api/tests/graphql/test_n1_regression.py
@@ -35,3 +35,131 @@ async def test_request_cache_dedupes_within_one_query() -> None:
     )
     assert a == b
     assert fetches == 1, "RequestCache failed to dedupe — N+1 risk"
+
+
+@pytest.mark.asyncio
+async def test_deep_network_query_makes_constant_manager_calls(
+    tmp_path, monkeypatch,
+) -> None:
+    """Phase 6 PR2.5 — deep query with N clients × their device makes exactly
+    2 manager calls (one for clients, one for devices). The request cache
+    prevents N×M fan-out across the relationship edge.
+    """
+    import json
+    import uuid
+    from datetime import datetime, timezone
+    from unittest.mock import AsyncMock, MagicMock
+
+    from httpx import ASGITransport, AsyncClient
+
+    from unifi_api.auth.api_key import generate_key, hash_key
+    from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+    from unifi_api.db.crypto import ColumnCipher, derive_key
+    from unifi_api.db.models import ApiKey, Base, Controller
+    from unifi_api.server import create_app
+
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    cfg = ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+    app = create_app(cfg)
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    sm = app.state.sessionmaker
+    material = generate_key()
+    cid = str(uuid.uuid4())
+    cipher = ColumnCipher(derive_key("k"))
+    cred_blob = cipher.encrypt(json.dumps(
+        {"username": "u", "password": "p", "api_token": None}
+    ).encode("utf-8"))
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="admin",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="c", base_url="https://c", product_kinds="network",
+            credentials_blob=cred_blob, verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+
+    # 10 clients all hanging off the same AP
+    fixture_clients = [
+        {"mac": f"aa:bb:cc:dd:ee:{i:02x}", "hostname": f"c{i}", "ap_mac": "ap:01"}
+        for i in range(10)
+    ]
+    fixture_devices = [{"mac": "ap:01", "name": "AP-1", "model": "U7PRO"}]
+
+    counts = {"get_clients": 0, "get_devices": 0}
+
+    async def _stub_get_clients():
+        counts["get_clients"] += 1
+        return fixture_clients
+
+    async def _stub_get_devices():
+        counts["get_devices"] += 1
+        return fixture_devices
+
+    fake_client_mgr = MagicMock()
+    fake_client_mgr.get_clients = _stub_get_clients
+    fake_device_mgr = MagicMock()
+    fake_device_mgr.get_devices = _stub_get_devices
+    fake_cm = MagicMock()
+    fake_cm.site = "default"
+    fake_cm.set_site = AsyncMock()
+
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+        if attr_name == "client_manager":
+            return fake_client_mgr
+        if attr_name == "device_manager":
+            return fake_device_mgr
+        return MagicMock()
+
+    async def _fake_get_connection_manager(self, session, controller_id, product):
+        return fake_cm
+
+    monkeypatch.setattr(
+        "unifi_api.services.managers.ManagerFactory.get_domain_manager",
+        _fake_get_domain_manager,
+    )
+    monkeypatch.setattr(
+        "unifi_api.services.managers.ManagerFactory.get_connection_manager",
+        _fake_get_connection_manager,
+    )
+
+    query = f'''{{
+      network {{
+        clients(controller: "{cid}", limit: 10) {{
+          items {{
+            mac
+            device {{ mac name model }}
+          }}
+        }}
+      }}
+    }}'''
+
+    headers = {"Authorization": f"Bearer {material.plaintext}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body.get("errors") is None, body
+        items = body["data"]["network"]["clients"]["items"]
+        assert len(items) == 10
+        # All 10 clients resolved their device — no fan-out
+        assert all(it["device"]["name"] == "AP-1" for it in items)
+
+    # The keystone N+1 assertion
+    assert counts["get_clients"] == 1, (
+        f"expected 1 client snapshot fetch, got {counts['get_clients']}"
+    )
+    assert counts["get_devices"] == 1, (
+        f"expected 1 device snapshot fetch (cache should dedupe), "
+        f"got {counts['get_devices']}"
+    )

--- a/apps/api/tests/graphql/test_query_e2e_network.py
+++ b/apps/api/tests/graphql/test_query_e2e_network.py
@@ -1,0 +1,334 @@
+"""Phase 6 PR2.5 — end-to-end network GraphQL queries.
+
+Five representative consumer flows (flat list, deep relationship edge,
+cross-resource fan-in, pagination, auth scope) plus the deep N+1 regression
+sibling lives in `test_n1_regression.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from unifi_api.auth.api_key import generate_key, hash_key
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.db.crypto import ColumnCipher, derive_key
+from unifi_api.db.models import ApiKey, Base, Controller
+from unifi_api.server import create_app
+
+
+def _cfg(tmp_path: Path) -> ApiConfig:
+    return ApiConfig(
+        http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+        logging=LoggingConfig(level="WARNING"),
+        db=DbConfig(path=str(tmp_path / "state.db")),
+    )
+
+
+async def _bootstrap(tmp_path: Path):
+    """Bootstrap an admin-keyed app with one controller seeded."""
+    app = create_app(_cfg(tmp_path))
+    async with app.state.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sm = app.state.sessionmaker
+    material = generate_key()
+    cid = str(uuid.uuid4())
+    cipher = ColumnCipher(derive_key("k"))
+    cred_blob = cipher.encrypt(json.dumps(
+        {"username": "u", "password": "p", "api_token": None}
+    ).encode("utf-8"))
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=material.prefix,
+            hash=hash_key(material.plaintext), scopes="admin",
+            name="t", created_at=datetime.now(timezone.utc),
+        ))
+        session.add(Controller(
+            id=cid, name="c", base_url="https://c", product_kinds="network",
+            credentials_blob=cred_blob, verify_tls=False, is_default=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+    return app, material.plaintext, cid
+
+
+def _stub_managers(
+    monkeypatch,
+    *,
+    clients: list[Any] | None = None,
+    devices: list[Any] | None = None,
+    networks: list[Any] | None = None,
+):
+    """Patch ManagerFactory.get_domain_manager / get_connection_manager so
+    network resolvers see preconfigured fixture data.
+
+    Returns a per-method call counter dict for N+1 assertions.
+    """
+    call_counts: dict[str, int] = {
+        "get_clients": 0,
+        "get_devices": 0,
+        "get_networks": 0,
+    }
+
+    async def _stub_get_clients():
+        call_counts["get_clients"] += 1
+        return clients or []
+
+    async def _stub_get_devices():
+        call_counts["get_devices"] += 1
+        return devices or []
+
+    async def _stub_get_networks():
+        call_counts["get_networks"] += 1
+        return networks or []
+
+    fake_client_mgr = MagicMock()
+    fake_client_mgr.get_clients = _stub_get_clients
+    fake_device_mgr = MagicMock()
+    fake_device_mgr.get_devices = _stub_get_devices
+    fake_network_mgr = MagicMock()
+    fake_network_mgr.get_networks = _stub_get_networks
+
+    domain_mgrs = {
+        ("network", "client_manager"): fake_client_mgr,
+        ("network", "device_manager"): fake_device_mgr,
+        ("network", "network_manager"): fake_network_mgr,
+    }
+
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+        return domain_mgrs[(product, attr_name)]
+
+    fake_cm = MagicMock()
+    fake_cm.site = "default"
+    fake_cm.set_site = AsyncMock()
+
+    async def _fake_get_connection_manager(self, session, controller_id, product):
+        return fake_cm
+
+    monkeypatch.setattr(
+        "unifi_api.services.managers.ManagerFactory.get_domain_manager",
+        _fake_get_domain_manager,
+    )
+    monkeypatch.setattr(
+        "unifi_api.services.managers.ManagerFactory.get_connection_manager",
+        _fake_get_connection_manager,
+    )
+
+    return call_counts
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — flat list query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_clients_flat_list(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    fixture_clients = [
+        {"mac": "aa:bb:cc:dd:ee:01", "hostname": "alpha", "is_online": True, "ap_mac": "ap:01"},
+        {"mac": "aa:bb:cc:dd:ee:02", "hostname": "beta", "is_online": False, "ap_mac": "ap:02"},
+        {"mac": "aa:bb:cc:dd:ee:03", "hostname": "gamma", "is_online": True, "ap_mac": "ap:01"},
+    ]
+    _stub_managers(monkeypatch, clients=fixture_clients)
+
+    headers = {"Authorization": f"Bearer {key}"}
+    query = (
+        f'{{ network {{ clients(controller: "{cid}", limit: 10) '
+        f'{{ items {{ mac hostname status }} nextCursor }} }} }}'
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("errors") is None, body
+        items = body["data"]["network"]["clients"]["items"]
+        assert len(items) == 3
+        assert {it["hostname"] for it in items} == {"alpha", "beta", "gamma"}
+        assert {it["status"] for it in items} == {"online", "offline"}
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — deep query with relationship edge (Client.device)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_clients_with_device_edge(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    fixture_clients = [
+        {"mac": "aa:bb:cc:dd:ee:01", "hostname": "alpha", "ap_mac": "ap:01"},
+    ]
+    fixture_devices = [
+        {"mac": "ap:01", "name": "Living-Room-AP", "model": "U7PRO"},
+    ]
+    counts = _stub_managers(monkeypatch, clients=fixture_clients, devices=fixture_devices)
+
+    headers = {"Authorization": f"Bearer {key}"}
+    query = f'''{{
+      network {{
+        clients(controller: "{cid}", limit: 5) {{
+          items {{
+            mac
+            hostname
+            device {{ mac name model }}
+          }}
+        }}
+      }}
+    }}'''
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("errors") is None, body
+        items = body["data"]["network"]["clients"]["items"]
+        assert len(items) == 1
+        assert items[0]["device"]["name"] == "Living-Room-AP"
+        assert items[0]["device"]["model"] == "U7PRO"
+        # Both manager methods called exactly once (request cache deduplication)
+        assert counts["get_clients"] == 1
+        assert counts["get_devices"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — cross-resource query (clients + devices + networks in one round-trip)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_cross_resource_query(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    fixture_clients = [{"mac": "aa:01", "hostname": "alpha"}]
+    fixture_devices = [{"mac": "ap:01", "name": "AP-1", "model": "U7PRO"}]
+    fixture_networks = [{"_id": "net-1", "name": "Trusted"}]
+    _stub_managers(
+        monkeypatch,
+        clients=fixture_clients,
+        devices=fixture_devices,
+        networks=fixture_networks,
+    )
+
+    headers = {"Authorization": f"Bearer {key}"}
+    query = f'''{{
+      network {{
+        clients(controller: "{cid}", limit: 5) {{ items {{ mac }} }}
+        devices(controller: "{cid}", limit: 5) {{ items {{ mac name }} }}
+        networks(controller: "{cid}", limit: 5) {{ items {{ id name }} }}
+      }}
+    }}'''
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("errors") is None, body
+        net = body["data"]["network"]
+        assert net["clients"]["items"][0]["mac"] == "aa:01"
+        assert net["devices"]["items"][0]["name"] == "AP-1"
+        assert net["networks"]["items"][0]["name"] == "Trusted"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — pagination with cursor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_clients_pagination(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    # 5 clients with monotonically increasing last_seen so paginate() (descending)
+    # produces a deterministic ordering across pages.
+    fixture_clients = [
+        {"mac": f"aa:{i:02x}", "hostname": f"c{i}", "last_seen": 1000 + i}
+        for i in range(5)
+    ]
+    _stub_managers(monkeypatch, clients=fixture_clients)
+
+    headers = {"Authorization": f"Bearer {key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        # Page 1: limit=2, cursor=null
+        q1 = (
+            f'{{ network {{ clients(controller: "{cid}", limit: 2) '
+            f'{{ items {{ mac }} nextCursor }} }} }}'
+        )
+        r1 = await c.post("/v1/graphql", headers=headers, json={"query": q1})
+        body1 = r1.json()
+        assert body1.get("errors") is None, body1
+        page1_macs = [it["mac"] for it in body1["data"]["network"]["clients"]["items"]]
+        next_cursor = body1["data"]["network"]["clients"]["nextCursor"]
+        assert len(page1_macs) == 2
+        assert next_cursor is not None
+
+        # Page 2: limit=2, cursor=<page 1's nextCursor>
+        q2 = (
+            f'{{ network {{ clients(controller: "{cid}", limit: 2, cursor: "{next_cursor}") '
+            f'{{ items {{ mac }} nextCursor }} }} }}'
+        )
+        r2 = await c.post("/v1/graphql", headers=headers, json={"query": q2})
+        body2 = r2.json()
+        assert body2.get("errors") is None, body2
+        page2_macs = [it["mac"] for it in body2["data"]["network"]["clients"]["items"]]
+        assert len(page2_macs) == 2
+        # No overlap between pages
+        assert set(page1_macs).isdisjoint(set(page2_macs))
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — auth scope (read-scope key works; no key fails)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_auth_scope(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, _admin_key, cid = await _bootstrap(tmp_path)
+
+    # Add a read-scope key
+    sm = app.state.sessionmaker
+    read_material = generate_key()
+    async with sm() as session:
+        session.add(ApiKey(
+            id=str(uuid.uuid4()), prefix=read_material.prefix,
+            hash=hash_key(read_material.plaintext), scopes="read",
+            name="r", created_at=datetime.now(timezone.utc),
+        ))
+        await session.commit()
+
+    _stub_managers(monkeypatch, clients=[{"mac": "aa:01", "hostname": "alpha"}])
+
+    query = (
+        f'{{ network {{ clients(controller: "{cid}", limit: 1) '
+        f'{{ items {{ mac }} }} }} }}'
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        # Read-scope key works for read fields
+        r_read = await c.post(
+            "/v1/graphql",
+            headers={"Authorization": f"Bearer {read_material.plaintext}"},
+            json={"query": query},
+        )
+        body_read = r_read.json()
+        assert body_read.get("errors") is None, body_read
+        assert body_read["data"]["network"]["clients"]["items"][0]["mac"] == "aa:01"
+
+        # No key -> errors with FORBIDDEN/UNAUTHENTICATED code
+        r_unauth = await c.post("/v1/graphql", json={"query": query})
+        body_unauth = r_unauth.json()
+        assert body_unauth.get("errors")
+        codes = [e.get("extensions", {}).get("code") for e in body_unauth["errors"]]
+        assert any(c in ("UNAUTHENTICATED", "FORBIDDEN") for c in codes)


### PR DESCRIPTION
## Summary

Phase 6 PR2.5 — completes the network GraphQL surface: ~80 NetworkQuery resolvers across 5 clusters, 3 relationship edges (Client.device, Device.portClients, Network.clients), 5 e2e tests, deep N+1 regression, and the keystone gate flip dropping `network` from `test_graphql_coverage`'s `EXEMPT_PRODUCTS`. Builds on PR2 (commit `6921570`).

This is the follow-up PR that the PR2 close-out flagged: PR2 promoted all 23 network read serializers to canonical Strawberry types and shipped a 3-resolver preview; this PR fills out the GraphQL surface to full network parity.

### What landed

**Resolvers (8 commits, ~80 methods):**

| Cluster | Commit | Resolvers |
|---|---|---|
| A — clients/devices/networks | `61b3258` | 15 (`client`, `blockedClients`, `clientByIp`, `device`, `deviceRadio`, `lldpNeighbors`, `rogueAps`, `knownRogueAps`, `rfScanResults`, `availableChannels`, `speedtestStatus`, `networkDetail`, `networkHealth`) |
| B — wlan/vpn/dns/routes | `3b35d99` | 13 (`wlans`/`wlan`, `vpnClients`/`vpnClient`, `vpnServers`/`vpnServer`, `dnsRecords`/`dnsRecord`, `routes`/`route`, `activeRoutes`, `trafficRoutes`/`trafficRoute`) |
| C — firewall/qos/dpi/cf/acl/oon/port_forwards | `8aca58d` | 16 |
| D — stats/events/system/vouchers/sessions | `dd4ca4a` | 25 (multi-kind dispatch on stats; event_log dispatch on alerts/anomalies/ipsEvents) |
| E — switch/ap_groups/client_groups | `40eb0c5` | 10 |

**Relationship edges (commit `0ece90f`):**
- `Client.device: Device | None` — the AP/switch this client connects through
- `Device.portClients: [Client!]!` — clients connected via this AP
- `Network.clients: [Client!]!` — clients on this network (filtered by `network_id`)

Implemented via `strawberry.Private` context-carrying fields (`_controller_id`, `_site`, `_ap_mac`) wired in by the parent resolvers. `to_dict()` strips private + callable values to keep REST output byte-identical.

**Coverage gap closed (commit `41c2417`):**
- `EXEMPT_PRODUCTS` in `test_graphql_coverage.py` reduced from `{network, protect, access}` to `{protect, access}`.
- Filter now uses tool-name prefix (`unifi_list_*`/`unifi_get_*`) plus RenderKind, distinguishing reads from mutation/action tools that share DETAIL kind.

**E2E tests + N+1 regression (commit `56d3c3e`):**
- 5 representative e2e queries: flat list, deep with relationship edge, cross-resource, pagination, auth scope.
- Deep N+1 regression: deep 10-client × `device` edge query produces exactly **2 manager calls** (1 client snapshot + 1 device snapshot). Proves `RequestCache` deduplicates per-request even across relationship edges that fan out from N items to a shared ancestor. Without the cache: 1 + 10 = 11.

### Test deltas

| Package | Before | After | Δ |
|---|---|---|---|
| unifi-core | 69 | 69 | 0 |
| unifi-mcp-shared | 205 | 205 | 0 |
| unifi-network-mcp | 630 | 630 | 0 |
| unifi-protect-mcp | 157 | 157 | 0 |
| unifi-access-mcp | 336 | 336 | 0 |
| **unifi-api** | **536** | **542** | **+6** |

Per Phase 6 spec §6 — gates + e2e + targeted coercion, no per-resolver unit tests. The +6 is exactly the e2e + N+1 regression set; the ~80 resolvers themselves are gate-policed (coverage + naming + drift + N+1).

All 6 GraphQL CI gates remain green throughout. Phase 4A/5A/5B gates remain green.

## Test plan

- [x] All 6 packages green per-package
- [x] All 6 GraphQL CI gates green (coverage now polices network; SDL drift, docs drift, N+1, naming, versioning)
- [x] Live smoke against the real network controller (UDM SE) using `.env` credentials:
  - Deep cross-resource query: `{ network { clients(...) { items { mac hostname device { mac name model } } } networks(...) { items { id name } } firewallPolicies(...) { items { id name action } } } }` resolves all three resources in one round-trip
  - All 3 real clients (Mac, DA16600-795E, DA16600-CD54) correctly resolve their `device` edge to the same AP (Novalis, U7PIW) — proving the relationship edge works end-to-end against the real controller
  - REST `/v1/sites/default/clients` continues to return byte-identical dict shape via `Type.from_manager_output(raw).to_dict()`

## Adaptations from the plan

1. **Strawberry forward references via `Annotated[..., strawberry.lazy(...)]`** — bare string forward refs failed `UnresolvedFieldTypeError`; lazy is the canonical fix for Client ↔ Device circular type references.
2. **Cycle protection in `_query_field_names()`** — relationship edges form a Client → Device → Client cycle in the type graph; added `seen: set[int]` guard.
3. **`to_dict()` callable filter** — `dataclasses.asdict()` includes Strawberry-injected resolver methods as callable fields; the strip filters both `_*` keys AND callable values to preserve REST byte-identity.
4. **Coverage gate prefix filter** — manifest mutation tools register with DETAIL kind. Adding a `unifi_list_*` / `unifi_get_*` prefix filter alongside the kind check correctly scopes the gate to read tools only.
5. **DpiStats / EventTypes shape adjustment** — both originally had only `strawberry.Private` fields, which Strawberry rejects when used as a GraphQL return type. Promoted stored payloads to public `JSON` scalar fields (`applications`/`categories` on DpiStats, `eventTypes` on EventTypes) while preserving REST `to_dict()` output identity.
6. **Strict prefix scope** — write/action tools (`unifi_update_*`, `unifi_block_*`, `unifi_archive_*`, `unifi_configure_*`, `unifi_authorize_*`, `unifi_upgrade_*`, etc.) are out of scope; gate filter handles this cleanly.

## What's next

PR3 (originally protect type migration + protect resolvers) cuts from main after this merges. Same playbook: cluster the type migrations by source file, add resolvers in clusters, add relationship edges (Camera.events, Camera.recordings, Liveview.cameras, Recording.camera), drop `protect` from EXEMPT_PRODUCTS, e2e tests, live smoke. PR4 finishes with access + collapse `type_registry` to types-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)