### PR TITLE
feat: track sponsor tier link intent

### DIFF
--- a/docs/sponsor/index.html
+++ b/docs/sponsor/index.html
@@ -143,31 +143,31 @@
       <div class="section-head">
         <span class="eyebrow"><span class="dot"></span>Simple options</span>
         <h2>Pick the level that matches how much UniFi MCP saves you.</h2>
-        <p>A small set of tiers keeps the ask clear. GitHub Sponsors also supports custom monthly and one-time amounts if these do not fit.</p>
+        <p>A small set of tiers keeps the ask clear. These links carry project and tier metadata for sponsorship exports; GitHub will still ask you to choose or confirm the matching tier.</p>
       </div>
       <div class="tier-grid">
-        <article class="tier-card">
+        <a class="tier-card" href="https://github.com/sponsors/sirkirby?metadata_project=unifi_mcp&metadata_tier=monthly_5">
           <div class="price">$5 <small>/ month</small></div>
           <h3>Supporter</h3>
           <p>For users who want the project to keep shipping fixes, docs, and compatibility updates.</p>
-        </article>
-        <article class="tier-card featured">
+        </a>
+        <a class="tier-card featured" href="https://github.com/sponsors/sirkirby?metadata_project=unifi_mcp&metadata_tier=monthly_15">
           <div class="price">$15 <small>/ month</small></div>
           <h3>Power user</h3>
           <p>Helps cover recurring AI maintenance costs and live compatibility checks across the active server packages.</p>
-        </article>
-        <article class="tier-card">
+        </a>
+        <a class="tier-card" href="https://github.com/sponsors/sirkirby?metadata_project=unifi_mcp&metadata_tier=monthly_50">
           <div class="price">$50 <small>/ month</small></div>
           <h3>MSP / team backer</h3>
           <p>For teams, homelab power users, and MSPs relying on UniFi MCP in repeatable workflows.</p>
-        </article>
-        <article class="tier-card">
+        </a>
+        <a class="tier-card" href="https://github.com/sponsors/sirkirby?metadata_project=unifi_mcp&metadata_tier=custom">
           <div class="price">$25+ <small>one time</small></div>
           <h3>Thank-you contribution</h3>
           <p>A direct way to support a release, bug fix, compatibility update, or doc improvement that helped your setup.</p>
-        </article>
+        </a>
       </div>
-      <p class="tier-note">Want to make a larger one-time contribution, sponsor as a company, or fund a specific compatibility push? Use a custom amount on <a href="https://github.com/sponsors/sirkirby">GitHub Sponsors</a> or start a roadmap discussion first.</p>
+      <p class="tier-note">Want to make a larger one-time contribution, sponsor as a company, or fund a specific compatibility push? Use a custom amount on <a href="https://github.com/sponsors/sirkirby?metadata_project=unifi_mcp&metadata_tier=custom">GitHub Sponsors</a> or start a roadmap discussion first.</p>
     </div>
   </section>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -831,11 +831,19 @@ section.block + section.block { padding-top: 0; }
   gap: 16px;
 }
 .tier-card {
+  display: block;
   background: var(--bg-2);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 24px;
   min-height: 190px;
+  color: inherit;
+  transition: border-color .2s, transform .2s, background .2s;
+}
+.tier-card:hover {
+  background: var(--bg-3);
+  border-color: var(--line-bright);
+  transform: translateY(-2px);
 }
 .tier-card.featured {
   border-color: rgba(79,240,208,.45);


### PR DESCRIPTION
## Summary

This makes the UniFi MCP sponsor page tier cards clickable and adds GitHub Sponsors metadata to each tier link. GitHub still owns tier selection and checkout, but the exported sponsorship metadata can now show which project and tier intent a sponsor started from.

## Changes

- Convert the visible sponsor tiers into full-card links.
- Add `metadata_project=unifi_mcp` plus `metadata_tier` values for the listed monthly and custom support options.
- Preserve the existing low-pressure sponsor page layout while adding hover affordance for clickable cards.

## Verification

- `git diff --check -- docs/sponsor/index.html docs/styles.css`
- Parsed `docs/sponsor/index.html` with Python's HTML parser.
- Served `/sponsor/` locally and verified the metadata links are present.
- Checked relative links in the docs pages.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT 5](https://img.shields.io/badge/GPT_5-000000)