### PR TITLE
fix(release): match package pin by name in plugin manifest bumper

### DIFF
--- a/.github/workflows/bump-plugin-versions.yml
+++ b/.github/workflows/bump-plugin-versions.yml
@@ -65,17 +65,22 @@ jobs:
           fi
 
           python3 -c "
-        import json, sys
+        import json, re, sys
         pj = sys.argv[1]
         ver = sys.argv[2]
         with open(pj) as f:
             data = json.load(f)
         data['version'] = ver
+        pkg_pin = re.compile(r'^(unifi-[a-z]+-mcp)==')
         for server in data.get('mcpServers', {}).values():
             args = server.get('args', [])
-            if args:
-                pkg = args[0].split('==')[0]
-                args[0] = f'{pkg}=={ver}'
+            for i, arg in enumerate(args):
+                m = pkg_pin.match(arg)
+                if m:
+                    args[i] = f'{m.group(1)}=={ver}'
+                    break
+            else:
+                raise SystemExit(f'{pj}: no unifi-*-mcp package pin found in args {args!r}')
         with open(pj, 'w') as f:
             json.dump(data, f, indent=2)
             f.write('\n')

--- a/plugins/unifi-network/.claude-plugin/plugin.json
+++ b/plugins/unifi-network/.claude-plugin/plugin.json
@@ -18,9 +18,9 @@
     "unifi-network": {
       "command": "uvx",
       "args": [
-        "--python-preference==0.16.0",
+        "--python-preference",
         "system",
-        "unifi-network-mcp==0.15.2"
+        "unifi-network-mcp==0.16.0"
       ],
       "env": {
         "UNIFI_HOST": "${UNIFI_NETWORK_HOST:-}",


### PR DESCRIPTION
## Summary

The version-sync workflow (`.github/workflows/bump-plugin-versions.yml`) assumed `args[0]` was the package pin. PR #222 prepended `--python-preference system` for macOS Python entitlements, shifting the package to `args[2]`. When `network/v0.16.0` was tagged, the auto-sync corrupted the published network manifest in two ways:

- `args[0]` mutated to `"--python-preference==0.16.0"` → `uvx` rejects it, MCP server fails to start (#225).
- `args[2]` left at `"unifi-network-mcp==0.15.2"` → users with the v0.16.0 plugin still get 0.15.2 code, missing the #223/#224 fixes.

`protect`/`access` weren't hit because no tag has been pushed since #222, but they would corrupt on the next release.

## Changes

- Workflow now scans `args` for the first entry matching `^unifi-[a-z]+-mcp==` and bumps that, instead of indexing `args[0]`. Raises if no pin is found, so future arg-shape changes fail loud at release time.
- Restored `plugins/unifi-network/.claude-plugin/plugin.json` `args` to `["--python-preference", "system", "unifi-network-mcp==0.16.0"]`.

## Test plan

- [x] Dry-ran the new bump logic against all three manifests at their current versions and at a synthetic next version — idempotent on no-op, bumps the correct arg.
- [x] Confirmed `uvx --python-preference system <pkg>` parses cleanly.
- [ ] Post-merge: verify `/plugin install unifi-network@unifi-plugins` connects on a fresh install (matches the repro in #225).

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)