### PR TITLE
chore(docker): dedicated compose for unifi-api-server local dev

### DIFF
--- a/docker/docker-compose-api.yml
+++ b/docker/docker-compose-api.yml
@@ -1,0 +1,48 @@
+# Local-dev compose for unifi-api-server.
+#
+# Independent of docker/docker-compose.yml (which stands up the 3 MCP servers).
+# These two compose files can run side-by-side or independently — neither
+# project depends on the other being running.
+#
+# Usage:
+#   cd docker/
+#   docker compose -f docker-compose-api.yml up --build -d
+#   docker logs unifi-api-server | grep "Initial admin API key"
+#   open http://localhost:8089/v1/docs
+#
+# State (controller registrations, audit log, admin keys) persists in the
+# named volume `unifi-api-state`. `docker compose down` keeps the volume;
+# `docker compose down -v` wipes it for a clean slate.
+#
+# First boot:
+#   - migrate runs, DB created, admin key emitted to logs (save it)
+#   - serve starts, listening on 0.0.0.0:8080 inside the container
+#   - register controllers via POST /v1/controllers or the admin UI at /admin/
+#
+# Bootstrap-from-env (env-driven controller seeding) is a Phase 9 candidate —
+# tracked at https://github.com/sirkirby/unifi-mcp/issues  (TBD on issue
+# creation). For now, controllers are registered post-boot via REST or UI.
+
+services:
+  unifi-api-server:
+    build:
+      context: ..
+      dockerfile: apps/api/Dockerfile
+    container_name: unifi-api-server
+    restart: unless-stopped
+    ports:
+      - "8089:8080"
+    volumes:
+      - unifi-api-state:/var/lib/unifi-api
+    environment:
+      # Required — encrypts controller credentials in the state DB.
+      # Generate once with: openssl rand -hex 32
+      - UNIFI_API_DB_KEY=${UNIFI_API_DB_KEY:?DB encryption key required (set in ../.env)}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  unifi-api-state:


### PR DESCRIPTION
## Summary

Adds a dedicated `docker/docker-compose-api.yml` for standing up `unifi-api-server` locally. Independent of `docker/docker-compose.yml` (the 3-MCP-server compose) — the two projects don't depend on each other so they get separate compose files.

```bash
cd docker/
docker compose -f docker-compose-api.yml up --build -d
docker logs unifi-api-server | grep "Initial admin API key"
open http://localhost:8089/v1/docs
```

Key features:
- **Named volume** `unifi-api-state` persists controller registrations, audit log, and admin keys across `compose up/down`.
- **Self-bootstrapping:** the Dockerfile's `migrate && serve` CMD (from PR4) creates the DB and emits the admin key on first boot. Subsequent boots are no-ops — same compose file works for `up`, `restart`, and `compose down && up`.
- **Healthcheck** against `/v1/health`.
- **`UNIFI_API_DB_KEY`** required in `../.env` (encrypts controller credentials in SQLite). One-line generate: `openssl rand -hex 32`.

## What this DOESN'T do (intentionally)

- **No env-driven controller seeding.** A fresh `compose up` still requires post-boot `POST /v1/controllers` (or admin UI registration) to add controllers. That's a Phase 9 DevX feature — filed as a separate issue with design questions (idempotency, multi-controller, naming dedup).
- **Doesn't bundle into `docker/docker-compose.yml`.** Per @sirkirby's call, the API is independent — bundling into the MCP compose would imply a coupling that doesn't exist.

## Verification

- [x] `yaml.safe_load` parses cleanly
- [x] `docker compose -f docker-compose-api.yml config` resolves
- [x] End-to-end smoke: `compose up -d --build` boots, `curl /v1/health` returns 200, admin key appears in logs, `compose down -v` cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)