### PR TITLE
fix(firewall): toggle delegates to update so PUT preserves required fields

### DIFF
--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -208,6 +208,64 @@ class TestUpdateFirewallPolicyEndpoint:
         assert policy.raw == original_raw
 
 
+class TestToggleFirewallPolicyPayload:
+    """Toggle must PUT a fully-merged object, not a partial {enabled} payload.
+
+    The controller rejects PUTs missing any required field (action,
+    ipVersion, name, source, destination, schedule). This is enforced by
+    delegating toggle through update_firewall_policy.
+    """
+
+    @pytest.mark.asyncio
+    async def test_put_payload_includes_all_required_fields(self, firewall_manager, mock_connection):
+        policy = _make_firewall_policy()  # raw enabled=True
+        policy.enabled = True  # explicit: helper uses MagicMock attrs which are truthy by default
+
+        with patch.object(firewall_manager, "get_firewall_policies", new_callable=AsyncMock, return_value=[policy]):
+            await firewall_manager.toggle_firewall_policy("pol001")
+
+        api_request = mock_connection.request.call_args[0][0]
+        payload = api_request.data
+        # All controller-required fields present
+        for required in ("action", "ip_version", "name", "source", "destination"):
+            assert required in payload, f"toggle PUT missing required field '{required}'"
+        # The toggled flag is what changed
+        assert payload["enabled"] is False
+        # Sibling fields preserved
+        assert payload["name"] == "Test Policy"
+        assert payload["action"] == "ALLOW"
+        assert payload["source"]["zone_id"] == "zone-internal"
+
+    @pytest.mark.asyncio
+    async def test_uses_single_policy_endpoint(self, firewall_manager, mock_connection):
+        policy = _make_firewall_policy()
+        policy.enabled = True
+        with patch.object(firewall_manager, "get_firewall_policies", new_callable=AsyncMock, return_value=[policy]):
+            await firewall_manager.toggle_firewall_policy("pol001")
+
+        api_request = mock_connection.request.call_args[0][0]
+        assert api_request.path == "/firewall-policies/pol001"
+        assert api_request.method == "put"
+
+    @pytest.mark.asyncio
+    async def test_flips_enabled_state(self, firewall_manager, mock_connection):
+        disabled = _make_firewall_policy({**SAMPLE_POLICY_RAW, "enabled": False})
+        disabled.enabled = False
+        with patch.object(firewall_manager, "get_firewall_policies", new_callable=AsyncMock, return_value=[disabled]):
+            await firewall_manager.toggle_firewall_policy("pol001")
+
+        payload = mock_connection.request.call_args[0][0].data
+        assert payload["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_raises_when_policy_missing(self, firewall_manager):
+        from unifi_core.exceptions import UniFiNotFoundError
+
+        with patch.object(firewall_manager, "get_firewall_policies", new_callable=AsyncMock, return_value=[]):
+            with pytest.raises(UniFiNotFoundError):
+                await firewall_manager.toggle_firewall_policy("does-not-exist")
+
+
 # ---------------------------------------------------------------------------
 # ID-lookup iteration robustness — issue #151
 #

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -77,6 +77,12 @@ class FirewallManager:
     async def toggle_firewall_policy(self, policy_id: str) -> bool:
         """Toggle a firewall policy on/off.
 
+        Delegates to ``update_firewall_policy`` so the controller PUT is a
+        deep-merge of the new ``enabled`` flag into the full policy object.
+        The controller rejects PUTs that omit any required field
+        (action, ipVersion, name, source, destination, schedule), so a
+        partial payload of ``{"enabled": ...}`` cannot be sent on its own.
+
         Returns:
             bool: True if successful.
 
@@ -96,19 +102,7 @@ class FirewallManager:
             new_state = not policy.enabled
             logger.info("Toggling firewall policy %s to %s", policy_id, "enabled" if new_state else "disabled")
 
-            update_payload = {"enabled": new_state}
-
-            api_request = ApiRequestV2(
-                method="put",
-                path=f"/firewall-policies/{policy_id}",
-                data=update_payload,
-            )
-            await self._connection.request(api_request)
-
-            self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_True_{self._connection.site}")
-            self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_False_{self._connection.site}")
-
-            return True
+            return await self.update_firewall_policy(policy_id, {"enabled": new_state})
         except Exception as e:
             logger.error("Error toggling firewall policy %s: %s", policy_id, e)
             raise


### PR DESCRIPTION
Fixes #221.

## Summary

`unifi_toggle_firewall_policy` was sending a partial `{"enabled": …}` payload to `PUT /firewall-policies/{id}`, which the controller rejects with a 400 because every other required field (action, ipVersion, name, source, destination, schedule) is null on the merge target. The convenience wrapper bypassed the fetch-merge-put pattern that `update_firewall_policy` already implements correctly.

## Fix

Toggle now resolves the policy, computes the new `enabled` state, and delegates to `update_firewall_policy(policy_id, {"enabled": new_state})`. The merge logic, cache invalidation, and endpoint selection all live in one code path.

```python
async def toggle_firewall_policy(self, policy_id: str) -> bool:
    policies = await self.get_firewall_policies(include_predefined=True)
    policy = next((p for p in policies
                   if isinstance(p.raw, dict) and p.raw.get("_id") == policy_id), None)
    if policy is None:
        raise UniFiNotFoundError("firewall_policy", policy_id)

    new_state = not policy.enabled
    return await self.update_firewall_policy(policy_id, {"enabled": new_state})
```

## Tests

Four new tests in `TestToggleFirewallPolicyPayload`:

- `test_put_payload_includes_all_required_fields` — locks in that every controller-required field reaches the wire (action, ip_version, name, source, destination), preventing this regression class from coming back via a different code path.
- `test_uses_single_policy_endpoint` — confirms the endpoint is `/firewall-policies/{id}`.
- `test_flips_enabled_state` — toggles a disabled policy and verifies the wire payload has `enabled: True`.
- `test_raises_when_policy_missing` — preserves the existing `UniFiNotFoundError` contract.

The previous coverage gap is the deeper issue: `update_firewall_policy` had four merge/endpoint tests; `toggle_firewall_policy` had zero. The PUT-payload assertion guards both code paths going forward.

## Live verification

Round-trip on a real disabled policy ("Block Finn's YouTube"):

```
toggle 1 (enable): True → enabled=True
toggle 2 (revert): True → enabled=False
preserved name="Block Finn's YouTube"
preserved action='BLOCK'
preserved client_macs n=4
preserved app_ids=[262256, 262447]
```

All sibling fields intact across the cycle.

## Test plan

- [x] `make core-test` (76 passed)
- [x] `make -C apps/network test` (685 passed)
- [x] Live toggle round-trip against UDM-SE controller (disable → enable → disable, all fields preserved)