### PR TITLE
fix(api): make unifi-api-server actually work for local dev + first-time users

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -6,10 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "unifi-mcp-shared>=0.4,<0.5",
-    "unifi-core>=0.2,<0.3",
+    # Access managers in unifi-core import unifi_access_api (PyPI name
+    # py-unifi-access); pull it in via the [access] extra rather than
+    # declaring py-unifi-access here directly.
+    "unifi-core[access]>=0.2,<0.3",
     "mcp[cli]>=1.26.0,<2",
     "aiohttp>=3.13.4",
-    "py-unifi-access>=1.1.1",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
     "omegaconf>=2.3.0",

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -197,6 +197,33 @@ uv run --package unifi-api-server python -m unifi_api.graphql.docgen
 The full project quality gate runs `make pre-commit` (lint + format + sync-skills
 + tests) at the repo root.
 
+### Image-level smoke harness
+
+`scripts/live_api_smoke.py` boots the API in-process via `ASGITransport`,
+which means it cannot detect dep-closure bugs that only manifest in the
+published Docker image (e.g. a missing runtime dependency that gets
+masked by a `uv sync --all-packages` workspace). For that, use
+`scripts/smoke-api-image.sh`:
+
+```bash
+# Optionally point at a real controller so authenticated paths get tested.
+# Without these env vars the sweep still verifies first-boot, auth, and
+# the capability_mismatch / api_key_required error paths.
+export UNIFI_HOST=10.0.0.1
+export UNIFI_USERNAME=svc
+export UNIFI_PASSWORD=...
+export UNIFI_API_TOKEN=...   # optional; required for DPI to return 200
+
+./scripts/smoke-api-image.sh
+```
+
+The script wipes any existing state, rebuilds the image, brings it up,
+registers a controller (when env vars are set), runs
+`scripts/api_image_smoke.py` against every GET endpoint in the schema,
+and fails on any 5xx or network error. Tears down on exit.
+
+This is the harness that should run on every release tag.
+
 ## License
 
 See the repository root [LICENSE](../../LICENSE) file. MIT License, © 2025 Chris Kirby.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -6,45 +6,42 @@ read access to UniFi Network, Protect, and Access without speaking MCP.
 
 ## Quickstart
 
-Two paths — pick the one that matches what you have. Both end at the same
-admin login URL with the same key-retrieval recipe. **No `UNIFI_API_DB_KEY` to
-generate, no `.env` file required.** The disk-encryption key and the
-bootstrap admin API key are both auto-generated on first boot and persisted
-inside the container's named volume.
+Two paths — pick the one that matches what you have. Both end with the admin
+URL and the bootstrap key printed in your terminal so you can paste and sign
+in. **No `UNIFI_API_DB_KEY` to generate, no `.env` file, no `docker exec`
+incantations.** The disk-encryption key and the bootstrap admin API key are
+both auto-generated on first boot and persisted inside the container's
+named volume.
 
-### A. Public image (just want to use it)
-
-```bash
-# 1. Start the container. Listens on localhost:8080.
-docker run -d \
-  --name unifi-api-server \
-  -p 8080:8080 \
-  -v unifi-api-state:/var/lib/unifi-api \
-  ghcr.io/sirkirby/unifi-api-server:latest
-
-# 2. Grab the bootstrap admin API key.
-docker exec unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key
-
-# 3. Open the admin UI and paste the key:
-#    http://localhost:8080/admin/login
-```
-
-### B. Local clone (developing or testing changes)
+### A. Local clone (developing or testing changes)
 
 Uses [`docker/docker-compose-api.yml`](../../docker/docker-compose-api.yml),
 which builds from source and exposes the API on `localhost:8089`.
 
 ```bash
-# 1. Build and start (run from the repo root).
-docker compose -f docker/docker-compose-api.yml up --build -d
-
-# 2. Grab the bootstrap admin API key.
-docker compose -f docker/docker-compose-api.yml exec \
-  unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key
-
-# 3. Open the admin UI and paste the key:
-#    http://localhost:8089/admin/login
+./scripts/start-api.sh
 ```
+
+That's the whole thing. The script builds, starts, waits for first-boot
+bootstrap + HTTP readiness, then prints the URL and the key. Paste the key
+into <http://localhost:8089/admin/login> and you're in.
+
+### B. Public image (just want to use it)
+
+```bash
+docker run -d --name unifi-api-server -p 8080:8080 \
+  -v unifi-api-state:/var/lib/unifi-api \
+  ghcr.io/sirkirby/unifi-api-server:latest && \
+  until docker exec unifi-api-server \
+    test -f /var/lib/unifi-api/bootstrap-admin-key 2>/dev/null; \
+    do sleep 1; done && \
+  echo "" && \
+  echo "Admin UI:  http://localhost:8080/admin/login" && \
+  echo "Admin key: $(docker exec unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key)"
+```
+
+Paste that whole block into a terminal. It starts the container, waits for
+first-boot, and prints the URL and key. Open the URL, paste the key, sign in.
 
 ### What's next
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -4,7 +4,76 @@ REST + GraphQL HTTP API for UniFi controllers — a standalone HTTP service for
 desktop apps, web dashboards, Pi extensions, and any consumer that wants typed
 read access to UniFi Network, Protect, and Access without speaking MCP.
 
-## Quick start
+## Quickstart
+
+Two paths — pick the one that matches what you have. Both end at the same
+admin login URL with the same key-retrieval recipe. **No `UNIFI_API_DB_KEY` to
+generate, no `.env` file required.** The disk-encryption key and the
+bootstrap admin API key are both auto-generated on first boot and persisted
+inside the container's named volume.
+
+### A. Public image (just want to use it)
+
+```bash
+# 1. Start the container. Listens on localhost:8080.
+docker run -d \
+  --name unifi-api-server \
+  -p 8080:8080 \
+  -v unifi-api-state:/var/lib/unifi-api \
+  ghcr.io/sirkirby/unifi-api-server:latest
+
+# 2. Grab the bootstrap admin API key.
+docker exec unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key
+
+# 3. Open the admin UI and paste the key:
+#    http://localhost:8080/admin/login
+```
+
+### B. Local clone (developing or testing changes)
+
+Uses [`docker/docker-compose-api.yml`](../../docker/docker-compose-api.yml),
+which builds from source and exposes the API on `localhost:8089`.
+
+```bash
+# 1. Build and start (run from the repo root).
+docker compose -f docker/docker-compose-api.yml up --build -d
+
+# 2. Grab the bootstrap admin API key.
+docker compose -f docker/docker-compose-api.yml exec \
+  unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key
+
+# 3. Open the admin UI and paste the key:
+#    http://localhost:8089/admin/login
+```
+
+### What's next
+
+Once you're signed in:
+
+- **Register a controller** via the **Controllers** tab (or `POST /v1/controllers`).
+- **Mint your own keys** via the **Keys** tab — pick `read`, `write`, or `admin`
+  scope per consumer. Once you have a personal key saved, revoke
+  `bootstrap-admin` and delete `/var/lib/unifi-api/bootstrap-admin-key`.
+- **Explore the APIs:**
+  - REST playground: `/v1/docs`
+  - GraphQL playground: `/v1/graphql`
+  - OpenAPI spec: `/v1/openapi.json`
+  - Health: `/v1/health`
+
+First GraphQL query:
+
+```bash
+curl -s http://localhost:8089/v1/graphql \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ network { clients(controller: \"<id>\") { items { mac hostname } } } }"}'
+```
+
+### Production deployments
+
+For shared / production deployments, set `UNIFI_API_DB_KEY` explicitly (e.g.
+from a secret manager) so the encryption key lives outside the container
+volume:
 
 ```bash
 docker run -d \
@@ -13,28 +82,26 @@ docker run -d \
   -e UNIFI_API_DB_KEY=$(openssl rand -hex 32) \
   -v unifi-api-state:/var/lib/unifi-api \
   ghcr.io/sirkirby/unifi-api-server:latest
-
-# Save the admin key shown in the logs.
-docker logs unifi-api-server | grep "Initial admin API key"
 ```
 
-Once running:
-- REST playground: <http://localhost:8080/v1/docs>
-- GraphQL playground: <http://localhost:8080/v1/graphql>
-- OpenAPI spec: <http://localhost:8080/v1/openapi.json>
-- Health: <http://localhost:8080/v1/health>
+When the env var is set, the file-backed fallback is skipped entirely.
 
-First GraphQL query:
+### Reset / lost-key recovery
+
+State (controllers, audit log, admin keys, both encryption and bootstrap key
+files) lives in the `unifi-api-state` volume. `docker compose down` keeps it;
+`docker compose down -v` wipes for a fresh bootstrap.
+
+If you lose the bootstrap admin key file *and* never saved a personal admin
+key, the simplest recovery is to wipe and re-bootstrap:
 
 ```bash
-curl -s http://localhost:8080/v1/graphql \
-  -H "Authorization: Bearer $ADMIN_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query":"{ network { clients(controller: \"<id>\") { items { mac hostname } } } }"}'
+docker compose -f docker/docker-compose-api.yml down -v
+docker compose -f docker/docker-compose-api.yml up --build -d
 ```
 
-You can register controllers via the admin UI at `/admin/` or the REST endpoint
-`POST /v1/controllers` once you have the admin key.
+Note that wiping also drops registered controller credentials, since they
+were encrypted with the now-discarded DB key.
 
 ## Architecture
 
@@ -70,7 +137,7 @@ standard local install; override only what you need.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `UNIFI_API_DB_KEY` | _(required)_ | Encrypts controller credentials in the state DB. Generate once: `openssl rand -hex 32` |
+| `UNIFI_API_DB_KEY` | _auto-generated on first boot_ | Encrypts controller credentials at rest. Auto-generated and persisted to `<state_dir>/.db_encryption_key` if unset. **Not a login credential** — set explicitly in production via secret manager so the key lives outside the volume. |
 | `UNIFI_API_STATE_DIR` | `/var/lib/unifi-api` | Where the SQLite state DB lives |
 | `UNIFI_API_HTTP_HOST` | `127.0.0.1` | Bind address (set to `0.0.0.0` for non-localhost access) |
 | `UNIFI_API_HTTP_PORT` | `8080` | Listen port |

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4383,6 +4383,13 @@
         "title": "WlanModel",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "description": "Paste your admin / write / read scoped API key (starts with `unifi_live_\u2026` or `unifi_test_\u2026`). Click 'Authorize' once and Swagger UI will send the Bearer header on every request.",
+        "scheme": "bearer",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -16206,5 +16213,10 @@
         "summary": "Stream Protect Events"
       }
     }
-  }
+  },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ]
 }

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -5,14 +5,10 @@ description = "UniFi rich HTTP API service"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-core>=0.2,<0.3",
-    # Product-library runtime deps. unifi-core imports these from inside
-    # network/protect/access manager modules, so any consumer of unifi-core
-    # that registers controllers across all three products has to declare
-    # them. Versions kept in sync with apps/{network,protect,access}.
-    "aiounifi>=88",
-    "uiprotect>=6.0.0",
-    "py-unifi-access>=1.1.1",
+    # API server registers controllers across all three products, so it
+    # needs every product extra. unifi-core's optional extras pull in
+    # aiounifi / uiprotect / py-unifi-access transparently.
+    "unifi-core[network,protect,access]>=0.2,<0.3",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "sqlalchemy[asyncio]>=2.0.36",

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -6,6 +6,13 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "unifi-core>=0.2,<0.3",
+    # Product-library runtime deps. unifi-core imports these from inside
+    # network/protect/access manager modules, so any consumer of unifi-core
+    # that registers controllers across all three products has to declare
+    # them. Versions kept in sync with apps/{network,protect,access}.
+    "aiounifi>=88",
+    "uiprotect>=6.0.0",
+    "py-unifi-access>=1.1.1",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "sqlalchemy[asyncio]>=2.0.36",

--- a/apps/api/src/unifi_api/cli.py
+++ b/apps/api/src/unifi_api/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 import uvicorn
 
-from unifi_api.config import load_config
+from unifi_api.config import ensure_db_encryption_key, load_config
 from unifi_api.logging import configure_logging
 from unifi_api.server import create_app
 
@@ -33,6 +33,7 @@ def serve(
     """Start the HTTP server."""
     cfg = load_config(config_path)
     configure_logging(cfg.logging.level)
+    ensure_db_encryption_key(cfg.db.path)
     app_instance = create_app(cfg)
     uvicorn.run(app_instance, host=host or cfg.http.host, port=port or cfg.http.port, log_config=None)
 
@@ -56,10 +57,7 @@ def migrate(
     from unifi_api.db.session import get_sessionmaker
 
     cfg = load_config(config_path)
-    db_key = os.environ.get("UNIFI_API_DB_KEY")
-    if not db_key:
-        typer.echo("UNIFI_API_DB_KEY environment variable is required", err=True)
-        raise typer.Exit(code=2)
+    ensure_db_encryption_key(cfg.db.path)
 
     env = dict(os.environ)
     env["UNIFI_API_DB_PATH"] = cfg.db.path
@@ -95,9 +93,30 @@ def migrate(
 
     plaintext = asyncio.run(_maybe_bootstrap())
     if plaintext:
+        bootstrap_file = Path(cfg.db.path).parent / "bootstrap-admin-key"
+        try:
+            bootstrap_file.parent.mkdir(parents=True, exist_ok=True)
+            bootstrap_file.write_text(plaintext, encoding="utf-8")
+            bootstrap_file.chmod(0o600)
+        except OSError:
+            bootstrap_file = None  # best-effort; log line is still authoritative
         typer.echo("=" * 60)
         typer.echo("Initial admin API key (shown once, save it now):")
         typer.echo(plaintext)
+        if bootstrap_file is not None:
+            typer.echo("")
+            typer.echo(f"Also written to: {bootstrap_file}")
+            typer.echo("Retrieve later with:")
+            typer.echo(
+                "  docker compose -f docker/docker-compose-api.yml exec \\"
+            )
+            typer.echo(
+                f"    unifi-api-server cat {bootstrap_file}"
+            )
+            typer.echo(
+                "Delete this file once you've saved the key in your "
+                "password manager."
+            )
         typer.echo("=" * 60)
 
 
@@ -110,7 +129,6 @@ def keys_create(
 ) -> None:
     """Create a new API key. Prints the plaintext exactly once."""
     import asyncio
-    import os
     import uuid
     from datetime import datetime, timezone
 
@@ -120,9 +138,7 @@ def keys_create(
     from unifi_api.db.session import get_sessionmaker
 
     cfg = load_config(config_path)
-    if not os.environ.get("UNIFI_API_DB_KEY"):
-        typer.echo("UNIFI_API_DB_KEY required", err=True)
-        raise typer.Exit(2)
+    ensure_db_encryption_key(cfg.db.path)
 
     async def _create() -> str:
         engine = create_engine(cfg.db.path)

--- a/apps/api/src/unifi_api/config.py
+++ b/apps/api/src/unifi_api/config.py
@@ -1,12 +1,16 @@
 """Config loader for unifi-api.
 
 YAML provides defaults; UNIFI_API_* env vars override.
-The column encryption key is env-only (UNIFI_API_DB_KEY).
+The column encryption key is normally env-only (UNIFI_API_DB_KEY); for
+zero-config local dev, `ensure_db_encryption_key` will auto-generate and
+persist one inside the state volume if no env value is provided.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import secrets
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -94,3 +98,53 @@ def _coerce_scalar(s: str) -> str | int | bool:
         return int(s)
     except ValueError:
         return s
+
+
+def ensure_db_encryption_key(db_path: str) -> str:
+    """Return UNIFI_API_DB_KEY, auto-generating + persisting one if unset.
+
+    Precedence:
+      1. UNIFI_API_DB_KEY env var (production / CI / explicit override)
+      2. <state_dir>/.db_encryption_key file (auto-generated on first boot)
+      3. Generate a new 32-byte hex key, write it to (2), return it
+
+    The auto-gen path makes local-dev zero-config — operators in production
+    set the env var explicitly (often from a secret manager) and this
+    function never touches the filesystem.
+
+    Storing the auto-generated key inside the same volume as the encrypted
+    SQLite file does not weaken the security model: the volume is already
+    the trust boundary for the encrypted DB. Anyone with read access to
+    the volume can read both files; an operator who wants stronger
+    separation should set UNIFI_API_DB_KEY explicitly.
+
+    Side effect: also sets os.environ["UNIFI_API_DB_KEY"] so downstream
+    callers of ApiConfig.read_db_key() see the resolved value.
+    """
+    existing = os.environ.get("UNIFI_API_DB_KEY")
+    if existing:
+        return existing
+
+    state_dir = Path(db_path).parent
+    key_file = state_dir / ".db_encryption_key"
+
+    if key_file.exists():
+        key = key_file.read_text(encoding="utf-8").strip()
+        if key:
+            os.environ["UNIFI_API_DB_KEY"] = key
+            return key
+
+    state_dir.mkdir(parents=True, exist_ok=True)
+    key = secrets.token_hex(32)
+    key_file.write_text(key, encoding="utf-8")
+    try:
+        key_file.chmod(0o600)
+    except OSError:
+        pass
+    os.environ["UNIFI_API_DB_KEY"] = key
+    logging.getLogger(__name__).info(
+        "Auto-generated UNIFI_API_DB_KEY persisted to %s. "
+        "Set UNIFI_API_DB_KEY explicitly to override.",
+        key_file,
+    )
+    return key

--- a/apps/api/src/unifi_api/routes/resources/network/dpi.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dpi.py
@@ -30,6 +30,36 @@ from unifi_api.services.pydantic_models import Page
 router = APIRouter()
 
 
+def _require_dpi_auth(cm: Any, controller_id: str) -> None:
+    """Raise 501 with a clear hint when the controller has no API token.
+
+    DPI lookups go through UniFi's integration API which requires a
+    bearer API key separate from the session-based auth used for
+    everything else. The api_token field on the controller record carries
+    it; when unset, the manager's `_request_integration_api` returns None
+    and the manager normalizes that to an empty wrapper — which would
+    silently look like 'no DPI apps found' rather than a configuration
+    issue. Surface the actual cause instead.
+    """
+    auth = getattr(cm, "unifi_auth", None)
+    if auth is None or not auth.has_api_key:
+        raise HTTPException(
+            status_code=501,
+            detail={
+                "kind": "api_key_required",
+                "missing": "controller_api_token",
+                "controller": controller_id,
+                "hint": (
+                    "The DPI integration endpoint requires a UniFi API "
+                    "token. Add one via Settings → Control Plane → "
+                    "Integrations on the controller, then update this "
+                    "controller via PATCH /v1/controllers/{id} (or the "
+                    "Controllers tab in the admin UI) with the token."
+                ),
+            },
+        )
+
+
 def _id_key(obj) -> tuple:
     """Sort by id; treats `None` (missing) as `0` so present 0s order naturally."""
     raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
@@ -81,6 +111,7 @@ async def list_dpi_applications(
             session, controller.id, "network", "dpi_manager",
         )
         cm = await factory.get_connection_manager(session, controller.id, "network")
+        _require_dpi_auth(cm, controller.id)
         if cm.site != site_id:
             await cm.set_site(site_id)
         # Manager returns the integration-API wrapper. Ask for a wide page so
@@ -131,6 +162,7 @@ async def list_dpi_categories(
             session, controller.id, "network", "dpi_manager",
         )
         cm = await factory.get_connection_manager(session, controller.id, "network")
+        _require_dpi_auth(cm, controller.id)
         if cm.site != site_id:
             await cm.set_site(site_id)
         result = await mgr.get_dpi_categories(limit=500, offset=0)

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
+from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.cors import CORSMiddleware
 from strawberry.fastapi import GraphQLRouter
@@ -254,6 +255,38 @@ def create_app(config: ApiConfig) -> FastAPI:
         docs_url="/v1/docs",
         lifespan=lifespan,
     )
+
+    # Auth doesn't use FastAPI's HTTPBearer dependency (the middleware reads
+    # the header directly to keep the audit-on-failure path simple), so the
+    # generated OpenAPI schema has no security info — which means Swagger UI
+    # at /v1/docs has no "Authorize" button. Inject a bearer scheme manually
+    # and mark it as the global default so "Try it out" can authenticate.
+    def _custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+        schema.setdefault("components", {}).setdefault("securitySchemes", {})[
+            "ApiKeyAuth"
+        ] = {
+            "type": "http",
+            "scheme": "bearer",
+            "description": (
+                "Paste your admin / write / read scoped API key "
+                "(starts with `unifi_live_…` or `unifi_test_…`). "
+                "Click 'Authorize' once and Swagger UI will send the "
+                "Bearer header on every request."
+            ),
+        }
+        schema["security"] = [{"ApiKeyAuth": []}]
+        app.openapi_schema = schema
+        return schema
+
+    app.openapi = _custom_openapi
 
     if config.http.cors_origins:
         app.add_middleware(

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -167,14 +167,31 @@ def create_app(config: ApiConfig) -> FastAPI:
                             session, controller.id, product, "event_manager",
                         )
                     if hasattr(mgr, "start_listening"):
-                        await mgr.start_listening()
-                        _streams_log.info(
-                            "[streams] start_listening ok for %s/%s",
-                            controller.id, product,
+                        # Background-launch: aiounifi's start_websocket awaits
+                        # its own message loop, so awaiting here blocks the
+                        # whole lifespan. The WS subscription is best-effort
+                        # warm-up for SSE consumers; failing it must not
+                        # delay HTTP readiness.
+                        async def _bg_start(c_id: str, p: str, m=mgr) -> None:
+                            try:
+                                await m.start_listening()
+                                _streams_log.info(
+                                    "[streams] start_listening ok for %s/%s",
+                                    c_id, p,
+                                )
+                            except Exception:
+                                _streams_log.warning(
+                                    "[streams] start_listening failed for %s/%s",
+                                    c_id, p, exc_info=True,
+                                )
+
+                        asyncio.create_task(
+                            _bg_start(controller.id, product),
+                            name=f"start_listening:{controller.id}/{product}",
                         )
                 except Exception:
                     _streams_log.warning(
-                        "[streams] start_listening failed for %s/%s",
+                        "[streams] start_listening setup failed for %s/%s",
                         controller.id, product, exc_info=True,
                     )
 

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -72,10 +72,11 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
         "content_filter_manager": lambda cm: ContentFilterManager(cm),
         "device_manager": lambda cm: DeviceManager(cm),
         "dns_manager": lambda cm: DnsManager(cm),
-        # DpiManager takes (cm, auth) — we pass None for auth here; tools
-        # that require auth will fail at call time. Action dispatcher path
-        # is for managers that work with bare connection. Tracked for Task 13.
-        "dpi_manager": lambda cm: DpiManager(cm, None),
+        # DpiManager takes (cm, auth). The connection manager carries a
+        # UniFiAuth instance (see _construct_connection_manager); when no
+        # API token is configured for the controller, the auth is unset
+        # internally and DpiManager returns None with a clear log line.
+        "dpi_manager": lambda cm: DpiManager(cm, getattr(cm, "unifi_auth", None)),
         "event_manager": lambda cm: EventManager(cm),
         "firewall_manager": lambda cm: FirewallManager(cm),
         "hotspot_manager": lambda cm: HotspotManager(cm),
@@ -207,6 +208,7 @@ class ManagerFactory:
         # failure, network error, etc.) the exception propagates so callers
         # see a clear error instead of a hang.
         if product == "network":
+            from unifi_core.auth import UniFiAuth
             from unifi_core.network.managers.connection_manager import (
                 ConnectionManager as NetCM,
             )
@@ -218,6 +220,12 @@ class ManagerFactory:
                 port=port,
                 verify_ssl=controller.verify_tls,
             )
+            # Stash a UniFiAuth carrying the controller's API token (if any)
+            # so managers that hit the official integration API (DPI today,
+            # potentially others later) can authenticate. None when the
+            # operator hasn't provided a token; consuming managers handle
+            # that case with a clear error rather than crashing.
+            cm.unifi_auth = UniFiAuth(api_key=creds.get("api_token") or None)
             await cm.initialize()
             return cm
         if product == "protect":

--- a/apps/api/src/unifi_api/templates/admin/login.html
+++ b/apps/api/src/unifi_api/templates/admin/login.html
@@ -1,10 +1,10 @@
 {% extends "_layout.html" %}
 {% block title %}Sign in — unifi-api admin{% endblock %}
 {% block content %}
-<article style="max-width: 28rem; margin: 4rem auto;">
+<article style="max-width: 32rem; margin: 4rem auto;">
   <header>
     <h2>Sign in</h2>
-    <p>Paste your admin-scoped Bearer key.</p>
+    <p>Paste your admin API key — the <code>unifi_live_…</code> string emitted by the server on first boot.</p>
   </header>
   <form id="login-form" method="post" action="/admin/login">
     <label for="key">Admin API key</label>
@@ -12,6 +12,12 @@
     <p id="login-error" class="error" hidden></p>
     <button type="submit">Sign in</button>
   </form>
+  <footer style="font-size: 0.85em; opacity: 0.75; margin-top: 1rem;">
+    <p style="margin: 0;">Lost it? Retrieve from the container:</p>
+    <pre style="margin: 0.25rem 0; padding: 0.5rem; overflow-x: auto;"><code>docker compose -f docker/docker-compose-api.yml exec \
+  unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key</code></pre>
+    <p style="margin: 0.5rem 0 0 0;">This is the admin API key, <strong>not</strong> the <code>UNIFI_API_DB_KEY</code> encryption key.</p>
+  </footer>
 </article>
 
 {% if bootstrap_key %}

--- a/apps/api/tests/routes/resources/test_network_filtering.py
+++ b/apps/api/tests/routes/resources/test_network_filtering.py
@@ -309,7 +309,10 @@ async def test_list_dpi_applications_happy_path(tmp_path, monkeypatch) -> None:
     """
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)
-    _stub_connection(app, cid)
+    fake_cm = _stub_connection(app, cid)
+    # DPI route requires the cm to carry a UniFiAuth with an API key.
+    from unifi_core.auth import UniFiAuth
+    fake_cm.unifi_auth = UniFiAuth(api_key="test-token")
 
     wrapper = {
         "data": [
@@ -339,10 +342,36 @@ async def test_list_dpi_applications_happy_path(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_dpi_applications_returns_501_when_no_api_token(
+    tmp_path, monkeypatch
+) -> None:
+    """When the controller has no API token, DPI must return 501 with a
+    clear `api_key_required` hint, not a silent empty list or 500."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    fake_cm = _stub_connection(app, cid)
+    from unifi_core.auth import UniFiAuth
+    fake_cm.unifi_auth = UniFiAuth(api_key=None)  # explicit no-token
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dpi-applications?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 501, r.text
+    detail = r.json()["detail"]
+    assert detail["kind"] == "api_key_required"
+    assert detail["missing"] == "controller_api_token"
+    assert detail["controller"] == cid
+
+
+@pytest.mark.asyncio
 async def test_list_dpi_categories_happy_path(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)
-    _stub_connection(app, cid)
+    fake_cm = _stub_connection(app, cid)
+    from unifi_core.auth import UniFiAuth
+    fake_cm.unifi_auth = UniFiAuth(api_key="test-token")
 
     wrapper = {
         "data": [

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -6,10 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "unifi-mcp-shared>=0.4,<0.5",
-    "unifi-core>=0.2,<0.3",
+    # Network managers in unifi-core import aiounifi; pull it in via the
+    # [network] extra rather than declaring aiounifi here directly so
+    # there's one source of truth.
+    "unifi-core[network]>=0.2,<0.3",
     "mcp[cli]>=1.26.0,<2",
     "aiohttp>=3.13.4",
-    "aiounifi>=88",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
     "omegaconf>=2.3.0",

--- a/apps/network/src/unifi_network_mcp/bootstrap.py
+++ b/apps/network/src/unifi_network_mcp/bootstrap.py
@@ -93,19 +93,16 @@ def load_config(path_override: str | Path | None = None):
 # Controller Type Configuration
 # ---------------------------------------------------------------------------
 
-# Controller type determines API path structure
-# Valid values: "auto" (detect), "proxy" (UniFi OS), "direct" (standard)
-VALID_CONTROLLER_TYPES = {"auto", "proxy", "direct"}
-UNIFI_CONTROLLER_TYPE = os.getenv("UNIFI_CONTROLLER_TYPE", "auto").lower()
+# Controller type determines API path structure. The resolution + validation
+# logic lives in unifi-core so every consumer (network MCP, unifi-api-server,
+# future SDKs) shares one source of truth — see commit history for the bug
+# that motivated extracting it.
+from unifi_core.network.controller_type import (  # noqa: E402
+    VALID_CONTROLLER_TYPES,
+    resolve_controller_type,
+)
 
-# Validate controller type
-if UNIFI_CONTROLLER_TYPE not in VALID_CONTROLLER_TYPES:
-    logger.warning(
-        "Invalid UNIFI_CONTROLLER_TYPE: '%s'. Must be one of: %s. Defaulting to 'auto'.",
-        UNIFI_CONTROLLER_TYPE,
-        ", ".join(sorted(VALID_CONTROLLER_TYPES)),
-    )
-    UNIFI_CONTROLLER_TYPE = "auto"
+UNIFI_CONTROLLER_TYPE = resolve_controller_type()
 
 from unifi_mcp_shared.bootstrap import validate_registration_mode
 

--- a/apps/network/tests/integration/test_path_interceptor.py
+++ b/apps/network/tests/integration/test_path_interceptor.py
@@ -4,6 +4,7 @@ Tests the integration between ConnectionManager and aiounifi library to verify
 that path overrides work correctly when making actual API requests.
 """
 
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -190,8 +191,12 @@ class TestPathInterception:
                 detection_called.append(True)
                 return None
 
-            # Patch both the environment variable and the detection function
-            with patch("unifi_network_mcp.bootstrap.UNIFI_CONTROLLER_TYPE", "proxy"):
+            # Patch the env var (read by resolve_controller_type) and the
+            # detection function. Previously this patched a module-level
+            # constant in unifi_network_mcp.bootstrap, but connection_manager
+            # now reads via unifi_core.network.controller_type.resolve_controller_type
+            # which calls os.getenv on each invocation.
+            with patch.dict(os.environ, {"UNIFI_CONTROLLER_TYPE": "proxy"}):
                 with patch(
                     "unifi_core.network.managers.connection_manager.detect_unifi_os_proactively",
                     mock_detect,
@@ -253,8 +258,9 @@ class TestPathInterception:
                 detection_called.append(True)
                 return None
 
-            # Patch both the environment variable and the detection function
-            with patch("unifi_network_mcp.bootstrap.UNIFI_CONTROLLER_TYPE", "direct"):
+            # See note on the proxy variant above — patch the env var, not
+            # the now-stale module-level constant.
+            with patch.dict(os.environ, {"UNIFI_CONTROLLER_TYPE": "direct"}):
                 with patch(
                     "unifi_core.network.managers.connection_manager.detect_unifi_os_proactively",
                     mock_detect,

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -6,10 +6,11 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "unifi-mcp-shared>=0.4,<0.5",
-    "unifi-core>=0.2,<0.3",
+    # Protect managers in unifi-core import uiprotect; pull it in via the
+    # [protect] extra rather than declaring uiprotect here directly.
+    "unifi-core[protect]>=0.2,<0.3",
     "mcp[cli]>=1.26.0,<2",
     "aiohttp>=3.13.4",
-    "uiprotect>=6.0.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
     "omegaconf>=2.3.0",

--- a/docker/docker-compose-api.yml
+++ b/docker/docker-compose-api.yml
@@ -1,27 +1,26 @@
 # Local-dev compose for unifi-api-server.
 #
 # Independent of docker/docker-compose.yml (which stands up the 3 MCP servers).
-# These two compose files can run side-by-side or independently — neither
-# project depends on the other being running.
+# These two compose files can run side-by-side or independently.
 #
-# Usage:
-#   cd docker/
-#   docker compose -f docker-compose-api.yml up --build -d
-#   docker logs unifi-api-server | grep "Initial admin API key"
-#   open http://localhost:8089/v1/docs
+# Quick start (from the repo root):
+#   docker compose -f docker/docker-compose-api.yml up --build -d
+#   docker compose -f docker/docker-compose-api.yml exec \
+#     unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key
+#   open http://localhost:8089/admin/login
 #
-# State (controller registrations, audit log, admin keys) persists in the
-# named volume `unifi-api-state`. `docker compose down` keeps the volume;
-# `docker compose down -v` wipes it for a clean slate.
+# Both the disk-encryption key (UNIFI_API_DB_KEY) and the bootstrap admin
+# API key are generated on first boot and persisted inside the
+# `unifi-api-state` named volume. No `.env` file or shell exports required
+# for local development.
 #
-# First boot:
-#   - migrate runs, DB created, admin key emitted to logs (save it)
-#   - serve starts, listening on 0.0.0.0:8080 inside the container
-#   - register controllers via POST /v1/controllers or the admin UI at /admin/
+# Production / shared deployments: set UNIFI_API_DB_KEY explicitly via env
+# var or a secret manager. When set, the file-backed fallback is skipped
+# entirely.
 #
-# Bootstrap-from-env (env-driven controller seeding) is a Phase 9 candidate —
-# tracked at https://github.com/sirkirby/unifi-mcp/issues  (TBD on issue
-# creation). For now, controllers are registered post-boot via REST or UI.
+# Wipe and re-bootstrap (regenerates DB key, admin key, registered
+# controllers, audit log):
+#   docker compose -f docker/docker-compose-api.yml down -v
 
 services:
   unifi-api-server:
@@ -34,10 +33,6 @@ services:
       - "8089:8080"
     volumes:
       - unifi-api-state:/var/lib/unifi-api
-    environment:
-      # Required — encrypts controller credentials in the state DB.
-      # Generate once with: openssl rand -hex 32
-      - UNIFI_API_DB_KEY=${UNIFI_API_DB_KEY:?DB encryption key required (set in ../.env)}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/v1/health"]
       interval: 30s

--- a/docker/docker-compose-api.yml
+++ b/docker/docker-compose-api.yml
@@ -3,7 +3,11 @@
 # Independent of docker/docker-compose.yml (which stands up the 3 MCP servers).
 # These two compose files can run side-by-side or independently.
 #
-# Quick start (from the repo root):
+# Recommended usage: run `./scripts/start-api.sh` from the repo root. It
+# wraps `docker compose ... up --build -d` plus the post-boot key
+# retrieval and prints the admin URL + key in one shot.
+#
+# Manual equivalent (if you'd rather not use the wrapper):
 #   docker compose -f docker/docker-compose-api.yml up --build -d
 #   docker compose -f docker/docker-compose-api.yml exec \
 #     unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key

--- a/packages/unifi-core/pyproject.toml
+++ b/packages/unifi-core/pyproject.toml
@@ -8,6 +8,16 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+# Product libraries are imported by `unifi_core/{network,protect,access}/`
+# manager modules. They live here as extras (rather than required deps or
+# in each consumer's pyproject) so consumers can opt in to the products
+# they need and can't accidentally forget to install one — that failure
+# mode hit prod historically. Versions floor at the lowest tested.
+[project.optional-dependencies]
+network = ["aiounifi>=88"]
+protect = ["uiprotect>=6.0.0"]
+access = ["py-unifi-access>=1.1.1"]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",

--- a/packages/unifi-core/src/unifi_core/network/controller_type.py
+++ b/packages/unifi-core/src/unifi_core/network/controller_type.py
@@ -1,0 +1,39 @@
+"""Resolution of the UNIFI_CONTROLLER_TYPE environment variable.
+
+Lives in unifi-core (not in any MCP server's bootstrap) because the
+connection logic that consumes it lives in unifi-core. Previously the
+constant was defined in `unifi_network_mcp.bootstrap` and the connection
+manager imported it back across the package boundary, which broke any
+unifi-core consumer that didn't also have unifi-network-mcp installed
+(e.g. unifi-api-server).
+
+`auto`   — detect controller type at login (default; works for UDM/UCK/Cloud)
+`proxy`  — force UniFi OS path prefix (`/proxy/network/api`)
+`direct` — force standard path prefix (`/api`)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+VALID_CONTROLLER_TYPES = frozenset({"auto", "proxy", "direct"})
+
+_logger = logging.getLogger(__name__)
+
+
+def resolve_controller_type() -> str:
+    """Return the configured controller type, falling back to 'auto'.
+
+    Reads each call so env changes propagate without a process restart;
+    consumers that want to cache should do so themselves.
+    """
+    value = os.getenv("UNIFI_CONTROLLER_TYPE", "auto").lower()
+    if value not in VALID_CONTROLLER_TYPES:
+        _logger.warning(
+            "Invalid UNIFI_CONTROLLER_TYPE: %r. Must be one of: %s. Defaulting to 'auto'.",
+            value,
+            ", ".join(sorted(VALID_CONTROLLER_TYPES)),
+        )
+        return "auto"
+    return value

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -285,7 +285,9 @@ class ConnectionManager:
                     # 1. Pre-login: Determines auth endpoint (/api/auth/login vs /api/login)
                     # 2. Post-login: Verifies API path prefix (/proxy/network/api vs /api)
                     # See: https://github.com/sirkirby/unifi-network-mcp/issues/33
-                    from unifi_network_mcp.bootstrap import UNIFI_CONTROLLER_TYPE
+                    from unifi_core.network.controller_type import resolve_controller_type
+
+                    UNIFI_CONTROLLER_TYPE = resolve_controller_type()
 
                     if UNIFI_CONTROLLER_TYPE == "proxy":
                         self._unifi_os_override = True
@@ -454,10 +456,7 @@ class ConnectionManager:
             response = await request_method(api_request)
             duration_ms = (_time.perf_counter() - start_ts) * 1000.0
             try:
-                from unifi_network_mcp.utils.diagnostics import (
-                    diagnostics_enabled,
-                    log_api_request,
-                )  # lazy import to avoid cycles
+                from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 
                 if diagnostics_enabled():
                     payload = getattr(api_request, "json", None) or getattr(api_request, "data", None)
@@ -484,10 +483,7 @@ class ConnectionManager:
                     retry_response = await request_method(api_request)
                     duration_ms = (_time.perf_counter() - start_ts) * 1000.0
                     try:
-                        from unifi_network_mcp.utils.diagnostics import (
-                            diagnostics_enabled,
-                            log_api_request,
-                        )
+                        from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 
                         if diagnostics_enabled():
                             payload = getattr(api_request, "json", None) or getattr(api_request, "data", None)
@@ -515,7 +511,7 @@ class ConnectionManager:
         except (RequestError, ResponseError, aiohttp.ClientError) as e:
             logger.error("API request error: %s %s - %s", api_request.method.upper(), api_request.path, e)
             try:
-                from unifi_network_mcp.utils.diagnostics import diagnostics_enabled, log_api_request
+                from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 
                 if diagnostics_enabled():
                     payload = getattr(api_request, "json", None) or getattr(api_request, "data", None)
@@ -539,7 +535,7 @@ class ConnectionManager:
                 exc_info=True,
             )
             try:
-                from unifi_network_mcp.utils.diagnostics import diagnostics_enabled, log_api_request
+                from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 
                 if diagnostics_enabled():
                     payload = getattr(api_request, "json", None) or getattr(api_request, "data", None)

--- a/packages/unifi-core/src/unifi_core/network/managers/dpi_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/dpi_manager.py
@@ -36,7 +36,7 @@ CACHE_PREFIX_DPI_CATEGORIES = "dpi_categories"
 class DpiManager:
     """Manages DPI application and category lookups via the official UniFi API."""
 
-    def __init__(self, connection_manager: ConnectionManager, auth: UniFiAuth):
+    def __init__(self, connection_manager: ConnectionManager, auth: UniFiAuth | None):
         self._connection = connection_manager
         self._auth = auth
 
@@ -50,8 +50,13 @@ class DpiManager:
         Returns:
             Response dict, or None on failure.
         """
-        if not self._auth.has_api_key:
-            logger.error("No API key configured. Set UNIFI_API_KEY or UNIFI_NETWORK_API_KEY.")
+        if self._auth is None or not self._auth.has_api_key:
+            logger.error(
+                "DPI integration API requires an API key. "
+                "Configure the controller with an API token (Settings → "
+                "Control Plane → Integrations) or set UNIFI_API_KEY / "
+                "UNIFI_NETWORK_API_KEY in the network MCP environment."
+            )
             return None
 
         base_url = f"https://{self._connection.host}:{self._connection.port}"

--- a/packages/unifi-core/tests/network/test_controller_type.py
+++ b/packages/unifi-core/tests/network/test_controller_type.py
@@ -1,0 +1,41 @@
+"""Tests for unifi_core.network.controller_type.resolve_controller_type."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from unifi_core.network.controller_type import (
+    VALID_CONTROLLER_TYPES,
+    resolve_controller_type,
+)
+
+
+def test_default_is_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNIFI_CONTROLLER_TYPE", raising=False)
+    assert resolve_controller_type() == "auto"
+
+
+@pytest.mark.parametrize("value", ["auto", "proxy", "direct"])
+def test_accepts_valid_values(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", value)
+    assert resolve_controller_type() == value
+
+
+def test_normalizes_case(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "PROXY")
+    assert resolve_controller_type() == "proxy"
+
+
+def test_invalid_falls_back_to_auto_with_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "udmpro")
+    with caplog.at_level(logging.WARNING, logger="unifi_core.network.controller_type"):
+        assert resolve_controller_type() == "auto"
+    assert any("Invalid UNIFI_CONTROLLER_TYPE" in rec.message for rec in caplog.records)
+
+
+def test_valid_values_constant_matches_resolver() -> None:
+    assert VALID_CONTROLLER_TYPES == frozenset({"auto", "proxy", "direct"})

--- a/scripts/api_image_smoke.py
+++ b/scripts/api_image_smoke.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Image-level smoke harness for unifi-api-server.
+
+Hits every GET endpoint exposed by the running container and asserts
+none of them return 5xx. Distinct from `scripts/live_api_smoke.py`,
+which runs the API in-process via ASGITransport and therefore can't
+detect dep-closure bugs that only manifest in the published image.
+
+Usage:
+    # Container must already be running (e.g. via scripts/start-api.sh).
+    # Pass the bootstrap admin key as $1 (or via UNIFI_API_KEY env).
+    # Optionally pass the registered controller UUID as $2.
+    python scripts/api_image_smoke.py <admin-key> [<controller-id>]
+
+Exit code:
+    0  no 5xx responses
+    1  one or more 5xx responses (details printed)
+    2  schema fetch failed / container unreachable
+
+Buckets reported:
+    200 ok                              — endpoint working
+    409 capability-mismatch             — expected when only some products are registered
+    404/422 not-found / validation      — expected for unknown-ID sentinels
+    501 not-implemented (api_key_required) — DPI without a token (expected when unset)
+    5xx server-error                    — REAL BUGS, fail
+    network/timeout                     — container unreachable, fail
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BASE = os.environ.get("UNIFI_API_BASE", "http://localhost:8089")
+SITE = os.environ.get("UNIFI_API_SITE", "default")
+SENTINEL = "__none__"
+
+
+def _hit(url: str, key: str) -> tuple[int, str, float]:
+    req = urllib.request.Request(
+        url,
+        headers={"Authorization": f"Bearer {key}", "Accept": "application/json"},
+    )
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read(8192).decode("utf-8", errors="replace")
+            return resp.status, body, (time.perf_counter() - start) * 1000
+    except urllib.error.HTTPError as e:
+        body = e.read(8192).decode("utf-8", errors="replace")
+        return e.code, body, (time.perf_counter() - start) * 1000
+    except Exception as e:
+        return 0, f"{type(e).__name__}: {e}", (time.perf_counter() - start) * 1000
+
+
+def _resolve_path(path: str, params: dict[str, str]) -> str:
+    out = path
+    for key, value in params.items():
+        out = out.replace("{" + key + "}", urllib.parse.quote(value, safe=""))
+    while "{" in out and "}" in out:
+        l = out.index("{")
+        r = out.index("}", l)
+        out = out[:l] + SENTINEL + out[r + 1 :]
+    return out
+
+
+def _classify(status: int, body: str) -> str:
+    if status == 0:
+        return "network/timeout"
+    if status == 501:
+        # The api_key_required path is an expected, well-formed response;
+        # bucket separately so it doesn't get conflated with real 5xx.
+        try:
+            detail = json.loads(body).get("detail") or {}
+            if isinstance(detail, dict) and detail.get("kind") == "api_key_required":
+                return "501 api-key-required (expected without controller API token)"
+        except Exception:
+            pass
+        return f"{status} server-error"
+    if status >= 500:
+        return f"{status} server-error"
+    if status == 409:
+        try:
+            detail = json.loads(body).get("detail") or {}
+            if isinstance(detail, dict) and detail.get("kind") == "capability_mismatch":
+                return "409 capability-mismatch (expected for unregistered products)"
+        except Exception:
+            pass
+        return f"{status} client-error"
+    if status == 404:
+        return "404 not-found (expected for unknown-ID sentinels)"
+    if status == 422:
+        return "422 validation (expected for sentinel input)"
+    if status >= 400:
+        return f"{status} client-error"
+    return f"{status} ok"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    key = argv[1]
+    controller_id = argv[2] if len(argv) > 2 else None
+
+    params: dict[str, str] = {"site_id": SITE}
+    if controller_id:
+        params["cid"] = controller_id
+        params["controller"] = controller_id
+
+    try:
+        with urllib.request.urlopen(f"{BASE}/v1/openapi.json", timeout=10) as r:
+            schema = json.load(r)
+    except Exception as e:
+        print(f"FAIL: could not fetch OpenAPI schema from {BASE}: {e}", file=sys.stderr)
+        return 2
+
+    rows: list[dict] = []
+    for path, ops in schema["paths"].items():
+        if "get" not in ops:
+            continue
+        if path.startswith("/v1/streams/"):
+            continue  # SSE streams won't terminate cleanly via urlopen
+        url = BASE + _resolve_path(path, params)
+        status, body, ms = _hit(url, key)
+        rows.append(
+            {"path": path, "url": url, "status": status, "ms": ms, "body": body}
+        )
+
+    buckets: dict[str, list[dict]] = {}
+    for r in rows:
+        buckets.setdefault(_classify(r["status"], r["body"]), []).append(r)
+
+    print(f"Swept {len(rows)} GET endpoints against {BASE}")
+    print()
+    for key in sorted(buckets, key=lambda k: ("ok" not in k, "expected" not in k, k)):
+        print(f"  [{len(buckets[key]):3d}]  {key}")
+    print()
+
+    failures = [
+        r for k, rows in buckets.items() for r in rows
+        if (k.startswith(("5", "network")) and "expected" not in k)
+    ]
+    if not failures:
+        print("PASS — no 5xx / network failures.")
+        return 0
+
+    print("=" * 70)
+    print(f"FAIL — {len(failures)} endpoint(s) returned 5xx or network failure")
+    print("=" * 70)
+    for r in failures:
+        print(f"  {r['status']}  {r['path']}  ({int(r['ms'])}ms)")
+        print(f"    {r['body'][:300]}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/smoke-api-image.sh
+++ b/scripts/smoke-api-image.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Build the unifi-api-server Docker image, bring it up via the local-dev
+# compose, run the GET-endpoint sweep, fail on any 5xx or network error,
+# tear down on exit.
+#
+# Optional env vars to exercise a real controller (else only public
+# endpoints + capability_mismatch paths get coverage):
+#   UNIFI_HOST       e.g. 10.29.13.1
+#   UNIFI_USERNAME   controller local account
+#   UNIFI_PASSWORD   ...
+#   UNIFI_API_TOKEN  optional; required for DPI endpoints to return 200
+#                    instead of 501 api_key_required
+#   UNIFI_VERIFY_TLS default false
+#
+# When the controller env vars are set, the script registers a controller
+# via POST /v1/controllers before sweeping; without them, the sweep still
+# verifies that the API container starts cleanly and that
+# unauthenticated paths plus 409/501 cases all behave correctly.
+#
+# Usage:
+#   ./scripts/smoke-api-image.sh
+#
+# CI: this is the harness that should run on every release tag. It
+# closes the gap left by scripts/live_api_smoke.py which boots in-process.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+COMPOSE_FILE="docker/docker-compose-api.yml"
+SERVICE="unifi-api-server"
+URL_BASE="http://localhost:8089"
+
+cleanup() {
+  echo ""
+  echo "→ Tearing down..."
+  docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "→ Wiping any prior state and rebuilding image..."
+docker compose -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true
+docker compose -f "$COMPOSE_FILE" up --build -d
+
+echo "→ Waiting for HTTP listener..."
+for _ in $(seq 1 30); do
+  if curl -fsS -o /dev/null "$URL_BASE/v1/health" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+# Pull bootstrap admin key (always present on first boot of a wiped volume).
+admin_key=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" \
+              cat /var/lib/unifi-api/bootstrap-admin-key 2>/dev/null | tr -d '\r\n' || true)
+if [ -z "$admin_key" ]; then
+  echo "FAIL: bootstrap admin key not found — container did not start cleanly" >&2
+  docker logs "$SERVICE" 2>&1 | tail -40
+  exit 1
+fi
+echo "→ Bootstrap admin key acquired"
+
+# Optionally register a real controller so the sweep can hit live endpoints.
+controller_id=""
+if [ -n "${UNIFI_HOST:-}" ] && [ -n "${UNIFI_USERNAME:-}" ] && [ -n "${UNIFI_PASSWORD:-}" ]; then
+  echo "→ Registering controller against $UNIFI_HOST..."
+  body=$(cat <<JSON
+{
+  "name": "smoke-test",
+  "base_url": "https://${UNIFI_HOST}:443",
+  "product_kinds": ["network"],
+  "username": "${UNIFI_USERNAME}",
+  "password": "${UNIFI_PASSWORD}",
+  "api_token": "${UNIFI_API_TOKEN:-}",
+  "verify_tls": ${UNIFI_VERIFY_TLS:-false},
+  "is_default": true
+}
+JSON
+)
+  registration=$(curl -fsS -X POST -H "Authorization: Bearer $admin_key" \
+    -H "Content-Type: application/json" -d "$body" \
+    "$URL_BASE/v1/controllers" || true)
+  if [ -z "$registration" ]; then
+    echo "FAIL: controller registration returned empty/error response" >&2
+    exit 1
+  fi
+  controller_id=$(printf '%s' "$registration" | \
+                  python3 -c "import json,sys;print(json.load(sys.stdin)['id'])" || true)
+  echo "→ Controller registered: $controller_id"
+fi
+
+echo ""
+echo "→ Running endpoint sweep..."
+echo ""
+if [ -n "$controller_id" ]; then
+  python3 scripts/api_image_smoke.py "$admin_key" "$controller_id"
+else
+  python3 scripts/api_image_smoke.py "$admin_key"
+fi

--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Stand up unifi-api-server locally and print everything you need to sign in.
+#
+# Wraps `docker compose -f docker/docker-compose-api.yml up --build -d` plus
+# the post-boot key retrieval, so first-time setup is a single command.
+#
+# Run from anywhere inside the repo:
+#   ./scripts/start-api.sh
+#
+# To stop:
+#   docker compose -f docker/docker-compose-api.yml down
+# To wipe and re-bootstrap (regenerates encryption + admin keys):
+#   docker compose -f docker/docker-compose-api.yml down -v
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+COMPOSE_FILE="docker/docker-compose-api.yml"
+SERVICE="unifi-api-server"
+URL_BASE="http://localhost:8089"
+KEY_PATH="/var/lib/unifi-api/bootstrap-admin-key"
+
+echo "→ Building and starting ${SERVICE}..."
+docker compose -f "$COMPOSE_FILE" up --build -d
+
+# Wait for the bootstrap key file (written by `migrate` before `serve` starts).
+echo "→ Waiting for first-boot bootstrap..."
+for _ in $(seq 1 30); do
+  if docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" \
+       test -f "$KEY_PATH" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+key=$(docker compose -f "$COMPOSE_FILE" exec -T "$SERVICE" \
+        cat "$KEY_PATH" 2>/dev/null | tr -d '\r\n' || true)
+
+# Wait for the HTTP listener (compose healthcheck takes ~30s to flip green;
+# poll the endpoint directly so we don't block on healthcheck cadence).
+echo "→ Waiting for HTTP listener..."
+for _ in $(seq 1 30); do
+  if curl -fsS -o /dev/null "$URL_BASE/v1/health" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+echo "  unifi-api-server is up"
+echo "════════════════════════════════════════════════════════════"
+echo "  Admin UI:    $URL_BASE/admin/login"
+echo "  REST docs:   $URL_BASE/v1/docs"
+echo "  GraphQL:     $URL_BASE/v1/graphql"
+echo ""
+if [ -n "$key" ]; then
+  echo "  Admin API key (paste into the Sign in form):"
+  echo ""
+  echo "    $key"
+  echo ""
+  echo "  This is the bootstrap admin key, persisted inside the"
+  echo "  container at $KEY_PATH. After signing in, mint a"
+  echo "  personal key via the Keys tab and revoke 'bootstrap-admin'."
+else
+  echo "  Bootstrap key not yet available. Once the container is healthy:"
+  echo "    docker compose -f $COMPOSE_FILE exec \\"
+  echo "      $SERVICE cat $KEY_PATH"
+fi
+echo "════════════════════════════════════════════════════════════"

--- a/uv.lock
+++ b/uv.lock
@@ -1933,18 +1933,21 @@ name = "unifi-api-server"
 source = { editable = "apps/api" }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "aiounifi" },
     { name = "alembic" },
     { name = "argon2-cffi" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "omegaconf" },
+    { name = "py-unifi-access" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "typer" },
+    { name = "uiprotect" },
     { name = "unifi-core" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1960,18 +1963,21 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "aiounifi", specifier = ">=88" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
+    { name = "py-unifi-access", specifier = ">=1.1.1" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.310.0,<0.320.0" },
     { name = "typer", specifier = ">=0.13.0" },
+    { name = "uiprotect", specifier = ">=6.0.0" },
     { name = "unifi-core", editable = "packages/unifi-core" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1886,11 +1886,10 @@ dependencies = [
     { name = "jsonschema" },
     { name = "mcp", extra = ["cli"] },
     { name = "omegaconf" },
-    { name = "py-unifi-access" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "typing-extensions" },
-    { name = "unifi-core" },
+    { name = "unifi-core", extra = ["access"] },
     { name = "unifi-mcp-shared" },
 ]
 
@@ -1910,11 +1909,10 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.17.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
-    { name = "py-unifi-access", specifier = ">=1.1.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typing-extensions", specifier = ">=4.4.0" },
-    { name = "unifi-core", editable = "packages/unifi-core" },
+    { name = "unifi-core", extras = ["access"], editable = "packages/unifi-core" },
     { name = "unifi-mcp-shared", editable = "packages/unifi-mcp-shared" },
 ]
 
@@ -1933,22 +1931,19 @@ name = "unifi-api-server"
 source = { editable = "apps/api" }
 dependencies = [
     { name = "aiosqlite" },
-    { name = "aiounifi" },
     { name = "alembic" },
     { name = "argon2-cffi" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "omegaconf" },
-    { name = "py-unifi-access" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "typer" },
-    { name = "uiprotect" },
-    { name = "unifi-core" },
+    { name = "unifi-core", extra = ["access", "network", "protect"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1963,22 +1958,19 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
-    { name = "aiounifi", specifier = ">=88" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
-    { name = "py-unifi-access", specifier = ">=1.1.1" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.310.0,<0.320.0" },
     { name = "typer", specifier = ">=0.13.0" },
-    { name = "uiprotect", specifier = ">=6.0.0" },
-    { name = "unifi-core", editable = "packages/unifi-core" },
+    { name = "unifi-core", extras = ["access", "network", "protect"], editable = "packages/unifi-core" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 
@@ -1998,6 +1990,17 @@ dependencies = [
     { name = "pyyaml" },
 ]
 
+[package.optional-dependencies]
+access = [
+    { name = "py-unifi-access" },
+]
+network = [
+    { name = "aiounifi" },
+]
+protect = [
+    { name = "uiprotect" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "aioresponses" },
@@ -2008,8 +2011,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "aiounifi", marker = "extra == 'network'", specifier = ">=88" },
+    { name = "py-unifi-access", marker = "extra == 'access'", specifier = ">=1.1.1" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=6.0.0" },
 ]
+provides-extras = ["access", "network", "protect"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2098,14 +2105,13 @@ name = "unifi-network-mcp"
 source = { editable = "apps/network" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "aiounifi" },
     { name = "jsonschema" },
     { name = "mcp", extra = ["cli"] },
     { name = "omegaconf" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "typing-extensions" },
-    { name = "unifi-core" },
+    { name = "unifi-core", extra = ["network"] },
     { name = "unifi-mcp-shared" },
 ]
 
@@ -2122,14 +2128,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
-    { name = "aiounifi", specifier = ">=88" },
     { name = "jsonschema", specifier = ">=4.17.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typing-extensions", specifier = ">=4.4.0" },
-    { name = "unifi-core", editable = "packages/unifi-core" },
+    { name = "unifi-core", extras = ["network"], editable = "packages/unifi-core" },
     { name = "unifi-mcp-shared", editable = "packages/unifi-mcp-shared" },
 ]
 
@@ -2154,8 +2159,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "typing-extensions" },
-    { name = "uiprotect" },
-    { name = "unifi-core" },
+    { name = "unifi-core", extra = ["protect"] },
     { name = "unifi-mcp-shared" },
 ]
 
@@ -2178,8 +2182,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typing-extensions", specifier = ">=4.4.0" },
-    { name = "uiprotect", specifier = ">=6.0.0" },
-    { name = "unifi-core", editable = "packages/unifi-core" },
+    { name = "unifi-core", extras = ["protect"], editable = "packages/unifi-core" },
     { name = "unifi-mcp-shared", editable = "packages/unifi-mcp-shared" },
 ]
 


### PR DESCRIPTION
## Summary

Started as "the local-dev experience for `unifi-api-server` is awful," ended up surfacing a chain of latent bugs where each fix exposed the next layer. Net result: the API server now works end-to-end against a real controller, in a single command, with no `.env` files, no `docker exec` incantations, and a CI gate that prevents this class of bug from shipping again.

Surfaced via manual probing of the freshly published `unifi-api-server 0.1.0` image. Each subsequent bug was masked by the one in front of it — without fixing them in series, none of the later ones were visible.

## Bugs fixed

| Layer | Symptom | Root cause | Fix |
|---|---|---|---|
| Local dev UX | Two confusingly-named "keys", `.env` plumbing, log-grep recovery | `UNIFI_API_DB_KEY` treated as user-facing config | Auto-generate + persist in volume; bootstrap admin key written to `bootstrap-admin-key` file |
| Local dev UX | `docker compose ... up` errored on missing env interpolation | Compose file used `${VAR:?...}` form which doesn't read `env_file:` | Use `env_file:` (later: dropped entirely; not needed) |
| Compose env | `docker exec` to read a key felt wrong for a prosumer audience | No wrapper script | `scripts/start-api.sh` — one command, prints URL + key |
| Image | Network controller probe failed in 1ms with "No module named 'aiounifi'" | API forgot to declare three product-library deps | Add deps directly (later: refactor to extras on `unifi-core`) |
| Architecture | `unifi-core/connection_manager.py` imported from `unifi_network_mcp` (a consumer) at 5 sites | Backwards coupling smell; one import unguarded | Extract `resolve_controller_type()` to `unifi-core`; switch diagnostics imports to the implementation that already lived in `unifi-core` |
| Lifespan | App startup never completed once a controller actually connected | `await mgr.start_listening()` blocks on aiounifi's WS message loop | Background-launch each `start_listening` as a named task |
| Swagger UI | "Try it out" returned `missing bearer token`; no Authorize button | OpenAPI schema had no `securitySchemes` | Inject HTTP bearer scheme via `app.openapi` override |
| DPI endpoints | `GET /v1/sites/{site_id}/dpi-applications` returned 500 with `AttributeError` | API server's `manager_factory` passed `None` for `auth` (`# TODO Task 13`) | Wire `UniFiAuth` from controller's stored API token; route returns 501 `api_key_required` when token unset |
| Test gap | Live smoke harness boots in-process via ASGITransport, can't catch dep-closure bugs | Phase 8 release smoke happens in dev workspace where everything is `uv sync`'d | New `scripts/smoke-api-image.sh` + `scripts/api_image_smoke.py` — image-level GET sweep, fails on any 5xx |
| Architecture | Each consumer redeclares `aiounifi`/`uiprotect`/`py-unifi-access` | Forgotten-dep bug (the original symptom) was a class issue | Move to `unifi-core[network|protect|access]` extras; consumers depend on the extras they need |

## End-state UX

**Local clone (zero config):**
```bash
./scripts/start-api.sh
# prints the URL + key, paste into http://localhost:8089/admin/login
```

**Public image:**
```bash
docker run -d --name unifi-api-server -p 8080:8080 \
  -v unifi-api-state:/var/lib/unifi-api \
  ghcr.io/sirkirby/unifi-api-server:latest && \
  until docker exec unifi-api-server test -f /var/lib/unifi-api/bootstrap-admin-key 2>/dev/null; do sleep 1; done && \
  echo "Admin URL:  http://localhost:8080/admin/login" && \
  echo "Admin key:  $(docker exec unifi-api-server cat /var/lib/unifi-api/bootstrap-admin-key)"
```

**Release smoke (image-level, the new CI gate):**
```bash
UNIFI_HOST=… UNIFI_USERNAME=… UNIFI_PASSWORD=… UNIFI_API_TOKEN=… \
  ./scripts/smoke-api-image.sh
```

## Verification

### Tests (1,924/1,924 across 5 packages)

| Package | Pass |
|---|---|
| unifi-core | 76/76 (incl. 7 new for `resolve_controller_type`) |
| unifi-network-mcp | 651/651 |
| unifi-protect-mcp | 336/336 |
| unifi-access-mcp | 157/157 |
| unifi-api-server | 704/704 (incl. 1 new for DPI 501 path) |

### Image smoke against a real UDM (network controller registered)

```
Swept 143 GET endpoints against http://localhost:8089
  [  2]  501 api-key-required (expected without controller API token)
  [ 63]  200 ok
  [ 24]  404 not-found (expected for unknown-ID sentinels)
  [ 44]  409 capability-mismatch (expected for unregistered products)
  [  9]  422 validation (expected for sentinel input)
  [  1]  400 client-error
PASS — no 5xx / network failures.
```

### Image smoke cold-start (no controller registered)

```
Swept 143 GET endpoints
  [ 11]  200 ok
  [  2]  404 not-found (expected for unknown-ID sentinels)
  [130]  400 client-error (controller required — expected)
PASS — no 5xx / network failures.
```

## Test plan

- [x] Pull the branch, `./scripts/start-api.sh`, paste the printed key at `/admin/login`, sign in.
- [x] Register a controller via the admin UI; click Probe — should be green.
- [x] Hit Swagger UI at `/v1/docs`, click Authorize, paste key, run `GET /v1/sites/default/clients` — should return real clients.
- [x] Run `GET /v1/sites/default/dpi-applications` against a controller without an API token — should return 501 with `kind: api_key_required` and a hint, not 500.
- [x] Add an API token to the controller record, retry DPI — should return data.
- [x] Run `./scripts/smoke-api-image.sh` (with optional `UNIFI_HOST`/`UNIFI_USERNAME`/`UNIFI_PASSWORD`/`UNIFI_API_TOKEN` env vars set) — should exit 0.
- [x] Confirm 1,924 tests still pass: `uv sync --all-packages && uv run --package unifi-core pytest packages/unifi-core/tests && uv run --package unifi-network-mcp pytest apps/network/tests && uv run --package unifi-protect-mcp pytest apps/protect/tests && uv run --package unifi-access-mcp pytest apps/access/tests && uv run --package unifi-api-server pytest apps/api/tests`.

## Follow-up worth tracking separately

- API-key controller registration as a first-class field (Phase 9): the API server can store an API token (existing `api_token` column) but doesn't yet have UI/REST flow for editing it without re-entering the password. Currently DPI works once the token is set; making that easy is its own change.
- Env-driven controller bootstrap (already on file as a Phase 9 candidate): would eliminate the post-boot REST registration step entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)