### PR TITLE
fix(unifi-network): restore --python-preference flag (server fails to start)

### DIFF
--- a/plugins/unifi-network/.claude-plugin/plugin.json
+++ b/plugins/unifi-network/.claude-plugin/plugin.json
@@ -18,7 +18,7 @@
     "unifi-network": {
       "command": "uvx",
       "args": [
-        "--python-preference==0.16.0",
+        "--python-preference",
         "system",
         "unifi-network-mcp==0.15.2"
       ],


### PR DESCRIPTION
Fixes #225.

## Summary
- `plugins/unifi-network/.claude-plugin/plugin.json` has `"--python-preference==0.16.0"` in the `mcpServers` args instead of `"--python-preference"`. `uvx` rejects `=0.16.0` as the flag value (`error: invalid value '=0.16.0' for '--python-preference'`) and the MCP server never starts — Claude Code reports `Failed to reconnect to plugin:unifi-network:unifi-network`.
- One-line fix: drop the trailing `==0.16.0` so the args match the working sibling plugins (`unifi-protect`, `unifi-access`).
- Likely introduced by the version-sync bot commit `c4761c3` ("chore(plugins): sync plugin versions to current release tags"). The two sibling plugins bumped in the same bot commit were not corrupted, so this looks like a one-file regex slip rather than a systemic issue with the sync script.

## Test plan
- [x] Reproduced the failure: `uvx --python-preference==0.16.0 system unifi-network-mcp==0.15.2` → `error: invalid value '=0.16.0' for '--python-preference <PYTHON_PREFERENCE>'`.
- [x] After fix: `uvx --python-preference system unifi-network-mcp==0.15.2` boots, loads bundled config, connects to the UniFi OS controller, registers the meta-tools (`unifi_tool_index`, `unifi_execute`, `unifi_batch`, `unifi_batch_status`, `unifi_load_tools`), reports 170 lazy-loadable tools, and starts the FastMCP stdio server in ~1.7 s.
- [x] Live MCP handshake against the patched command succeeds: `initialize` returns `unifi-network-mcp v1.27.1`; `tools/list` returns the five meta-tools.
- [x] Re-installed via the Claude Code plugin loader: `mcp__plugin_unifi-network_unifi-network__*` tools register, `/mcp` shows the server connected, and `unifi_execute` returns real device data from a UDM Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)