### PR TITLE
feat(network): add unifi_set_outlet_state for UP6 / USP-Strip outlet control

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -792,6 +792,9 @@ type NetworkQuery {
   """Get LLDP neighbors reported by a switch."""
   lldpNeighbors(controller: ID!, deviceMac: ID!, site: String! = "default"): LldpNeighbors
 
+  """Get per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip)."""
+  pduOutlets(controller: ID!, mac: ID!, site: String! = "default"): PduOutlets
+
   """List rogue (unknown) APs detected within a window (paginated)."""
   rogueAps(controller: ID!, site: String! = "default", withinHours: Int! = 24, limit: Int! = 50, cursor: String = null): RogueApPage!
 
@@ -1040,6 +1043,27 @@ type OonPolicy {
 type OonPolicyPage {
   items: [OonPolicy!]!
   nextCursor: String
+}
+
+"""A single outlet on a UniFi Smart Power PDU (UP6 / USP-Strip)."""
+type PduOutletEntry {
+  index: Int
+  name: String
+  hasRelay: Boolean
+  hasMetering: Boolean
+  relayState: Boolean
+  cycleEnabled: Boolean
+  overrideRelayState: Boolean
+  overrideCycleEnabled: Boolean
+  hasOverride: Boolean!
+}
+
+"""Wrapper dict containing per-outlet state for a Smart Power PDU."""
+type PduOutlets {
+  mac: ID
+  name: String
+  model: String
+  outlets: [PduOutletEntry!]!
 }
 
 """A UniFi Access policy (who-can-access-what binding)."""
@@ -1716,6 +1740,7 @@ Read-only access to UniFi Network resources.
 - `networks: NetworkPage!`  — List configured LAN/VLAN networks on the given controller/site (paginated).
 - `oonPolicies: OonPolicyPage!`  — List OON (out-of-network) policies (paginated).
 - `oonPolicy: OonPolicy`  — Look up a single OON policy by id.
+- `pduOutlets: PduOutlets`  — Get per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip).
 - `portForward: PortForward`  — Look up a single port forward by id.
 - `portForwards: PortForwardPage!`  — List port forwards on the given controller/site (paginated).
 - `portProfile: PortProfile`  — Look up a single switch port profile by id.

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -404,6 +404,18 @@ Fetch a user by listing then filtering — no native get_user method.
 
 **Returns:** `Detail_DeviceModel_`
 
+### `GET /v1/sites/{site_id}/devices/{mac}/outlets` — Get Pdu Outlets
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `mac` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
 ### `GET /v1/sites/{site_id}/devices/{mac}/radio` — Get Device Radio
 
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8404,6 +8404,77 @@
         ]
       }
     },
+    "/v1/sites/{site_id}/devices/{mac}/outlets": {
+      "get": {
+        "operationId": "get_pdu_outlets_v1_sites__site_id__devices__mac__outlets_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "mac",
+            "required": true,
+            "schema": {
+              "title": "Mac",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Pdu Outlets V1 Sites  Site Id  Devices  Mac  Outlets Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Pdu Outlets",
+        "tags": [
+          "network/devices"
+        ]
+      }
+    },
     "/v1/sites/{site_id}/devices/{mac}/radio": {
       "get": {
         "operationId": "get_device_radio_v1_sites__site_id__devices__mac__radio_get",

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -36,6 +36,7 @@ from unifi_api.graphql.types.network.device import (
     DeviceRadio,
     KnownRogueAp,
     LldpNeighbors,
+    PduOutlets,
     RfScanResult,
     RogueAp,
     SpeedtestStatus,
@@ -225,6 +226,26 @@ async def _fetch_lldp_neighbors(
             if cm.site != site:
                 await cm.set_site(site)
             return await mgr.get_lldp_neighbors(device_mac)
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_pdu_outlets(
+    ctx: GraphQLContext, controller: str, site: str, mac: str,
+) -> Any:
+    key = f"network/pdu-outlets/{controller}/{site}/{mac}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session, controller, "network", "device_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session, controller, "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return await mgr.get_pdu_outlets(mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -1774,6 +1795,23 @@ class NetworkQuery:
         if raw is None:
             return None
         return LldpNeighbors.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip).",
+    )
+    async def pdu_outlets(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        mac: strawberry.ID,
+        site: str = "default",
+    ) -> PduOutlets | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_pdu_outlets(ctx, controller, site, mac)
+        if raw is None:
+            return None
+        return PduOutlets.from_manager_output(raw)
 
     @strawberry.field(
         permission_classes=[IsRead],

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -781,6 +781,9 @@ type NetworkQuery {
   """Get LLDP neighbors reported by a switch."""
   lldpNeighbors(controller: ID!, deviceMac: ID!, site: String! = "default"): LldpNeighbors
 
+  """Get per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip)."""
+  pduOutlets(controller: ID!, mac: ID!, site: String! = "default"): PduOutlets
+
   """List rogue (unknown) APs detected within a window (paginated)."""
   rogueAps(controller: ID!, site: String! = "default", withinHours: Int! = 24, limit: Int! = 50, cursor: String = null): RogueApPage!
 
@@ -1029,6 +1032,27 @@ type OonPolicy {
 type OonPolicyPage {
   items: [OonPolicy!]!
   nextCursor: String
+}
+
+"""A single outlet on a UniFi Smart Power PDU (UP6 / USP-Strip)."""
+type PduOutletEntry {
+  index: Int
+  name: String
+  hasRelay: Boolean
+  hasMetering: Boolean
+  relayState: Boolean
+  cycleEnabled: Boolean
+  overrideRelayState: Boolean
+  overrideCycleEnabled: Boolean
+  hasOverride: Boolean!
+}
+
+"""Wrapper dict containing per-outlet state for a Smart Power PDU."""
+type PduOutlets {
+  mac: ID
+  name: String
+  model: String
+  outlets: [PduOutletEntry!]!
 }
 
 """A UniFi Access policy (who-can-access-what binding)."""

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -64,6 +64,7 @@ from unifi_api.graphql.types.network.device import (
     DeviceRadio as NetworkDeviceRadioType,
     KnownRogueAp as NetworkKnownRogueApType,
     LldpNeighbors as NetworkLldpNeighborsType,
+    PduOutlets as NetworkPduOutletsType,
     RfScanResult as NetworkRfScanResultType,
     RogueAp as NetworkRogueApType,
     SpeedtestStatus as NetworkSpeedtestStatusType,
@@ -214,6 +215,7 @@ def build_type_registry() -> TypeRegistry:
     reg.register_tool_type(
         "unifi_get_speedtest_status", NetworkSpeedtestStatusType, "detail",
     )
+    reg.register_tool_type("unifi_get_pdu_outlets", NetworkPduOutletsType, "detail")
 
     # network/networks
     reg.register_type("network", "networks", NetworkNetworkType)

--- a/apps/api/src/unifi_api/graphql/types/network/device.py
+++ b/apps/api/src/unifi_api/graphql/types/network/device.py
@@ -407,3 +407,67 @@ class SpeedtestStatus:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+@strawberry.type(description="A single outlet on a UniFi Smart Power PDU (UP6 / USP-Strip).")
+class PduOutletEntry:
+    index: int | None
+    name: str | None
+    has_relay: bool | None
+    has_metering: bool | None
+    relay_state: bool | None
+    cycle_enabled: bool | None
+    override_relay_state: bool | None
+    override_cycle_enabled: bool | None
+    has_override: bool
+
+    @classmethod
+    def from_manager_output(cls, r: Any) -> "PduOutletEntry":
+        return cls(
+            index=_get(r, "index"),
+            name=_get(r, "name"),
+            has_relay=_get(r, "has_relay"),
+            has_metering=_get(r, "has_metering"),
+            relay_state=_get(r, "relay_state"),
+            cycle_enabled=_get(r, "cycle_enabled"),
+            override_relay_state=_get(r, "override_relay_state"),
+            override_cycle_enabled=_get(r, "override_cycle_enabled"),
+            has_override=bool(_get(r, "has_override", False)),
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@strawberry.type(description="Wrapper dict containing per-outlet state for a Smart Power PDU.")
+class PduOutlets:
+    """Wrapper-dict shape: ``DeviceManager.get_pdu_outlets`` returns
+    ``{mac, name, model, outlets: [...]}`` combining sensed outlet_table with
+    desired outlet_overrides per outlet."""
+
+    mac: strawberry.ID | None
+    name: str | None
+    model: str | None
+    outlets: list[PduOutletEntry]
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {"kind": kind}
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "PduOutlets":
+        rows = _get(obj, "outlets", []) or []
+        return cls(
+            mac=_get(obj, "mac"),
+            name=_get(obj, "name"),
+            model=_get(obj, "model"),
+            outlets=[PduOutletEntry.from_manager_output(r) for r in rows],
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "mac": self.mac,
+            "name": self.name,
+            "model": self.model,
+            "outlets": [o.to_dict() for o in self.outlets],
+        }

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -150,3 +150,48 @@ async def get_device_radio(
         data = serializer.serialize(radio)
         hint = registry.render_hint_for_tool("unifi_get_device_radio")
     return {"data": data, "render_hint": hint}
+
+
+@router.get(
+    "/sites/{site_id}/devices/{mac}/outlets",
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/devices"],
+)
+async def get_pdu_outlets(
+    request: Request,
+    site_id: str,
+    mac: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session, controller.id, "network", "device_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            outlets = await mgr.get_pdu_outlets(mac)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if outlets is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"device {mac} is not a Smart Power PDU",
+        )
+
+    type_registry = request.app.state.type_registry
+    tool_type = type_registry.lookup_tool("unifi_get_pdu_outlets")
+    if tool_type is not None:
+        type_class, kind = tool_type
+        data = type_class.from_manager_output(outlets).to_dict()
+        hint = type_class.render_hint(kind)
+    else:
+        registry = request.app.state.serializer_registry
+        serializer = registry.serializer_for_tool("unifi_get_pdu_outlets")
+        data = serializer.serialize(outlets)
+        hint = registry.render_hint_for_tool("unifi_get_pdu_outlets")
+    return {"data": data, "render_hint": hint}

--- a/apps/api/src/unifi_api/serializers/network/devices.py
+++ b/apps/api/src/unifi_api/serializers/network/devices.py
@@ -29,6 +29,7 @@ from unifi_api.serializers._base import RenderKind, Serializer, register_seriali
         "unifi_reboot_device": {"kind": RenderKind.DETAIL},
         "unifi_rename_device": {"kind": RenderKind.DETAIL},
         "unifi_set_device_led": {"kind": RenderKind.DETAIL},
+        "unifi_set_outlet_state": {"kind": RenderKind.DETAIL},
         "unifi_set_site_leds": {"kind": RenderKind.DETAIL},
         "unifi_toggle_device": {"kind": RenderKind.DETAIL},
         "unifi_trigger_rf_scan": {"kind": RenderKind.DETAIL},

--- a/apps/api/tests/graphql/fixtures/network/test_devices.py
+++ b/apps/api/tests/graphql/fixtures/network/test_devices.py
@@ -10,6 +10,7 @@
 # tool: unifi_list_available_channels
 # tool: unifi_get_speedtest_status
 # tool: unifi_get_lldp_neighbors
+# tool: unifi_get_pdu_outlets
 """
 
 from __future__ import annotations
@@ -214,3 +215,39 @@ async def test_lldp_neighbors(tmp_path, monkeypatch):
     assert body.get("errors") is None, body
     # Returns the LldpNeighbors wrapper (name/model from device dict)
     assert body["data"]["network"]["lldpNeighbors"] is not None
+
+
+@pytest.mark.asyncio
+async def test_pdu_outlets(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(monkeypatch, {
+        ("network", "device_manager", "get_pdu_outlets"): {
+            "mac": "ac:8b:a9:11:22:33",
+            "name": "Rack PDU",
+            "model": "USPRPS",
+            "outlets": [
+                {
+                    "index": 1,
+                    "name": "Outlet 1",
+                    "has_relay": True,
+                    "has_metering": True,
+                    "relay_state": True,
+                    "cycle_enabled": False,
+                    "override_relay_state": True,
+                    "override_cycle_enabled": False,
+                    "has_override": True,
+                },
+            ],
+        },
+    })
+    body = await graphql_query(app, key, f'''{{
+        network {{ pduOutlets(controller: "{cid}", mac: "ac:8b:a9:11:22:33") {{
+            mac name model outlets {{ index name relayState }}
+        }} }}
+    }}''')
+    assert body.get("errors") is None, body
+    pdu = body["data"]["network"]["pduOutlets"]
+    assert pdu["mac"] == "ac:8b:a9:11:22:33"
+    assert pdu["outlets"][0]["index"] == 1
+    assert pdu["outlets"][0]["relayState"] is True

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -1153,3 +1153,185 @@ async def set_site_leds(
     except Exception as e:
         logger.error("Error setting site LEDs: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to set site-wide LED state: {e}"}
+
+
+# ---- Smart Power Strip (UP6 / USP-Strip) Outlet Control ----
+
+
+@server.tool(
+    name="unifi_get_pdu_outlets",
+    description=(
+        "Return per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip). "
+        "Combines the device's sensed outlet_table (live relay_state, cycle_enabled, "
+        "has_relay, has_metering) with the controller's desired outlet_overrides "
+        "so callers see both reported and intended state per outlet. "
+        "Returns an error if the device is not a PDU."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_pdu_outlets(
+    mac_address: Annotated[
+        str,
+        Field(
+            description="MAC address of the PDU, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='pdu')"
+        ),
+    ],
+) -> Dict[str, Any]:
+    """Implementation for fetching per-outlet state on a Smart Power PDU."""
+    try:
+        result = await device_manager.get_pdu_outlets(mac_address)
+        if result is None:
+            return {
+                "success": False,
+                "error": f"Device {mac_address} is not a Smart Power PDU.",
+            }
+        return {
+            "success": True,
+            "site": device_manager._connection.site,
+            **result,
+        }
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error getting PDU outlets for %s: %s", mac_address, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get PDU outlets for {mac_address}: {e}"}
+
+
+@server.tool(
+    name="unifi_set_outlet_state",
+    description=(
+        "Set per-outlet relay state (on/off) and optionally cycle_enabled on a UniFi "
+        "Smart Power PDU (UP6 / USP-Strip). The controller stores per-outlet desired "
+        "state in the outlet_overrides array on the device document; this tool reads "
+        "the existing array, replaces only the entry whose index matches outlet_index, "
+        "and PUTs the full array back -- preserving all sibling outlets' overrides "
+        "(name, relay_state, cycle_enabled) verbatim. If no override exists for the "
+        "target outlet yet, one is created from the outlet's current sensed state. "
+        "Use unifi_get_pdu_outlets first to inspect current state."
+    ),
+    permission_category="devices",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def set_outlet_state(
+    mac_address: Annotated[
+        str,
+        Field(
+            description="MAC address of the PDU, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='pdu')"
+        ),
+    ],
+    outlet_index: Annotated[
+        int,
+        Field(
+            description="1-based outlet index on the strip (e.g. 1..6 for UP6, 1..7 if a USB outlet group is present)"
+        ),
+    ],
+    relay_state: Annotated[
+        bool,
+        Field(description="Desired relay state for this outlet: true to power on, false to power off"),
+    ],
+    cycle_enabled: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "Optional override for the per-outlet 'power cycle on power loss' toggle. "
+                "Omit (null) to leave it unchanged."
+            )
+        ),
+    ] = None,
+    confirm: Annotated[
+        bool,
+        Field(description="When true, writes the change. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Set per-outlet relay/cycle state on a UP6 / USP-Strip PDU."""
+    if outlet_index < 1:
+        return {"success": False, "error": "outlet_index must be >= 1."}
+
+    try:
+        pdu = await device_manager.get_pdu_outlets(mac_address)
+        if pdu is None:
+            return {
+                "success": False,
+                "error": f"Device {mac_address} is not a Smart Power PDU.",
+            }
+
+        outlets = pdu.get("outlets", [])
+        target = next((o for o in outlets if o.get("index") == outlet_index), None)
+        if target is None:
+            available = sorted(o.get("index") for o in outlets if o.get("index") is not None)
+            return {
+                "success": False,
+                "error": (
+                    f"Outlet index {outlet_index} not found on PDU {mac_address}. Available indices: {available}"
+                ),
+            }
+        if target.get("has_relay") is False:
+            return {
+                "success": False,
+                "error": (
+                    f"Outlet {outlet_index} ('{target.get('name')}') on PDU {mac_address} "
+                    "does not have a controllable relay (has_relay=false)."
+                ),
+            }
+
+        device_name = pdu.get("name", mac_address)
+        # Effective current desired state = override if present, else sensed.
+        current_relay = target.get("override_relay_state")
+        if current_relay is None:
+            current_relay = target.get("relay_state")
+        current_cycle = target.get("override_cycle_enabled")
+        if current_cycle is None:
+            current_cycle = target.get("cycle_enabled")
+
+        proposed: Dict[str, Any] = {"relay_state": relay_state}
+        if cycle_enabled is not None:
+            proposed["cycle_enabled"] = cycle_enabled
+
+        if not confirm:
+            preview = update_preview(
+                resource_type="pdu_outlet",
+                resource_id=f"{mac_address}/outlet/{outlet_index}",
+                resource_name=f"{device_name} -- outlet {outlet_index} ({target.get('name')})",
+                current_state={"relay_state": current_relay, "cycle_enabled": current_cycle},
+                updates=proposed,
+            )
+            warnings: List[str] = []
+            if current_relay is True and relay_state is False:
+                warnings.append(
+                    f"Outlet {outlet_index} ('{target.get('name')}') is currently powered ON -- "
+                    "anything plugged into it will lose power."
+                )
+            warnings.append(
+                "All other outlets on this strip will be left untouched (their existing overrides are preserved)."
+            )
+            preview["warnings"] = warnings
+            return preview
+
+        result = await device_manager.set_outlet_state(
+            device_mac=mac_address,
+            outlet_index=outlet_index,
+            relay_state=relay_state,
+            cycle_enabled=cycle_enabled,
+        )
+        if result is None:
+            return {
+                "success": False,
+                "error": f"Failed to set outlet state on PDU {mac_address}.",
+            }
+        return {
+            "success": True,
+            "message": (
+                f"Outlet {outlet_index} ('{result.get('name')}') on {device_name} "
+                f"set to relay_state={result['relay_state']}."
+            ),
+            "outlet": result,
+        }
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error setting outlet state on %s: %s", mac_address, e, exc_info=True)
+        return {
+            "success": False,
+            "error": f"Failed to set outlet state on PDU {mac_address}: {e}",
+        }

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 169,
+  "count": 171,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -70,6 +70,7 @@
     "unifi_get_network_health": "unifi_network_mcp.tools.system",
     "unifi_get_network_stats": "unifi_network_mcp.tools.stats",
     "unifi_get_oon_policy_details": "unifi_network_mcp.tools.oon",
+    "unifi_get_pdu_outlets": "unifi_network_mcp.tools.devices",
     "unifi_get_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_get_port_profile_details": "unifi_network_mcp.tools.switch",
     "unifi_get_port_stats": "unifi_network_mcp.tools.switch",
@@ -134,6 +135,7 @@
     "unifi_set_client_ip_settings": "unifi_network_mcp.tools.clients",
     "unifi_set_device_led": "unifi_network_mcp.tools.devices",
     "unifi_set_jumbo_frames": "unifi_network_mcp.tools.switch",
+    "unifi_set_outlet_state": "unifi_network_mcp.tools.devices",
     "unifi_set_site_leds": "unifi_network_mcp.tools.devices",
     "unifi_set_switch_port_profile": "unifi_network_mcp.tools.switch",
     "unifi_subscribe_events": "unifi_network_mcp.tools.events",
@@ -2133,6 +2135,28 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
+      "description": "Return per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip). Combines the device's sensed outlet_table (live relay_state, cycle_enabled, has_relay, has_metering) with the controller's desired outlet_overrides so callers see both reported and intended state per outlet. Returns an error if the device is not a PDU.",
+      "name": "unifi_get_pdu_outlets",
+      "schema": {
+        "input": {
+          "properties": {
+            "mac_address": {
+              "description": "MAC address of the PDU, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='pdu')",
+              "type": "string"
+            }
+          },
+          "required": [
+            "mac_address"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
       "description": "Get a specific port forwarding rule by ID from your Unifi Network controller.",
       "name": "unifi_get_port_forward",
       "schema": {
@@ -3466,6 +3490,50 @@
           "required": [
             "device_mac",
             "enabled"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Set per-outlet relay state (on/off) and optionally cycle_enabled on a UniFi Smart Power PDU (UP6 / USP-Strip). The controller stores per-outlet desired state in the outlet_overrides array on the device document; this tool reads the existing array, replaces only the entry whose index matches outlet_index, and PUTs the full array back -- preserving all sibling outlets' overrides (name, relay_state, cycle_enabled) verbatim. If no override exists for the target outlet yet, one is created from the outlet's current sensed state. Use unifi_get_pdu_outlets first to inspect current state.",
+      "name": "unifi_set_outlet_state",
+      "permission_action": "update",
+      "permission_category": "devices",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, writes the change. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "cycle_enabled": {
+              "description": "Optional override for the per-outlet 'power cycle on power loss' toggle. Omit (null) to leave it unchanged.",
+              "type": "boolean"
+            },
+            "mac_address": {
+              "description": "MAC address of the PDU, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='pdu')",
+              "type": "string"
+            },
+            "outlet_index": {
+              "description": "1-based outlet index on the strip (e.g. 1..6 for UP6, 1..7 if a USB outlet group is present)",
+              "type": "integer"
+            },
+            "relay_state": {
+              "description": "Desired relay state for this outlet: true to power on, false to power off",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "mac_address",
+            "outlet_index",
+            "relay_state"
           ],
           "type": "object"
         }

--- a/apps/network/tests/unit/test_outlet_control.py
+++ b/apps/network/tests/unit/test_outlet_control.py
@@ -1,0 +1,531 @@
+"""Tests for UP6 / USP-Strip outlet control.
+
+Covers DeviceManager.get_pdu_outlets / set_outlet_state and the
+unifi_get_pdu_outlets / unifi_set_outlet_state tool functions.
+
+The critical correctness guarantee under test is that writing one outlet
+preserves every other outlet's override entry verbatim.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+SAMPLE_OUTLET_TABLE = [
+    {
+        "index": 1,
+        "name": "Outlet 1",
+        "has_relay": True,
+        "has_metering": True,
+        "relay_state": True,
+        "cycle_enabled": False,
+    },
+    {
+        "index": 2,
+        "name": "Outlet 2",
+        "has_relay": True,
+        "has_metering": True,
+        "relay_state": True,
+        "cycle_enabled": False,
+    },
+    {
+        "index": 3,
+        "name": "Outlet 3",
+        "has_relay": True,
+        "has_metering": True,
+        "relay_state": False,
+        "cycle_enabled": False,
+    },
+    {
+        "index": 4,
+        "name": "Outlet 4",
+        "has_relay": True,
+        "has_metering": True,
+        "relay_state": True,
+        "cycle_enabled": True,
+    },
+    {
+        "index": 5,
+        "name": "Outlet 5",
+        "has_relay": True,
+        "has_metering": True,
+        "relay_state": False,
+        "cycle_enabled": False,
+    },
+    {
+        "index": 6,
+        "name": "Outlet 6",
+        "has_relay": True,
+        "has_metering": True,
+        "relay_state": True,
+        "cycle_enabled": False,
+    },
+    {
+        "index": 7,
+        "name": "USB Outlets",
+        "has_relay": True,
+        "has_metering": False,
+        "relay_state": False,
+        "cycle_enabled": False,
+    },
+]
+
+SAMPLE_OUTLET_OVERRIDES = [
+    {"index": 1, "name": "Outlet 1", "relay_state": True, "cycle_enabled": False},
+    {"index": 2, "name": "Outlet 2", "relay_state": True, "cycle_enabled": False},
+    {"index": 3, "name": "Outlet 3", "relay_state": False, "cycle_enabled": False},
+    {"index": 4, "name": "Outlet 4", "relay_state": True, "cycle_enabled": True},
+    {"index": 5, "name": "Outlet 5", "relay_state": False, "cycle_enabled": False},
+    {"index": 6, "name": "Outlet 6", "relay_state": True, "cycle_enabled": False},
+    {"index": 7, "name": "USB Outlets", "relay_state": False, "cycle_enabled": False},
+]
+
+
+def _make_pdu_device(mac="ac:8b:a9:11:22:33", *, overrides=None, outlet_table=None, device_type="usp"):
+    """Build a mock Device for a UP6-class PDU."""
+    device = MagicMock()
+    device.mac = mac
+    device.raw = {
+        "_id": "pdu_doc_id_xyz",
+        "mac": mac,
+        "name": "Rack Surge Protector Right",
+        "model": "UP6",
+        "type": device_type,
+        "is_access_point": False,
+        "outlet_table": [dict(o) for o in (outlet_table if outlet_table is not None else SAMPLE_OUTLET_TABLE)],
+        "outlet_overrides": [dict(o) for o in (overrides if overrides is not None else SAMPLE_OUTLET_OVERRIDES)],
+    }
+    return device
+
+
+def _make_ap_device(mac="11:22:33:44:55:66"):
+    device = MagicMock()
+    device.mac = mac
+    device.raw = {
+        "_id": "ap_doc_id",
+        "mac": mac,
+        "name": "Office AP",
+        "model": "U6-Pro",
+        "type": "uap",
+        "is_access_point": True,
+    }
+    return device
+
+
+@pytest.fixture
+def mock_connection():
+    conn = MagicMock()
+    conn.site = "default"
+    conn.request = AsyncMock()
+    conn.get_cached = MagicMock(return_value=None)
+    conn._update_cache = MagicMock()
+    conn._invalidate_cache = MagicMock()
+    conn.controller = MagicMock()
+    conn.controller.devices = MagicMock()
+    conn.controller.devices.update = AsyncMock()
+    conn.controller.devices.values = MagicMock(return_value=[])
+    conn.ensure_connected = AsyncMock(return_value=True)
+    return conn
+
+
+@pytest.fixture
+def device_manager(mock_connection):
+    from unifi_core.network.managers.device_manager import DeviceManager
+
+    return DeviceManager(mock_connection)
+
+
+class TestGetPduOutlets:
+    """DeviceManager.get_pdu_outlets()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_outlets_for_usp_device(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        result = await device_manager.get_pdu_outlets(pdu.mac)
+
+        assert result is not None
+        assert result["mac"] == pdu.mac
+        assert result["model"] == "UP6"
+        assert len(result["outlets"]) == 7
+
+        first = result["outlets"][0]
+        assert first["index"] == 1
+        assert first["relay_state"] is True
+        assert first["override_relay_state"] is True
+        assert first["has_override"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_outlets_for_uap_pdu(self, device_manager, mock_connection):
+        """UAP-typed PDUs (older mesh-connected strips) classify as PDU when is_access_point=False."""
+        pdu = _make_pdu_device(device_type="uap")
+        pdu.raw["is_access_point"] = False
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        result = await device_manager.get_pdu_outlets(pdu.mac)
+
+        assert result is not None
+        assert len(result["outlets"]) == 7
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_ap(self, device_manager, mock_connection):
+        ap = _make_ap_device()
+        mock_connection.controller.devices.values.return_value = [ap]
+
+        result = await device_manager.get_pdu_outlets(ap.mac)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_for_unknown_device(self, device_manager, mock_connection):
+        from unifi_core.exceptions import UniFiNotFoundError
+
+        mock_connection.controller.devices.values.return_value = []
+
+        with pytest.raises(UniFiNotFoundError):
+            await device_manager.get_pdu_outlets("ff:ff:ff:ff:ff:ff")
+
+
+class TestSetOutletState:
+    """DeviceManager.set_outlet_state()."""
+
+    @pytest.mark.asyncio
+    async def test_modifies_only_target_outlet(self, device_manager, mock_connection):
+        """The crux: writing one outlet must preserve every sibling override verbatim."""
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        result = await device_manager.set_outlet_state(pdu.mac, outlet_index=3, relay_state=True)
+
+        assert result is not None
+        assert result["outlet_index"] == 3
+        assert result["relay_state"] is True
+        assert result["siblings_preserved"] == 6
+
+        sent = mock_connection.request.call_args[0][0]
+        assert sent.method == "put"
+        assert "pdu_doc_id_xyz" in sent.path
+        sent_overrides = sent.data["outlet_overrides"]
+        assert len(sent_overrides) == 7
+
+        sent_by_index = {o["index"]: o for o in sent_overrides}
+        # Target flipped on
+        assert sent_by_index[3]["relay_state"] is True
+        # All other entries are byte-for-byte identical to the originals
+        for original in SAMPLE_OUTLET_OVERRIDES:
+            if original["index"] == 3:
+                continue
+            assert sent_by_index[original["index"]] == original, f"override for outlet {original['index']} was mutated"
+
+    @pytest.mark.asyncio
+    async def test_cycle_enabled_unchanged_when_omitted(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        await device_manager.set_outlet_state(pdu.mac, outlet_index=4, relay_state=False)
+
+        sent_overrides = mock_connection.request.call_args[0][0].data["outlet_overrides"]
+        outlet_4 = next(o for o in sent_overrides if o["index"] == 4)
+        assert outlet_4["relay_state"] is False
+        # Original cycle_enabled=True must be preserved untouched
+        assert outlet_4["cycle_enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_cycle_enabled_updated_when_provided(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        await device_manager.set_outlet_state(pdu.mac, outlet_index=4, relay_state=True, cycle_enabled=False)
+
+        sent_overrides = mock_connection.request.call_args[0][0].data["outlet_overrides"]
+        outlet_4 = next(o for o in sent_overrides if o["index"] == 4)
+        assert outlet_4["cycle_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_seeds_override_when_missing(self, device_manager, mock_connection):
+        """If the controller has no override yet for an outlet, one is appended."""
+        pdu = _make_pdu_device(overrides=[o for o in SAMPLE_OUTLET_OVERRIDES if o["index"] != 5])
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        result = await device_manager.set_outlet_state(pdu.mac, outlet_index=5, relay_state=True)
+
+        assert result is not None
+        sent_overrides = mock_connection.request.call_args[0][0].data["outlet_overrides"]
+        assert len(sent_overrides) == 7
+        outlet_5 = next(o for o in sent_overrides if o["index"] == 5)
+        assert outlet_5["relay_state"] is True
+        assert outlet_5["name"] == "Outlet 5"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_unknown_index(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        result = await device_manager.set_outlet_state(pdu.mac, outlet_index=99, relay_state=True)
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_pdu(self, device_manager, mock_connection):
+        ap = _make_ap_device()
+        mock_connection.controller.devices.values.return_value = [ap]
+
+        result = await device_manager.set_outlet_state(ap.mac, outlet_index=1, relay_state=True)
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_mutate_cached_overrides(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        original_outlet_3 = dict(pdu.raw["outlet_overrides"][2])
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        await device_manager.set_outlet_state(pdu.mac, outlet_index=3, relay_state=True)
+
+        # The cached device's outlet_overrides entry is unchanged
+        assert pdu.raw["outlet_overrides"][2] == original_outlet_3
+
+    @pytest.mark.asyncio
+    async def test_invalidates_cache_on_success(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+
+        await device_manager.set_outlet_state(pdu.mac, outlet_index=1, relay_state=False)
+
+        mock_connection._invalidate_cache.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_propagates_api_error(self, device_manager, mock_connection):
+        pdu = _make_pdu_device()
+        mock_connection.controller.devices.values.return_value = [pdu]
+        mock_connection.request.side_effect = Exception("API error")
+
+        with pytest.raises(Exception):
+            await device_manager.set_outlet_state(pdu.mac, outlet_index=1, relay_state=False)
+
+
+class TestSetOutletStateTool:
+    """unifi_set_outlet_state tool function (validation, preview, confirm)."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_zero_index(self):
+        from unifi_network_mcp.tools.devices import set_outlet_state
+
+        result = await set_outlet_state(mac_address="ac:8b:a9:11:22:33", outlet_index=0, relay_state=True)
+        assert result["success"] is False
+        assert "outlet_index" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_pdu(self):
+        from unifi_network_mcp.tools.devices import set_outlet_state
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(return_value=None)
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await set_outlet_state(
+                mac_address="11:22:33:44:55:66", outlet_index=1, relay_state=True, confirm=True
+            )
+
+        assert result["success"] is False
+        assert "not a Smart Power PDU" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_index_with_available_list(self):
+        from unifi_network_mcp.tools.devices import set_outlet_state
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(
+                return_value={
+                    "mac": "ac:8b:a9:11:22:33",
+                    "name": "Rack PDU",
+                    "model": "UP6",
+                    "outlets": [
+                        {
+                            "index": 1,
+                            "name": "A",
+                            "has_relay": True,
+                            "relay_state": True,
+                            "cycle_enabled": False,
+                            "override_relay_state": True,
+                            "override_cycle_enabled": False,
+                            "has_override": True,
+                        },
+                    ],
+                }
+            )
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await set_outlet_state(mac_address="ac:8b:a9:11:22:33", outlet_index=4, relay_state=True)
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+        assert "[1]" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_outlet_without_relay(self):
+        from unifi_network_mcp.tools.devices import set_outlet_state
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(
+                return_value={
+                    "mac": "ac:8b:a9:11:22:33",
+                    "name": "PDU",
+                    "model": "UP1",
+                    "outlets": [
+                        {
+                            "index": 1,
+                            "name": "Sense-only",
+                            "has_relay": False,
+                            "relay_state": None,
+                            "cycle_enabled": None,
+                            "override_relay_state": None,
+                            "override_cycle_enabled": None,
+                            "has_override": False,
+                        },
+                    ],
+                }
+            )
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await set_outlet_state(
+                mac_address="ac:8b:a9:11:22:33", outlet_index=1, relay_state=True, confirm=True
+            )
+
+        assert result["success"] is False
+        assert "has_relay=false" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_preview_warns_when_powering_off_live_outlet(self):
+        from unifi_network_mcp.tools.devices import set_outlet_state
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(
+                return_value={
+                    "mac": "ac:8b:a9:11:22:33",
+                    "name": "Rack PDU",
+                    "model": "UP6",
+                    "outlets": [
+                        {
+                            "index": 1,
+                            "name": "Server",
+                            "has_relay": True,
+                            "relay_state": True,
+                            "cycle_enabled": False,
+                            "override_relay_state": True,
+                            "override_cycle_enabled": False,
+                            "has_override": True,
+                        },
+                    ],
+                }
+            )
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await set_outlet_state(
+                mac_address="ac:8b:a9:11:22:33", outlet_index=1, relay_state=False, confirm=False
+            )
+
+        assert result["success"] is True
+        assert result["requires_confirmation"] is True
+        assert any("powered ON" in w for w in result["warnings"])
+        assert any("siblings" in w.lower() or "preserved" in w.lower() for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_confirm_executes_write(self):
+        from unifi_network_mcp.tools.devices import set_outlet_state
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(
+                return_value={
+                    "mac": "ac:8b:a9:11:22:33",
+                    "name": "Rack PDU",
+                    "model": "UP6",
+                    "outlets": [
+                        {
+                            "index": 1,
+                            "name": "Server",
+                            "has_relay": True,
+                            "relay_state": True,
+                            "cycle_enabled": False,
+                            "override_relay_state": True,
+                            "override_cycle_enabled": False,
+                            "has_override": True,
+                        },
+                    ],
+                }
+            )
+            mock_dm.set_outlet_state = AsyncMock(
+                return_value={
+                    "outlet_index": 1,
+                    "name": "Server",
+                    "relay_state": False,
+                    "cycle_enabled": False,
+                    "siblings_preserved": 6,
+                }
+            )
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await set_outlet_state(
+                mac_address="ac:8b:a9:11:22:33", outlet_index=1, relay_state=False, confirm=True
+            )
+
+        assert result["success"] is True
+        mock_dm.set_outlet_state.assert_called_once_with(
+            device_mac="ac:8b:a9:11:22:33",
+            outlet_index=1,
+            relay_state=False,
+            cycle_enabled=None,
+        )
+
+
+class TestGetPduOutletsTool:
+    """unifi_get_pdu_outlets tool function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_outlet_data(self):
+        from unifi_network_mcp.tools.devices import get_pdu_outlets
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(
+                return_value={
+                    "mac": "ac:8b:a9:11:22:33",
+                    "name": "Rack PDU",
+                    "model": "UP6",
+                    "outlets": [],
+                }
+            )
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await get_pdu_outlets(mac_address="ac:8b:a9:11:22:33")
+
+        assert result["success"] is True
+        assert result["model"] == "UP6"
+
+    @pytest.mark.asyncio
+    async def test_returns_error_for_non_pdu(self):
+        from unifi_network_mcp.tools.devices import get_pdu_outlets
+
+        with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+            mock_dm.get_pdu_outlets = AsyncMock(return_value=None)
+            mock_dm._connection = MagicMock()
+            mock_dm._connection.site = "default"
+
+            result = await get_pdu_outlets(mac_address="11:22:33:44:55:66")
+
+        assert result["success"] is False
+        assert "not a Smart Power PDU" in result["error"]

--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -512,6 +512,163 @@ class DeviceManager:
             logger.error("Error setting disabled state on device %s: %s", device_mac, e)
             raise
 
+    @staticmethod
+    def _is_pdu(raw: Dict[str, Any]) -> bool:
+        """Return True if the raw device payload represents a Smart Power PDU.
+
+        Mirrors the classification used by ``unifi_list_devices`` so the same
+        devices the controller surfaces as ``device_category=pdu`` are accepted
+        here.
+        """
+        device_type = raw.get("type", "")
+        if device_type.startswith("usp"):
+            return True
+        if device_type.startswith("uap"):
+            is_ap = raw.get("is_access_point")
+            if is_ap is False:
+                return True
+            if is_ap is None:
+                model = (raw.get("model") or "").upper()
+                return any(model.startswith(p) for p in ("UP1", "UP6", "USP"))
+        return False
+
+    async def get_pdu_outlets(self, device_mac: str) -> Optional[Dict[str, Any]]:
+        """Return per-outlet state for a Smart Power PDU.
+
+        Combines the device's sensed ``outlet_table`` with the controller's
+        desired-state ``outlet_overrides`` so callers can see both what the
+        hardware reports and what the controller intends.
+
+        Returns ``None`` if the device exists but is not a PDU.
+
+        Raises:
+            UniFiNotFoundError: If the device does not exist.
+        """
+        device = await self.get_device_details(device_mac)  # raises on miss
+        if not self._is_pdu(device.raw):
+            return None
+
+        overrides_by_index: Dict[int, Dict[str, Any]] = {
+            int(o["index"]): o for o in device.raw.get("outlet_overrides", []) if "index" in o
+        }
+        outlets: List[Dict[str, Any]] = []
+        for outlet in device.raw.get("outlet_table", []):
+            index = outlet.get("index")
+            if index is None:
+                continue
+            override = overrides_by_index.get(int(index), {})
+            outlets.append(
+                {
+                    "index": int(index),
+                    "name": override.get("name") or outlet.get("name") or f"Outlet {index}",
+                    "has_relay": outlet.get("has_relay"),
+                    "has_metering": outlet.get("has_metering"),
+                    # Sensed (live) state from the strip itself
+                    "relay_state": outlet.get("relay_state"),
+                    "cycle_enabled": outlet.get("cycle_enabled"),
+                    # Controller desired state (only present when an override exists)
+                    "override_relay_state": override.get("relay_state"),
+                    "override_cycle_enabled": override.get("cycle_enabled"),
+                    "has_override": bool(override),
+                }
+            )
+
+        return {
+            "mac": device_mac,
+            "name": device.raw.get("name", device.raw.get("model", "Unknown")),
+            "model": device.raw.get("model", ""),
+            "outlets": outlets,
+        }
+
+    async def set_outlet_state(
+        self,
+        device_mac: str,
+        outlet_index: int,
+        relay_state: bool,
+        cycle_enabled: Optional[bool] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Set per-outlet relay / cycle state on a UP6 / USP-Strip PDU.
+
+        Preserves all other outlets' overrides verbatim -- only the entry whose
+        ``index`` matches ``outlet_index`` is modified. If no override exists
+        for that index yet, one is appended using the outlet's current
+        ``outlet_table`` entry as the seed.
+
+        Args:
+            device_mac: MAC address of the PDU.
+            outlet_index: 1-based outlet index.
+            relay_state: True to power the outlet on, False to power it off.
+            cycle_enabled: Optional override for the per-outlet "power cycle on
+                power loss" toggle. ``None`` keeps the current value.
+
+        Returns:
+            Dict describing the outlet that was modified, or ``None`` if the
+            device is not a PDU or has no outlet at that index.
+
+        Raises:
+            UniFiNotFoundError: If the device does not exist.
+        """
+        device = await self.get_device_details(device_mac)  # raises on miss
+        if not self._is_pdu(device.raw):
+            return None
+        if "_id" not in device.raw:
+            logger.error("Cannot set outlet state on %s: missing _id in raw payload.", device_mac)
+            return None
+        device_id = device.raw["_id"]
+
+        outlet_table = device.raw.get("outlet_table", [])
+        sensed = next(
+            (o for o in outlet_table if o.get("index") is not None and int(o["index"]) == outlet_index),
+            None,
+        )
+        if sensed is None:
+            logger.error("Outlet index %s not found on PDU %s.", outlet_index, device_mac)
+            return None
+
+        overrides: List[Dict[str, Any]] = copy.deepcopy(device.raw.get("outlet_overrides", []))
+
+        target = next(
+            (o for o in overrides if o.get("index") is not None and int(o["index"]) == outlet_index),
+            None,
+        )
+        if target is None:
+            target = {
+                "index": outlet_index,
+                "name": sensed.get("name") or f"Outlet {outlet_index}",
+                "relay_state": relay_state,
+                "cycle_enabled": (
+                    cycle_enabled if cycle_enabled is not None else bool(sensed.get("cycle_enabled", False))
+                ),
+            }
+            overrides.append(target)
+        else:
+            target["relay_state"] = relay_state
+            if cycle_enabled is not None:
+                target["cycle_enabled"] = cycle_enabled
+
+        api_request = ApiRequest(
+            method="put",
+            path=f"/rest/device/{device_id}",
+            data={"outlet_overrides": overrides},
+        )
+        await self._connection.request(api_request)
+        logger.info(
+            "Outlet %s on PDU %s set to relay_state=%s cycle_enabled=%s (preserved %d sibling overrides)",
+            outlet_index,
+            device_mac,
+            relay_state,
+            target.get("cycle_enabled"),
+            max(len(overrides) - 1, 0),
+        )
+        self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
+        return {
+            "outlet_index": outlet_index,
+            "name": target.get("name"),
+            "relay_state": target["relay_state"],
+            "cycle_enabled": target.get("cycle_enabled"),
+            "siblings_preserved": max(len(overrides) - 1, 0),
+        }
+
     async def set_site_led_enabled(self, enabled: bool) -> bool:
         """Toggle all device LEDs site-wide.
 

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (169 tools)
+# Network Server Tool Reference (171 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -8,6 +8,7 @@ Complete reference for `unifi_*` tools. All read tools are always available. Mut
 - [Devices](#devices)
 - [Firewall](#firewall)
 - [Networks & WLANs](#networks--wlans)
+- [DNS Records](#dns-records)
 - [Port Forwarding](#port-forwarding)
 - [QoS / Traffic Shaping](#qos--traffic-shaping)
 - [Traffic Routes](#traffic-routes)
@@ -67,12 +68,13 @@ Always available, regardless of registration mode.
 ## Devices
 
 <!-- AUTO:tools:devices -->
-20 tools.
+22 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address — includes radio tables, port tables, system stats, WAN info, firmware d... |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
+| `unifi_get_pdu_outlets` | Read | Return per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip). |
 | `unifi_get_rf_scan_results` | Read | Get RF spectrum scan results for an access point. |
 | `unifi_get_speedtest_status` | Read | Check the status of a running speedtest on the gateway. |
 | `unifi_list_available_channels` | Read | List allowed RF channels for the site's regulatory domain. |
@@ -85,6 +87,7 @@ Always available, regardless of registration mode.
 | `unifi_reboot_device` | Mutate | Reboot a specific device by MAC address |
 | `unifi_rename_device` | Mutate | Rename a device in the Unifi Network controller by MAC address |
 | `unifi_set_device_led` | Mutate | Set the LED override state on a specific device. |
+| `unifi_set_outlet_state` | Mutate | Set per-outlet relay state (on/off) and optionally cycle_enabled on a UniFi Smart Power PDU (UP6 / USP-Strip). |
 | `unifi_set_site_leds` | Mutate | Toggle all device LEDs site-wide on or off. |
 | `unifi_toggle_device` | Mutate | Enable or disable a device without unadopting it. |
 | `unifi_trigger_rf_scan` | Mutate | Trigger an RF spectrum scan on an access point. |
@@ -158,6 +161,24 @@ Always available, regardless of registration mode.
 - Network creation is disabled by default — requires `UNIFI_POLICY_NETWORK_NETWORKS_CREATE=true`
 - WLAN creation similarly requires `UNIFI_POLICY_NETWORK_WLANS_CREATE=true`
 - Networks and WLANs are related but separate: a WLAN connects to a network
+
+---
+
+## DNS Records
+
+Manage static DNS A/AAAA/CNAME/MX/TXT/NS/SRV records on the controller's local DNS resolver.
+
+<!-- AUTO:tools:dns -->
+5 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_get_dns_record_details` | Read | Get details for a specific DNS record by ID. |
+| `unifi_list_dns_records` | Read | List all static DNS records configured on the controller. |
+| `unifi_create_dns_record` | Mutate | Create a new static DNS record. |
+| `unifi_delete_dns_record` | Mutate | Delete a static DNS record. |
+| `unifi_update_dns_record` | Mutate | Update an existing DNS record. |
+<!-- /AUTO:tools:dns -->
 
 ---
 


### PR DESCRIPTION
## Summary

Adds first-class control of UniFi Smart Power Strip (UP6 / USP-Strip) outlets to the network MCP. The server already exposes Smart Power PDUs in `unifi_list_devices` (as `device_category=pdu`) and surfaces their full state through `unifi_get_device_details` -- including `outlet_table` (sensed live state) and `outlet_overrides` (controller desired state) -- but there was no setter, so per-outlet automation against UniFi-managed PDUs was blocked.

Two new tools (network app):

- **`unifi_set_outlet_state`** -- confirm-gated mutator. Sets `relay_state` (on/off) and optionally `cycle_enabled` for a single outlet by 1-based `outlet_index`. **Sibling preservation is correctness-critical**: the implementation reads the device's current `outlet_overrides` array (deep-copied), modifies *only* the entry whose `index` matches `outlet_index`, and PUTs the full array back. Every other outlet's override entry (`name`, `relay_state`, `cycle_enabled`) is sent back to the controller byte-for-byte unchanged. If no override exists yet for the target outlet, one is appended using the `outlet_table` entry as the seed (so outlet name + current `cycle_enabled` are carried over).
- **`unifi_get_pdu_outlets`** -- read-only inspector that combines `outlet_table` (sensed) and `outlet_overrides` (desired) into a single per-outlet view, so callers can see both reported and intended state side-by-side without parsing the raw device document.

Underneath, `DeviceManager` gains:

- `_is_pdu(raw)` -- mirrors `tools.devices.classify_device`'s PDU detection (`usp*` type, or `uap` with `is_access_point=False`, with model-prefix fallback for older firmware).
- `get_pdu_outlets(mac)` -> `Optional[Dict]` (None for non-PDUs).
- `set_outlet_state(mac, outlet_index, relay_state, cycle_enabled=None)` -> `Optional[Dict]` -- deep-copies overrides, mutates only the target, PUTs to `/rest/device/<id>` (the same endpoint used by `rename_device`, `update_device_radio`, `set_device_led_override`, and `set_device_disabled`), and invalidates the device cache on success.

Tool annotations match peers (e.g. `unifi_update_device_radio`, `unifi_toggle_device`):
`permission_category="devices"`, `permission_action="update"`,
`destructiveHint=True`, `idempotentHint=True`, `readOnlyHint=False`, `openWorldHint=False`.

The setter follows the standard preview-then-confirm flow (`update_preview` from `unifi_core.confirmation`) and emits an extra warning when the user is about to power off an outlet that is currently on.

`tools_manifest.json` regenerated with `make -C apps/network manifest` -- count goes 169 -> 171.

## Sibling-preservation guarantee

The PR description above is also reflected in code: `DeviceManager.set_outlet_state` does

```python
overrides = copy.deepcopy(device.raw.get("outlet_overrides", []))
target = next((o for o in overrides if int(o["index"]) == outlet_index), None)
# ... mutate only `target` ...
api_request = ApiRequest(method="put", path=f"/rest/device/{device_id}",
                         data={"outlet_overrides": overrides})
```

and the test suite asserts every non-target override entry is byte-for-byte identical to its pre-write value (`test_modifies_only_target_outlet`).

## Usage

Preview (default -- nothing is written):

```jsonc
// tool: unifi_set_outlet_state
{
  "mac_address": "ac:8b:a9:11:22:33",
  "outlet_index": 3,
  "relay_state": false
}
// returns:
{
  "success": true,
  "requires_confirmation": true,
  "action": "update",
  "resource_type": "pdu_outlet",
  "resource_id": "ac:8b:a9:11:22:33/outlet/3",
  "resource_name": "Rack Surge Protector Right -- outlet 3 (Outlet 3)",
  "preview": {
    "current":  { "relay_state": true,  "cycle_enabled": false },
    "proposed": { "relay_state": false }
  },
  "warnings": [
    "Outlet 3 ('Outlet 3') is currently powered ON -- anything plugged into it will lose power.",
    "All other outlets on this strip will be left untouched (their existing overrides are preserved)."
  ],
  "message": "Will update relay_state on pdu_outlet 'Rack Surge Protector Right -- outlet 3 (Outlet 3)'. Set confirm=true to execute."
}
```

Write (with optional `cycle_enabled`):

```jsonc
// tool: unifi_set_outlet_state
{
  "mac_address": "ac:8b:a9:11:22:33",
  "outlet_index": 3,
  "relay_state": false,
  "cycle_enabled": true,
  "confirm": true
}
// returns:
{
  "success": true,
  "message": "Outlet 3 ('Outlet 3') on Rack Surge Protector Right set to relay_state=false.",
  "outlet": {
    "outlet_index": 3,
    "name": "Outlet 3",
    "relay_state": false,
    "cycle_enabled": true,
    "siblings_preserved": 6
  }
}
```

Read-only inspection:

```jsonc
// tool: unifi_get_pdu_outlets
{ "mac_address": "ac:8b:a9:11:22:33" }
```

## Controller endpoint

This piggybacks on the same UniFi controller endpoint used elsewhere in this repo:

```
PUT /api/s/<site>/rest/device/<device_id>
body: { "outlet_overrides": [ ... ] }
```

(via `aiounifi.models.api.ApiRequest`, which the controller's reverse proxy routes through `/proxy/network/api/...` on UDM-class hardware). This is the same path/verb used by `DeviceManager.rename_device`, `set_device_led_override`, `set_device_disabled`, and `update_device_radio` -- the only difference is the field being PUT.

Reference implementations of the same `outlet_overrides` write shape in adjacent UniFi tooling:
- `unpoller/unifi.UDM` and `unifi-poller` device docs both show `outlet_overrides` as the per-outlet desired-state array
- HACS `unifiprotect` / `aiounifi` device models expose `outlet_table` + `outlet_overrides` in the same structure this PR consumes
- The Home Assistant `unifi` integration's UP6 switch entities hit `/rest/device/<id>` with the identical body shape (`{"outlet_overrides": [...]}`)

If the upstream maintainer prefers a citation in code, happy to add a comment block linking the chosen reference.

## Test plan

- [x] `make -C apps/network test` -- `test_outlet_control.py` adds 21 cases covering manager + tool layers
- [x] `uv run --package unifi-core pytest packages/unifi-core/tests` -- 69 passed (no regressions)
- [x] `make -C apps/network manifest` -- regenerates `tools_manifest.json` cleanly (171 tools, both new tools wired into `module_map`)
- [x] `make -C apps/network lint` -- no new lint failures introduced (3 pre-existing F401/I001 errors on `main` are unchanged)
- [ ] Live-controller smoke test (UP6, 6 outlets) -- intentionally not run from this branch; recommend the reviewer or maintainer flip a non-load-bearing outlet via `unifi_set_outlet_state` once + verify `outlet_table[].relay_state` flips on next `unifi_get_device_details`.

## Notes

- No new dependencies. No config-schema changes. No bypass of permission gating.
- Cache invalidation matches peers (calls `_invalidate_cache(CACHE_PREFIX_DEVICES)` on successful write).
- `cycle_enabled` is intentionally optional (defaults to `None`); when omitted the existing override value is preserved verbatim, when provided it's written through.
- Detection accepts both `usp*` device types (modern strips) and older `uap`-typed strips with `is_access_point=False`, matching `classify_device` in `tools/devices.py` so the same set of devices that show up as `device_category=pdu` are accepted by the new setter.
