### PR TITLE
Phase 8 PR1: doc artifacts (Strawberry→Pydantic walker, response_model wiring, openapi.json + drift gates, doc index)

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -7,3 +7,13 @@ depend on the MCP packages.
 
 See `docs/superpowers/specs/2026-04-28-unifi-rich-api-design.md` for the full
 design.
+
+## MFA / 2FA support
+
+`unifi-api-server` connects to UniFi controllers using local-account credentials (username + password + optional API token). It does **not** currently support controllers that require MFA / 2FA on local accounts.
+
+If your controller has MFA enabled, you'll need either:
+- A separate local account with MFA disabled (recommended for service accounts)
+- A long-lived API token (UniFi Network and Protect both support this on recent firmware)
+
+This is the same constraint the MCP servers (`unifi-network-mcp`, `unifi-protect-mcp`, `unifi-access-mcp`) inherit. See issue #150 for context.

--- a/apps/api/docs/README.md
+++ b/apps/api/docs/README.md
@@ -1,0 +1,42 @@
+# unifi-api-server documentation
+
+This directory contains the auto-generated reference docs and operational
+guides for `unifi-api-server`. All artifacts here are checked-in and
+drift-gated by CI — `openapi.json`, `openapi-reference.md`, and
+`graphql-reference.md` are regenerated from code, never edited by hand.
+
+## Reference
+
+- **REST**
+  - [`openapi.json`](../openapi.json) — OpenAPI 3.x spec; consumable by codegen tools (`openapi-generator`, `graphql-codegen`, `Postman`)
+  - [`openapi-reference.md`](./openapi-reference.md) — human-readable REST reference, grouped by tag
+  - **Live exploration**: `GET /v1/docs` serves Swagger UI; `GET /v1/openapi.json` serves the live spec
+- **GraphQL**
+  - [`../src/unifi_api/graphql/schema.graphql`](../src/unifi_api/graphql/schema.graphql) — SDL artifact
+  - [`graphql-reference.md`](./graphql-reference.md) — human-readable reference, grouped by namespace
+  - **Live exploration**: `GET /v1/graphql` serves GraphiQL playground; `POST /v1/graphql` accepts queries
+
+## Operations
+
+- [`graphql-versioning.md`](./graphql-versioning.md) — schema versioning policy (Phase 6)
+- [`release-smoke-checklist.md`](./release-smoke-checklist.md) — manual smoke checklist (Phase 8 — added in PR3)
+- [`release-coverage.md`](./release-coverage.md) — release coverage matrix (Phase 8 — added in PR3)
+- [`docker-compose.example.yml`](./docker-compose.example.yml) — deployment patterns (Phase 8 — added in PR4)
+
+## Deployment
+
+`unifi-api-server` is a standalone HTTP service. It runs **independently** of the MCP servers — both projects share the same manager packages from `unifi-core`, but neither depends on the other being running.
+
+Common patterns:
+- **Hobbyist with Claude Code**: run only the MCP servers; skip `unifi-api-server`.
+- **App developer building on the API**: run only `unifi-api-server` via Docker; skip the MCP servers.
+- **Tool builder who wants both**: run both as parallel containers (see `docker-compose.example.yml`).
+
+## Distribution
+
+`unifi-api-server` is published to:
+- PyPI: `pip install unifi-api-server`
+- GHCR: `docker pull ghcr.io/sirkirby/unifi-api-server:latest`
+- GitHub Releases: built wheels attached to each `api/v*` tag
+
+The distribution name `unifi-api-server` establishes `unifi-api-*` as the family namespace for the API and its future ecosystem (SDKs, CLIs).

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1,11 +1,14 @@
-# unifi-api GraphQL Reference
+# unifi-api-server GraphQL Reference
 
 > Auto-generated from the Strawberry schema by `unifi_api.graphql.docgen`.
-> Do not edit by hand. Regenerate with `python -m unifi_api.graphql.docgen`.
+> Regenerate with `python -m unifi_api.graphql.docgen`.
 
-## Schema (SDL)
+
+## Schema (full SDL)
+
 
 ```graphql
+
 """A UniFi Access device (reader / hub / lock)."""
 type AccessDevice {
   id: ID
@@ -1606,4 +1609,173 @@ type WlanPage {
   items: [Wlan!]!
   nextCursor: String
 }
+
 ```
+
+
+## Query namespaces
+
+
+### `query.access`
+
+
+Read-only access to UniFi Access resources.
+
+
+**Fields:**
+
+- `activitySummary: ActivitySummary`  — Get the access activity histogram summary.
+- `credential: Credential`  — Look up a single Access credential by id.
+- `credentials: CredentialPage!`  — List Access credentials (NFC / PIN / etc., paginated).
+- `device: AccessDevice`  — Look up a single Access device by id.
+- `devices: AccessDevicePage!`  — List Access devices (readers / hubs / locks, paginated).
+- `door: Door`  — Look up a single Access door by id.
+- `doorGroups: DoorGroupPage!`  — List Access door groups (paginated).
+- `doorStatus: DoorStatus`  — Get the live status (lock state + last event) of a door.
+- `doors: DoorPage!`  — List doors on the Access controller (paginated).
+- `event: AccessEvent`  — Look up a single Access event by id.
+- `events: AccessEventPage!`  — List Access events (paginated, most recent first).
+- `health: AccessHealth`  — Get the Access health probe summary.
+- `policies: PolicyPage!`  — List Access policies (who-can-access-what bindings).
+- `policy: Policy`  — Look up a single Access policy by id.
+- `schedules: SchedulePage!`  — List Access schedules (weekly access windows).
+- `systemInfo: AccessSystemInfo`  — Get the Access application info (name + version + host).
+- `users: UserPage!`  — List Access users (employees / cardholders, paginated).
+- `visitor: Visitor`  — Look up a single Access visitor by id.
+- `visitors: VisitorPage!`  — List Access visitors (time-bounded guest passes).
+
+
+### `query.health`
+
+
+Liveness probe; mirrors GET /v1/health/ready.
+
+
+**Fields:**
+
+- `ok: Boolean!`
+- `pythonVersion: String!`
+- `version: String!`
+
+
+### `query.network`
+
+
+Read-only access to UniFi Network resources.
+
+
+**Fields:**
+
+- `aclRule: AclRule`  — Look up a single ACL rule by id.
+- `aclRules: AclRulePage!`  — List ACL rules on the given controller/site (paginated).
+- `activeRoutes: ActiveRoutePage!`  — List the gateway's active kernel routing-table entries (paginated).
+- `alarms: AlarmPage!`  — List controller alarms (paginated).
+- `alerts: EventLogPage!`  — List active alerts (paginated).
+- `anomalies: EventLogPage!`  — List recent anomalies (paginated).
+- `apGroup: ApGroup`  — Look up a single AP group by id.
+- `apGroups: ApGroupPage!`  — List AP groups on the given controller/site (paginated).
+- `autobackupSettings: AutoBackupSettings`  — Get auto-backup schedule + retention settings.
+- `availableChannels: [AvailableChannel!]!`  — List wireless channels allowed by the regulatory domain.
+- `backups: BackupPage!`  — List controller backups (paginated).
+- `blockedClients: BlockedClientPage!`  — List clients currently blocked from the network (paginated).
+- `client: Client`  — Look up a single client by MAC address.
+- `clientByIp: ClientLookup`  — Look up a client by IP address (online-presence check).
+- `clientDpiTraffic: [StatPoint!]!`  — Per-client DPI traffic breakdown.
+- `clientGroup: ClientGroup`  — Look up a single network member client group by id.
+- `clientGroups: ClientGroupPage!`  — List network member client groups on the given controller/site (paginated).
+- `clientSessions: ClientSessionPage!`  — List a client's association sessions (paginated).
+- `clientStats: [StatPoint!]!`  — Per-client stats timeseries (by MAC).
+- `clientWifiDetails: ClientWifiDetails`  — Get a client's current WiFi parameters (signal, rates).
+- `clients: ClientPage!`  — List clients on the given controller/site (paginated).
+- `contentFilter: ContentFilter`  — Look up a single content filter by id.
+- `contentFilters: ContentFilterPage!`  — List content filters on the given controller/site (paginated).
+- `dashboardStats: [StatPoint!]!`  — Site dashboard timeseries (all-points).
+- `device: Device`  — Look up a single device by MAC address.
+- `deviceRadio: DeviceRadio`  — Get the radio configuration for a UniFi access point.
+- `deviceStats: [StatPoint!]!`  — Per-device stats timeseries (by MAC).
+- `devices: DevicePage!`  — List devices on the given controller/site (paginated).
+- `dnsRecord: DnsRecord`  — Look up a single DNS record by id.
+- `dnsRecords: DnsRecordPage!`  — List static DNS records on the given controller/site (paginated).
+- `dpiApplications: DpiApplicationPage!`  — List DPI applications (paginated).
+- `dpiCategories: DpiCategoryPage!`  — List DPI categories (paginated).
+- `dpiStats: DpiStats`  — DPI stats catalog (applications + categories).
+- `eventLog: EventLogPage!`  — List recent controller events (paginated).
+- `eventTypes: EventTypes`  — Get the controller's event-type prefix catalog.
+- `firewallGroup: FirewallGroup`  — Look up a single firewall group by id.
+- `firewallGroups: FirewallGroupPage!`  — List firewall address/port groups (paginated).
+- `firewallPolicies: FirewallRulePage!`  — List firewall policies/rules on the given controller/site (paginated).
+- `firewallPolicy: FirewallRule`  — Look up a single firewall policy/rule by id.
+- `firewallZones: [FirewallZone!]!`  — List firewall zones (typically a small flat list — no pagination).
+- `gatewayStats: [StatPoint!]!`  — Gateway stats timeseries.
+- `ipsEvents: EventLogPage!`  — List recent IPS/IDS events (paginated).
+- `knownRogueAps: KnownRogueApPage!`  — List known (allowlisted) rogue APs (paginated).
+- `lldpNeighbors: LldpNeighbors`  — Get LLDP neighbors reported by a switch.
+- `networkDetail: Network`  — Look up a single LAN/VLAN network by id. (Named ``networkDetail`` because ``network`` is reserved for the namespace.)
+- `networkHealth: [NetworkHealth!]!`  — Get the controller's network-health subsystems list.
+- `networkStats: [StatPoint!]!`  — Network-wide stats timeseries.
+- `networks: NetworkPage!`  — List configured LAN/VLAN networks on the given controller/site (paginated).
+- `oonPolicies: OonPolicyPage!`  — List OON (out-of-network) policies (paginated).
+- `oonPolicy: OonPolicy`  — Look up a single OON policy by id.
+- `portForward: PortForward`  — Look up a single port forward by id.
+- `portForwards: PortForwardPage!`  — List port forwards on the given controller/site (paginated).
+- `portProfile: PortProfile`  — Look up a single switch port profile by id.
+- `portProfiles: PortProfilePage!`  — List switch port profiles on the given controller/site (paginated).
+- `portStats: PortStats`  — Get the per-port stats wrapper for a switch (name/model + port_table).
+- `qosRule: QosRule`  — Look up a single QoS rule by id.
+- `qosRules: QosRulePage!`  — List QoS rules on the given controller/site (paginated).
+- `rfScanResults: [RfScanResult!]!`  — List RF-scan results for a specific access point.
+- `rogueAps: RogueApPage!`  — List rogue (unknown) APs detected within a window (paginated).
+- `route: Route`  — Look up a single static route by id.
+- `routes: RoutePage!`  — List configured static routes (paginated).
+- `siteDpiTraffic: [StatPoint!]!`  — Site-wide DPI traffic breakdown.
+- `siteSettings: SiteSettings`  — Get site-level settings (locale, timezone, advanced).
+- `snmpSettings: SnmpSettings`  — Get SNMP settings.
+- `speedtestResults: SpeedtestResultPage!`  — List recent speedtest results (paginated).
+- `speedtestStatus: SpeedtestStatus`  — Get the gateway speedtest status (idle/running + last results).
+- `switchCapabilities: SwitchCapabilities`  — Get switch capabilities (caps dict + STP / dot1x flags).
+- `switchPorts: SwitchPorts`  — Get the port-override wrapper for a switch (name/model + per-port overrides).
+- `systemInfo: SystemInfo`  — Get controller system info (build, uptime, hardware).
+- `topClients: [TopClient!]!`  — List top-traffic clients within a window.
+- `trafficRoute: TrafficRoute`  — Look up a single traffic-route policy by id.
+- `trafficRoutes: TrafficRoutePage!`  — List traffic-route policies (V2 /trafficroutes) (paginated).
+- `userGroup: UserGroup`  — Look up a single QoS user group by id.
+- `userGroups: UserGroupPage!`  — List QoS user groups (V1 /rest/usergroup) on the given controller/site (paginated).
+- `voucher: Voucher`  — Look up a single hotspot voucher by id.
+- `vouchers: VoucherPage!`  — List hotspot vouchers on the given controller/site (paginated).
+- `vpnClient: VpnClient`  — Look up a single VPN client by id.
+- `vpnClients: VpnClientPage!`  — List configured VPN clients (outbound tunnels) (paginated).
+- `vpnServer: VpnServer`  — Look up a single VPN server by id.
+- `vpnServers: VpnServerPage!`  — List configured VPN servers (inbound tunnels) (paginated).
+- `wlan: Wlan`  — Look up a single WLAN/SSID by id.
+- `wlans: WlanPage!`  — List WLAN/SSID configurations on the given controller/site (paginated).
+
+
+### `query.protect`
+
+
+Read-only access to UniFi Protect resources.
+
+
+**Fields:**
+
+- `alarmProfiles: AlarmProfileList`  — List configured alarm profiles ({profiles, count}).
+- `alarmStatus: AlarmStatus`  — Get the alarm system arm-state snapshot.
+- `camera: Camera`  — Look up a single Protect camera by id.
+- `cameraAnalytics: CameraAnalytics`  — Get analytics summary for a Protect camera.
+- `cameraStreams: CameraStreams`  — Get the stream catalog (channels + RTSPS URLs) for a camera.
+- `cameras: CameraPage!`  — List cameras on the Protect controller (paginated).
+- `chimes: ChimePage!`  — List paired Protect chimes (paginated).
+- `event: Event`  — Look up a single Protect event by id.
+- `eventThumbnail: EventThumbnail`  — Get the thumbnail for a Protect event.
+- `events: EventPage!`  — List Protect events (paginated, most recent first).
+- `firmwareStatus: FirmwareStatus`  — Get firmware status for the NVR plus its devices.
+- `health: ProtectHealth`  — Get the NVR health snapshot (cpu / memory / storage).
+- `lights: LightPage!`  — List Protect lights (PIR-triggered floodlights).
+- `liveviews: LiveviewPage!`  — List Protect liveviews (multi-camera grid layouts).
+- `recordingStatus: RecordingStatusList`  — Get current recording state for one or all cameras ({cameras, count}).
+- `recordings: RecordingPage!`  — List Protect recording windows for a camera. UniFi Protect exposes a single continuous recording window per camera.
+- `sensors: SensorPage!`  — List Protect sensors (motion / leak / temperature).
+- `smartDetections: SmartDetectionPage!`  — List Protect smart-detection events (paginated, most recent first).
+- `snapshot: Snapshot`  — Capture a JPEG snapshot from a camera (metadata only).
+- `systemInfo: ProtectSystemInfo`  — Get the NVR-level system info snapshot.
+- `viewers: ViewerList`  — List Protect viewers ({viewers, count}).

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1,0 +1,2001 @@
+# unifi-api-server REST Reference
+
+> Auto-generated from `openapi.json` by `unifi_api.graphql.docgen`.
+> Regenerate with `python -m unifi_api.graphql.docgen`.
+
+
+## access/credentials
+
+### `GET /v1/sites/{site_id}/credentials` — List Credentials
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_CredentialModel_`
+
+### `GET /v1/sites/{site_id}/credentials/{credential_id}` — Get Credential
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `credential_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_CredentialModel_`
+
+
+## access/devices
+
+### `GET /v1/sites/{site_id}/access-devices` — List Access Devices
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/access-devices/{device_id}` — Get Access Device
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `device_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## access/doors
+
+### `GET /v1/sites/{site_id}/door-groups` — List Door Groups
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/doors` — List Doors
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_DoorModel_`
+
+### `GET /v1/sites/{site_id}/doors/{door_id}` — Get Door
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `door_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_DoorModel_`
+
+### `GET /v1/sites/{site_id}/doors/{door_id}/status` — Get Door Status
+
+
+Per-door status (nested under /doors/{door_id}/status).
+
+Mirrors the protect /cameras/{id}/analytics nested-detail pattern.
+DoorManager.get_door_status raises UniFiNotFoundError on miss → 404.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `door_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## access/events
+
+### `GET /v1/sites/{site_id}/access/activity-summary` — Get Access Activity Summary
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `door_id` (query)
+- `days` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/access/events` — List Access Events
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/access/events/{event_id}` — Get Access Event
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `event_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/access/recent-events` — Recent Access Events
+
+
+Return a snapshot of the websocket ring buffer.
+
+Differs from the SSE stream at ``/v1/streams/access/events``: this is
+a buffer-snapshot REST surface, not a tailing stream. Mirrors PR3's
+protect ``/recent-events`` shape: ``{events, count, source, buffer_size}``.
+``EventManager.get_recent_from_buffer`` is synchronous (in-memory ring
+buffer read).
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `event_type` (query)
+- `door_id` (query)
+- `limit` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## access/policies
+
+### `GET /v1/sites/{site_id}/policies` — List Policies
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/policies/{policy_id}` — Get Policy
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `policy_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## access/schedules
+
+### `GET /v1/sites/{site_id}/schedules` — List Schedules
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## access/system
+
+### `GET /v1/sites/{site_id}/access/health` — Get Access Health
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/access/system-info` — Get Access System Info
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## access/users
+
+### `GET /v1/sites/{site_id}/users` — List Users
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_UserModel_`
+
+### `GET /v1/sites/{site_id}/users/{user_id}` — Get User
+
+
+Fetch a user by listing then filtering — no native get_user method.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `user_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_UserModel_`
+
+
+## access/visitors
+
+### `GET /v1/sites/{site_id}/visitors` — List Visitors
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/visitors/{visitor_id}` — Get Visitor
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `visitor_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/clients
+
+### `GET /v1/sites/{site_id}/blocked-clients` — List Blocked Clients
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_BlockedClientModel_`
+
+### `GET /v1/sites/{site_id}/client-sessions` — Get Client Sessions
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/client-wifi-details/{mac}` — Get Client Wifi Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/clients` — List Clients
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_ClientModel_`
+
+### `GET /v1/sites/{site_id}/clients/{mac}` — Get Client
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_ClientModel_`
+
+
+## network/devices
+
+### `GET /v1/sites/{site_id}/devices` — List Devices
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_DeviceModel_`
+
+### `GET /v1/sites/{site_id}/devices/{mac}` — Get Device
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_DeviceModel_`
+
+### `GET /v1/sites/{site_id}/devices/{mac}/radio` — Get Device Radio
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/dns
+
+### `GET /v1/sites/{site_id}/dns-records` — List Dns Records
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_DnsRecordModel_`
+
+### `GET /v1/sites/{site_id}/dns-records/{record_id}` — Get Dns Record Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `record_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_DnsRecordModel_`
+
+
+## network/firewall
+
+### `GET /v1/sites/{site_id}/acl-rules` — List Acl Rules
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_AclRuleModel_`
+
+### `GET /v1/sites/{site_id}/acl-rules/{rule_id}` — Get Acl Rule Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `rule_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_AclRuleModel_`
+
+### `GET /v1/sites/{site_id}/firewall/groups` — List Firewall Groups
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_FirewallGroupModel_`
+
+### `GET /v1/sites/{site_id}/firewall/groups/{group_id}` — Get Firewall Group Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `group_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_FirewallGroupModel_`
+
+### `GET /v1/sites/{site_id}/firewall/rules` — List Firewall Rules
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_FirewallRuleModel_`
+
+### `GET /v1/sites/{site_id}/firewall/rules/{rule_id}` — Get Firewall Rule
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `rule_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_FirewallRuleModel_`
+
+### `GET /v1/sites/{site_id}/firewall/zones` — List Firewall Zones
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_FirewallZoneModel_`
+
+
+## network/groups
+
+### `GET /v1/sites/{site_id}/ap-groups` — List Ap Groups
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_ApGroupModel_`
+
+### `GET /v1/sites/{site_id}/ap-groups/{group_id}` — Get Ap Group Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `group_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_ApGroupModel_`
+
+### `GET /v1/sites/{site_id}/client-groups` — List Client Groups
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_ClientGroupModel_`
+
+### `GET /v1/sites/{site_id}/client-groups/{group_id}` — Get Client Group Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `group_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_ClientGroupModel_`
+
+### `GET /v1/sites/{site_id}/user-groups` — List User Groups
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_UserGroupModel_`
+
+### `GET /v1/sites/{site_id}/user-groups/{group_id}` — Get User Group Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `group_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_UserGroupModel_`
+
+
+## network/lldp
+
+### `GET /v1/sites/{site_id}/lldp-neighbors` — List Lldp Neighbors
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `device_mac` (query) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/lookup
+
+### `GET /v1/sites/{site_id}/lookup-by-ip` — Lookup Client By Ip
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `ip` (query) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/networks
+
+### `GET /v1/sites/{site_id}/networks` — List Networks
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_NetworkModel_`
+
+### `GET /v1/sites/{site_id}/networks/{network_id}` — Get Network
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `network_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_NetworkModel_`
+
+
+## network/observability
+
+### `GET /v1/sites/{site_id}/alerts` — Get Alerts
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/anomalies` — Get Anomalies
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/ips-events` — Get Ips Events
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/speedtest-results` — Get Speedtest Results
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/speedtest-status` — Get Speedtest Status
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `gateway_mac` (query) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/clients/{mac}` — Get Client Stats
+
+
+TIMESERIES; calls stats_manager.get_client_stats (PR4).
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/dashboard` — Get Dashboard Stats
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/devices/{mac}` — Get Device Stats
+
+
+TIMESERIES; calls stats_manager.get_device_stats (PR4).
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/dpi` — Get Dpi Stats
+
+
+DETAIL kind currently; manager method is stats_manager.get_dpi_stats.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/dpi/clients/{mac}` — Get Client Dpi Traffic
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/dpi/site` — Get Site Dpi Traffic
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/gateway` — Get Gateway Stats
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/stats/network` — Get Network Stats
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/policy
+
+### `GET /v1/sites/{site_id}/content-filters` — List Content Filters
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_ContentFilterModel_`
+
+### `GET /v1/sites/{site_id}/content-filters/{filter_id}` — Get Content Filter Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `filter_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_ContentFilterModel_`
+
+### `GET /v1/sites/{site_id}/dpi-applications` — List Dpi Applications
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_DpiApplicationModel_`
+
+### `GET /v1/sites/{site_id}/dpi-categories` — List Dpi Categories
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_DpiCategoryModel_`
+
+### `GET /v1/sites/{site_id}/oon-policies` — List Oon Policies
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_OonPolicyModel_`
+
+### `GET /v1/sites/{site_id}/oon-policies/{policy_id}` — Get Oon Policy Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `policy_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_OonPolicyModel_`
+
+### `GET /v1/sites/{site_id}/port-forwards` — List Port Forwards
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_PortForwardModel_`
+
+### `GET /v1/sites/{site_id}/port-forwards/{port_forward_id}` — Get Port Forward
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `port_forward_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_PortForwardModel_`
+
+### `GET /v1/sites/{site_id}/qos-rules` — List Qos Rules
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_QosRuleModel_`
+
+### `GET /v1/sites/{site_id}/qos-rules/{rule_id}` — Get Qos Rule Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `rule_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_QosRuleModel_`
+
+
+## network/routes
+
+### `GET /v1/sites/{site_id}/active-routes` — List Active Routes
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_ActiveRouteModel_`
+
+### `GET /v1/sites/{site_id}/static-routes` — List Routes
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_RouteModel_`
+
+### `GET /v1/sites/{site_id}/static-routes/{route_id}` — Get Route Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `route_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_RouteModel_`
+
+### `GET /v1/sites/{site_id}/traffic-routes` — List Traffic Routes
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_TrafficRouteModel_`
+
+### `GET /v1/sites/{site_id}/traffic-routes/{route_id}` — Get Traffic Route Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `route_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_TrafficRouteModel_`
+
+
+## network/snmp
+
+### `GET /v1/sites/{site_id}/snmp-settings` — Get Snmp Settings
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/switch
+
+### `GET /v1/sites/{site_id}/port-profiles` — List Port Profiles
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_PortProfileModel_`
+
+### `GET /v1/sites/{site_id}/port-profiles/{profile_id}` — Get Port Profile Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `profile_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_PortProfileModel_`
+
+### `GET /v1/sites/{site_id}/port-stats` — List Port Stats
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `device_mac` (query) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/switch-capabilities` — Get Switch Capabilities
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `device_mac` (query) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/switch-ports` — List Switch Ports
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `device_mac` (query) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/system
+
+### `GET /v1/sites/{site_id}/alarms` — List Alarms
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/autobackup-settings` — Get Autobackup Settings
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/backups` — List Backups
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/event-types` — Get Event Types
+
+
+DETAIL — event_manager.get_event_type_prefixes (sync method, returns list).
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/network-health` — Get Network Health
+
+
+LIST kind per Phase 4A — manager returns multi-element list of subsystems.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/site-settings` — Get Site Settings
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/system-info` — Get System Info
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/top-clients` — Get Top Clients
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/vouchers
+
+### `GET /v1/sites/{site_id}/voucher-details/{voucher_id}` — Get Voucher Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `voucher_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_VoucherModel_`
+
+### `GET /v1/sites/{site_id}/vouchers` — List Vouchers
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_VoucherModel_`
+
+
+## network/vpn
+
+### `GET /v1/sites/{site_id}/vpn-clients` — List Vpn Clients
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_VpnClientModel_`
+
+### `GET /v1/sites/{site_id}/vpn-clients/{client_id}` — Get Vpn Client Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `client_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_VpnClientModel_`
+
+### `GET /v1/sites/{site_id}/vpn-servers` — List Vpn Servers
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_VpnServerModel_`
+
+### `GET /v1/sites/{site_id}/vpn-servers/{server_id}` — Get Vpn Server Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `server_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_VpnServerModel_`
+
+
+## network/wireless
+
+### `GET /v1/sites/{site_id}/available-channels` — List Available Channels
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_AvailableChannelModel_`
+
+### `GET /v1/sites/{site_id}/known-rogue-aps` — List Known Rogue Aps
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/rf-scan-results` — List Rf Scan Results
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `ap_mac` (query) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_RfScanResultModel_`
+
+### `GET /v1/sites/{site_id}/rogue-aps` — List Rogue Aps
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `within_hours` (query)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## network/wlans
+
+### `GET /v1/sites/{site_id}/wlans` — List Wlans
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_WlanModel_`
+
+### `GET /v1/sites/{site_id}/wlans/{wlan_id}` — Get Wlan
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `wlan_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_WlanModel_`
+
+
+## protect/cameras
+
+### `GET /v1/sites/{site_id}/cameras` — List Cameras
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_CameraModel_`
+
+### `GET /v1/sites/{site_id}/cameras/{camera_id}` — Get Camera
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_CameraModel_`
+
+### `GET /v1/sites/{site_id}/cameras/{camera_id}/analytics` — Get Camera Analytics
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/cameras/{camera_id}/snapshot` — Get Camera Snapshot
+
+
+Return snapshot metadata (size_bytes / content_type / captured_at).
+
+The manager returns raw JPEG bytes; the SnapshotSerializer surfaces
+metadata only. A future ``/snapshot/raw`` endpoint that returns the
+binary body is deferred to Phase 5B if a UI consumer needs it.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/cameras/{camera_id}/streams` — Get Camera Streams
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/chimes` — List Chimes
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## protect/events
+
+### `GET /v1/sites/{site_id}/event-thumbnails/{event_id}` — Get Event Thumbnail
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `event_id` (path) (required)
+- `width` (query)
+- `height` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/events` — List Events
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_EventModel_`
+
+### `GET /v1/sites/{site_id}/events/{event_id}` — Get Event
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `event_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/recent-events` — Recent Events
+
+
+Return a snapshot of the websocket ring buffer.
+
+Differs from the SSE stream at ``/v1/streams/protect/events``: this is
+a buffer-snapshot REST surface, not a tailing stream. ``DETAIL`` render
+kind — the manager's wrapper dict (events / count / source / buffer_size)
+is itself the payload.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `event_type` (query)
+- `camera_id` (query)
+- `min_confidence` (query)
+- `limit` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/recording-status` — Get Recording Status
+
+
+Return current recording state for one or all cameras.
+
+The ``camera_id`` query is optional: omitting it returns the
+aggregate (all cameras), supplying it scopes to one camera and
+raises 404 via UniFiNotFoundError if the camera is unknown.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/recordings` — List Recordings
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (query) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/recordings/{recording_id}` — Get Recording
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `recording_id` (path) (required)
+- `camera_id` (query) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/smart-detections` — List Smart Detections
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `camera_id` (query)
+- `detection_type` (query)
+- `min_confidence` (query)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## protect/lights
+
+### `GET /v1/sites/{site_id}/lights` — List Lights
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/lights/{light_id}` — Get Light Details
+
+
+No native ``protect_get_light`` tool exists — filter from LIST.
+
+LightManager._get_light raises UniFiNotFoundError, but list_lights
+does not invoke that helper. We wrap the manager call defensively
+so any future refactor that surfaces UniFiNotFoundError keeps mapping
+cleanly to a 404.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `light_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## protect/liveviews
+
+### `GET /v1/sites/{site_id}/liveviews` — List Liveviews
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/liveviews/{liveview_id}` — Get Liveview
+
+
+No native ``protect_get_liveview`` tool — filter from LIST.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `liveview_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## protect/sensors
+
+### `GET /v1/sites/{site_id}/sensors` — List Sensors
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/sensors/{sensor_id}` — Get Sensor Details
+
+
+No native ``protect_get_sensor`` tool exists — filter from LIST.
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `sensor_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## protect/system
+
+### `GET /v1/sites/{site_id}/alarm-profiles` — Alarm List Profiles
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/alarm-status` — Alarm Get Status
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/firmware-status` — Get Firmware Status
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/protect/health` — Get Protect Health
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/protect/system-info` — Get Protect System Info
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/sites/{site_id}/viewers` — List Viewers
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
+
+## untagged
+
+### `POST /v1/actions/{tool_name}` — Post Action
+
+
+**Parameters:**
+
+- `tool_name` (path) (required)
+
+
+**Returns:** `object`
+
+### `GET /v1/audit` — List Audit
+
+
+**Parameters:**
+
+- `controller` (query)
+- `outcome` (query)
+- `since` (query)
+- `until` (query)
+- `q` (query)
+- `limit` (query)
+- `cursor` (query)
+
+
+**Returns:** `object`
+
+### `POST /v1/audit/prune` — Prune Endpoint
+
+
+**Returns:** `object`
+
+### `GET /v1/catalog/categories` — Get Categories
+
+
+**Returns:** `object`
+
+### `GET /v1/catalog/render-hints` — Get Render Hints
+
+
+**Returns:** `object`
+
+### `GET /v1/catalog/resources` — Get Resources
+
+
+Discoverability endpoint: every registered resource path with render_hint.
+
+Lists every (product, resource_path) pair from the serializer registry.
+For paths with placeholders (e.g., 'clients/{mac}'), renders as a path
+template under /v1/sites/{site_id}/.
+
+
+**Returns:** `object`
+
+### `GET /v1/catalog/tools` — Get Tools
+
+
+**Returns:** `object`
+
+### `GET /v1/controllers` — List Endpoint
+
+
+**Returns:** `array`
+
+### `POST /v1/controllers` — Post Controller
+
+### `DELETE /v1/controllers/{cid}` — Delete Endpoint
+
+
+**Parameters:**
+
+- `cid` (path) (required)
+
+### `GET /v1/controllers/{cid}` — Get Endpoint
+
+
+**Parameters:**
+
+- `cid` (path) (required)
+
+
+**Returns:** `ControllerOut`
+
+### `PATCH /v1/controllers/{cid}` — Patch Endpoint
+
+
+**Parameters:**
+
+- `cid` (path) (required)
+
+
+**Returns:** `ControllerOut`
+
+### `GET /v1/controllers/{cid}/capabilities` — Capabilities Endpoint
+
+
+**Parameters:**
+
+- `cid` (path) (required)
+- `refresh` (query)
+
+
+**Returns:** `object`
+
+### `POST /v1/controllers/{cid}/probe` — Probe Endpoint
+
+
+**Parameters:**
+
+- `cid` (path) (required)
+
+
+**Returns:** `object`
+
+### `GET /v1/diagnostics` — Get Diagnostics
+
+
+**Returns:** `object`
+
+### `GET /v1/graphql` — Handle Http Get
+
+### `POST /v1/graphql` — Handle Http Post
+
+### `GET /v1/health` — Liveness
+
+
+**Returns:** `object`
+
+### `GET /v1/health/ready` — Readiness
+
+
+**Returns:** `object`
+
+### `GET /v1/logs` — Get Logs
+
+
+**Parameters:**
+
+- `level` (query)
+- `logger` (query)
+- `q` (query)
+- `limit` (query)
+
+
+**Returns:** `object`
+
+### `GET /v1/settings` — Get Settings
+
+
+**Returns:** `object`
+
+### `PUT /v1/settings` — Put Settings
+
+
+**Returns:** `object`
+
+### `GET /v1/streams/access/doors/{door_id}/events` — Stream Access Door Events
+
+
+**Parameters:**
+
+- `door_id` (path) (required)
+- `controller` (query)
+- `Last-Event-ID` (header)
+
+### `GET /v1/streams/access/events` — Stream Access Events
+
+
+**Parameters:**
+
+- `controller` (query)
+- `Last-Event-ID` (header)
+
+### `GET /v1/streams/audit` — Stream Audit
+
+
+SSE stream of audit rows. One frame per row inserted via write_audit.
+
+### `GET /v1/streams/network/devices/{mac}/events` — Stream Network Device Events
+
+
+**Parameters:**
+
+- `mac` (path) (required)
+- `controller` (query)
+- `Last-Event-ID` (header)
+
+### `GET /v1/streams/network/events` — Stream Network Events
+
+
+**Parameters:**
+
+- `controller` (query)
+- `Last-Event-ID` (header)
+
+### `GET /v1/streams/protect/cameras/{camera_id}/events` — Stream Protect Camera Events
+
+
+**Parameters:**
+
+- `camera_id` (path) (required)
+- `controller` (query)
+- `Last-Event-ID` (header)
+
+### `GET /v1/streams/protect/events` — Stream Protect Events
+
+
+**Parameters:**
+
+- `controller` (query)
+- `Last-Event-ID` (header)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1,0 +1,16139 @@
+{
+  "components": {
+    "schemas": {
+      "AclRuleModel": {
+        "additionalProperties": true,
+        "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "destination": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "source": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "title": "AclRuleModel",
+        "type": "object"
+      },
+      "ActionIn": {
+        "properties": {
+          "args": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Args",
+            "type": "object"
+          },
+          "confirm": {
+            "default": false,
+            "title": "Confirm",
+            "type": "boolean"
+          },
+          "controller": {
+            "title": "Controller",
+            "type": "string"
+          },
+          "site": {
+            "title": "Site",
+            "type": "string"
+          }
+        },
+        "required": [
+          "site",
+          "controller"
+        ],
+        "title": "ActionIn",
+        "type": "object"
+      },
+      "ActiveRouteModel": {
+        "additionalProperties": true,
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance"
+          },
+          "gateway": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway"
+          },
+          "interface": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interface"
+          },
+          "target_subnet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Subnet"
+          }
+        },
+        "title": "ActiveRouteModel",
+        "type": "object"
+      },
+      "ApGroupModel": {
+        "additionalProperties": true,
+        "properties": {
+          "ap_count": {
+            "title": "Ap Count",
+            "type": "integer"
+          },
+          "device_macs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Device Macs",
+            "type": "array"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "ApGroupModel",
+        "type": "object"
+      },
+      "AvailableChannelModel": {
+        "additionalProperties": true,
+        "properties": {
+          "allowed": {
+            "title": "Allowed",
+            "type": "boolean"
+          },
+          "channel": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel"
+          },
+          "frequency_mhz": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Mhz"
+          },
+          "width_mhz": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Width Mhz"
+          }
+        },
+        "title": "AvailableChannelModel",
+        "type": "object"
+      },
+      "BlockedClientModel": {
+        "additionalProperties": true,
+        "properties": {
+          "blocked": {
+            "title": "Blocked",
+            "type": "boolean"
+          },
+          "hostname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hostname"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          },
+          "mac": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac"
+          }
+        },
+        "title": "BlockedClientModel",
+        "type": "object"
+      },
+      "CameraModel": {
+        "additionalProperties": true,
+        "properties": {
+          "channels": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channels"
+          },
+          "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "is_motion_detected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Motion Detected"
+          },
+          "is_recording": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Recording"
+          },
+          "is_smart_detected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Smart Detected"
+          },
+          "mac": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "CameraModel",
+        "type": "object"
+      },
+      "ClientGroupModel": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "qos_rate_max_down": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qos Rate Max Down"
+          },
+          "qos_rate_max_up": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qos Rate Max Up"
+          }
+        },
+        "title": "ClientGroupModel",
+        "type": "object"
+      },
+      "ClientModel": {
+        "additionalProperties": true,
+        "properties": {
+          "first_seen": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Seen"
+          },
+          "hostname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hostname"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip"
+          },
+          "is_guest": {
+            "title": "Is Guest",
+            "type": "boolean"
+          },
+          "is_wired": {
+            "title": "Is Wired",
+            "type": "boolean"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          },
+          "mac": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "usergroup_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Usergroup Id"
+          }
+        },
+        "title": "ClientModel",
+        "type": "object"
+      },
+      "ContentFilterModel": {
+        "additionalProperties": true,
+        "properties": {
+          "applies_to": {
+            "title": "Applies To"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile"
+          }
+        },
+        "title": "ContentFilterModel",
+        "type": "object"
+      },
+      "ControllerIn": {
+        "properties": {
+          "api_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Token"
+          },
+          "base_url": {
+            "title": "Base Url",
+            "type": "string"
+          },
+          "is_default": {
+            "default": false,
+            "title": "Is Default",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "product_kinds": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Product Kinds",
+            "type": "array"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          },
+          "verify_tls": {
+            "default": true,
+            "title": "Verify Tls",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "base_url",
+          "username",
+          "password",
+          "product_kinds"
+        ],
+        "title": "ControllerIn",
+        "type": "object"
+      },
+      "ControllerOut": {
+        "properties": {
+          "base_url": {
+            "title": "Base Url",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "is_default": {
+            "title": "Is Default",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "product_kinds": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Product Kinds",
+            "type": "array"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "verify_tls": {
+            "title": "Verify Tls",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "base_url",
+          "product_kinds",
+          "verify_tls",
+          "is_default",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ControllerOut",
+        "type": "object"
+      },
+      "ControllerPatch": {
+        "properties": {
+          "api_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Token"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Default"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          },
+          "product_kinds": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Product Kinds"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "verify_tls": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verify Tls"
+          }
+        },
+        "title": "ControllerPatch",
+        "type": "object"
+      },
+      "CredentialModel": {
+        "additionalProperties": true,
+        "properties": {
+          "expiry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiry"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "last_used": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "title": "CredentialModel",
+        "type": "object"
+      },
+      "Detail_AclRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/AclRuleModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[AclRuleModel]",
+        "type": "object"
+      },
+      "Detail_ApGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ApGroupModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[ApGroupModel]",
+        "type": "object"
+      },
+      "Detail_CameraModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/CameraModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[CameraModel]",
+        "type": "object"
+      },
+      "Detail_ClientGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ClientGroupModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[ClientGroupModel]",
+        "type": "object"
+      },
+      "Detail_ClientModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ClientModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[ClientModel]",
+        "type": "object"
+      },
+      "Detail_ContentFilterModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ContentFilterModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[ContentFilterModel]",
+        "type": "object"
+      },
+      "Detail_CredentialModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/CredentialModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[CredentialModel]",
+        "type": "object"
+      },
+      "Detail_DeviceModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DeviceModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[DeviceModel]",
+        "type": "object"
+      },
+      "Detail_DnsRecordModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DnsRecordModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[DnsRecordModel]",
+        "type": "object"
+      },
+      "Detail_DoorModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DoorModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[DoorModel]",
+        "type": "object"
+      },
+      "Detail_FirewallGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/FirewallGroupModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[FirewallGroupModel]",
+        "type": "object"
+      },
+      "Detail_FirewallRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/FirewallRuleModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[FirewallRuleModel]",
+        "type": "object"
+      },
+      "Detail_NetworkModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/NetworkModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[NetworkModel]",
+        "type": "object"
+      },
+      "Detail_OonPolicyModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/OonPolicyModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[OonPolicyModel]",
+        "type": "object"
+      },
+      "Detail_PortForwardModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PortForwardModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[PortForwardModel]",
+        "type": "object"
+      },
+      "Detail_PortProfileModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PortProfileModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[PortProfileModel]",
+        "type": "object"
+      },
+      "Detail_QosRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/QosRuleModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[QosRuleModel]",
+        "type": "object"
+      },
+      "Detail_RouteModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/RouteModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[RouteModel]",
+        "type": "object"
+      },
+      "Detail_TrafficRouteModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TrafficRouteModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[TrafficRouteModel]",
+        "type": "object"
+      },
+      "Detail_UserGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/UserGroupModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[UserGroupModel]",
+        "type": "object"
+      },
+      "Detail_UserModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/UserModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[UserModel]",
+        "type": "object"
+      },
+      "Detail_VoucherModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/VoucherModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[VoucherModel]",
+        "type": "object"
+      },
+      "Detail_VpnClientModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/VpnClientModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[VpnClientModel]",
+        "type": "object"
+      },
+      "Detail_VpnServerModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/VpnServerModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[VpnServerModel]",
+        "type": "object"
+      },
+      "Detail_WlanModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WlanModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[WlanModel]",
+        "type": "object"
+      },
+      "DeviceModel": {
+        "additionalProperties": true,
+        "properties": {
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip"
+          },
+          "mac": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "ports": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ports"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          },
+          "uptime": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uptime"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          }
+        },
+        "title": "DeviceModel",
+        "type": "object"
+      },
+      "DnsRecordModel": {
+        "additionalProperties": true,
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "hostname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hostname"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip"
+          },
+          "ttl": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "DnsRecordModel",
+        "type": "object"
+      },
+      "DoorModel": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "is_locked": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Locked"
+          },
+          "is_online": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Online"
+          },
+          "last_event": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "lock_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lock State"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "DoorModel",
+        "type": "object"
+      },
+      "DpiApplicationModel": {
+        "additionalProperties": true,
+        "properties": {
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "DpiApplicationModel",
+        "type": "object"
+      },
+      "DpiCategoryModel": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "DpiCategoryModel",
+        "type": "object"
+      },
+      "EventModel": {
+        "additionalProperties": true,
+        "properties": {
+          "camera": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Camera"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "smart_detect_types": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Smart Detect Types",
+            "type": "array"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "thumbnail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "EventModel",
+        "type": "object"
+      },
+      "FirewallGroupModel": {
+        "additionalProperties": true,
+        "properties": {
+          "group_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group Type"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "members": {
+            "title": "Members"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "FirewallGroupModel",
+        "type": "object"
+      },
+      "FirewallRuleModel": {
+        "additionalProperties": true,
+        "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "destination": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "predefined": {
+            "title": "Predefined",
+            "type": "boolean"
+          },
+          "source": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "title": "FirewallRuleModel",
+        "type": "object"
+      },
+      "FirewallZoneModel": {
+        "additionalProperties": true,
+        "properties": {
+          "default_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Policy"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "networks": {
+            "title": "Networks"
+          }
+        },
+        "title": "FirewallZoneModel",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "NetworkModel": {
+        "additionalProperties": true,
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "purpose": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purpose"
+          },
+          "subnet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subnet"
+          },
+          "vlan": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vlan"
+          }
+        },
+        "title": "NetworkModel",
+        "type": "object"
+      },
+      "OonPolicyModel": {
+        "additionalProperties": true,
+        "properties": {
+          "applies_to": {
+            "title": "Applies To"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "restriction_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restriction Level"
+          }
+        },
+        "title": "OonPolicyModel",
+        "type": "object"
+      },
+      "Page_AclRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AclRuleModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[AclRuleModel]",
+        "type": "object"
+      },
+      "Page_ActiveRouteModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ActiveRouteModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[ActiveRouteModel]",
+        "type": "object"
+      },
+      "Page_ApGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ApGroupModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[ApGroupModel]",
+        "type": "object"
+      },
+      "Page_AvailableChannelModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AvailableChannelModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[AvailableChannelModel]",
+        "type": "object"
+      },
+      "Page_BlockedClientModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BlockedClientModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[BlockedClientModel]",
+        "type": "object"
+      },
+      "Page_CameraModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CameraModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[CameraModel]",
+        "type": "object"
+      },
+      "Page_ClientGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ClientGroupModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[ClientGroupModel]",
+        "type": "object"
+      },
+      "Page_ClientModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ClientModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[ClientModel]",
+        "type": "object"
+      },
+      "Page_ContentFilterModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ContentFilterModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[ContentFilterModel]",
+        "type": "object"
+      },
+      "Page_CredentialModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[CredentialModel]",
+        "type": "object"
+      },
+      "Page_DeviceModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DeviceModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[DeviceModel]",
+        "type": "object"
+      },
+      "Page_DnsRecordModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DnsRecordModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[DnsRecordModel]",
+        "type": "object"
+      },
+      "Page_DoorModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DoorModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[DoorModel]",
+        "type": "object"
+      },
+      "Page_DpiApplicationModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DpiApplicationModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[DpiApplicationModel]",
+        "type": "object"
+      },
+      "Page_DpiCategoryModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DpiCategoryModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[DpiCategoryModel]",
+        "type": "object"
+      },
+      "Page_EventModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/EventModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[EventModel]",
+        "type": "object"
+      },
+      "Page_FirewallGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FirewallGroupModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[FirewallGroupModel]",
+        "type": "object"
+      },
+      "Page_FirewallRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FirewallRuleModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[FirewallRuleModel]",
+        "type": "object"
+      },
+      "Page_FirewallZoneModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/FirewallZoneModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[FirewallZoneModel]",
+        "type": "object"
+      },
+      "Page_NetworkModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NetworkModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[NetworkModel]",
+        "type": "object"
+      },
+      "Page_OonPolicyModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OonPolicyModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[OonPolicyModel]",
+        "type": "object"
+      },
+      "Page_PortForwardModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PortForwardModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[PortForwardModel]",
+        "type": "object"
+      },
+      "Page_PortProfileModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PortProfileModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[PortProfileModel]",
+        "type": "object"
+      },
+      "Page_QosRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/QosRuleModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[QosRuleModel]",
+        "type": "object"
+      },
+      "Page_RfScanResultModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RfScanResultModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[RfScanResultModel]",
+        "type": "object"
+      },
+      "Page_RouteModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RouteModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[RouteModel]",
+        "type": "object"
+      },
+      "Page_TrafficRouteModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficRouteModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[TrafficRouteModel]",
+        "type": "object"
+      },
+      "Page_UserGroupModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserGroupModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[UserGroupModel]",
+        "type": "object"
+      },
+      "Page_UserModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UserModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[UserModel]",
+        "type": "object"
+      },
+      "Page_VoucherModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/VoucherModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[VoucherModel]",
+        "type": "object"
+      },
+      "Page_VpnClientModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/VpnClientModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[VpnClientModel]",
+        "type": "object"
+      },
+      "Page_VpnServerModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/VpnServerModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[VpnServerModel]",
+        "type": "object"
+      },
+      "Page_WlanModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WlanModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[WlanModel]",
+        "type": "object"
+      },
+      "PortForwardModel": {
+        "additionalProperties": true,
+        "properties": {
+          "dst_port": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dst Port"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "fwd_port": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fwd Port"
+          },
+          "fwd_protocol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fwd Protocol"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "log": {
+            "title": "Log",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "src": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src"
+          }
+        },
+        "title": "PortForwardModel",
+        "type": "object"
+      },
+      "PortProfileModel": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "isolation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Isolation"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "native_networkconf_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Native Networkconf Id"
+          },
+          "poe_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poe Mode"
+          },
+          "tagged_networkconf_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tagged Networkconf Ids",
+            "type": "array"
+          }
+        },
+        "title": "PortProfileModel",
+        "type": "object"
+      },
+      "QosRuleModel": {
+        "additionalProperties": true,
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          },
+          "rate_max_down": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Max Down"
+          },
+          "rate_max_up": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Max Up"
+          }
+        },
+        "title": "QosRuleModel",
+        "type": "object"
+      },
+      "RfScanResultModel": {
+        "additionalProperties": true,
+        "properties": {
+          "bssid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bssid"
+          },
+          "captured_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Captured At"
+          },
+          "channel": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel"
+          },
+          "signal_dbm": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Signal Dbm"
+          },
+          "ssid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ssid"
+          }
+        },
+        "title": "RfScanResultModel",
+        "type": "object"
+      },
+      "RouteModel": {
+        "additionalProperties": true,
+        "properties": {
+          "distance": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Distance"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "gateway": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "target_subnet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Subnet"
+          }
+        },
+        "title": "RouteModel",
+        "type": "object"
+      },
+      "SettingsBody": {
+        "properties": {
+          "settings": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Settings",
+            "type": "object"
+          }
+        },
+        "required": [
+          "settings"
+        ],
+        "title": "SettingsBody",
+        "type": "object"
+      },
+      "TrafficRouteModel": {
+        "additionalProperties": true,
+        "properties": {
+          "destination_targets": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination Targets"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "matching_target": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matching Target"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "next_hop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Hop"
+          },
+          "source_targets": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Targets"
+          }
+        },
+        "title": "TrafficRouteModel",
+        "type": "object"
+      },
+      "UserGroupModel": {
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "qos_rate_max_down": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qos Rate Max Down"
+          },
+          "qos_rate_max_up": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qos Rate Max Up"
+          }
+        },
+        "title": "UserGroupModel",
+        "type": "object"
+      },
+      "UserModel": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "employee_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Employee Id"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "title": "UserModel",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "VoucherModel": {
+        "additionalProperties": true,
+        "properties": {
+          "code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "qos_overwrite": {
+            "title": "Qos Overwrite",
+            "type": "boolean"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "used_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Used At"
+          }
+        },
+        "title": "VoucherModel",
+        "type": "object"
+      },
+      "VpnClientModel": {
+        "additionalProperties": true,
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "last_handshake": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Handshake"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "server_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server Address"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "VpnClientModel",
+        "type": "object"
+      },
+      "VpnServerModel": {
+        "additionalProperties": true,
+        "properties": {
+          "allowed_subnets": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Subnets"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "listen_port": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Listen Port"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "VpnServerModel",
+        "type": "object"
+      },
+      "WlanModel": {
+        "additionalProperties": true,
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "hide_ssid": {
+            "title": "Hide Ssid",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "network_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Network Id"
+          },
+          "security": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Security"
+          },
+          "vlan_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vlan Id"
+          }
+        },
+        "title": "WlanModel",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "unifi-api",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/v1/actions/{tool_name}": {
+      "post": {
+        "operationId": "post_action_v1_actions__tool_name__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tool_name",
+            "required": true,
+            "schema": {
+              "title": "Tool Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Post Action V1 Actions  Tool Name  Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Action"
+      }
+    },
+    "/v1/audit": {
+      "get": {
+        "operationId": "list_audit_v1_audit_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "query",
+            "name": "outcome",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Outcome"
+            }
+          },
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Until"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Audit V1 Audit Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Audit"
+      }
+    },
+    "/v1/audit/prune": {
+      "post": {
+        "operationId": "prune_endpoint_v1_audit_prune_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Prune Endpoint V1 Audit Prune Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Prune Endpoint"
+      }
+    },
+    "/v1/catalog/categories": {
+      "get": {
+        "operationId": "get_categories_v1_catalog_categories_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Categories V1 Catalog Categories Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Categories"
+      }
+    },
+    "/v1/catalog/render-hints": {
+      "get": {
+        "operationId": "get_render_hints_v1_catalog_render_hints_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Render Hints V1 Catalog Render Hints Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Render Hints"
+      }
+    },
+    "/v1/catalog/resources": {
+      "get": {
+        "description": "Discoverability endpoint: every registered resource path with render_hint.\n\nLists every (product, resource_path) pair from the serializer registry.\nFor paths with placeholders (e.g., 'clients/{mac}'), renders as a path\ntemplate under /v1/sites/{site_id}/.",
+        "operationId": "get_resources_v1_catalog_resources_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Resources V1 Catalog Resources Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Resources"
+      }
+    },
+    "/v1/catalog/tools": {
+      "get": {
+        "operationId": "get_tools_v1_catalog_tools_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Tools V1 Catalog Tools Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Tools"
+      }
+    },
+    "/v1/controllers": {
+      "get": {
+        "operationId": "list_endpoint_v1_controllers_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ControllerOut"
+                  },
+                  "title": "Response List Endpoint V1 Controllers Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Endpoint"
+      },
+      "post": {
+        "operationId": "post_controller_v1_controllers_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControllerIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ControllerOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Controller"
+      }
+    },
+    "/v1/controllers/{cid}": {
+      "delete": {
+        "operationId": "delete_endpoint_v1_controllers__cid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "title": "Cid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Endpoint"
+      },
+      "get": {
+        "operationId": "get_endpoint_v1_controllers__cid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "title": "Cid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ControllerOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Endpoint"
+      },
+      "patch": {
+        "operationId": "patch_endpoint_v1_controllers__cid__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "title": "Cid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ControllerPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ControllerOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Patch Endpoint"
+      }
+    },
+    "/v1/controllers/{cid}/capabilities": {
+      "get": {
+        "operationId": "capabilities_endpoint_v1_controllers__cid__capabilities_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "title": "Cid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "refresh",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Refresh",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Capabilities Endpoint V1 Controllers  Cid  Capabilities Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Capabilities Endpoint"
+      }
+    },
+    "/v1/controllers/{cid}/probe": {
+      "post": {
+        "operationId": "probe_endpoint_v1_controllers__cid__probe_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "title": "Cid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Probe Endpoint V1 Controllers  Cid  Probe Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Probe Endpoint"
+      }
+    },
+    "/v1/diagnostics": {
+      "get": {
+        "operationId": "get_diagnostics_v1_diagnostics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Diagnostics V1 Diagnostics Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Diagnostics"
+      }
+    },
+    "/v1/graphql": {
+      "get": {
+        "operationId": "handle_http_get_v1_graphql_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "The GraphiQL integrated development environment."
+          },
+          "404": {
+            "description": "Not found if GraphiQL or query via GET are not enabled."
+          }
+        },
+        "summary": "Handle Http Get"
+      },
+      "post": {
+        "operationId": "handle_http_post_v1_graphql_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Handle Http Post"
+      }
+    },
+    "/v1/health": {
+      "get": {
+        "operationId": "liveness_v1_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Liveness V1 Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Liveness"
+      }
+    },
+    "/v1/health/ready": {
+      "get": {
+        "operationId": "readiness_v1_health_ready_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Readiness V1 Health Ready Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Readiness"
+      }
+    },
+    "/v1/logs": {
+      "get": {
+        "operationId": "get_logs_v1_logs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "level",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Level"
+            }
+          },
+          {
+            "in": "query",
+            "name": "logger",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Logger"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Logs V1 Logs Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Logs"
+      }
+    },
+    "/v1/settings": {
+      "get": {
+        "operationId": "get_settings_v1_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Settings V1 Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Settings"
+      },
+      "put": {
+        "operationId": "put_settings_v1_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SettingsBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Put Settings V1 Settings Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Settings"
+      }
+    },
+    "/v1/sites/{site_id}/access-devices": {
+      "get": {
+        "operationId": "list_access_devices_v1_sites__site_id__access_devices_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Access Devices V1 Sites  Site Id  Access Devices Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Access Devices",
+        "tags": [
+          "access/devices"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access-devices/{device_id}": {
+      "get": {
+        "operationId": "get_access_device_v1_sites__site_id__access_devices__device_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "device_id",
+            "required": true,
+            "schema": {
+              "title": "Device Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Access Device V1 Sites  Site Id  Access Devices  Device Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Access Device",
+        "tags": [
+          "access/devices"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access/activity-summary": {
+      "get": {
+        "operationId": "get_access_activity_summary_v1_sites__site_id__access_activity_summary_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "door_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Door Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 7,
+              "maximum": 90,
+              "minimum": 1,
+              "title": "Days",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Access Activity Summary V1 Sites  Site Id  Access Activity Summary Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Access Activity Summary",
+        "tags": [
+          "access/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access/events": {
+      "get": {
+        "operationId": "list_access_events_v1_sites__site_id__access_events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Access Events V1 Sites  Site Id  Access Events Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Access Events",
+        "tags": [
+          "access/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access/events/{event_id}": {
+      "get": {
+        "operationId": "get_access_event_v1_sites__site_id__access_events__event_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Access Event V1 Sites  Site Id  Access Events  Event Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Access Event",
+        "tags": [
+          "access/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access/health": {
+      "get": {
+        "operationId": "get_access_health_v1_sites__site_id__access_health_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Access Health V1 Sites  Site Id  Access Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Access Health",
+        "tags": [
+          "access/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access/recent-events": {
+      "get": {
+        "description": "Return a snapshot of the websocket ring buffer.\n\nDiffers from the SSE stream at ``/v1/streams/access/events``: this is\na buffer-snapshot REST surface, not a tailing stream. Mirrors PR3's\nprotect ``/recent-events`` shape: ``{events, count, source, buffer_size}``.\n``EventManager.get_recent_from_buffer`` is synchronous (in-memory ring\nbuffer read).",
+        "operationId": "recent_access_events_v1_sites__site_id__access_recent_events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "door_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Door Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 500,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Recent Access Events V1 Sites  Site Id  Access Recent Events Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Recent Access Events",
+        "tags": [
+          "access/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/access/system-info": {
+      "get": {
+        "operationId": "get_access_system_info_v1_sites__site_id__access_system_info_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Access System Info V1 Sites  Site Id  Access System Info Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Access System Info",
+        "tags": [
+          "access/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/acl-rules": {
+      "get": {
+        "operationId": "list_acl_rules_v1_sites__site_id__acl_rules_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_AclRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Acl Rules",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/acl-rules/{rule_id}": {
+      "get": {
+        "operationId": "get_acl_rule_details_v1_sites__site_id__acl_rules__rule_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_AclRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Acl Rule Details",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/active-routes": {
+      "get": {
+        "operationId": "list_active_routes_v1_sites__site_id__active_routes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_ActiveRouteModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Active Routes",
+        "tags": [
+          "network/routes"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/alarm-profiles": {
+      "get": {
+        "operationId": "alarm_list_profiles_v1_sites__site_id__alarm_profiles_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Alarm List Profiles V1 Sites  Site Id  Alarm Profiles Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Alarm List Profiles",
+        "tags": [
+          "protect/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/alarm-status": {
+      "get": {
+        "operationId": "alarm_get_status_v1_sites__site_id__alarm_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Alarm Get Status V1 Sites  Site Id  Alarm Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Alarm Get Status",
+        "tags": [
+          "protect/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/alarms": {
+      "get": {
+        "operationId": "list_alarms_v1_sites__site_id__alarms_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Alarms V1 Sites  Site Id  Alarms Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Alarms",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/alerts": {
+      "get": {
+        "operationId": "get_alerts_v1_sites__site_id__alerts_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Alerts V1 Sites  Site Id  Alerts Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Alerts",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/anomalies": {
+      "get": {
+        "operationId": "get_anomalies_v1_sites__site_id__anomalies_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Anomalies V1 Sites  Site Id  Anomalies Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Anomalies",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/ap-groups": {
+      "get": {
+        "operationId": "list_ap_groups_v1_sites__site_id__ap_groups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_ApGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Ap Groups",
+        "tags": [
+          "network/groups"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/ap-groups/{group_id}": {
+      "get": {
+        "operationId": "get_ap_group_details_v1_sites__site_id__ap_groups__group_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "title": "Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_ApGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ap Group Details",
+        "tags": [
+          "network/groups"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/autobackup-settings": {
+      "get": {
+        "operationId": "get_autobackup_settings_v1_sites__site_id__autobackup_settings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Autobackup Settings V1 Sites  Site Id  Autobackup Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Autobackup Settings",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/available-channels": {
+      "get": {
+        "operationId": "list_available_channels_v1_sites__site_id__available_channels_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_AvailableChannelModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Available Channels",
+        "tags": [
+          "network/wireless"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/backups": {
+      "get": {
+        "operationId": "list_backups_v1_sites__site_id__backups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Backups V1 Sites  Site Id  Backups Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Backups",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/blocked-clients": {
+      "get": {
+        "operationId": "list_blocked_clients_v1_sites__site_id__blocked_clients_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_BlockedClientModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Blocked Clients",
+        "tags": [
+          "network/clients"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/cameras": {
+      "get": {
+        "operationId": "list_cameras_v1_sites__site_id__cameras_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_CameraModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Cameras",
+        "tags": [
+          "protect/cameras"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/cameras/{camera_id}": {
+      "get": {
+        "operationId": "get_camera_v1_sites__site_id__cameras__camera_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_CameraModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Camera",
+        "tags": [
+          "protect/cameras"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/cameras/{camera_id}/analytics": {
+      "get": {
+        "operationId": "get_camera_analytics_v1_sites__site_id__cameras__camera_id__analytics_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Camera Analytics V1 Sites  Site Id  Cameras  Camera Id  Analytics Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Camera Analytics",
+        "tags": [
+          "protect/cameras"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/cameras/{camera_id}/snapshot": {
+      "get": {
+        "description": "Return snapshot metadata (size_bytes / content_type / captured_at).\n\nThe manager returns raw JPEG bytes; the SnapshotSerializer surfaces\nmetadata only. A future ``/snapshot/raw`` endpoint that returns the\nbinary body is deferred to Phase 5B if a UI consumer needs it.",
+        "operationId": "get_camera_snapshot_v1_sites__site_id__cameras__camera_id__snapshot_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Camera Snapshot V1 Sites  Site Id  Cameras  Camera Id  Snapshot Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Camera Snapshot",
+        "tags": [
+          "protect/cameras"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/cameras/{camera_id}/streams": {
+      "get": {
+        "operationId": "get_camera_streams_v1_sites__site_id__cameras__camera_id__streams_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Camera Streams V1 Sites  Site Id  Cameras  Camera Id  Streams Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Camera Streams",
+        "tags": [
+          "protect/cameras"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/chimes": {
+      "get": {
+        "operationId": "list_chimes_v1_sites__site_id__chimes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Chimes V1 Sites  Site Id  Chimes Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Chimes",
+        "tags": [
+          "protect/cameras"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/client-groups": {
+      "get": {
+        "operationId": "list_client_groups_v1_sites__site_id__client_groups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_ClientGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Client Groups",
+        "tags": [
+          "network/groups"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/client-groups/{group_id}": {
+      "get": {
+        "operationId": "get_client_group_details_v1_sites__site_id__client_groups__group_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "title": "Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_ClientGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Client Group Details",
+        "tags": [
+          "network/groups"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/client-sessions": {
+      "get": {
+        "operationId": "get_client_sessions_v1_sites__site_id__client_sessions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Client Sessions V1 Sites  Site Id  Client Sessions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Client Sessions",
+        "tags": [
+          "network/clients"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/client-wifi-details/{mac}": {
+      "get": {
+        "operationId": "get_client_wifi_details_v1_sites__site_id__client_wifi_details__mac__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Client Wifi Details V1 Sites  Site Id  Client Wifi Details  Mac  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Client Wifi Details",
+        "tags": [
+          "network/clients"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/clients": {
+      "get": {
+        "operationId": "list_clients_v1_sites__site_id__clients_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_ClientModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Clients",
+        "tags": [
+          "network/clients"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/clients/{mac}": {
+      "get": {
+        "operationId": "get_client_v1_sites__site_id__clients__mac__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_ClientModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Client",
+        "tags": [
+          "network/clients"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/content-filters": {
+      "get": {
+        "operationId": "list_content_filters_v1_sites__site_id__content_filters_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_ContentFilterModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Content Filters",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/content-filters/{filter_id}": {
+      "get": {
+        "operationId": "get_content_filter_details_v1_sites__site_id__content_filters__filter_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "filter_id",
+            "required": true,
+            "schema": {
+              "title": "Filter Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_ContentFilterModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Content Filter Details",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/credentials": {
+      "get": {
+        "operationId": "list_credentials_v1_sites__site_id__credentials_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_CredentialModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Credentials",
+        "tags": [
+          "access/credentials"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/credentials/{credential_id}": {
+      "get": {
+        "operationId": "get_credential_v1_sites__site_id__credentials__credential_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "credential_id",
+            "required": true,
+            "schema": {
+              "title": "Credential Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_CredentialModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Credential",
+        "tags": [
+          "access/credentials"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/devices": {
+      "get": {
+        "operationId": "list_devices_v1_sites__site_id__devices_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_DeviceModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Devices",
+        "tags": [
+          "network/devices"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/devices/{mac}": {
+      "get": {
+        "operationId": "get_device_v1_sites__site_id__devices__mac__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_DeviceModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Device",
+        "tags": [
+          "network/devices"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/devices/{mac}/radio": {
+      "get": {
+        "operationId": "get_device_radio_v1_sites__site_id__devices__mac__radio_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Device Radio V1 Sites  Site Id  Devices  Mac  Radio Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Device Radio",
+        "tags": [
+          "network/devices"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/dns-records": {
+      "get": {
+        "operationId": "list_dns_records_v1_sites__site_id__dns_records_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_DnsRecordModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Dns Records",
+        "tags": [
+          "network/dns"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/dns-records/{record_id}": {
+      "get": {
+        "operationId": "get_dns_record_details_v1_sites__site_id__dns_records__record_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "record_id",
+            "required": true,
+            "schema": {
+              "title": "Record Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_DnsRecordModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Dns Record Details",
+        "tags": [
+          "network/dns"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/door-groups": {
+      "get": {
+        "operationId": "list_door_groups_v1_sites__site_id__door_groups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Door Groups V1 Sites  Site Id  Door Groups Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Door Groups",
+        "tags": [
+          "access/doors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/doors": {
+      "get": {
+        "operationId": "list_doors_v1_sites__site_id__doors_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_DoorModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Doors",
+        "tags": [
+          "access/doors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/doors/{door_id}": {
+      "get": {
+        "operationId": "get_door_v1_sites__site_id__doors__door_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "door_id",
+            "required": true,
+            "schema": {
+              "title": "Door Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_DoorModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Door",
+        "tags": [
+          "access/doors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/doors/{door_id}/status": {
+      "get": {
+        "description": "Per-door status (nested under /doors/{door_id}/status).\n\nMirrors the protect /cameras/{id}/analytics nested-detail pattern.\nDoorManager.get_door_status raises UniFiNotFoundError on miss \u2192 404.",
+        "operationId": "get_door_status_v1_sites__site_id__doors__door_id__status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "door_id",
+            "required": true,
+            "schema": {
+              "title": "Door Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Door Status V1 Sites  Site Id  Doors  Door Id  Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Door Status",
+        "tags": [
+          "access/doors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/dpi-applications": {
+      "get": {
+        "operationId": "list_dpi_applications_v1_sites__site_id__dpi_applications_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_DpiApplicationModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Dpi Applications",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/dpi-categories": {
+      "get": {
+        "operationId": "list_dpi_categories_v1_sites__site_id__dpi_categories_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_DpiCategoryModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Dpi Categories",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/event-thumbnails/{event_id}": {
+      "get": {
+        "operationId": "get_event_thumbnail_v1_sites__site_id__event_thumbnails__event_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "width",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 4096,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Width"
+            }
+          },
+          {
+            "in": "query",
+            "name": "height",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 4096,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Height"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Event Thumbnail V1 Sites  Site Id  Event Thumbnails  Event Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Event Thumbnail",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/event-types": {
+      "get": {
+        "description": "DETAIL \u2014 event_manager.get_event_type_prefixes (sync method, returns list).",
+        "operationId": "get_event_types_v1_sites__site_id__event_types_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Event Types V1 Sites  Site Id  Event Types Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Event Types",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/events": {
+      "get": {
+        "operationId": "list_events_v1_sites__site_id__events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_EventModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Events",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/events/{event_id}": {
+      "get": {
+        "operationId": "get_event_v1_sites__site_id__events__event_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Event V1 Sites  Site Id  Events  Event Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Event",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/groups": {
+      "get": {
+        "operationId": "list_firewall_groups_v1_sites__site_id__firewall_groups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_FirewallGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Firewall Groups",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/groups/{group_id}": {
+      "get": {
+        "operationId": "get_firewall_group_details_v1_sites__site_id__firewall_groups__group_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "title": "Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_FirewallGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Firewall Group Details",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/rules": {
+      "get": {
+        "operationId": "list_firewall_rules_v1_sites__site_id__firewall_rules_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_FirewallRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Firewall Rules",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/rules/{rule_id}": {
+      "get": {
+        "operationId": "get_firewall_rule_v1_sites__site_id__firewall_rules__rule_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_FirewallRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Firewall Rule",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/zones": {
+      "get": {
+        "operationId": "list_firewall_zones_v1_sites__site_id__firewall_zones_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_FirewallZoneModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Firewall Zones",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firmware-status": {
+      "get": {
+        "operationId": "get_firmware_status_v1_sites__site_id__firmware_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Firmware Status V1 Sites  Site Id  Firmware Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Firmware Status",
+        "tags": [
+          "protect/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/ips-events": {
+      "get": {
+        "operationId": "get_ips_events_v1_sites__site_id__ips_events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Ips Events V1 Sites  Site Id  Ips Events Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ips Events",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/known-rogue-aps": {
+      "get": {
+        "operationId": "list_known_rogue_aps_v1_sites__site_id__known_rogue_aps_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Known Rogue Aps V1 Sites  Site Id  Known Rogue Aps Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Known Rogue Aps",
+        "tags": [
+          "network/wireless"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/lights": {
+      "get": {
+        "operationId": "list_lights_v1_sites__site_id__lights_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Lights V1 Sites  Site Id  Lights Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Lights",
+        "tags": [
+          "protect/lights"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/lights/{light_id}": {
+      "get": {
+        "description": "No native ``protect_get_light`` tool exists \u2014 filter from LIST.\n\nLightManager._get_light raises UniFiNotFoundError, but list_lights\ndoes not invoke that helper. We wrap the manager call defensively\nso any future refactor that surfaces UniFiNotFoundError keeps mapping\ncleanly to a 404.",
+        "operationId": "get_light_details_v1_sites__site_id__lights__light_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "light_id",
+            "required": true,
+            "schema": {
+              "title": "Light Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Light Details V1 Sites  Site Id  Lights  Light Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Light Details",
+        "tags": [
+          "protect/lights"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/liveviews": {
+      "get": {
+        "operationId": "list_liveviews_v1_sites__site_id__liveviews_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Liveviews V1 Sites  Site Id  Liveviews Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Liveviews",
+        "tags": [
+          "protect/liveviews"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/liveviews/{liveview_id}": {
+      "get": {
+        "description": "No native ``protect_get_liveview`` tool \u2014 filter from LIST.",
+        "operationId": "get_liveview_v1_sites__site_id__liveviews__liveview_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "liveview_id",
+            "required": true,
+            "schema": {
+              "title": "Liveview Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Liveview V1 Sites  Site Id  Liveviews  Liveview Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Liveview",
+        "tags": [
+          "protect/liveviews"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/lldp-neighbors": {
+      "get": {
+        "operationId": "list_lldp_neighbors_v1_sites__site_id__lldp_neighbors_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "MAC address of the switch",
+            "in": "query",
+            "name": "device_mac",
+            "required": true,
+            "schema": {
+              "description": "MAC address of the switch",
+              "title": "Device Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Lldp Neighbors V1 Sites  Site Id  Lldp Neighbors Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Lldp Neighbors",
+        "tags": [
+          "network/lldp"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/lookup-by-ip": {
+      "get": {
+        "operationId": "lookup_client_by_ip_v1_sites__site_id__lookup_by_ip_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Client IP address to look up",
+            "in": "query",
+            "name": "ip",
+            "required": true,
+            "schema": {
+              "description": "Client IP address to look up",
+              "title": "Ip",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Lookup Client By Ip V1 Sites  Site Id  Lookup By Ip Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Lookup Client By Ip",
+        "tags": [
+          "network/lookup"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/network-health": {
+      "get": {
+        "description": "LIST kind per Phase 4A \u2014 manager returns multi-element list of subsystems.",
+        "operationId": "get_network_health_v1_sites__site_id__network_health_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Network Health V1 Sites  Site Id  Network Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Network Health",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/networks": {
+      "get": {
+        "operationId": "list_networks_v1_sites__site_id__networks_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_NetworkModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Networks",
+        "tags": [
+          "network/networks"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/networks/{network_id}": {
+      "get": {
+        "operationId": "get_network_v1_sites__site_id__networks__network_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "network_id",
+            "required": true,
+            "schema": {
+              "title": "Network Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_NetworkModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Network",
+        "tags": [
+          "network/networks"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/oon-policies": {
+      "get": {
+        "operationId": "list_oon_policies_v1_sites__site_id__oon_policies_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_OonPolicyModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Oon Policies",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/oon-policies/{policy_id}": {
+      "get": {
+        "operationId": "get_oon_policy_details_v1_sites__site_id__oon_policies__policy_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "policy_id",
+            "required": true,
+            "schema": {
+              "title": "Policy Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_OonPolicyModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Oon Policy Details",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/policies": {
+      "get": {
+        "operationId": "list_policies_v1_sites__site_id__policies_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Policies V1 Sites  Site Id  Policies Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Policies",
+        "tags": [
+          "access/policies"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/policies/{policy_id}": {
+      "get": {
+        "operationId": "get_policy_v1_sites__site_id__policies__policy_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "policy_id",
+            "required": true,
+            "schema": {
+              "title": "Policy Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Policy V1 Sites  Site Id  Policies  Policy Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Policy",
+        "tags": [
+          "access/policies"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/port-forwards": {
+      "get": {
+        "operationId": "list_port_forwards_v1_sites__site_id__port_forwards_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_PortForwardModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Port Forwards",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/port-forwards/{port_forward_id}": {
+      "get": {
+        "operationId": "get_port_forward_v1_sites__site_id__port_forwards__port_forward_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "port_forward_id",
+            "required": true,
+            "schema": {
+              "title": "Port Forward Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_PortForwardModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Port Forward",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/port-profiles": {
+      "get": {
+        "operationId": "list_port_profiles_v1_sites__site_id__port_profiles_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_PortProfileModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Port Profiles",
+        "tags": [
+          "network/switch"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/port-profiles/{profile_id}": {
+      "get": {
+        "operationId": "get_port_profile_details_v1_sites__site_id__port_profiles__profile_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "profile_id",
+            "required": true,
+            "schema": {
+              "title": "Profile Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_PortProfileModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Port Profile Details",
+        "tags": [
+          "network/switch"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/port-stats": {
+      "get": {
+        "operationId": "list_port_stats_v1_sites__site_id__port_stats_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "MAC address of the switch",
+            "in": "query",
+            "name": "device_mac",
+            "required": true,
+            "schema": {
+              "description": "MAC address of the switch",
+              "title": "Device Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Port Stats V1 Sites  Site Id  Port Stats Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Port Stats",
+        "tags": [
+          "network/switch"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/protect/health": {
+      "get": {
+        "operationId": "get_protect_health_v1_sites__site_id__protect_health_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Protect Health V1 Sites  Site Id  Protect Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Protect Health",
+        "tags": [
+          "protect/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/protect/system-info": {
+      "get": {
+        "operationId": "get_protect_system_info_v1_sites__site_id__protect_system_info_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Protect System Info V1 Sites  Site Id  Protect System Info Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Protect System Info",
+        "tags": [
+          "protect/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/qos-rules": {
+      "get": {
+        "operationId": "list_qos_rules_v1_sites__site_id__qos_rules_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_QosRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Qos Rules",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/qos-rules/{rule_id}": {
+      "get": {
+        "operationId": "get_qos_rule_details_v1_sites__site_id__qos_rules__rule_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "title": "Rule Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_QosRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Qos Rule Details",
+        "tags": [
+          "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/recent-events": {
+      "get": {
+        "description": "Return a snapshot of the websocket ring buffer.\n\nDiffers from the SSE stream at ``/v1/streams/protect/events``: this is\na buffer-snapshot REST surface, not a tailing stream. ``DETAIL`` render\nkind \u2014 the manager's wrapper dict (events / count / source / buffer_size)\nis itself the payload.",
+        "operationId": "recent_events_v1_sites__site_id__recent_events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "camera_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Camera Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_confidence",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Confidence"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 500,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Recent Events V1 Sites  Site Id  Recent Events Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Recent Events",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/recording-status": {
+      "get": {
+        "description": "Return current recording state for one or all cameras.\n\nThe ``camera_id`` query is optional: omitting it returns the\naggregate (all cameras), supplying it scopes to one camera and\nraises 404 via UniFiNotFoundError if the camera is unknown.",
+        "operationId": "get_recording_status_v1_sites__site_id__recording_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional \u2014 limit to a single camera",
+            "in": "query",
+            "name": "camera_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional \u2014 limit to a single camera",
+              "title": "Camera Id"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Recording Status V1 Sites  Site Id  Recording Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Recording Status",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/recordings": {
+      "get": {
+        "operationId": "list_recordings_v1_sites__site_id__recordings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Camera ID to query recordings for",
+            "in": "query",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "description": "Camera ID to query recordings for",
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Recordings V1 Sites  Site Id  Recordings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Recordings",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/recordings/{recording_id}": {
+      "get": {
+        "operationId": "get_recording_v1_sites__site_id__recordings__recording_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "recording_id",
+            "required": true,
+            "schema": {
+              "title": "Recording Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Camera ID the recording belongs to",
+            "in": "query",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "description": "Camera ID the recording belongs to",
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Recording V1 Sites  Site Id  Recordings  Recording Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Recording",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/rf-scan-results": {
+      "get": {
+        "operationId": "list_rf_scan_results_v1_sites__site_id__rf_scan_results_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "MAC address of the access point",
+            "in": "query",
+            "name": "ap_mac",
+            "required": true,
+            "schema": {
+              "description": "MAC address of the access point",
+              "title": "Ap Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_RfScanResultModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Rf Scan Results",
+        "tags": [
+          "network/wireless"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/rogue-aps": {
+      "get": {
+        "operationId": "list_rogue_aps_v1_sites__site_id__rogue_aps_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "within_hours",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "maximum": 168,
+              "minimum": 1,
+              "title": "Within Hours",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Rogue Aps V1 Sites  Site Id  Rogue Aps Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Rogue Aps",
+        "tags": [
+          "network/wireless"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/schedules": {
+      "get": {
+        "operationId": "list_schedules_v1_sites__site_id__schedules_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Schedules V1 Sites  Site Id  Schedules Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Schedules",
+        "tags": [
+          "access/schedules"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/sensors": {
+      "get": {
+        "operationId": "list_sensors_v1_sites__site_id__sensors_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Sensors V1 Sites  Site Id  Sensors Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Sensors",
+        "tags": [
+          "protect/sensors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/sensors/{sensor_id}": {
+      "get": {
+        "description": "No native ``protect_get_sensor`` tool exists \u2014 filter from LIST.",
+        "operationId": "get_sensor_details_v1_sites__site_id__sensors__sensor_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sensor_id",
+            "required": true,
+            "schema": {
+              "title": "Sensor Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Sensor Details V1 Sites  Site Id  Sensors  Sensor Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Sensor Details",
+        "tags": [
+          "protect/sensors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/site-settings": {
+      "get": {
+        "operationId": "get_site_settings_v1_sites__site_id__site_settings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Site Settings V1 Sites  Site Id  Site Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Site Settings",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/smart-detections": {
+      "get": {
+        "operationId": "list_smart_detections_v1_sites__site_id__smart_detections_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "camera_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Camera Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "detection_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Detection Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_confidence",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Confidence"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Smart Detections V1 Sites  Site Id  Smart Detections Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Smart Detections",
+        "tags": [
+          "protect/events"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/snmp-settings": {
+      "get": {
+        "operationId": "get_snmp_settings_v1_sites__site_id__snmp_settings_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Snmp Settings V1 Sites  Site Id  Snmp Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Snmp Settings",
+        "tags": [
+          "network/snmp"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/speedtest-results": {
+      "get": {
+        "operationId": "get_speedtest_results_v1_sites__site_id__speedtest_results_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Speedtest Results V1 Sites  Site Id  Speedtest Results Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Speedtest Results",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/speedtest-status": {
+      "get": {
+        "operationId": "get_speedtest_status_v1_sites__site_id__speedtest_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "MAC address of the gateway device",
+            "in": "query",
+            "name": "gateway_mac",
+            "required": true,
+            "schema": {
+              "description": "MAC address of the gateway device",
+              "title": "Gateway Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Speedtest Status V1 Sites  Site Id  Speedtest Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Speedtest Status",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/static-routes": {
+      "get": {
+        "operationId": "list_routes_v1_sites__site_id__static_routes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_RouteModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Routes",
+        "tags": [
+          "network/routes"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/static-routes/{route_id}": {
+      "get": {
+        "operationId": "get_route_details_v1_sites__site_id__static_routes__route_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "route_id",
+            "required": true,
+            "schema": {
+              "title": "Route Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_RouteModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Route Details",
+        "tags": [
+          "network/routes"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/clients/{mac}": {
+      "get": {
+        "description": "TIMESERIES; calls stats_manager.get_client_stats (PR4).",
+        "operationId": "get_client_stats_v1_sites__site_id__stats_clients__mac__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Client Stats V1 Sites  Site Id  Stats Clients  Mac  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Client Stats",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/dashboard": {
+      "get": {
+        "operationId": "get_dashboard_stats_v1_sites__site_id__stats_dashboard_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Dashboard Stats V1 Sites  Site Id  Stats Dashboard Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Dashboard Stats",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/devices/{mac}": {
+      "get": {
+        "description": "TIMESERIES; calls stats_manager.get_device_stats (PR4).",
+        "operationId": "get_device_stats_v1_sites__site_id__stats_devices__mac__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Device Stats V1 Sites  Site Id  Stats Devices  Mac  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Device Stats",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/dpi": {
+      "get": {
+        "description": "DETAIL kind currently; manager method is stats_manager.get_dpi_stats.",
+        "operationId": "get_dpi_stats_v1_sites__site_id__stats_dpi_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Dpi Stats V1 Sites  Site Id  Stats Dpi Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Dpi Stats",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/dpi/clients/{mac}": {
+      "get": {
+        "operationId": "get_client_dpi_traffic_v1_sites__site_id__stats_dpi_clients__mac__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Client Dpi Traffic V1 Sites  Site Id  Stats Dpi Clients  Mac  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Client Dpi Traffic",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/dpi/site": {
+      "get": {
+        "operationId": "get_site_dpi_traffic_v1_sites__site_id__stats_dpi_site_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Site Dpi Traffic V1 Sites  Site Id  Stats Dpi Site Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Site Dpi Traffic",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/gateway": {
+      "get": {
+        "operationId": "get_gateway_stats_v1_sites__site_id__stats_gateway_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Gateway Stats V1 Sites  Site Id  Stats Gateway Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gateway Stats",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/stats/network": {
+      "get": {
+        "operationId": "get_network_stats_v1_sites__site_id__stats_network_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Network Stats V1 Sites  Site Id  Stats Network Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Network Stats",
+        "tags": [
+          "network/observability"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/switch-capabilities": {
+      "get": {
+        "operationId": "get_switch_capabilities_v1_sites__site_id__switch_capabilities_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "MAC address of the switch",
+            "in": "query",
+            "name": "device_mac",
+            "required": true,
+            "schema": {
+              "description": "MAC address of the switch",
+              "title": "Device Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Switch Capabilities V1 Sites  Site Id  Switch Capabilities Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Switch Capabilities",
+        "tags": [
+          "network/switch"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/switch-ports": {
+      "get": {
+        "operationId": "list_switch_ports_v1_sites__site_id__switch_ports_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "MAC address of the switch",
+            "in": "query",
+            "name": "device_mac",
+            "required": true,
+            "schema": {
+              "description": "MAC address of the switch",
+              "title": "Device Mac",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Switch Ports V1 Sites  Site Id  Switch Ports Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Switch Ports",
+        "tags": [
+          "network/switch"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/system-info": {
+      "get": {
+        "operationId": "get_system_info_v1_sites__site_id__system_info_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get System Info V1 Sites  Site Id  System Info Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get System Info",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/top-clients": {
+      "get": {
+        "operationId": "get_top_clients_v1_sites__site_id__top_clients_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Top Clients V1 Sites  Site Id  Top Clients Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Top Clients",
+        "tags": [
+          "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/traffic-routes": {
+      "get": {
+        "operationId": "list_traffic_routes_v1_sites__site_id__traffic_routes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_TrafficRouteModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Traffic Routes",
+        "tags": [
+          "network/routes"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/traffic-routes/{route_id}": {
+      "get": {
+        "operationId": "get_traffic_route_details_v1_sites__site_id__traffic_routes__route_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "route_id",
+            "required": true,
+            "schema": {
+              "title": "Route Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_TrafficRouteModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Traffic Route Details",
+        "tags": [
+          "network/routes"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/user-groups": {
+      "get": {
+        "operationId": "list_user_groups_v1_sites__site_id__user_groups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_UserGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List User Groups",
+        "tags": [
+          "network/groups"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/user-groups/{group_id}": {
+      "get": {
+        "operationId": "get_user_group_details_v1_sites__site_id__user_groups__group_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "title": "Group Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_UserGroupModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get User Group Details",
+        "tags": [
+          "network/groups"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/users": {
+      "get": {
+        "operationId": "list_users_v1_sites__site_id__users_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_UserModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Users",
+        "tags": [
+          "access/users"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/users/{user_id}": {
+      "get": {
+        "description": "Fetch a user by listing then filtering \u2014 no native get_user method.",
+        "operationId": "get_user_v1_sites__site_id__users__user_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_UserModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get User",
+        "tags": [
+          "access/users"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/viewers": {
+      "get": {
+        "operationId": "list_viewers_v1_sites__site_id__viewers_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Viewers V1 Sites  Site Id  Viewers Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Viewers",
+        "tags": [
+          "protect/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/visitors": {
+      "get": {
+        "operationId": "list_visitors_v1_sites__site_id__visitors_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Visitors V1 Sites  Site Id  Visitors Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Visitors",
+        "tags": [
+          "access/visitors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/visitors/{visitor_id}": {
+      "get": {
+        "operationId": "get_visitor_v1_sites__site_id__visitors__visitor_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "visitor_id",
+            "required": true,
+            "schema": {
+              "title": "Visitor Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Visitor V1 Sites  Site Id  Visitors  Visitor Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Visitor",
+        "tags": [
+          "access/visitors"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/voucher-details/{voucher_id}": {
+      "get": {
+        "operationId": "get_voucher_details_v1_sites__site_id__voucher_details__voucher_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "voucher_id",
+            "required": true,
+            "schema": {
+              "title": "Voucher Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_VoucherModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Voucher Details",
+        "tags": [
+          "network/vouchers"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/vouchers": {
+      "get": {
+        "operationId": "list_vouchers_v1_sites__site_id__vouchers_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_VoucherModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Vouchers",
+        "tags": [
+          "network/vouchers"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/vpn-clients": {
+      "get": {
+        "operationId": "list_vpn_clients_v1_sites__site_id__vpn_clients_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_VpnClientModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Vpn Clients",
+        "tags": [
+          "network/vpn"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/vpn-clients/{client_id}": {
+      "get": {
+        "operationId": "get_vpn_client_details_v1_sites__site_id__vpn_clients__client_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "client_id",
+            "required": true,
+            "schema": {
+              "title": "Client Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_VpnClientModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vpn Client Details",
+        "tags": [
+          "network/vpn"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/vpn-servers": {
+      "get": {
+        "operationId": "list_vpn_servers_v1_sites__site_id__vpn_servers_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_VpnServerModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Vpn Servers",
+        "tags": [
+          "network/vpn"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/vpn-servers/{server_id}": {
+      "get": {
+        "operationId": "get_vpn_server_details_v1_sites__site_id__vpn_servers__server_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "server_id",
+            "required": true,
+            "schema": {
+              "title": "Server Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_VpnServerModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Vpn Server Details",
+        "tags": [
+          "network/vpn"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/wlans": {
+      "get": {
+        "operationId": "list_wlans_v1_sites__site_id__wlans_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_WlanModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Wlans",
+        "tags": [
+          "network/wlans"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/wlans/{wlan_id}": {
+      "get": {
+        "operationId": "get_wlan_v1_sites__site_id__wlans__wlan_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "wlan_id",
+            "required": true,
+            "schema": {
+              "title": "Wlan Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_WlanModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Wlan",
+        "tags": [
+          "network/wlans"
+        ]
+      }
+    },
+    "/v1/streams/access/doors/{door_id}/events": {
+      "get": {
+        "operationId": "stream_access_door_events_v1_streams_access_doors__door_id__events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "door_id",
+            "required": true,
+            "schema": {
+              "title": "Door Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Last-Event-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Access Door Events"
+      }
+    },
+    "/v1/streams/access/events": {
+      "get": {
+        "operationId": "stream_access_events_v1_streams_access_events_get",
+        "parameters": [
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Last-Event-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Access Events"
+      }
+    },
+    "/v1/streams/audit": {
+      "get": {
+        "description": "SSE stream of audit rows. One frame per row inserted via write_audit.",
+        "operationId": "stream_audit_v1_streams_audit_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Stream Audit"
+      }
+    },
+    "/v1/streams/network/devices/{mac}/events": {
+      "get": {
+        "operationId": "stream_network_device_events_v1_streams_network_devices__mac__events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Last-Event-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Network Device Events"
+      }
+    },
+    "/v1/streams/network/events": {
+      "get": {
+        "operationId": "stream_network_events_v1_streams_network_events_get",
+        "parameters": [
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Last-Event-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Network Events"
+      }
+    },
+    "/v1/streams/protect/cameras/{camera_id}/events": {
+      "get": {
+        "operationId": "stream_protect_camera_events_v1_streams_protect_cameras__camera_id__events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "camera_id",
+            "required": true,
+            "schema": {
+              "title": "Camera Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Last-Event-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Protect Camera Events"
+      }
+    },
+    "/v1/streams/protect/events": {
+      "get": {
+        "operationId": "stream_protect_events_v1_streams_protect_events_get",
+        "parameters": [
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Last-Event-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last-Event-Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Protect Events"
+      }
+    }
+  }
+}

--- a/apps/api/src/unifi_api/graphql/docgen.py
+++ b/apps/api/src/unifi_api/graphql/docgen.py
@@ -1,40 +1,117 @@
-"""Auto-generate apps/api/docs/graphql-reference.md from the SDL.
+"""Auto-generate apps/api/docs/graphql-reference.md and openapi-reference.md.
 
 Run: `uv run --package unifi-api python -m unifi_api.graphql.docgen`
-to regenerate. CI gate (test_docs_drift) catches staleness.
+to regenerate. CI gates catch staleness.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from unifi_api.graphql.schema import schema
 
 
-HEADER = """# unifi-api GraphQL Reference
-
-> Auto-generated from the Strawberry schema by `unifi_api.graphql.docgen`.
-> Do not edit by hand. Regenerate with `python -m unifi_api.graphql.docgen`.
-
-"""
-
-
 def render_reference() -> str:
-    """Render the markdown reference from the schema's SDL."""
+    """Render apps/api/docs/graphql-reference.md grouped by top-level Query field.
+
+    Walks the schema's introspection metadata and emits markdown sections
+    per Query namespace (network / protect / access) plus type definitions.
+    """
     sdl = str(schema).strip()
-    return (
-        HEADER
-        + "## Schema (SDL)\n\n```graphql\n"
-        + sdl
-        + "\n```\n"
-    )
+    out: list[str] = []
+    out.append("# unifi-api-server GraphQL Reference\n")
+    out.append("> Auto-generated from the Strawberry schema by `unifi_api.graphql.docgen`.")
+    out.append("> Regenerate with `python -m unifi_api.graphql.docgen`.\n")
+    out.append("\n## Schema (full SDL)\n")
+    out.append("\n```graphql\n")
+    out.append(sdl)
+    out.append("\n```\n")
+
+    gql_schema = schema._schema
+    query_type = gql_schema.query_type
+    if query_type is not None:
+        out.append("\n## Query namespaces\n")
+        for field_name, field in sorted(query_type.fields.items()):
+            description = field.description or ""
+            out.append(f"\n### `query.{field_name}`\n")
+            if description:
+                out.append(f"\n{description}\n")
+            target = field.type
+            while hasattr(target, "of_type"):
+                target = target.of_type
+            if hasattr(target, "fields"):
+                out.append("\n**Fields:**\n")
+                for sub_name, sub_field in sorted(target.fields.items()):
+                    sub_desc = sub_field.description or ""
+                    sub_type_str = str(sub_field.type)
+                    line = f"- `{sub_name}: {sub_type_str}`"
+                    if sub_desc:
+                        line += f"  — {sub_desc}"
+                    out.append(line)
+                out.append("")
+
+    return "\n".join(out)
+
+
+def render_openapi_reference() -> str:
+    """Render apps/api/docs/openapi-reference.md from openapi.json."""
+    spec_path = Path(__file__).resolve().parents[3] / "openapi.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    out: list[str] = []
+    out.append("# unifi-api-server REST Reference\n")
+    out.append("> Auto-generated from `openapi.json` by `unifi_api.graphql.docgen`.")
+    out.append("> Regenerate with `python -m unifi_api.graphql.docgen`.\n")
+
+    # Group endpoints by tag
+    by_tag: dict[str, list[tuple[str, str, dict]]] = {}
+    for path, ops in sorted(spec.get("paths", {}).items()):
+        for method, op in ops.items():
+            if not isinstance(op, dict):
+                continue
+            for tag in op.get("tags", ["untagged"]):
+                by_tag.setdefault(tag, []).append((method.upper(), path, op))
+
+    for tag in sorted(by_tag):
+        out.append(f"\n## {tag}\n")
+        for method, path, op in by_tag[tag]:
+            summary = op.get("summary") or op.get("operationId") or ""
+            out.append(f"### `{method} {path}` — {summary}\n")
+            if op.get("description"):
+                out.append(f"\n{op['description']}\n")
+            params = op.get("parameters") or []
+            if params:
+                out.append("\n**Parameters:**\n")
+                for p in params:
+                    name = p.get("name", "")
+                    where = p.get("in", "")
+                    required = " (required)" if p.get("required") else ""
+                    out.append(f"- `{name}` ({where}){required}")
+                out.append("")
+            response_200 = op.get("responses", {}).get("200", {})
+            response_schema = (
+                response_200.get("content", {})
+                .get("application/json", {})
+                .get("schema")
+            )
+            if response_schema:
+                schema_name = (
+                    response_schema.get("$ref", "").split("/")[-1]
+                    or response_schema.get("type", "object")
+                )
+                out.append(f"\n**Returns:** `{schema_name}`\n")
+
+    return "\n".join(out)
 
 
 def main() -> None:
-    out_path = Path(__file__).resolve().parents[3] / "docs" / "graphql-reference.md"
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(render_reference(), encoding="utf-8")
-    print(f"wrote {out_path}")
+    docs_dir = Path(__file__).resolve().parents[3] / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "graphql-reference.md").write_text(render_reference(), encoding="utf-8")
+    (docs_dir / "openapi-reference.md").write_text(render_openapi_reference(), encoding="utf-8")
+    print(f"wrote {docs_dir / 'graphql-reference.md'}")
+    print(f"wrote {docs_dir / 'openapi-reference.md'}")
 
 
 if __name__ == "__main__":

--- a/apps/api/src/unifi_api/graphql/pydantic_export.py
+++ b/apps/api/src/unifi_api/graphql/pydantic_export.py
@@ -1,0 +1,117 @@
+"""Walker that derives a Pydantic model from a Strawberry type.
+
+Single source of truth: the Strawberry types from Phase 6 are the canonical
+projection layer. This walker derives the Pydantic mirror REST routes use
+as ``response_model=...`` so OpenAPI shows real type information instead of
+opaque dict.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, get_args, get_origin
+
+import strawberry
+from pydantic import BaseModel, ConfigDict, create_model
+from strawberry.types.base import StrawberryList, StrawberryOptional
+from strawberry.types.private import StrawberryPrivate
+
+_MODEL_CACHE: dict[type, type[BaseModel]] = {}
+
+
+def _is_private_field(field: Any) -> bool:
+    """Return True if the field is marked strawberry.Private.
+
+    In 0.315.x, Private fields are Annotated[T, StrawberryPrivate()] at the
+    raw ``field.type`` level.
+    """
+    t = field.type
+    if get_origin(t) is not None:
+        # Annotated[...] form used for strawberry.Private
+        for meta in get_args(t):
+            if isinstance(meta, StrawberryPrivate):
+                return True
+    return False
+
+
+def _strawberry_type_to_pydantic(strawberry_type_obj: Any) -> Any:
+    """Map a Strawberry type object (field.type) to a Pydantic-compatible annotation.
+
+    Handles:
+    - StrawberryOptional wrapping any inner type
+    - StrawberryList wrapping any inner type
+    - strawberry.ID → str
+    - Nested @strawberry.type → recurse via to_pydantic_model
+    - Scalar primitives (str, int, bool, float, dict, datetime.datetime)
+    - strawberry.scalars.JSON → Any
+    - Annotated[...] private fields (already filtered upstream, but handled safely)
+    - Fallback → Any
+    """
+    if isinstance(strawberry_type_obj, StrawberryOptional):
+        inner = _strawberry_type_to_pydantic(strawberry_type_obj.of_type)
+        return inner | None
+
+    if isinstance(strawberry_type_obj, StrawberryList):
+        inner = _strawberry_type_to_pydantic(strawberry_type_obj.of_type)
+        return list[inner]  # type: ignore[valid-type]
+
+    if strawberry_type_obj is strawberry.ID:
+        return str
+
+    if hasattr(strawberry_type_obj, "__strawberry_definition__"):
+        return to_pydantic_model(strawberry_type_obj)
+
+    # Strawberry-decorated enums expose Python's enum class via __strawberry_enum_definition__.
+    # Pydantic v2 handles Python enums natively, so pass them through.
+    if hasattr(strawberry_type_obj, "_enum_definition") or hasattr(
+        strawberry_type_obj, "__strawberry_enum_definition__"
+    ):
+        return strawberry_type_obj
+
+    if strawberry_type_obj in (str, int, bool, float, dict, datetime.datetime, type(None)):
+        return strawberry_type_obj
+
+    try:
+        from strawberry.scalars import JSON
+        if strawberry_type_obj is JSON:
+            return Any
+    except ImportError:
+        pass
+
+    return Any
+
+
+def to_pydantic_model(strawberry_type: type) -> type[BaseModel]:
+    """Derive a Pydantic model from a Strawberry ``@strawberry.type`` class.
+
+    Cached per type. Skips ``strawberry.Private`` fields and ``@strawberry.field``
+    resolver methods (cross-resource edges — not in ``to_dict``).
+    """
+    if strawberry_type in _MODEL_CACHE:
+        return _MODEL_CACHE[strawberry_type]
+
+    definition = getattr(strawberry_type, "__strawberry_definition__", None)
+    if definition is None:
+        raise TypeError(
+            f"{strawberry_type.__name__} is not a Strawberry type"
+        )
+
+    fields: dict[str, tuple[Any, Any]] = {}
+    for field in definition.fields:
+        if field.base_resolver is not None:
+            # @strawberry.field resolver — cross-resource edge, not in to_dict()
+            continue
+        if _is_private_field(field):
+            # strawberry.Private — internal context, not in to_dict()
+            continue
+        annotation = _strawberry_type_to_pydantic(field.type)
+        fields[field.python_name] = (annotation, None)
+
+    model = create_model(
+        f"{strawberry_type.__name__}Model",
+        # extra="allow": REST routes return manager-extra keys; Pydantic must not reject them.
+        __config__=ConfigDict(extra="allow"),
+        **fields,
+    )
+    _MODEL_CACHE[strawberry_type] = model
+    return model

--- a/apps/api/src/unifi_api/routes/resources/access/credentials.py
+++ b/apps/api/src/unifi_api/routes/resources/access/credentials.py
@@ -11,12 +11,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.access.credentials import Credential
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -37,7 +39,9 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 
 @router.get(
     "/sites/{site_id}/credentials",
+    response_model=Page[to_pydantic_model(Credential)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/credentials"],
 )
 async def list_credentials(
     request: Request,
@@ -81,7 +85,9 @@ async def list_credentials(
 
 @router.get(
     "/sites/{site_id}/credentials/{credential_id}",
+    response_model=Detail[to_pydantic_model(Credential)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/credentials"],
 )
 async def get_credential(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/access/devices.py
@@ -11,7 +11,6 @@ DeviceManager.get_device raises UniFiNotFoundError on miss → 404.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -22,7 +21,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.access.doors import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -44,6 +42,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/access-devices",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/devices"],
 )
 async def list_access_devices(
     request: Request,
@@ -88,6 +87,7 @@ async def list_access_devices(
 @router.get(
     "/sites/{site_id}/access-devices/{device_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/devices"],
 )
 async def get_access_device(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/doors.py
+++ b/apps/api/src/unifi_api/routes/resources/access/doors.py
@@ -8,17 +8,18 @@ so the endpoint shape stays consistent with the network resources.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.access.doors import Door
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -45,7 +46,9 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 
 @router.get(
     "/sites/{site_id}/doors",
+    response_model=Page[to_pydantic_model(Door)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/doors"],
 )
 async def list_doors(
     request: Request,
@@ -89,7 +92,9 @@ async def list_doors(
 
 @router.get(
     "/sites/{site_id}/doors/{door_id}",
+    response_model=Detail[to_pydantic_model(Door)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/doors"],
 )
 async def get_door(
     request: Request,
@@ -123,6 +128,7 @@ async def get_door(
 @router.get(
     "/sites/{site_id}/doors/{door_id}/status",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/doors"],
 )
 async def get_door_status(
     request: Request,
@@ -171,6 +177,7 @@ async def get_door_status(
 @router.get(
     "/sites/{site_id}/door-groups",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/doors"],
 )
 async def list_door_groups(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/events.py
+++ b/apps/api/src/unifi_api/routes/resources/access/events.py
@@ -19,7 +19,6 @@ capability-aware ``/events`` dispatcher (PR2) and protect's ``/events``
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -29,7 +28,6 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -55,6 +53,7 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 @router.get(
     "/sites/{site_id}/access/events",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/events"],
 )
 async def list_access_events(
     request: Request,
@@ -106,6 +105,7 @@ async def list_access_events(
 @router.get(
     "/sites/{site_id}/access/events/{event_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/events"],
 )
 async def get_access_event(
     request: Request,
@@ -147,6 +147,7 @@ async def get_access_event(
 @router.get(
     "/sites/{site_id}/access/recent-events",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/events"],
 )
 async def recent_access_events(
     request: Request,
@@ -204,6 +205,7 @@ async def recent_access_events(
 @router.get(
     "/sites/{site_id}/access/activity-summary",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/events"],
 )
 async def get_access_activity_summary(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/policies.py
+++ b/apps/api/src/unifi_api/routes/resources/access/policies.py
@@ -8,7 +8,6 @@ UniFiNotFoundError post-#175 when proxy returns a miss.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -19,7 +18,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.access.doors import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -41,6 +39,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/policies",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/policies"],
 )
 async def list_policies(
     request: Request,
@@ -85,6 +84,7 @@ async def list_policies(
 @router.get(
     "/sites/{site_id}/policies/{policy_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/policies"],
 )
 async def get_policy(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/schedules.py
+++ b/apps/api/src/unifi_api/routes/resources/access/schedules.py
@@ -17,7 +17,6 @@ from unifi_api.routes.resources._common import (
 from unifi_api.routes.resources.access.doors import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
-
 router = APIRouter()
 
 
@@ -29,6 +28,7 @@ def _id_key(obj) -> tuple:
 @router.get(
     "/sites/{site_id}/schedules",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/schedules"],
 )
 async def list_schedules(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/system.py
+++ b/apps/api/src/unifi_api/routes/resources/access/system.py
@@ -13,7 +13,6 @@ equivalents (PR3 Cluster 2).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -24,13 +23,13 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.access.events import _maybe_set_site
 
-
 router = APIRouter()
 
 
 @router.get(
     "/sites/{site_id}/access/health",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/system"],
 )
 async def get_access_health(
     request: Request,
@@ -71,6 +70,7 @@ async def get_access_health(
 @router.get(
     "/sites/{site_id}/access/system-info",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/system"],
 )
 async def get_access_system_info(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/users.py
+++ b/apps/api/src/unifi_api/routes/resources/access/users.py
@@ -13,12 +13,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.access.users import User
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -39,7 +41,9 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 
 @router.get(
     "/sites/{site_id}/users",
+    response_model=Page[to_pydantic_model(User)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/users"],
 )
 async def list_users(
     request: Request,
@@ -83,7 +87,9 @@ async def list_users(
 
 @router.get(
     "/sites/{site_id}/users/{user_id}",
+    response_model=Detail[to_pydantic_model(User)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/users"],
 )
 async def get_user(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/access/visitors.py
+++ b/apps/api/src/unifi_api/routes/resources/access/visitors.py
@@ -6,7 +6,6 @@ VisitorManager.get_visitor raises UniFiNotFoundError on miss → 404.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -17,7 +16,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.access.doors import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -40,6 +38,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/visitors",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/visitors"],
 )
 async def list_visitors(
     request: Request,
@@ -84,6 +83,7 @@ async def list_visitors(
 @router.get(
     "/sites/{site_id}/visitors/{visitor_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/visitors"],
 )
 async def get_visitor(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/acl.py
+++ b/apps/api/src/unifi_api/routes/resources/network/acl.py
@@ -6,17 +6,18 @@ Phase 5A PR2 Cluster 4 — network filtering routes.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.acl import AclRule
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/acl-rules",
+    response_model=Page[to_pydantic_model(AclRule)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def list_acl_rules(
     request: Request,
@@ -83,6 +86,7 @@ async def list_acl_rules(
 @router.get(
     "/sites/{site_id}/acl-rules/{rule_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def get_acl_rule_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/acl.py
+++ b/apps/api/src/unifi_api/routes/resources/network/acl.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -85,6 +85,7 @@ async def list_acl_rules(
 
 @router.get(
     "/sites/{site_id}/acl-rules/{rule_id}",
+    response_model=Detail[to_pydantic_model(AclRule)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/firewall"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
@@ -19,7 +19,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -87,6 +87,7 @@ async def list_ap_groups(
 
 @router.get(
     "/sites/{site_id}/ap-groups/{group_id}",
+    response_model=Detail[to_pydantic_model(ApGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/groups"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
@@ -8,17 +8,18 @@ AP groups live on ``NetworkManager`` per Phase 4A discovery, not a separate
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.ap_group import ApGroup
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -39,7 +40,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/ap-groups",
+    response_model=Page[to_pydantic_model(ApGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/groups"],
 )
 async def list_ap_groups(
     request: Request,
@@ -85,6 +88,7 @@ async def list_ap_groups(
 @router.get(
     "/sites/{site_id}/ap-groups/{group_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/groups"],
 )
 async def get_ap_group_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/blocked_clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/blocked_clients.py
@@ -9,12 +9,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.client import BlockedClient
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -35,7 +37,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/blocked-clients",
+    response_model=Page[to_pydantic_model(BlockedClient)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/clients"],
 )
 async def list_blocked_clients(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/client_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/client_groups.py
@@ -6,17 +6,18 @@ Phase 5A PR1 Cluster 2 — clients & user groups.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.client_group import ClientGroup
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/client-groups",
+    response_model=Page[to_pydantic_model(ClientGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/groups"],
 )
 async def list_client_groups(
     request: Request,
@@ -84,6 +87,7 @@ async def list_client_groups(
 @router.get(
     "/sites/{site_id}/client-groups/{group_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/groups"],
 )
 async def get_client_group_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/client_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/client_groups.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -86,6 +86,7 @@ async def list_client_groups(
 
 @router.get(
     "/sites/{site_id}/client-groups/{group_id}",
+    response_model=Detail[to_pydantic_model(ClientGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/groups"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/clients.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.client import Client
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -32,7 +33,9 @@ def _client_key(obj) -> tuple:
 
 @router.get(
     "/sites/{site_id}/clients",
+    response_model=Page[to_pydantic_model(Client)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/clients"],
 )
 async def list_clients(
     request: Request,
@@ -78,6 +81,7 @@ async def list_clients(
 @router.get(
     "/sites/{site_id}/clients/{mac}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/clients"],
 )
 async def get_client(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/clients.py
@@ -14,7 +14,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -80,6 +80,7 @@ async def list_clients(
 
 @router.get(
     "/sites/{site_id}/clients/{mac}",
+    response_model=Detail[to_pydantic_model(Client)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/clients"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/content_filters.py
+++ b/apps/api/src/unifi_api/routes/resources/network/content_filters.py
@@ -6,17 +6,18 @@ Phase 5A PR2 Cluster 4 — network filtering routes.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.content_filter import ContentFilter
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/content-filters",
+    response_model=Page[to_pydantic_model(ContentFilter)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def list_content_filters(
     request: Request,
@@ -83,6 +86,7 @@ async def list_content_filters(
 @router.get(
     "/sites/{site_id}/content-filters/{filter_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def get_content_filter_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/content_filters.py
+++ b/apps/api/src/unifi_api/routes/resources/network/content_filters.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -85,6 +85,7 @@ async def list_content_filters(
 
 @router.get(
     "/sites/{site_id}/content-filters/{filter_id}",
+    response_model=Detail[to_pydantic_model(ContentFilter)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/policy"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.device import Device
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -26,7 +27,9 @@ def _device_key(obj) -> tuple:
 
 @router.get(
     "/sites/{site_id}/devices",
+    response_model=Page[to_pydantic_model(Device)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/devices"],
 )
 async def list_devices(
     request: Request,
@@ -72,6 +75,7 @@ async def list_devices(
 @router.get(
     "/sites/{site_id}/devices/{mac}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/devices"],
 )
 async def get_device(
     request: Request,
@@ -105,6 +109,7 @@ async def get_device(
 @router.get(
     "/sites/{site_id}/devices/{mac}/radio",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/devices"],
 )
 async def get_device_radio(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -14,7 +14,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -74,6 +74,7 @@ async def list_devices(
 
 @router.get(
     "/sites/{site_id}/devices/{mac}",
+    response_model=Detail[to_pydantic_model(Device)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/devices"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dns.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -85,6 +85,7 @@ async def list_dns_records(
 
 @router.get(
     "/sites/{site_id}/dns-records/{record_id}",
+    response_model=Detail[to_pydantic_model(DnsRecord)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/dns"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dns.py
@@ -6,17 +6,18 @@ Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.dns import DnsRecord
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/dns-records",
+    response_model=Page[to_pydantic_model(DnsRecord)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/dns"],
 )
 async def list_dns_records(
     request: Request,
@@ -83,6 +86,7 @@ async def list_dns_records(
 @router.get(
     "/sites/{site_id}/dns-records/{record_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/dns"],
 )
 async def get_dns_record_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/dpi.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dpi.py
@@ -18,12 +18,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.dpi import DpiApplication, DpiCategory
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -60,7 +62,9 @@ def _unwrap(result: Any) -> list:
 
 @router.get(
     "/sites/{site_id}/dpi-applications",
+    response_model=Page[to_pydantic_model(DpiApplication)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def list_dpi_applications(
     request: Request,
@@ -108,7 +112,9 @@ async def list_dpi_applications(
 
 @router.get(
     "/sites/{site_id}/dpi-categories",
+    response_model=Page[to_pydantic_model(DpiCategory)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def list_dpi_categories(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/events.py
+++ b/apps/api/src/unifi_api/routes/resources/network/events.py
@@ -20,7 +20,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
-
 router = APIRouter()
 
 
@@ -76,6 +75,7 @@ def _controller_products(controller) -> list[str]:
 @router.get(
     "/sites/{site_id}/events",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def list_events_dispatch(
     request: Request,
@@ -160,6 +160,7 @@ async def _list_protect_events(
 @router.get(
     "/sites/{site_id}/alerts",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_alerts(
     request: Request,
@@ -186,6 +187,7 @@ async def get_alerts(
 @router.get(
     "/sites/{site_id}/anomalies",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_anomalies(
     request: Request,
@@ -212,6 +214,7 @@ async def get_anomalies(
 @router.get(
     "/sites/{site_id}/ips-events",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_ips_events(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -85,6 +85,7 @@ async def list_firewall_groups(
 
 @router.get(
     "/sites/{site_id}/firewall/groups/{group_id}",
+    response_model=Detail[to_pydantic_model(FirewallGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/firewall"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
@@ -6,17 +6,18 @@ Phase 5A PR2 Cluster 4 — network filtering routes.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.firewall import FirewallGroup
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/firewall/groups",
+    response_model=Page[to_pydantic_model(FirewallGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def list_firewall_groups(
     request: Request,
@@ -83,6 +86,7 @@ async def list_firewall_groups(
 @router.get(
     "/sites/{site_id}/firewall/groups/{group_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def get_firewall_group_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -14,7 +14,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -74,6 +74,7 @@ async def list_firewall_rules(
 
 @router.get(
     "/sites/{site_id}/firewall/rules/{rule_id}",
+    response_model=Detail[to_pydantic_model(FirewallRule)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/firewall"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.firewall import FirewallRule
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -26,7 +27,9 @@ def _rule_key(obj) -> tuple:
 
 @router.get(
     "/sites/{site_id}/firewall/rules",
+    response_model=Page[to_pydantic_model(FirewallRule)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def list_firewall_rules(
     request: Request,
@@ -72,6 +75,7 @@ async def list_firewall_rules(
 @router.get(
     "/sites/{site_id}/firewall/rules/{rule_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def get_firewall_rule(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_zones.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_zones.py
@@ -12,12 +12,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.firewall import FirewallZone
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -38,7 +40,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/firewall/zones",
+    response_model=Page[to_pydantic_model(FirewallZone)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
 )
 async def list_firewall_zones(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/lldp.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lldp.py
@@ -16,7 +16,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
-
 router = APIRouter()
 
 
@@ -39,6 +38,7 @@ def _normalize_lldp_row(r: dict) -> dict:
 @router.get(
     "/sites/{site_id}/lldp-neighbors",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/lldp"],
 )
 async def list_lldp_neighbors(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/lookup.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lookup.py
@@ -8,7 +8,6 @@ manager method name diverges from the tool name).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -18,13 +17,13 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 
-
 router = APIRouter()
 
 
 @router.get(
     "/sites/{site_id}/lookup-by-ip",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/lookup"],
 )
 async def lookup_client_by_ip(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/networks.py
+++ b/apps/api/src/unifi_api/routes/resources/network/networks.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.network import Network
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -26,7 +27,9 @@ def _network_key(obj) -> tuple:
 
 @router.get(
     "/sites/{site_id}/networks",
+    response_model=Page[to_pydantic_model(Network)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/networks"],
 )
 async def list_networks(
     request: Request,
@@ -72,6 +75,7 @@ async def list_networks(
 @router.get(
     "/sites/{site_id}/networks/{network_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/networks"],
 )
 async def get_network(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/networks.py
+++ b/apps/api/src/unifi_api/routes/resources/network/networks.py
@@ -14,7 +14,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -74,6 +74,7 @@ async def list_networks(
 
 @router.get(
     "/sites/{site_id}/networks/{network_id}",
+    response_model=Detail[to_pydantic_model(Network)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/networks"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/oon.py
+++ b/apps/api/src/unifi_api/routes/resources/network/oon.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -85,6 +85,7 @@ async def list_oon_policies(
 
 @router.get(
     "/sites/{site_id}/oon-policies/{policy_id}",
+    response_model=Detail[to_pydantic_model(OonPolicy)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/policy"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/oon.py
+++ b/apps/api/src/unifi_api/routes/resources/network/oon.py
@@ -6,17 +6,18 @@ Phase 5A PR2 Cluster 4 — network filtering routes.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.oon import OonPolicy
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/oon-policies",
+    response_model=Page[to_pydantic_model(OonPolicy)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def list_oon_policies(
     request: Request,
@@ -83,6 +86,7 @@ async def list_oon_policies(
 @router.get(
     "/sites/{site_id}/oon-policies/{policy_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def get_oon_policy_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
+++ b/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
@@ -7,17 +7,18 @@ Phase 5A PR2 Cluster 5 — port forwards / vouchers / SNMP. Backed by
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.port_forward import PortForward
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -38,7 +39,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/port-forwards",
+    response_model=Page[to_pydantic_model(PortForward)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def list_port_forwards(
     request: Request,
@@ -84,6 +87,7 @@ async def list_port_forwards(
 @router.get(
     "/sites/{site_id}/port-forwards/{port_forward_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def get_port_forward(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
+++ b/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
@@ -18,7 +18,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -86,6 +86,7 @@ async def list_port_forwards(
 
 @router.get(
     "/sites/{site_id}/port-forwards/{port_forward_id}",
+    response_model=Detail[to_pydantic_model(PortForward)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/policy"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/qos.py
+++ b/apps/api/src/unifi_api/routes/resources/network/qos.py
@@ -6,17 +6,18 @@ Phase 5A PR2 Cluster 4 — network filtering routes.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.qos import QosRule
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -37,7 +38,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/qos-rules",
+    response_model=Page[to_pydantic_model(QosRule)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def list_qos_rules(
     request: Request,
@@ -83,6 +86,7 @@ async def list_qos_rules(
 @router.get(
     "/sites/{site_id}/qos-rules/{rule_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/policy"],
 )
 async def get_qos_rule_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/qos.py
+++ b/apps/api/src/unifi_api/routes/resources/network/qos.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -85,6 +85,7 @@ async def list_qos_rules(
 
 @router.get(
     "/sites/{site_id}/qos-rules/{rule_id}",
+    response_model=Detail[to_pydantic_model(QosRule)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/policy"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/rogue_aps.py
+++ b/apps/api/src/unifi_api/routes/resources/network/rogue_aps.py
@@ -11,12 +11,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.device import RfScanResult
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -54,6 +56,7 @@ def _serialize_rogue(row, *, is_known: bool) -> dict:
 @router.get(
     "/sites/{site_id}/rogue-aps",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/wireless"],
 )
 async def list_rogue_aps(
     request: Request,
@@ -99,6 +102,7 @@ async def list_rogue_aps(
 @router.get(
     "/sites/{site_id}/known-rogue-aps",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/wireless"],
 )
 async def list_known_rogue_aps(
     request: Request,
@@ -142,7 +146,9 @@ async def list_known_rogue_aps(
 
 @router.get(
     "/sites/{site_id}/rf-scan-results",
+    response_model=Page[to_pydantic_model(RfScanResult)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/wireless"],
 )
 async def list_rf_scan_results(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/routes.py
+++ b/apps/api/src/unifi_api/routes/resources/network/routes.py
@@ -7,17 +7,18 @@ Three resources in one module since they all live in the routing domain.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.route import ActiveRoute, Route, TrafficRoute
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -41,7 +42,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/active-routes",
+    response_model=Page[to_pydantic_model(ActiveRoute)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/routes"],
 )
 async def list_active_routes(
     request: Request,
@@ -89,7 +92,9 @@ async def list_active_routes(
 
 @router.get(
     "/sites/{site_id}/static-routes",
+    response_model=Page[to_pydantic_model(Route)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/routes"],
 )
 async def list_routes(
     request: Request,
@@ -135,6 +140,7 @@ async def list_routes(
 @router.get(
     "/sites/{site_id}/static-routes/{route_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/routes"],
 )
 async def get_route_details(
     request: Request,
@@ -177,7 +183,9 @@ async def get_route_details(
 
 @router.get(
     "/sites/{site_id}/traffic-routes",
+    response_model=Page[to_pydantic_model(TrafficRoute)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/routes"],
 )
 async def list_traffic_routes(
     request: Request,
@@ -223,6 +231,7 @@ async def list_traffic_routes(
 @router.get(
     "/sites/{site_id}/traffic-routes/{route_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/routes"],
 )
 async def get_traffic_route_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/routes.py
+++ b/apps/api/src/unifi_api/routes/resources/network/routes.py
@@ -18,7 +18,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -139,6 +139,7 @@ async def list_routes(
 
 @router.get(
     "/sites/{site_id}/static-routes/{route_id}",
+    response_model=Detail[to_pydantic_model(Route)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/routes"],
 )
@@ -230,6 +231,7 @@ async def list_traffic_routes(
 
 @router.get(
     "/sites/{site_id}/traffic-routes/{route_id}",
+    response_model=Detail[to_pydantic_model(TrafficRoute)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/routes"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/snmp.py
+++ b/apps/api/src/unifi_api/routes/resources/network/snmp.py
@@ -16,13 +16,13 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 
-
 router = APIRouter()
 
 
 @router.get(
     "/sites/{site_id}/snmp-settings",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/snmp"],
 )
 async def get_snmp_settings(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/speedtest.py
+++ b/apps/api/src/unifi_api/routes/resources/network/speedtest.py
@@ -11,13 +11,13 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 
-
 router = APIRouter()
 
 
 @router.get(
     "/sites/{site_id}/speedtest-status",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_speedtest_status(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/stats.py
+++ b/apps/api/src/unifi_api/routes/resources/network/stats.py
@@ -16,7 +16,6 @@ Stats endpoints span TIMESERIES and DETAIL kinds. After PR4:
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -26,7 +25,6 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -109,6 +107,7 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 @router.get(
     "/sites/{site_id}/stats/dashboard",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_dashboard_stats(
     request: Request,
@@ -135,6 +134,7 @@ async def get_dashboard_stats(
 @router.get(
     "/sites/{site_id}/stats/network",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_network_stats(
     request: Request,
@@ -161,6 +161,7 @@ async def get_network_stats(
 @router.get(
     "/sites/{site_id}/stats/gateway",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_gateway_stats(
     request: Request,
@@ -187,6 +188,7 @@ async def get_gateway_stats(
 @router.get(
     "/sites/{site_id}/stats/dpi/site",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_site_dpi_traffic(
     request: Request,
@@ -213,6 +215,7 @@ async def get_site_dpi_traffic(
 @router.get(
     "/sites/{site_id}/stats/dpi/clients/{mac}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_client_dpi_traffic(
     request: Request,
@@ -243,6 +246,7 @@ async def get_client_dpi_traffic(
 @router.get(
     "/sites/{site_id}/stats/dpi",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_dpi_stats(
     request: Request,
@@ -270,6 +274,7 @@ async def get_dpi_stats(
 @router.get(
     "/sites/{site_id}/stats/devices/{mac}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_device_stats(
     request: Request,
@@ -301,6 +306,7 @@ async def get_device_stats(
 @router.get(
     "/sites/{site_id}/stats/clients/{mac}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_client_stats(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/switch.py
+++ b/apps/api/src/unifi_api/routes/resources/network/switch.py
@@ -12,17 +12,18 @@ row-level serialization inline (matching the wrapper serializer's row shape).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.switch import PortProfile
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -52,7 +53,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/port-profiles",
+    response_model=Page[to_pydantic_model(PortProfile)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/switch"],
 )
 async def list_port_profiles(
     request: Request,
@@ -99,6 +102,7 @@ async def list_port_profiles(
 @router.get(
     "/sites/{site_id}/port-profiles/{profile_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/switch"],
 )
 async def get_port_profile_details(
     request: Request,
@@ -153,6 +157,7 @@ def _normalize_port_override(p: dict) -> dict:
 @router.get(
     "/sites/{site_id}/switch-ports",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/switch"],
 )
 async def list_switch_ports(
     request: Request,
@@ -227,6 +232,7 @@ def _normalize_port_stat(p: dict) -> dict:
 @router.get(
     "/sites/{site_id}/port-stats",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/switch"],
 )
 async def list_port_stats(
     request: Request,
@@ -281,6 +287,7 @@ async def list_port_stats(
 @router.get(
     "/sites/{site_id}/switch-capabilities",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/switch"],
 )
 async def get_switch_capabilities(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/switch.py
+++ b/apps/api/src/unifi_api/routes/resources/network/switch.py
@@ -17,13 +17,13 @@ from unifi_core.exceptions import UniFiNotFoundError
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.graphql.pydantic_export import to_pydantic_model
-from unifi_api.graphql.types.network.switch import PortProfile
+from unifi_api.graphql.types.network.switch import PortOverrideRow, PortProfile, PortStatRow
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -101,6 +101,7 @@ async def list_port_profiles(
 
 @router.get(
     "/sites/{site_id}/port-profiles/{profile_id}",
+    response_model=Detail[to_pydantic_model(PortProfile)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/switch"],
 )
@@ -190,7 +191,6 @@ async def list_switch_ports(
     type_registry = request.app.state.type_registry
     tool_type = type_registry.lookup_tool("unifi_get_switch_ports")
     if tool_type is not None:
-        from unifi_api.graphql.types.network.switch import PortOverrideRow
         type_class, _kind = tool_type
         items = [PortOverrideRow.from_manager_output(p).to_dict() for p in page]
         hint = {**type_class.render_hint("list"), "kind": "list"}
@@ -265,7 +265,6 @@ async def list_port_stats(
     type_registry = request.app.state.type_registry
     tool_type = type_registry.lookup_tool("unifi_get_port_stats")
     if tool_type is not None:
-        from unifi_api.graphql.types.network.switch import PortStatRow
         type_class, _kind = tool_type
         items = [PortStatRow.from_manager_output(p).to_dict() for p in page]
         hint = {**type_class.render_hint("list"), "kind": "list"}

--- a/apps/api/src/unifi_api/routes/resources/network/system.py
+++ b/apps/api/src/unifi_api/routes/resources/network/system.py
@@ -22,7 +22,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
-
 router = APIRouter()
 
 
@@ -91,6 +90,7 @@ def _detail_response(request, payload, tool_name):
 @router.get(
     "/sites/{site_id}/alarms",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def list_alarms(
     request: Request,
@@ -117,6 +117,7 @@ async def list_alarms(
 @router.get(
     "/sites/{site_id}/backups",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def list_backups(
     request: Request,
@@ -143,6 +144,7 @@ async def list_backups(
 @router.get(
     "/sites/{site_id}/top-clients",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def get_top_clients(
     request: Request,
@@ -169,6 +171,7 @@ async def get_top_clients(
 @router.get(
     "/sites/{site_id}/client-sessions",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/clients"],
 )
 async def get_client_sessions(
     request: Request,
@@ -195,6 +198,7 @@ async def get_client_sessions(
 @router.get(
     "/sites/{site_id}/network-health",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def get_network_health(
     request: Request,
@@ -222,6 +226,7 @@ async def get_network_health(
 @router.get(
     "/sites/{site_id}/speedtest-results",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/observability"],
 )
 async def get_speedtest_results(
     request: Request,
@@ -251,6 +256,7 @@ async def get_speedtest_results(
 @router.get(
     "/sites/{site_id}/event-types",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def get_event_types(
     request: Request,
@@ -276,6 +282,7 @@ async def get_event_types(
 @router.get(
     "/sites/{site_id}/autobackup-settings",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def get_autobackup_settings(
     request: Request,
@@ -298,6 +305,7 @@ async def get_autobackup_settings(
 @router.get(
     "/sites/{site_id}/site-settings",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def get_site_settings(
     request: Request,
@@ -320,6 +328,7 @@ async def get_site_settings(
 @router.get(
     "/sites/{site_id}/system-info",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/system"],
 )
 async def get_system_info(
     request: Request,
@@ -342,6 +351,7 @@ async def get_system_info(
 @router.get(
     "/sites/{site_id}/client-wifi-details/{mac}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/clients"],
 )
 async def get_client_wifi_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/user_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/user_groups.py
@@ -19,7 +19,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -88,6 +88,7 @@ async def list_user_groups(
 
 @router.get(
     "/sites/{site_id}/user-groups/{group_id}",
+    response_model=Detail[to_pydantic_model(UserGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/groups"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/user_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/user_groups.py
@@ -8,17 +8,18 @@ Phase 5A PR1 Cluster 2 — clients & user groups. Manager methods are
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.client_group import UserGroup
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -39,7 +40,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/user-groups",
+    response_model=Page[to_pydantic_model(UserGroup)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/groups"],
 )
 async def list_user_groups(
     request: Request,
@@ -86,6 +89,7 @@ async def list_user_groups(
 @router.get(
     "/sites/{site_id}/user-groups/{group_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/groups"],
 )
 async def get_user_group_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/vouchers.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vouchers.py
@@ -10,17 +10,18 @@ the manager actually accepts.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.voucher import Voucher
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -41,7 +42,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/vouchers",
+    response_model=Page[to_pydantic_model(Voucher)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/vouchers"],
 )
 async def list_vouchers(
     request: Request,
@@ -87,6 +90,7 @@ async def list_vouchers(
 @router.get(
     "/sites/{site_id}/voucher-details/{voucher_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/vouchers"],
 )
 async def get_voucher_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/vouchers.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vouchers.py
@@ -21,7 +21,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -89,6 +89,7 @@ async def list_vouchers(
 
 @router.get(
     "/sites/{site_id}/voucher-details/{voucher_id}",
+    response_model=Detail[to_pydantic_model(Voucher)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/vouchers"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/vpn.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vpn.py
@@ -6,17 +6,18 @@ Phase 5A PR1 Cluster 3 — networks/WLANs/VPN/DNS/routing.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.vpn import VpnClient, VpnServer
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -40,7 +41,9 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 
 @router.get(
     "/sites/{site_id}/vpn-clients",
+    response_model=Page[to_pydantic_model(VpnClient)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/vpn"],
 )
 async def list_vpn_clients(
     request: Request,
@@ -86,6 +89,7 @@ async def list_vpn_clients(
 @router.get(
     "/sites/{site_id}/vpn-clients/{client_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/vpn"],
 )
 async def get_vpn_client_details(
     request: Request,
@@ -130,7 +134,9 @@ async def get_vpn_client_details(
 
 @router.get(
     "/sites/{site_id}/vpn-servers",
+    response_model=Page[to_pydantic_model(VpnServer)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/vpn"],
 )
 async def list_vpn_servers(
     request: Request,
@@ -176,6 +182,7 @@ async def list_vpn_servers(
 @router.get(
     "/sites/{site_id}/vpn-servers/{server_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/vpn"],
 )
 async def get_vpn_server_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/vpn.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vpn.py
@@ -17,7 +17,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -88,6 +88,7 @@ async def list_vpn_clients(
 
 @router.get(
     "/sites/{site_id}/vpn-clients/{client_id}",
+    response_model=Detail[to_pydantic_model(VpnClient)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/vpn"],
 )
@@ -181,6 +182,7 @@ async def list_vpn_servers(
 
 @router.get(
     "/sites/{site_id}/vpn-servers/{server_id}",
+    response_model=Detail[to_pydantic_model(VpnServer)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/vpn"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/wireless.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wireless.py
@@ -6,12 +6,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.device import AvailableChannel
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -24,7 +26,9 @@ def _channel_key(row) -> tuple:
 
 @router.get(
     "/sites/{site_id}/available-channels",
+    response_model=Page[to_pydantic_model(AvailableChannel)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/wireless"],
 )
 async def list_available_channels(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/wlans.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wlans.py
@@ -14,7 +14,7 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -75,6 +75,7 @@ async def list_wlans(
 
 @router.get(
     "/sites/{site_id}/wlans/{wlan_id}",
+    response_model=Detail[to_pydantic_model(Wlan)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/wlans"],
 )

--- a/apps/api/src/unifi_api/routes/resources/network/wlans.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wlans.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.wlan import Wlan
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -26,7 +27,9 @@ def _wlan_key(obj) -> tuple:
 
 @router.get(
     "/sites/{site_id}/wlans",
+    response_model=Page[to_pydantic_model(Wlan)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/wlans"],
 )
 async def list_wlans(
     request: Request,
@@ -73,6 +76,7 @@ async def list_wlans(
 @router.get(
     "/sites/{site_id}/wlans/{wlan_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/wlans"],
 )
 async def get_wlan(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/cameras.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/cameras.py
@@ -8,17 +8,18 @@ so the endpoint shape stays consistent with the network resources.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.protect.cameras import Camera
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -45,7 +46,9 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 
 @router.get(
     "/sites/{site_id}/cameras",
+    response_model=Page[to_pydantic_model(Camera)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/cameras"],
 )
 async def list_cameras(
     request: Request,
@@ -89,7 +92,9 @@ async def list_cameras(
 
 @router.get(
     "/sites/{site_id}/cameras/{camera_id}",
+    response_model=Detail[to_pydantic_model(Camera)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/cameras"],
 )
 async def get_camera(
     request: Request,
@@ -133,6 +138,7 @@ async def get_camera(
 @router.get(
     "/sites/{site_id}/cameras/{camera_id}/analytics",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/cameras"],
 )
 async def get_camera_analytics(
     request: Request,
@@ -178,6 +184,7 @@ async def get_camera_analytics(
 @router.get(
     "/sites/{site_id}/cameras/{camera_id}/streams",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/cameras"],
 )
 async def get_camera_streams(
     request: Request,
@@ -223,6 +230,7 @@ async def get_camera_streams(
 @router.get(
     "/sites/{site_id}/cameras/{camera_id}/snapshot",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/cameras"],
 )
 async def get_camera_snapshot(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/chimes.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/chimes.py
@@ -18,7 +18,6 @@ from unifi_api.routes.resources._common import (
 from unifi_api.routes.resources.protect.cameras import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
-
 router = APIRouter()
 
 
@@ -39,6 +38,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/chimes",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/cameras"],
 )
 async def list_chimes(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/events.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/events.py
@@ -14,17 +14,18 @@ capability-aware dispatcher — that one only owns the bare ``/events`` path.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.protect.events import Event
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
+from unifi_api.services.pydantic_models import Page
 
 router = APIRouter()
 
@@ -52,7 +53,9 @@ async def _maybe_set_site(cm, site_id: str) -> None:
 
 @router.get(
     "/sites/{site_id}/events",
+    response_model=Page[to_pydantic_model(Event)],
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def list_events(
     request: Request,
@@ -97,6 +100,7 @@ async def list_events(
 @router.get(
     "/sites/{site_id}/events/{event_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def get_event(
     request: Request,
@@ -138,6 +142,7 @@ async def get_event(
 @router.get(
     "/sites/{site_id}/event-thumbnails/{event_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def get_event_thumbnail(
     request: Request,
@@ -181,6 +186,7 @@ async def get_event_thumbnail(
 @router.get(
     "/sites/{site_id}/smart-detections",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def list_smart_detections(
     request: Request,
@@ -240,6 +246,7 @@ async def list_smart_detections(
 @router.get(
     "/sites/{site_id}/recent-events",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def recent_events(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/lights.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/lights.py
@@ -13,7 +13,6 @@ through the shared ``_maybe_set_site`` helper.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -24,7 +23,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.protect.cameras import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -46,6 +44,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/lights",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/lights"],
 )
 async def list_lights(
     request: Request,
@@ -90,6 +89,7 @@ async def list_lights(
 @router.get(
     "/sites/{site_id}/lights/{light_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/lights"],
 )
 async def get_light_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/liveviews.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/liveviews.py
@@ -8,7 +8,6 @@ filters from the LIST response (mirrors the lights/sensors pattern).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -19,7 +18,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.protect.cameras import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -41,6 +39,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/liveviews",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/liveviews"],
 )
 async def list_liveviews(
     request: Request,
@@ -85,6 +84,7 @@ async def list_liveviews(
 @router.get(
     "/sites/{site_id}/liveviews/{liveview_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/liveviews"],
 )
 async def get_liveview(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/recordings.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recordings.py
@@ -13,7 +13,6 @@ id, since the manager exposes no native ``get_recording``.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -23,7 +22,6 @@ from unifi_api.routes.resources._common import (
     resolve_controller,
 )
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -59,6 +57,7 @@ def _normalize_recordings(result) -> list[dict]:
 @router.get(
     "/sites/{site_id}/recordings",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def list_recordings(
     request: Request,
@@ -106,6 +105,7 @@ async def list_recordings(
 @router.get(
     "/sites/{site_id}/recordings/{recording_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def get_recording(
     request: Request,
@@ -148,6 +148,7 @@ async def get_recording(
 @router.get(
     "/sites/{site_id}/recording-status",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/events"],
 )
 async def get_recording_status(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/sensors.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/sensors.py
@@ -9,7 +9,6 @@ the LIST response (mirrors lights.py / network firewall_rules).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -20,7 +19,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.protect.cameras import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -42,6 +40,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/sensors",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/sensors"],
 )
 async def list_sensors(
     request: Request,
@@ -86,6 +85,7 @@ async def list_sensors(
 @router.get(
     "/sites/{site_id}/sensors/{sensor_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/sensors"],
 )
 async def get_sensor_details(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/protect/system.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/system.py
@@ -16,7 +16,6 @@ The ``/protect/...`` prefix is in the URL path — not a router prefix.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
 from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.auth.middleware import require_scope
@@ -27,7 +26,6 @@ from unifi_api.routes.resources._common import (
 )
 from unifi_api.routes.resources.protect.cameras import _maybe_set_site
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
-
 
 router = APIRouter()
 
@@ -54,6 +52,7 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
 @router.get(
     "/sites/{site_id}/firmware-status",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/system"],
 )
 async def get_firmware_status(
     request: Request,
@@ -99,6 +98,7 @@ async def get_firmware_status(
 @router.get(
     "/sites/{site_id}/alarm-status",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/system"],
 )
 async def alarm_get_status(
     request: Request,
@@ -139,6 +139,7 @@ async def alarm_get_status(
 @router.get(
     "/sites/{site_id}/alarm-profiles",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/system"],
 )
 async def alarm_list_profiles(
     request: Request,
@@ -196,6 +197,7 @@ async def alarm_list_profiles(
 @router.get(
     "/sites/{site_id}/protect/health",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/system"],
 )
 async def get_protect_health(
     request: Request,
@@ -236,6 +238,7 @@ async def get_protect_health(
 @router.get(
     "/sites/{site_id}/protect/system-info",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/system"],
 )
 async def get_protect_system_info(
     request: Request,
@@ -281,6 +284,7 @@ async def get_protect_system_info(
 @router.get(
     "/sites/{site_id}/viewers",
     dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/system"],
 )
 async def list_viewers(
     request: Request,

--- a/apps/api/src/unifi_api/services/pydantic_models.py
+++ b/apps/api/src/unifi_api/services/pydantic_models.py
@@ -19,3 +19,15 @@ class Page(BaseModel, Generic[T]):
     items: list[T]
     next_cursor: str | None = None
     render_hint: dict | None = None
+
+
+class Detail(BaseModel, Generic[T]):
+    """Single-resource detail envelope: {data, render_hint}.
+
+    Mirrors what detail handlers return and lets ``response_model=Detail[ItemModel]``
+    project the underlying type into OpenAPI.
+    """
+
+    model_config = ConfigDict(extra="allow")
+    data: T
+    render_hint: dict | None = None

--- a/apps/api/src/unifi_api/services/pydantic_models.py
+++ b/apps/api/src/unifi_api/services/pydantic_models.py
@@ -1,0 +1,21 @@
+"""Re-exported / wrapper Pydantic models for REST routes.
+
+The Page wrapper matches the canonical pagination envelope returned by
+list endpoints: {items, next_cursor, render_hint}. REST routes use
+``response_model=Page[to_pydantic_model(SomeType)]``.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+T = TypeVar("T")
+
+
+class Page(BaseModel, Generic[T]):
+    model_config = ConfigDict(extra="allow")
+    items: list[T]
+    next_cursor: str | None = None
+    render_hint: dict | None = None

--- a/apps/api/tests/graphql/test_openapi_docs_drift.py
+++ b/apps/api/tests/graphql/test_openapi_docs_drift.py
@@ -1,0 +1,16 @@
+"""CI gate: openapi-reference.md matches the docgen render."""
+
+from pathlib import Path
+
+from unifi_api.graphql.docgen import render_openapi_reference
+
+REF_PATH = Path(__file__).resolve().parents[2] / "docs" / "openapi-reference.md"
+
+
+def test_openapi_reference_matches_render() -> None:
+    expected = render_openapi_reference().strip()
+    actual = REF_PATH.read_text(encoding="utf-8").strip()
+    assert actual == expected, (
+        "openapi-reference.md is stale. Re-generate with:\n"
+        "  uv run --package unifi-api python -m unifi_api.graphql.docgen\n"
+    )

--- a/apps/api/tests/graphql/test_openapi_drift.py
+++ b/apps/api/tests/graphql/test_openapi_drift.py
@@ -1,0 +1,46 @@
+"""CI gate: checked-in openapi.json matches FastAPI's app.openapi() output.
+
+Re-generate with:
+    uv run --package unifi-api python -c \\
+      "from unifi_api.server import create_app; \\
+       from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig; \\
+       import os, tempfile, json; os.environ['UNIFI_API_DB_KEY'] = 'k'; \\
+       td = tempfile.mkdtemp(); \\
+       cfg = ApiConfig(http=HttpConfig(host='127.0.0.1', port=8080, cors_origins=()), \\
+                       logging=LoggingConfig(level='WARNING'), \\
+                       db=DbConfig(path=f'{td}/state.db')); \\
+       app = create_app(cfg); \\
+       print(json.dumps(app.openapi(), indent=2, sort_keys=True))" \\
+      > apps/api/openapi.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.server import create_app
+
+SPEC_PATH = Path(__file__).resolve().parents[2] / "openapi.json"
+
+
+def test_openapi_artifact_matches_app() -> None:
+    """The checked-in openapi.json matches the live app.openapi() output."""
+    os.environ["UNIFI_API_DB_KEY"] = "k"
+    with tempfile.TemporaryDirectory() as td:
+        cfg = ApiConfig(
+            http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
+            logging=LoggingConfig(level="WARNING"),
+            db=DbConfig(path=f"{td}/state.db"),
+        )
+        app = create_app(cfg)
+        actual = json.dumps(app.openapi(), indent=2, sort_keys=True).strip()
+
+    expected = SPEC_PATH.read_text(encoding="utf-8").strip()
+
+    assert actual == expected, (
+        "openapi.json is stale. Re-export per docstring above."
+    )

--- a/apps/api/tests/graphql/test_pydantic_export.py
+++ b/apps/api/tests/graphql/test_pydantic_export.py
@@ -1,0 +1,78 @@
+"""Custom Strawberry → Pydantic walker for OpenAPI response_model."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+
+
+def test_simple_strawberry_type_to_pydantic() -> None:
+    """A flat Strawberry type maps to a Pydantic model with the same fields."""
+    from unifi_api.graphql.types.network.client import Client
+    Model = to_pydantic_model(Client)
+    assert issubclass(Model, BaseModel)
+    fields = set(Model.model_fields.keys())
+    assert "mac" in fields
+    assert "hostname" in fields
+    assert "is_wired" in fields
+
+
+def test_strawberry_id_becomes_str() -> None:
+    """strawberry.ID fields project as Optional[str] in Pydantic."""
+    from unifi_api.graphql.types.network.client import Client
+    Model = to_pydantic_model(Client)
+    field = Model.model_fields["mac"]
+    annotation = field.annotation
+    assert "str" in str(annotation)
+
+
+def test_pydantic_model_validates_to_dict_output() -> None:
+    """The Pydantic model accepts the dict shape that Type.to_dict() produces."""
+    from unifi_api.graphql.types.network.client import Client
+    Model = to_pydantic_model(Client)
+    sample_raw = {
+        "mac": "aa:bb:cc:dd:ee:01",
+        "hostname": "alpha",
+        "is_wired": True,
+        "is_guest": False,
+        "is_online": True,
+        "last_seen": 1700000000,
+        "first_seen": 1690000000,
+        "ip": "10.0.0.5",
+    }
+    inst = Client.from_manager_output(sample_raw)
+    out = inst.to_dict()
+    Model(**out)
+
+
+def test_pydantic_model_rejects_unknown_fields_loosely() -> None:
+    """Pydantic models built from Strawberry types accept extras (Strawberry semantics).
+
+    REST routes return dicts that may include manager-extra keys; Pydantic must
+    not reject them, matching Strawberry's permissive shape.
+    """
+    from unifi_api.graphql.types.network.client import Client
+    Model = to_pydantic_model(Client)
+    sample = {
+        "mac": "aa:01", "hostname": "x", "is_wired": True, "is_guest": False,
+        "ip": None, "status": "online", "last_seen": "2025-01-01T00:00:00",
+        "first_seen": None, "note": None, "usergroup_id": None,
+        "extra_field_we_dont_care_about": "extra",
+    }
+    Model(**sample)  # must not raise
+
+
+def test_to_pydantic_model_caches_by_type() -> None:
+    """Repeated calls return the same Pydantic class (identity-stable for response_model=)."""
+    from unifi_api.graphql.types.network.client import Client
+    assert to_pydantic_model(Client) is to_pydantic_model(Client)
+
+
+def test_to_pydantic_model_raises_on_non_strawberry_type() -> None:
+    """Non-Strawberry inputs raise TypeError so callers don't get a silently-broken model."""
+    class NotStrawberry:
+        pass
+
+    with pytest.raises(TypeError, match="not a Strawberry type"):
+        to_pydantic_model(NotStrawberry)

--- a/apps/api/tests/graphql/test_pydantic_page_wrapper.py
+++ b/apps/api/tests/graphql/test_pydantic_page_wrapper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unifi_api.graphql.pydantic_export import to_pydantic_model
 from unifi_api.graphql.types.network.client import Client
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 
 def test_page_accepts_typed_items() -> None:
@@ -22,3 +22,19 @@ def test_page_accepts_extras_in_envelope() -> None:
     ItemModel = to_pydantic_model(Client)
     PageOfClients = Page[ItemModel]
     PageOfClients(items=[], next_cursor="abc", render_hint={"k": "v"})
+
+
+def test_detail_accepts_typed_data() -> None:
+    ItemModel = to_pydantic_model(Client)
+    DetailOfClient = Detail[ItemModel]
+    detail = DetailOfClient(
+        data={"mac": "aa:01", "hostname": "x", "is_wired": True},
+        render_hint=None,
+    )
+    assert detail.data.mac == "aa:01"
+
+
+def test_detail_accepts_extras_in_envelope() -> None:
+    ItemModel = to_pydantic_model(Client)
+    DetailOfClient = Detail[ItemModel]
+    DetailOfClient(data={"mac": "aa:01"}, render_hint={"k": "v"})

--- a/apps/api/tests/graphql/test_pydantic_page_wrapper.py
+++ b/apps/api/tests/graphql/test_pydantic_page_wrapper.py
@@ -1,0 +1,24 @@
+"""Page wrapper accepts a typed item list and the canonical envelope."""
+
+from __future__ import annotations
+
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.client import Client
+from unifi_api.services.pydantic_models import Page
+
+
+def test_page_accepts_typed_items() -> None:
+    ItemModel = to_pydantic_model(Client)
+    PageOfClients = Page[ItemModel]
+    page = PageOfClients(
+        items=[{"mac": "aa:01", "hostname": "x", "is_wired": True}],
+        next_cursor=None,
+        render_hint=None,
+    )
+    assert page.items[0].mac == "aa:01"
+
+
+def test_page_accepts_extras_in_envelope() -> None:
+    ItemModel = to_pydantic_model(Client)
+    PageOfClients = Page[ItemModel]
+    PageOfClients(items=[], next_cursor="abc", render_hint={"k": "v"})


### PR DESCRIPTION
## Summary

Phase 8 PR1 ships the **doc-artifacts** half of release-quality finale. Closes the door on Phase 6's GraphQL surface by wiring its types as the single source of truth for the REST `response_model` projection layer, and ships drift-gated reference docs for both REST and GraphQL.

- **Strawberry → Pydantic walker** (`unifi_api.graphql.pydantic_export.to_pydantic_model`) derives a Pydantic v2 model from any `@strawberry.type`. The Phase 6 types stay canonical; the Pydantic mirrors are derived. Walker handles `StrawberryOptional` / `StrawberryList`, `strawberry.ID`, nested types, primitives, JSON scalar, enums, with `extra="allow"` to tolerate manager-extra keys at the REST boundary.
- **Page[T] / Detail[T] envelope generics** (`unifi_api.services.pydantic_models`) match the `{items, next_cursor, render_hint}` and `{data, render_hint}` shapes REST handlers actually return. `response_model=Page[to_pydantic_model(T)]` / `Detail[to_pydantic_model(T)]` projects the underlying type into OpenAPI.
- **Wired response_model + tags into ~50 REST routes** across network/protect/access. Routes with dynamic dispatch (`lookup_tool`) or wrapper-dict shapes are tags-only — flagged in PR comments.
- **Tag convention** `<product>/<category>` applied across all REST routes for OpenAPI grouping.
- **Checked-in `apps/api/openapi.json` artifact** (405KB, 152 paths, 98 schema components) + `test_openapi_drift` gate.
- **Auto-generated `apps/api/docs/openapi-reference.md`** (~2,000 lines, grouped by tag) + `test_openapi_docs_drift` gate.
- **Upgraded `apps/api/docs/graphql-reference.md`** from "SDL in a code block" to grouped-by-namespace with field descriptions; existing `test_docs_drift` gate covers it.
- **`apps/api/docs/README.md` index** linking all artifacts + deployment patterns.
- **MFA doc note** in `apps/api/README.md`; closes #150.

### Known concerns

- `recordings.py` Strawberry type declares `start: str | None` / `end: str | None` but the manager actually returns Unix epoch ints (or differently-named keys depending on path). `response_model` was reverted on the two recordings routes to avoid shipping broken validation. **Worth a follow-up issue** to align the Recording type with the actual data contract before wiring response_model in PR2 territory or earlier.

### Tests

| Package | Before | After |
|---|---|---|
| unifi-core | 69 | 69 |
| unifi-mcp-shared | 205 | 205 |
| unifi-network-mcp | 630 | 630 |
| unifi-protect-mcp | 336 | 336 |
| unifi-access-mcp | 157 | 157 |
| unifi-api | 552 | **564** |

`unifi-api` delta: +12 (`pydantic_export` walker tests + cache/TypeError follow-ups + `Page` / `Detail` wrapper tests + `test_openapi_drift` + `test_openapi_docs_drift`).

All 6 GraphQL gates from Phase 6 still green; 2 new doc-drift gates green.

## Test plan

- [x] `uv run --package unifi-api pytest apps/api/tests` — 564 passed
- [x] All 6 packages green per-package
- [x] `uv run ruff check` clean for files modified in this PR
- [ ] Reviewer eyeballs the auto-generated `apps/api/docs/openapi-reference.md` for sanity (grouped by tag, ~50 endpoints, response shapes referenced)
- [ ] Reviewer eyeballs the upgraded `apps/api/docs/graphql-reference.md` (Query namespaces section + full SDL)
- [ ] Reviewer confirms `apps/api/openapi.json` is comprehensive (152 paths, 98 components)
- [ ] Reviewer confirms drift gates fire by editing one tag locally before approving

🤖 Generated with [Claude Code](https://claude.com/claude-code)