### PR TITLE
fix(network): require explicit vlan for corporate and vlan-only purposes (#209)

### DIFF
--- a/apps/network/src/unifi_network_mcp/schemas.py
+++ b/apps/network/src/unifi_network_mcp/schemas.py
@@ -417,7 +417,14 @@ NETWORK_SCHEMA = {
         "vlan": {"type": "string", "description": "VLAN ID (if VLAN is enabled)"},
         "ip_subnet": {
             "type": "string",
-            "description": "IP subnet in CIDR notation (e.g., '192.168.1.0/24')",
+            "description": (
+                "IP subnet in host-address-form CIDR (e.g., '192.168.1.1/24'). "
+                "Note: the controller rejects the network-address form "
+                "('192.168.1.0/24') with api.err.IncorrectIPSubnetSpec. Optional "
+                "for vlan-only purpose; recommended for corporate (the network "
+                "won't be functional without it, though the controller doesn't "
+                "force-require it on create)."
+            ),
         },
         "enabled": {
             "type": "boolean",
@@ -566,7 +573,17 @@ NETWORK_SCHEMA = {
         {
             "if": {"properties": {"vlan_enabled": {"enum": [True]}}},
             "then": {"required": ["vlan"]},
-        }
+        },
+        {
+            # Controller defaults `vlan` to 1 when not supplied for corporate/vlan-only
+            # purposes, which collides with the default LAN (api.err.VlanUsed). Force
+            # callers to explicitly choose a non-conflicting VLAN. See issue #209.
+            "if": {"properties": {"purpose": {"enum": ["corporate", "vlan-only"]}}},
+            "then": {
+                "required": ["vlan", "vlan_enabled"],
+                "properties": {"vlan_enabled": {"enum": [True]}},
+            },
+        },
     ],
     "additionalProperties": False,
 }

--- a/apps/network/tests/unit/test_network_schema.py
+++ b/apps/network/tests/unit/test_network_schema.py
@@ -259,3 +259,76 @@ class TestWlanCreateSchema:
         )
         assert not is_valid
         assert "type" in error_msg.lower() or "string" in error_msg.lower()
+
+
+class TestNetworkCreateSchemaPurposeRequirements:
+    """Tests for NETWORK_SCHEMA conditional vlan requirement on create (#209).
+
+    Live-controller probe (UDM-SE 8.4.17) confirmed:
+    - For purpose in {corporate, vlan-only}, the controller silently defaults
+      vlan=1 when not supplied, which collides with the default LAN
+      (api.err.VlanUsed). Schema now requires explicit vlan + vlan_enabled=True.
+    - ip_subnet is NOT force-required by the controller for corporate purpose
+      (the network is non-functional without it, but create succeeds).
+    """
+
+    def test_corporate_with_explicit_vlan_accepted(self):
+        """Corporate purpose with explicit vlan + vlan_enabled=True validates."""
+        is_valid, error_msg, data = UniFiValidatorRegistry.validate(
+            "network",
+            {"name": "x", "purpose": "corporate", "vlan_enabled": True, "vlan": "100"},
+        )
+        assert is_valid, error_msg
+        assert data["vlan"] == "100"
+        assert data["vlan_enabled"] is True
+
+    def test_vlan_only_with_explicit_vlan_accepted(self):
+        """vlan-only purpose with explicit vlan + vlan_enabled=True validates."""
+        is_valid, error_msg, data = UniFiValidatorRegistry.validate(
+            "network",
+            {"name": "x", "purpose": "vlan-only", "vlan_enabled": True, "vlan": "100"},
+        )
+        assert is_valid, error_msg
+        assert data["vlan"] == "100"
+
+    def test_corporate_missing_vlan_rejected(self):
+        """Corporate purpose without vlan fails with mention of vlan."""
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate(
+            "network",
+            {"name": "x", "purpose": "corporate"},
+        )
+        assert not is_valid
+        assert "vlan" in error_msg.lower()
+
+    def test_vlan_only_missing_vlan_rejected(self):
+        """vlan-only purpose without vlan fails with mention of vlan."""
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate(
+            "network",
+            {"name": "x", "purpose": "vlan-only"},
+        )
+        assert not is_valid
+        assert "vlan" in error_msg.lower()
+
+    def test_corporate_with_vlan_enabled_false_rejected(self):
+        """Corporate with vlan_enabled=False fails the conditional rule.
+
+        The conditional `properties: {vlan_enabled: {enum: [True]}}` produces a
+        jsonschema error like "False is not one of [True]" — match on the enum
+        violation rather than the field name.
+        """
+        is_valid, error_msg, _ = UniFiValidatorRegistry.validate(
+            "network",
+            {"name": "x", "purpose": "corporate", "vlan_enabled": False, "vlan": "100"},
+        )
+        assert not is_valid
+        lowered = error_msg.lower()
+        assert "false" in lowered and "true" in lowered
+
+    def test_corporate_without_ip_subnet_accepted(self):
+        """ip_subnet is NOT force-required for corporate (per live probe findings)."""
+        is_valid, error_msg, data = UniFiValidatorRegistry.validate(
+            "network",
+            {"name": "x", "purpose": "corporate", "vlan_enabled": True, "vlan": "100"},
+        )
+        assert is_valid, error_msg
+        assert "ip_subnet" not in data


### PR DESCRIPTION
Closes #209.

## What this PR does

`unifi_create_network` failed end-to-end on UDM-SE 8.4.x for the `corporate` and `vlan-only` purposes when callers omitted `vlan` / `vlan_enabled`. The wrapper schema accepted these incomplete payloads, but the controller silently defaulted `vlan=1` and then rejected the create with `api.err.VlanUsed` (collision with the default LAN). Callers got an opaque controller error with no clear path to fix.

## Live-controller probe correction (UDM-SE 8.4.17)

The probe (Task A in this branch) reduced all five #209-style failures to a single root cause:

- Real error: `api.err.VlanUsed`, NOT `api.err.InvalidValue` as the issue body initially assumed.
- All required fields ARE in `NETWORK_SCHEMA["properties"]` already — no missing properties.
- The fix is purely a `required` / `allOf` correctness update.
- Surprise finding: `ip_subnet` is NOT force-required by the controller for `corporate` purpose (the network is non-functional without it, but the controller doesn't enforce on create). The schema must NOT force-require it.

This is the third time the live-probe-before-patching approach has corrected an initial assumption (after #203's enum casing and #208's `ap_group_mode` enum values).

## Schema changes

`apps/network/src/unifi_network_mcp/schemas.py`:

1. Extended `NETWORK_SCHEMA["allOf"]` with a second if-then rule: when `purpose` is `corporate` or `vlan-only`, require `vlan` and `vlan_enabled=true`. Comment cites the controller's silent-default-vlan-1 behavior. `NETWORK_UPDATE_SCHEMA` strips `allOf`, so the conditional only fires on create.

2. Rewrote the `ip_subnet` description to:
   - Note the host-address-form requirement (`192.168.1.1/24`, not `192.168.1.0/24`).
   - Document that the controller rejects network-address form with `api.err.IncorrectIPSubnetSpec`.
   - Clarify `ip_subnet` is optional for `vlan-only` and recommended (but not enforced) for `corporate`.

The previous example in the description (`192.168.1.0/24`) was the network address — misleading documentation that contributed to the silent-drop class of bug.

## Tests

6 new tests in `test_network_schema.py::TestNetworkCreateSchemaPurposeRequirements` covering both purposes' happy paths, missing-required rejections, the `vlan_enabled=false` rejection, and the `ip_subnet`-not-force-required case.

Full network unit suite: **666 passed** (was 660 before this PR, +6 new).

## Live smoke (UDM-SE 8.4.17)

All 6/6 PASS through the actual MCP tool entry point (`unifi_create_network`, not the manager) on the live controller. Each successful create was deleted before script exit; final sweep confirmed zero `smoke209-*` leftovers.

| # | Scenario | Result |
|---|---|---|
| 1 | Happy `vlan-only` (vlan=990, vlan_enabled=true) | PASS — `success=True`, `network_id=69fe459564a402651f30bff1`. Cleaned up. |
| 2 | Happy `corporate` (vlan=991, vlan_enabled=true, ip_subnet=10.99.99.1/24) | PASS — `success=True`, `network_id=69fe459764a402651f30c06f`. Cleaned up. |
| 3 | Missing-vlan probe, `purpose=corporate` | PASS — Wrapper rejects: `'vlan' is a required property`. Schema's new conditional fires before the controller can produce `api.err.VlanUsed`. |
| 4 | Missing-vlan probe, `purpose=vlan-only` | PASS — Same wrapper-side rejection on the other affected purpose. |
| 5 | Network-address-form `ip_subnet=10.99.99.0/24` (full corporate payload otherwise) | PASS — Wrapper passes through; controller rejects with `api.err.IncorrectIPSubnetSpec` reason `CANNOT_BE_NETWORK_ADDRESS`. Confirms the schema fix didn't accidentally start eating that error path. |
| 6 | Unknown-key probe (`BOGUS_PROBE_KEY: "x"` on full happy payload) | PASS — Wrapper rejects: `Additional properties are not allowed ('BOGUS_PROBE_KEY' was unexpected)`. Confirms PR #205's `additionalProperties: false` still works post-our-changes. |

## Out of scope

- `wan` and `guest` purposes — not probed in this PR. They have additional constraints; file a separate issue if/when those purposes are exercised through the wrapper and surface gaps.
- Validating `ip_subnet` host-vs-network form at the wrapper level — left to the controller to reject. Could be added as a `pattern` constraint on `ip_subnet` in a follow-up PR if the validation is worth running before sending the controller request.
- Field-symmetry migration of NETWORK to a Pydantic model (#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)