### PR TITLE
fix(wlan): add ap_group_ids and ap_group_mode to WLAN_SCHEMA (#208)

### DIFF
--- a/apps/network/src/unifi_network_mcp/schemas.py
+++ b/apps/network/src/unifi_network_mcp/schemas.py
@@ -235,7 +235,7 @@ TRAFFIC_ROUTE_SIMPLE_SCHEMA = {
 # WLAN (Wireless Network) schema
 WLAN_SCHEMA = {
     "type": "object",
-    "required": ["name", "security", "enabled"],
+    "required": ["name", "security", "enabled", "ap_group_ids"],
     "properties": {
         "name": {
             "type": "string",
@@ -357,6 +357,27 @@ WLAN_SCHEMA = {
         "iapp_enabled": {
             "type": "boolean",
             "description": "Enable Inter-AP communication protocol",
+        },
+        "ap_group_ids": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "description": (
+                "AP group IDs that this WLAN broadcasts on. Required on create; "
+                "an empty list is rejected by the controller. Use "
+                "`unifi_list_ap_groups` to discover available IDs (the default "
+                'all-APs group has type "All-APs").'
+            ),
+        },
+        "ap_group_mode": {
+            "type": "string",
+            "enum": ["all", "groups"],
+            "description": (
+                "Whether the WLAN broadcasts on all APs (`all`) or only the "
+                "groups listed in `ap_group_ids` (`groups`). Optional — the "
+                "controller infers and may rewrite the value to keep it "
+                "consistent with the supplied IDs. Case-sensitive."
+            ),
         },
     },
     "allOf": [

--- a/apps/network/tests/unit/test_network_schema.py
+++ b/apps/network/tests/unit/test_network_schema.py
@@ -181,3 +181,81 @@ class TestNetworkUpdateSchema:
         assert is_valid
         assert data["dhcpguard_enabled"] is True
         assert data["dhcpd_ip_1"] == "192.168.1.1"
+
+
+class TestWlanCreateSchema:
+    """Tests for WLAN_SCHEMA validation around ap_group_ids and ap_group_mode (#208).
+
+    Live-controller probe (UDM-SE 8.4.17) confirmed:
+    - ap_group_ids: required on create, array of strings, empty list rejected
+    - ap_group_mode: optional, enum ["all", "groups"], case-sensitive
+    """
+
+    def _base_payload(self, **overrides):
+        payload = {
+            "name": "TestSSID",
+            "security": "wpa2-psk",
+            "x_passphrase": "supersecret",
+            "enabled": True,
+            "ap_group_ids": ["abc"],
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_create_with_ap_group_ids_and_mode_all_accepted(self):
+        """Valid create with both ap_group_ids and ap_group_mode='all' validates."""
+        is_valid, error_msg, data = UniFiValidatorRegistry.validate(
+            "wlan",
+            self._base_payload(ap_group_mode="all"),
+        )
+        assert is_valid, error_msg
+        assert data["ap_group_ids"] == ["abc"]
+        assert data["ap_group_mode"] == "all"
+
+    def test_create_with_ap_group_ids_only_accepted(self):
+        """ap_group_mode is optional; create succeeds without it."""
+        is_valid, error_msg, data = UniFiValidatorRegistry.validate(
+            "wlan",
+            self._base_payload(),
+        )
+        assert is_valid, error_msg
+        assert data["ap_group_ids"] == ["abc"]
+        assert "ap_group_mode" not in data
+
+    def test_create_missing_ap_group_ids_rejected(self):
+        """Create without ap_group_ids fails validation with field name in error."""
+        payload = self._base_payload()
+        payload.pop("ap_group_ids")
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate("wlan", payload)
+        assert not is_valid
+        assert "ap_group_ids" in error_msg
+
+    def test_create_with_invalid_ap_group_mode_rejected(self):
+        """ap_group_mode='custom' (the wrong-but-natural guess) fails with enum listed."""
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate(
+            "wlan",
+            self._base_payload(ap_group_mode="custom"),
+        )
+        assert not is_valid
+        # Enum error should mention the accepted values
+        assert "all" in error_msg
+        assert "groups" in error_msg
+
+    def test_create_with_empty_ap_group_ids_rejected(self):
+        """ap_group_ids: [] is rejected by minItems: 1 (mirrors controller behavior)."""
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate(
+            "wlan",
+            self._base_payload(ap_group_ids=[]),
+        )
+        assert not is_valid
+        # jsonschema reports minItems violations as "should be non-empty" / "too short"
+        assert "non-empty" in error_msg.lower() or "short" in error_msg.lower() or "ap_group_ids" in error_msg
+
+    def test_create_with_int_items_in_ap_group_ids_rejected(self):
+        """ap_group_ids items must be strings; ints fail with a type error."""
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate(
+            "wlan",
+            self._base_payload(ap_group_ids=[123]),
+        )
+        assert not is_valid
+        assert "type" in error_msg.lower() or "string" in error_msg.lower()


### PR DESCRIPTION
Closes #208.

## What this PR does

`unifi_create_wlan` could not complete end-to-end on UDM-SE 8.4.x because `WLAN_SCHEMA` was missing two fields the controller requires. Pre-PR-#206 the wrapper silently dropped them; post-#206 they were rejected at the wrapper boundary. This PR adds the two fields with controller-verified types and enums so the round trip works.

## Live-controller probe findings (UDM-SE 8.4.17)

Important correction to the original #208 issue body — the probe extracted authoritative values that differ from what I had assumed:

- **`ap_group_mode` enum** is `["all", "groups"]`, NOT `["all", "custom"]` as the issue body initially guessed. Case-sensitive.
- **`ap_group_ids` is REQUIRED on every create** (not optional). Empty list is rejected.
- **`ap_group_mode` is optional** — controller infers from IDs and may rewrite the value to keep mode/IDs consistent server-side.

This is exactly why we live-probe before adding schema constraints (the lesson from #203's enum-casing case).

## Schema additions

`apps/network/src/unifi_network_mcp/schemas.py`:
- `ap_group_ids` added to `required`. Type: `array of strings`, `minItems: 1`.
- `ap_group_mode` added with `enum: ["all", "groups"]` (optional).
- `WLAN_UPDATE_SCHEMA` inherits via deepcopy + strips `required`, so update calls don't have to re-supply `ap_group_ids`.

## Tests

6 new tests in `test_network_schema.py::TestWlanCreateSchema` covering:
- valid create with both fields
- valid create with `ap_group_mode` omitted
- missing-required rejection
- wrong-enum rejection (`"custom"` — the natural mistake)
- empty-list rejection
- wrong-item-type rejection

Full suite: **660 passed** (was 654 baseline + 6 new).

## Live smoke (UDM-SE 8.4.17) — 5/5 PASS

Driver `scripts/smoke_208.py` (one-shot, deleted post-run). Goes through `unifi_create_wlan` (the tool wrapper), not the manager.

| # | Scenario | Result |
|---|---|---|
| 1 | Happy path: `ap_group_mode="all"` + `ap_group_ids=[<All APs>]` | **PASS** — `success=True`, WLAN created on controller, cleaned up. |
| 2 | Happy path: `ap_group_mode` omitted, `ap_group_ids=[<All APs>]` | **PASS** — `success=True`, controller infers mode, cleaned up. |
| 3 | Unknown-key probe (`BOGUS_PROBE_KEY`) | **PASS** — rejected at wrapper: `Additional properties are not allowed ('BOGUS_PROBE_KEY' was unexpected)`. Confirms #205's `additionalProperties: false` still works. |
| 4 | Wrong-enum probe (`ap_group_mode="custom"`) | **PASS** — rejected at wrapper: `'custom' is not one of ['all', 'groups']`. Both accepted values surfaced in the error. |
| 5 | Missing-required probe (no `ap_group_ids`) | **PASS** — rejected at wrapper: `'ap_group_ids' is a required property`. |

`unifi_create_wlan` is now end-to-end functional on UDM-SE 8.4.x — for the first time, since pre-this-PR the controller rejected every wrapper-validated payload with `api.err.ApGroupMissing`.

## Out of scope

- WLAN field-symmetry migration (#137).
- Any other WLAN schema completeness gaps the smoke might surface (file separately if found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)