### PR TITLE
feat: add project sponsorship page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,3 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: sirkirby
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: sirkirby
+custom:
+  - "https://unifimcp.com/sponsor/"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,13 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, including how to work with the monorepo, run tests, and submit PRs.
 
+## Support the Project
+
+UniFi MCP is maintained as an independent open-source project. Sponsorship helps cover the ongoing AI costs behind building, testing, and maintaining the project, plus live controller compatibility testing, release maintenance, documentation, and issue triage across the Network, Protect, Access, API, relay, and plugin packages.
+
+- [Sponsor on GitHub](https://github.com/sponsors/sirkirby)
+- [See what sponsorship funds](https://unifimcp.com/sponsor/)
+
 ## License
 
 [MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Complete documentation for the UniFi Network MCP Server v0.2.0.
 
 - **[Main README](../README.md)** - Project overview and installation
 - **[Quick Start](../QUICKSTART.md)** - Get started in 5 minutes
+- **[Sponsor UniFi MCP](sponsor/)** - Support maintenance, AI costs, compatibility testing, and releases
 
 ---
 
@@ -142,6 +143,7 @@ See [CLAUDE.md](../CLAUDE.md) for project development guidelines.
 ### Core Documentation (docs/)
 - [context-optimization-comparison.md](context-optimization-comparison.md) - Mode comparison
 - [tool-index.md](tool-index.md) - Tool index documentation
+- [sponsor/](sponsor/) - Sponsorship landing page
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,6 +39,10 @@
         Star on GitHub
         <span class="star-count" data-stars aria-label="GitHub stars"></span>
       </a>
+      <a href="sponsor/" class="btn btn-sponsor" aria-label="Sponsor UniFi MCP">
+        <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 14.25l-.345-.666C3.612 9.73 1 7.197 1 4.25 1 2.178 2.678.5 4.75.5 6.13.5 7.365 1.31 8 2.476 8.635 1.31 9.87.5 11.25.5 13.322.5 15 2.178 15 4.25c0 2.947-2.612 5.48-6.655 9.334L8 14.25z"/></svg>
+        <span>Sponsor</span>
+      </a>
       <a href="#install" class="btn btn-primary">
         Get started
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
@@ -811,6 +815,7 @@ pipx install <span class="s">unifi-access-mcp</span>
           <li><a href="https://github.com/sirkirby/unifi-mcp">GitHub</a></li>
           <li><a href="https://github.com/sirkirby/unifi-mcp/tree/main/docs">Docs</a></li>
           <li><a href="https://github.com/sirkirby/unifi-mcp/blob/main/CONTRIBUTING.md">Contributing</a></li>
+          <li><a href="sponsor/">Sponsor</a></li>
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </div>
@@ -819,7 +824,7 @@ pipx install <span class="s">unifi-access-mcp</span>
         <ul>
           <li><a href="https://github.com/sirkirby/unifi-mcp/issues">Issues</a></li>
           <li><a href="https://github.com/sirkirby/unifi-mcp/discussions">Discussions</a></li>
-          <li><a href="https://buymeacoffee.com/sirkirby">Buy me a coffee</a></li>
+          <li><a href="https://github.com/sponsors/sirkirby">GitHub Sponsors</a></li>
         </ul>
       </div>
     </div>

--- a/docs/sponsor/index.html
+++ b/docs/sponsor/index.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sponsor UniFi MCP — fund compatibility testing, AI costs, and releases</title>
+<meta name="description" content="Sponsor UniFi MCP to fund AI-assisted development costs, live UniFi controller compatibility testing, release maintenance, docs, and issue triage.">
+<meta name="theme-color" content="#070a14">
+<link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <a href="../" class="brand" aria-label="UniFi MCP home">
+      <span class="brand-mark">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M2 8 L6 4 L10 8 L6 12 Z"/><path d="M14 8 L10 4 M14 8 L10 12"/>
+        </svg>
+      </span>
+      <span>UniFi MCP</span>
+    </a>
+    <div class="nav-links">
+      <a href="../#servers">Servers</a>
+      <a href="../#examples">Ask the agent</a>
+      <a href="../#relay">Cloud Relay</a>
+      <a href="../#skills">Skills</a>
+      <a href="../#install">Install</a>
+      <a href="https://github.com/sirkirby/unifi-mcp">GitHub</a>
+    </div>
+    <div class="nav-cta">
+      <a href="https://github.com/sponsors/sirkirby" class="btn btn-primary">
+        Sponsor
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+      </a>
+    </div>
+  </div>
+</nav>
+
+<main>
+  <section class="sponsor-hero">
+    <div class="shell">
+      <div class="sponsor-grid">
+        <div class="sponsor-copy">
+          <span class="eyebrow"><span class="dot"></span>Sustain the project</span>
+          <h1>Keep UniFi MCP <span class="accent">reliable for real deployments.</span></h1>
+          <p class="lead">
+            UniFi MCP is an independent open-source project that gives AI agents safe, structured access to UniFi Network, Protect, and Access controllers. Sponsorship funds the work that keeps it useful as UniFi firmware, MCP clients, Python packages, agent tooling, and controller APIs keep moving.
+          </p>
+          <div class="hero-ctas">
+            <a href="https://github.com/sponsors/sirkirby" class="btn btn-primary btn-lg">
+              Sponsor on GitHub
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+            </a>
+            <a href="#tiers" class="btn btn-ghost btn-lg">
+              View support options
+            </a>
+          </div>
+          <div class="hero-meta">
+            <span class="pill">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 1l6 3v4c0 4-3 6.5-6 7-3-.5-6-3-6-7V4l6-3z"/></svg>
+              independent · MIT
+            </span>
+            <span class="pill">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="6"/><path d="M8 5v3l2 2"/></svg>
+              release maintenance
+            </span>
+            <span class="pill">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h12v8H2z"/><path d="M5 8h6"/></svg>
+              live controller testing
+            </span>
+          </div>
+        </div>
+
+        <aside class="sponsor-panel">
+          <h2>What sponsors fund</h2>
+          <p>Recurring sponsorship turns maintenance from spare-time reaction into planned project work.</p>
+          <ul class="sponsor-list">
+            <li>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 4L6 11 3 8"/></svg>
+              <span>AI model and agent costs used to build, test, document, review, and maintain the project.</span>
+            </li>
+            <li>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 4L6 11 3 8"/></svg>
+              <span>Live compatibility checks against real UniFi controllers, firmware versions, and hardware classes.</span>
+            </li>
+            <li>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 4L6 11 3 8"/></svg>
+              <span>Release maintenance across PyPI packages, Docker images, Claude Code plugins, and the Cloudflare relay.</span>
+            </li>
+            <li>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 4L6 11 3 8"/></svg>
+              <span>Docs, examples, issue triage, security hardening, and safe mutation patterns.</span>
+            </li>
+          </ul>
+          <div class="sponsor-actions">
+            <a href="https://github.com/sponsors/sirkirby" class="btn btn-primary">GitHub Sponsors</a>
+            <a href="https://github.com/sirkirby/unifi-mcp/discussions" class="btn btn-ghost">Discuss roadmap</a>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </section>
+
+  <section class="block" id="tiers">
+    <div class="shell">
+      <div class="section-head">
+        <span class="eyebrow"><span class="dot"></span>Maintenance budget</span>
+        <h2>The work behind a reliable agent-to-controller bridge.</h2>
+        <p>Sponsorship is not a feature bounty system. It funds the unglamorous maintenance work that keeps a local-first UniFi automation stack dependable.</p>
+      </div>
+      <div class="funding-grid">
+        <article class="funding-card">
+          <div class="num">01</div>
+          <h3>AI operating costs</h3>
+          <p>Model usage for development, code review, compatibility research, test generation, release notes, and documentation.</p>
+        </article>
+        <article class="funding-card">
+          <div class="num">02</div>
+          <h3>Controller reality checks</h3>
+          <p>Real-device probes catch UniFi field names, endpoint behavior, permission gaps, and firmware changes before users find them.</p>
+        </article>
+        <article class="funding-card">
+          <div class="num">03</div>
+          <h3>Release work</h3>
+          <p>Versioning, changelogs, manifests, plugin packaging, Docker images, PyPI publishing, npm relay updates, and regression checks.</p>
+        </article>
+        <article class="funding-card">
+          <div class="num">04</div>
+          <h3>Community support</h3>
+          <p>Issue triage, setup guidance, docs, examples, and patterns that keep controller-changing tools safe by default.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="shell">
+      <div class="section-head">
+        <span class="eyebrow"><span class="dot"></span>Simple options</span>
+        <h2>Pick the level that matches how much UniFi MCP saves you.</h2>
+        <p>A small set of tiers keeps the ask clear. GitHub Sponsors also supports custom monthly and one-time amounts if these do not fit.</p>
+      </div>
+      <div class="tier-grid">
+        <article class="tier-card">
+          <div class="price">$5 <small>/ month</small></div>
+          <h3>Supporter</h3>
+          <p>For users who want the project to keep shipping fixes, docs, and compatibility updates.</p>
+        </article>
+        <article class="tier-card featured">
+          <div class="price">$15 <small>/ month</small></div>
+          <h3>Power user</h3>
+          <p>Helps cover recurring AI maintenance costs and live compatibility checks across the active server packages.</p>
+        </article>
+        <article class="tier-card">
+          <div class="price">$50 <small>/ month</small></div>
+          <h3>MSP / team backer</h3>
+          <p>For teams, homelab power users, and MSPs relying on UniFi MCP in repeatable workflows.</p>
+        </article>
+        <article class="tier-card">
+          <div class="price">$25+ <small>one time</small></div>
+          <h3>Thank-you contribution</h3>
+          <p>A direct way to support a release, bug fix, compatibility update, or doc improvement that helped your setup.</p>
+        </article>
+      </div>
+      <p class="tier-note">Want to make a larger one-time contribution, sponsor as a company, or fund a specific compatibility push? Use a custom amount on <a href="https://github.com/sponsors/sirkirby">GitHub Sponsors</a> or start a roadmap discussion first.</p>
+    </div>
+  </section>
+
+  <section class="block">
+    <div class="shell">
+      <div class="section-head">
+        <span class="eyebrow"><span class="dot"></span>Boundaries</span>
+        <h2>What sponsorship does and does not change.</h2>
+        <p>The project stays open, local-first, safety-minded, and independent.</p>
+      </div>
+      <div class="principles">
+        <article class="principle">
+          <h3>No paywall</h3>
+          <p>Core packages, plugins, docs, and safety patterns remain open source under the MIT license.</p>
+        </article>
+        <article class="principle">
+          <h3>No unsafe shortcuts</h3>
+          <p>Sponsorship does not bypass preview-then-confirm mutations, permission gates, or compatibility checks.</p>
+        </article>
+        <article class="principle">
+          <h3>No guaranteed feature queue</h3>
+          <p>Sponsors help sustain the project, but roadmap decisions still follow user impact, safety, and maintainability.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="block" style="padding-top: 40px;">
+    <div class="shell">
+      <div class="cta-card">
+        <h2>Help keep UniFi MCP maintained.</h2>
+        <p>Recurring sponsorship is the strongest signal that this project should keep getting real maintenance time, AI-assisted development budget, and controller compatibility testing.</p>
+        <div class="cta-ctas">
+          <a href="https://github.com/sponsors/sirkirby" class="btn btn-primary btn-lg">
+            Sponsor on GitHub
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+          </a>
+          <a href="#tiers" class="btn btn-ghost btn-lg">View support options</a>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="shell">
+    <div class="footer-grid">
+      <div class="foot-brand">
+        <div class="brand">
+          <span class="brand-mark">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8 L6 4 L10 8 L6 12 Z"/><path d="M14 8 L10 4 M14 8 L10 12"/></svg>
+          </span>
+          <span>UniFi MCP</span>
+        </div>
+        <p>An open-source toolkit for giving AI agents safe, structured access to UniFi controllers. Independent project · MIT license.</p>
+      </div>
+      <div class="foot-col">
+        <h5>Servers</h5>
+        <ul>
+          <li><a href="https://pypi.org/project/unifi-network-mcp/">Network on PyPI</a></li>
+          <li><a href="https://pypi.org/project/unifi-protect-mcp/">Protect on PyPI</a></li>
+          <li><a href="https://pypi.org/project/unifi-access-mcp/">Access on PyPI</a></li>
+          <li><a href="https://pypi.org/project/unifi-mcp-relay/">Cloud Relay</a></li>
+        </ul>
+      </div>
+      <div class="foot-col">
+        <h5>Project</h5>
+        <ul>
+          <li><a href="../">Home</a></li>
+          <li><a href="https://github.com/sirkirby/unifi-mcp">GitHub</a></li>
+          <li><a href="https://github.com/sirkirby/unifi-mcp/tree/main/docs">Docs</a></li>
+          <li><a href="../privacy.html">Privacy</a></li>
+        </ul>
+      </div>
+      <div class="foot-col">
+        <h5>Support</h5>
+        <ul>
+          <li><a href="https://github.com/sponsors/sirkirby">GitHub Sponsors</a></li>
+          <li><a href="https://github.com/sirkirby/unifi-mcp/discussions">Discussions</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>MIT License · © 2025–2026 contributors</span>
+      <span>Not affiliated with Ubiquiti Inc. UniFi is a trademark of its respective owner.</span>
+    </div>
+  </div>
+</footer>
+
+<script src="../app.js" defer></script>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -177,6 +177,17 @@ h1, h2, h3, h4 { font-family: var(--ff-display); letter-spacing: -0.02em; line-h
   border: 1px solid var(--line-2);
 }
 .btn-ghost:hover { color: var(--fg); border-color: var(--line-bright); }
+.btn-sponsor {
+  color: var(--fg-2);
+  border: 1px solid rgba(255,107,138,.30);
+  background: rgba(255,107,138,.05);
+}
+.btn-sponsor svg { color: var(--rose); }
+.btn-sponsor:hover {
+  color: var(--fg);
+  border-color: rgba(255,107,138,.55);
+  background: rgba(255,107,138,.08);
+}
 .btn-primary {
   background: linear-gradient(180deg, var(--cyan) 0%, var(--cyan-2) 100%);
   color: #042418;
@@ -709,6 +720,180 @@ section.block + section.block { padding-top: 0; }
 }
 .pillar-icon svg { width: 20px; height: 20px; }
 
+/* ============== Sponsorship ============== */
+.sponsor-hero {
+  padding: 88px 0 48px;
+}
+.sponsor-grid {
+  display: grid;
+  grid-template-columns: 1.05fr .95fr;
+  gap: 56px;
+  align-items: start;
+}
+.sponsor-copy h1 {
+  font-size: clamp(44px, 5.6vw, 72px);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.02;
+  margin: 22px 0;
+  max-width: 820px;
+}
+.sponsor-copy h1 .accent {
+  background: linear-gradient(120deg, var(--cyan) 0%, #6affd9 40%, var(--blue) 100%);
+  -webkit-background-clip: text; background-clip: text;
+  color: transparent;
+}
+.sponsor-copy .lead {
+  font-size: 19px;
+  color: var(--fg-2);
+  max-width: 680px;
+  margin-bottom: 28px;
+}
+.sponsor-panel {
+  background: linear-gradient(180deg, #0d1424, #08101e);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 30px;
+  position: relative;
+  overflow: hidden;
+}
+.sponsor-panel::before {
+  content: "";
+  position: absolute; inset: 0;
+  background: radial-gradient(460px 220px at 50% 0%, rgba(79,240,208,.12), transparent 70%);
+  pointer-events: none;
+}
+.sponsor-panel > * { position: relative; }
+.sponsor-panel h2 {
+  font-size: 30px;
+  margin-bottom: 12px;
+}
+.sponsor-panel p {
+  color: var(--fg-2);
+  font-size: 15px;
+  margin-bottom: 20px;
+}
+.sponsor-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+.sponsor-list li {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  color: var(--fg-2);
+  font-size: 14px;
+}
+.sponsor-list svg {
+  width: 18px;
+  height: 18px;
+  color: var(--cyan);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.sponsor-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.funding-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.funding-card {
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 24px;
+}
+.funding-card .num {
+  font-family: var(--ff-display);
+  color: var(--cyan);
+  font-weight: 700;
+  font-size: 18px;
+  margin-bottom: 12px;
+}
+.funding-card h3 {
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+.funding-card p {
+  color: var(--fg-3);
+  font-size: 14px;
+}
+.tier-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.tier-card {
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 24px;
+  min-height: 190px;
+}
+.tier-card.featured {
+  border-color: rgba(79,240,208,.45);
+  box-shadow: var(--glow-cyan);
+}
+.tier-card .price {
+  font-family: var(--ff-display);
+  font-size: 34px;
+  line-height: 1;
+  font-weight: 700;
+  color: var(--fg);
+  margin-bottom: 12px;
+}
+.tier-card .price small {
+  font-size: 14px;
+  color: var(--fg-4);
+  font-weight: 500;
+}
+.tier-card h3 {
+  font-size: 19px;
+  margin-bottom: 10px;
+}
+.tier-card p {
+  color: var(--fg-3);
+  font-size: 14px;
+}
+.tier-note {
+  margin-top: 18px;
+  color: var(--fg-3);
+  font-size: 14px;
+  max-width: 760px;
+}
+.tier-note a {
+  color: var(--cyan);
+  font-weight: 600;
+}
+.principles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.principle {
+  background: var(--bg-2);
+  padding: 28px;
+}
+.principle h3 {
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+.principle p {
+  color: var(--fg-3);
+  font-size: 14px;
+}
+
 /* ============== FAQ ============== */
 .faq { display: flex; flex-direction: column; gap: 0; }
 .faq-item {
@@ -836,6 +1021,7 @@ footer.footer {
   .relay-card { grid-template-columns: 1fr; padding: 28px; }
   .asks-grid, .skills-grid, .install-meta { grid-template-columns: 1fr; }
   .pillars { grid-template-columns: 1fr; }
+  .sponsor-grid, .funding-grid, .tier-grid, .principles { grid-template-columns: 1fr; }
   .footer-grid { grid-template-columns: 1fr 1fr; }
   .nav-links { display: none; }
   .nav-cta .btn-ghost { display: none; }
@@ -845,6 +1031,8 @@ footer.footer {
   .stats { grid-template-columns: 1fr 1fr; }
   .stat { padding: 20px; }
   .stat .num { font-size: 32px; }
+  .btn-sponsor span { display: none; }
+  .btn-sponsor { padding: 10px 12px; }
   section.block { padding: 60px 0; }
   .cta-card { padding: 36px 24px; }
 }


### PR DESCRIPTION
## Summary

This adds a project-specific sponsorship path for UniFi MCP now that GitHub Sponsors is live. GitHub Sponsors becomes the single funding platform, while the docs site explains that sponsorship funds AI-assisted maintenance costs, live controller compatibility testing, release work, documentation, and issue triage.

## Changes

- Replace the repo funding metadata with GitHub Sponsors plus the project sponsor landing page.
- Add a sponsor landing page under the existing published docs site at `/sponsor/`.
- Add a subtle heart-style Sponsor button to the docs header while keeping Get started as the primary action.
- Link the support page from README/docs surfaces and remove Buy Me a Coffee from project funding paths.
- Keep larger one-time or company support available through GitHub Sponsors custom amounts without featuring large tiers.

## Verification

- Parsed `docs/index.html` and `docs/sponsor/index.html` with Python's HTML parser.
- Served the docs site locally and verified `/` and `/sponsor/` return 200.
- Checked local HTML links for missing relative targets.
- Verified no remaining Buy Me a Coffee references in the project sponsor surfaces.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT 5](https://img.shields.io/badge/GPT_5-000000)