### PR TITLE
fix(transport): HTTP failure no longer cancels stdio (#200)

### DIFF
--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
@@ -80,15 +80,21 @@ async def run_transports(
     logger: logging.Logger,
     protocol_version: str = "v1",
 ) -> None:
-    """Run stdio (always) and optionally HTTP, with coupled lifecycles.
+    """Run stdio (always) and optionally HTTP, with stdio as the primary.
 
-    When both transports are active, uses ``asyncio.wait(FIRST_COMPLETED)``
-    so that when either transport exits the other is cancelled.  This ensures
-    the process terminates cleanly when the stdio client disconnects instead
-    of being kept alive by the HTTP server.
+    Stdio is the primary transport — Claude Code (and any other stdio MCP
+    client) talks to the server over it.  HTTP, when enabled, is a side
+    channel that runs as a background task: if HTTP fails (port conflict,
+    bind error, etc.) stdio keeps serving.  When stdio exits, HTTP is
+    cancelled so the process terminates cleanly.
+
+    The previous implementation used ``asyncio.wait(FIRST_COMPLETED)``, which
+    caused HTTP-died-fast to look like "transport finished" and cancelled
+    stdio — taking down the only transport Claude Code actually uses.  See
+    issue #200.
 
     ``SystemExit`` raised by uvicorn on port-bind failures is caught inside
-    ``run_http`` so it does not propagate and kill the stdio transport.
+    ``run_http`` so it does not propagate.
     """
     # Future: when MCP SDK v2 changes the transport API, branch here:
     # if protocol_version == "v2":
@@ -151,30 +157,29 @@ async def run_transports(
             raise
         return
 
-    # Use asyncio tasks so we can cancel HTTP when stdio exits (or vice versa).
-    # Without this, the HTTP server keeps the process alive as an orphan after
-    # the stdio client disconnects.
-    stdio_task = asyncio.create_task(run_stdio(), name="stdio")
+    # Run HTTP as a background task and await stdio in the main flow.  If
+    # HTTP fails (port conflict, etc.) the failure is contained inside
+    # run_http (which logs and returns), the http_task completes, and stdio
+    # keeps serving.  When stdio exits — for any reason — we cancel HTTP so
+    # we don't leave an orphan listener behind.
     http_task = asyncio.create_task(run_http(), name="http")
-
+    # Yield once so http_task gets to start before stdio races to completion
+    # in the (rare) case where stdio exits without ever awaiting.
+    await asyncio.sleep(0)
     try:
-        done, pending = await asyncio.wait(
-            [stdio_task, http_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        # Whichever finished first — cancel the other and let it clean up
-        for task in pending:
-            logger.info("Cancelling %s transport (other transport exited).", task.get_name())
-            task.cancel()
+        await run_stdio()
+        logger.info("FastMCP stdio server exited.")
+    finally:
+        if not http_task.done():
+            logger.info("Stdio transport exited; cancelling HTTP transport.")
+            http_task.cancel()
             try:
-                await task
+                await http_task
             except asyncio.CancelledError:
                 pass
-        # Re-raise if the completed task had an exception
-        for task in done:
-            if not task.cancelled() and task.exception():
-                raise task.exception()
-        logger.info("FastMCP servers exited.")
-    except Exception as e:
-        logger.error("Error running FastMCP servers: %s", e, exc_info=True)
-        raise
+            except Exception as http_e:
+                logger.warning("HTTP task error during shutdown: %s", http_e)
+        elif (http_exc := http_task.exception()) is not None:
+            # run_http normally swallows uvicorn errors and returns; this branch
+            # only fires for unexpected exceptions that escaped its try/except.
+            logger.warning("HTTP task exited with unhandled error: %s", http_exc)

--- a/packages/unifi-mcp-shared/tests/test_transport.py
+++ b/packages/unifi-mcp-shared/tests/test_transport.py
@@ -127,3 +127,79 @@ class TestRunTransports:
                 logger=logging.getLogger("test"),
             )
         assert "bind failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_http_systemexit_does_not_cancel_stdio(self, mock_server):
+        """Regression for issue #200: HTTP bind failure must not cascade to stdio.
+
+        Previously ``asyncio.wait(FIRST_COMPLETED)`` treated HTTP-died-fast as
+        'transport finished' and cancelled stdio — taking down the only
+        transport Claude Code talks over.  After the refactor stdio is the
+        primary control flow and HTTP failures are contained.
+        """
+        mock_server.run_streamable_http_async.side_effect = SystemExit(1)
+
+        stdio_completed = False
+
+        async def stdio_runs_for_a_moment():
+            nonlocal stdio_completed
+            await asyncio.sleep(0.05)
+            stdio_completed = True
+
+        mock_server.run_stdio_async.side_effect = stdio_runs_for_a_moment
+
+        with patch("unifi_mcp_shared.transport.os.getpid", return_value=12345):
+            await run_transports(
+                server=mock_server,
+                http_enabled=True,
+                host="0.0.0.0",
+                port=3000,
+                http_transport="streamable-http",
+                logger=logging.getLogger("test"),
+            )
+
+        assert stdio_completed, (
+            "stdio was cancelled when HTTP failed — the bug from #200 has regressed"
+        )
+        mock_server.run_streamable_http_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stdio_exit_cancels_http(self, mock_server):
+        """When stdio exits (client disconnect), HTTP must be cancelled.
+
+        Without this, the HTTP server would keep the process alive as an
+        orphan after the stdio client disconnected.
+        """
+        # stdio returns immediately (simulates client disconnect at startup).
+        mock_server.run_stdio_async.return_value = None
+
+        http_started = asyncio.Event()
+        http_was_cancelled = False
+
+        async def long_running_http():
+            nonlocal http_was_cancelled
+            http_started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                http_was_cancelled = True
+                raise
+
+        mock_server.run_streamable_http_async.side_effect = long_running_http
+
+        with patch("unifi_mcp_shared.transport.os.getpid", return_value=12345):
+            # Should complete promptly: stdio exits, then http_task is cancelled.
+            await asyncio.wait_for(
+                run_transports(
+                    server=mock_server,
+                    http_enabled=True,
+                    host="0.0.0.0",
+                    port=3000,
+                    http_transport="streamable-http",
+                    logger=logging.getLogger("test"),
+                ),
+                timeout=2.0,
+            )
+
+        assert http_started.is_set(), "HTTP transport never started"
+        assert http_was_cancelled, "HTTP transport was not cancelled when stdio exited"

--- a/plugins/unifi-access/.claude-plugin/plugin.json
+++ b/plugins/unifi-access/.claude-plugin/plugin.json
@@ -35,7 +35,7 @@
         "UNIFI_ACCESS_VERIFY_SSL": "${UNIFI_ACCESS_VERIFY_SSL:-false}",
         "UNIFI_TOOL_REGISTRATION_MODE": "${UNIFI_TOOL_REGISTRATION_MODE:-lazy}",
         "UNIFI_MCP_HTTP_ENABLED": "true",
-        "UNIFI_MCP_HTTP_FORCE": "true",
+        "UNIFI_MCP_HTTP_FORCE": "false",
         "UNIFI_MCP_PORT": "${UNIFI_ACCESS_MCP_PORT:-3002}"
       }
     }

--- a/plugins/unifi-network/.claude-plugin/plugin.json
+++ b/plugins/unifi-network/.claude-plugin/plugin.json
@@ -35,7 +35,7 @@
         "UNIFI_NETWORK_VERIFY_SSL": "${UNIFI_NETWORK_VERIFY_SSL:-false}",
         "UNIFI_TOOL_REGISTRATION_MODE": "${UNIFI_TOOL_REGISTRATION_MODE:-lazy}",
         "UNIFI_MCP_HTTP_ENABLED": "true",
-        "UNIFI_MCP_HTTP_FORCE": "true",
+        "UNIFI_MCP_HTTP_FORCE": "false",
         "UNIFI_MCP_PORT": "${UNIFI_NETWORK_MCP_PORT:-3000}"
       }
     }

--- a/plugins/unifi-protect/.claude-plugin/plugin.json
+++ b/plugins/unifi-protect/.claude-plugin/plugin.json
@@ -34,7 +34,7 @@
         "UNIFI_PROTECT_VERIFY_SSL": "${UNIFI_PROTECT_VERIFY_SSL:-false}",
         "UNIFI_TOOL_REGISTRATION_MODE": "${UNIFI_TOOL_REGISTRATION_MODE:-lazy}",
         "UNIFI_MCP_HTTP_ENABLED": "true",
-        "UNIFI_MCP_HTTP_FORCE": "true",
+        "UNIFI_MCP_HTTP_FORCE": "false",
         "UNIFI_MCP_PORT": "${UNIFI_PROTECT_MCP_PORT:-3001}"
       }
     }


### PR DESCRIPTION
## Summary

When \`UNIFI_MCP_HTTP_FORCE=true\` and the HTTP bind fails (e.g. something else is on port 3000), the entire MCP server becomes unreachable — including the stdio transport that Claude Code actually talks over. Caught by @patrick-motard with a clean test matrix on #200:

| HTTP_ENABLED | HTTP_FORCE | PORT | Result |
|---|---|---|---|
| false | false | 3000 | works |
| true | false | 3000 | works |
| true | true | 3000 | **fails (the bug)** |
| true | true | 3001 | works |

**Root cause**: \`run_transports\` used \`asyncio.wait(FIRST_COMPLETED)\`. When uvicorn's bind fails it raises \`SystemExit\`; \`run_http\` catches it and returns normally. From asyncio.wait's perspective HTTP "finished first", so stdio was cancelled as the pending task — taking down the only transport Claude Code uses.

## Two fixes bundled

### 1. plugin.json default (immediate user fix)

Flip \`UNIFI_MCP_HTTP_FORCE\` from \`"true"\` → \`"false"\` in all three plugin manifests. Claude Code drives the server over stdio (uvx-launched, not PID 1), so HTTP is a side channel at best — FORCE=true was buying users a port-conflict footgun. With FORCE=false, the existing PID-1 check in \`resolve_http_config\` disables HTTP cleanly in plugin contexts; nothing else changes.

### 2. shared/transport.py refactor (defensive fix)

Restructure \`run_transports\` so stdio is the primary control flow and HTTP runs as a cancellable background task:

- HTTP failure is contained: stdio keeps serving when HTTP dies fast.
- Stdio exit cancels HTTP via the \`finally\` clause, preserving the original "no orphan listener" behaviour.
- Adds two regression tests pinning both behaviours (\`test_http_systemexit_does_not_cancel_stdio\`, \`test_stdio_exit_cancels_http\`).

This protects anyone who deliberately sets \`FORCE=true\` (e.g. for local debugging) from the same crash class.

## Test plan

- [x] \`uv run pytest packages/unifi-mcp-shared/tests/test_transport.py\` — 9/9 (7 existing + 2 new regression tests)
- [x] \`uv run pytest packages/unifi-mcp-shared\` — 207/207
- [x] \`uv run pytest apps/network/tests\` — 651/651
- [x] \`uv run pytest apps/protect/tests\` — 336/336
- [x] \`uv run pytest apps/access/tests\` — 157/157
- [x] \`claude plugin validate\` passes for all three plugin manifests
- [x] \`/bin/bash scripts/smoke-plugin-setup.sh\` — 25/25
- [ ] **Reporter re-test:** ask @patrick-motard to re-verify with the merged fix

Refs #200. Will require a release wave once merged: \`shared\` (real code change), then \`network\`, \`protect\`, \`access\` (plugin manifests + transitive shared bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)