### PR TITLE
fix(port_forward): handle bare-list controller response on UDM-SE 8.4.x (#207)

### DIFF
--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -371,3 +371,59 @@ class TestGetFirewallZones:
             await firewall_manager.get_firewall_zones()
 
         assert mock_connection.request.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# create_port_forward — V1 POST response shape handling (issue #207)
+#
+# UDM-SE 8.4.x returns a bare list `[{...}]` from POST /rest/portforward
+# while older firmware returns the wrapped shape `{"data": [{...}]}`. The
+# manager must extract the created rule from both shapes — see #207.
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_CREATED_PORT_FORWARD = {
+    "_id": "abc123",
+    "name": "test",
+    "dst_port": "80",
+    "fwd_port": "80",
+    "fwd_ip": "10.0.0.1",
+}
+
+
+class TestCreatePortForwardResponseShapes:
+    """Issue #207 — create_port_forward must accept both wrapped and bare-list responses."""
+
+    @pytest.mark.asyncio
+    async def test_create_port_forward_handles_wrapped_response_shape(
+        self, firewall_manager, mock_connection
+    ):
+        """Older firmware returns {"data": [{...}]} — manager must extract the rule."""
+        mock_connection.request = AsyncMock(
+            return_value={"data": [copy.deepcopy(SAMPLE_CREATED_PORT_FORWARD)]}
+        )
+
+        result = await firewall_manager.create_port_forward(
+            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd_ip": "10.0.0.1"}
+        )
+
+        assert result is not None
+        assert result["_id"] == "abc123"
+        assert result["name"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_create_port_forward_handles_bare_list_response_shape(
+        self, firewall_manager, mock_connection
+    ):
+        """UDM-SE 8.4.x returns [{...}] — manager must extract the rule (regression test for #207)."""
+        mock_connection.request = AsyncMock(
+            return_value=[copy.deepcopy(SAMPLE_CREATED_PORT_FORWARD)]
+        )
+
+        result = await firewall_manager.create_port_forward(
+            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd_ip": "10.0.0.1"}
+        )
+
+        assert result is not None
+        assert result["_id"] == "abc123"
+        assert result["name"] == "test"

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -550,16 +550,17 @@ class FirewallManager:
             )
             response = await self._connection.request(api_request)
 
-            # V1 POST usually returns a list containing the created object within 'data'
-            created_rule = None
-            if (
-                isinstance(response, dict)
-                and "data" in response
-                and isinstance(response["data"], list)
-                and len(response["data"]) > 0
-            ):
-                created_rule = response["data"][0]
-            else:
+            # V1 POST may return either {"data": [{...}]} (older firmware) or a bare
+            # list [{...}] (UDM-SE 8.4.x and similar). Handle both — see #207.
+            data = (
+                response
+                if isinstance(response, list)
+                else response.get("data", [])
+                if isinstance(response, dict)
+                else []
+            )
+            created_rule = data[0] if data else None
+            if not created_rule:
                 logger.error("Unexpected response format creating port forward: %s", response)
                 return None
 


### PR DESCRIPTION
Closes #207.

## What this PR does

`firewall_manager.create_port_forward` mis-parsed the controller's response on UDM-SE 8.4.x. The controller returns a bare list `[{...}]`; the manager only recognized the older wrapped shape `{"data": [{...}]}`. Result: the rule WAS created, but the manager returned `None` and the tool reported `success=False` with "Unexpected response format" — leaving users to assume the rule wasn't created.

This PR fixes that one method by mirroring the dual-shape handler that already lives 250 lines lower in the same file (`create_firewall_group`, lines 807-814).

## Audit findings

Audited every `async def create_*` method across the network managers (17 methods). Only `create_port_forward` had this bug. Every other V1 `create_*` method already handles both response shapes. Audit table:

| Class | Count | Methods |
|-------|-------|---------|
| **BUG (this PR fixes)** | 1 | `create_port_forward` |
| Already MIXED (handles both shapes) | 9 | `create_route`, `create_voucher`, `create_firewall_group`, `create_network`, `create_wlan`, `create_port_profile`, `create_usergroup`, `create_qos_rule`, `create_dns_record` |
| V2 reference pattern (`_id`-based) | 6 | `create_firewall_policy`, `create_traffic_route`, `create_acl_rule`, `create_client_group`, `create_ap_group`, `create_oon_policy` |
| Custom (out-of-scope shapes) | 3 | `create_admin_user`, `create_site`, `create_backup` |

So the scope is genuinely one-method.

## The fix (manager-side)

`packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py:553-565` — drop-in adoption of the existing `create_firewall_group` pattern:

```python
# V1 POST may return either {"data": [{...}]} (older firmware) or a bare
# list [{...}] (UDM-SE 8.4.x and similar). Handle both — see #207.
data = (
    response
    if isinstance(response, list)
    else response.get("data", [])
    if isinstance(response, dict)
    else []
)
created_rule = data[0] if data else None
if not created_rule:
    logger.error("Unexpected response format creating port forward: %s", response)
    return None
```

## Tests

Added two unit tests in `apps/network/tests/unit/test_firewall_manager.py` under `TestCreatePortForwardResponseShapes`:
- `test_create_port_forward_handles_wrapped_response_shape` — older firmware shape
- `test_create_port_forward_handles_bare_list_response_shape` — the #207 regression

Both pass. Full network unit suite: **654 passed** (was 652 baseline + 2 new).

## Live smoke (UDM-SE 8.4.17, 2026-05-08)

End-to-end through the actual MCP tool entry point:

| Check | Result |
|-------|--------|
| `unifi_create_port_forward` happy path | ✅ `success=True`, `port_forward_id=69fe3a15...` |
| Cleanup (`unifi_delete_port_forward`) | ✅ Rule deleted, controller confirmed |

The exact failure mode reported in #207 — `success=False` with "Unexpected response format" while the rule was created — is gone.

## Out of scope

- The audit incidentally noticed `create_qos_rule` returns the raw `response` as a fallback if extraction fails (could surface odd shapes in failure modes). Not the #207 bug class; leaving for future cleanup if it ever bites.
- The smoke also incidentally surfaced that the `log` field documented in the port-forward tool description isn't in the strict schema. That's a schema-completeness gap of the kind tracked in #208 / #209; a separate small fix when/if a user reports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)