### PR TITLE
feat: enrich Protect face events

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -607,6 +607,10 @@ type Event {
   smartDetectTypes: [String!]!
   camera: ID
   thumbnail: ID
+  recognizedPersonId: ID
+  recognizedPersonName: String
+  recognizedPersonConfidence: Int
+  detectedThumbnailId: ID
 }
 
 """A curated event-log entry."""
@@ -1527,6 +1531,10 @@ type SmartDetection {
   smartDetectTypes: [String!]!
   camera: ID
   thumbnail: ID
+  recognizedPersonId: ID
+  recognizedPersonName: String
+  recognizedPersonConfidence: Int
+  detectedThumbnailId: ID
 }
 
 """Paginated page of UniFi Protect smart-detections."""

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2087,6 +2087,17 @@
             ],
             "title": "Camera"
           },
+          "detected_thumbnail_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detected Thumbnail Id"
+          },
           "end": {
             "anyOf": [
               {
@@ -2108,6 +2119,39 @@
               }
             ],
             "title": "Id"
+          },
+          "recognized_person_confidence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Person Confidence"
+          },
+          "recognized_person_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Person Id"
+          },
+          "recognized_person_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Person Name"
           },
           "score": {
             "anyOf": [

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -596,6 +596,10 @@ type Event {
   smartDetectTypes: [String!]!
   camera: ID
   thumbnail: ID
+  recognizedPersonId: ID
+  recognizedPersonName: String
+  recognizedPersonConfidence: Int
+  detectedThumbnailId: ID
 }
 
 """A curated event-log entry."""
@@ -1516,6 +1520,10 @@ type SmartDetection {
   smartDetectTypes: [String!]!
   camera: ID
   thumbnail: ID
+  recognizedPersonId: ID
+  recognizedPersonName: String
+  recognizedPersonConfidence: Int
+  detectedThumbnailId: ID
 }
 
 """Paginated page of UniFi Protect smart-detections."""

--- a/apps/api/src/unifi_api/graphql/types/protect/events.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/events.py
@@ -61,6 +61,10 @@ class Event:
     smart_detect_types: list[str]
     camera: strawberry.ID | None
     thumbnail: strawberry.ID | None
+    recognized_person_id: strawberry.ID | None
+    recognized_person_name: str | None
+    recognized_person_confidence: int | None
+    detected_thumbnail_id: strawberry.ID | None
 
     # Context for relationship edges — NOT in SDL, NOT in to_dict().
     _controller_id: strawberry.Private[str | None] = None
@@ -85,6 +89,10 @@ class Event:
             smart_detect_types=_get(obj, "smart_detect_types") or [],
             camera=_get(obj, "camera_id"),
             thumbnail=_get(obj, "thumbnail_id"),
+            recognized_person_id=_get(obj, "recognized_person_id"),
+            recognized_person_name=_get(obj, "recognized_person_name"),
+            recognized_person_confidence=_get(obj, "recognized_person_confidence"),
+            detected_thumbnail_id=_get(obj, "detected_thumbnail_id"),
         )
 
     def to_dict(self) -> dict:
@@ -97,6 +105,10 @@ class Event:
             "smart_detect_types": list(self.smart_detect_types),
             "camera": self.camera,
             "thumbnail": self.thumbnail,
+            "recognized_person_id": self.recognized_person_id,
+            "recognized_person_name": self.recognized_person_name,
+            "recognized_person_confidence": self.recognized_person_confidence,
+            "detected_thumbnail_id": self.detected_thumbnail_id,
         }
 
 
@@ -115,13 +127,17 @@ class SmartDetection:
     smart_detect_types: list[str]
     camera: strawberry.ID | None
     thumbnail: strawberry.ID | None
+    recognized_person_id: strawberry.ID | None
+    recognized_person_name: str | None
+    recognized_person_confidence: int | None
+    detected_thumbnail_id: strawberry.ID | None
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
         return {
             "kind": kind,
             "primary_key": "id",
-            "display_columns": ["type", "start", "score", "smart_detect_types"],
+            "display_columns": ["type", "start", "score", "smart_detect_types", "recognized_person_name"],
             "sort_default": "start:desc",
         }
 
@@ -136,6 +152,10 @@ class SmartDetection:
             smart_detect_types=_get(obj, "smart_detect_types") or [],
             camera=_get(obj, "camera_id"),
             thumbnail=_get(obj, "thumbnail_id"),
+            recognized_person_id=_get(obj, "recognized_person_id"),
+            recognized_person_name=_get(obj, "recognized_person_name"),
+            recognized_person_confidence=_get(obj, "recognized_person_confidence"),
+            detected_thumbnail_id=_get(obj, "detected_thumbnail_id"),
         )
 
     def to_dict(self) -> dict:
@@ -148,6 +168,10 @@ class SmartDetection:
             "smart_detect_types": list(self.smart_detect_types),
             "camera": self.camera,
             "thumbnail": self.thumbnail,
+            "recognized_person_id": self.recognized_person_id,
+            "recognized_person_name": self.recognized_person_name,
+            "recognized_person_confidence": self.recognized_person_confidence,
+            "detected_thumbnail_id": self.detected_thumbnail_id,
         }
 
 

--- a/apps/api/tests/graphql/fixtures/protect/test_events.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_events.py
@@ -19,59 +19,96 @@ from tests.graphql.fixtures._helpers import bootstrap, graphql_query, stub_manag
 async def test_protect_events_list(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")
-    stub_managers(monkeypatch, {
-        ("protect", "event_manager", "list_events"): [
-            {"id": "evt1", "type": "motion", "camera_id": "cam1", "start": 1000},
-            {"id": "evt2", "type": "person", "camera_id": "cam1", "start": 2000},
-        ],
-    })
-    body = await graphql_query(app, key, f'''{{
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "list_events"): [
+                {
+                    "id": "evt1",
+                    "type": "motion",
+                    "camera_id": "cam1",
+                    "start": 1000,
+                    "recognized_person_name": "Assigned Person",
+                },
+                {"id": "evt2", "type": "person", "camera_id": "cam1", "start": 2000},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
         protect {{ events(controller: "{cid}", limit: 10) {{
-            items {{ id type }}
+            items {{ id type recognizedPersonName }}
         }} }}
-    }}''')
+    }}''',
+    )
     assert body.get("errors") is None, body
     items = body["data"]["protect"]["events"]["items"]
     assert len(items) == 2
     assert {it["id"] for it in items} == {"evt1", "evt2"}
+    assert next(it for it in items if it["id"] == "evt1")["recognizedPersonName"] == "Assigned Person"
 
 
 @pytest.mark.asyncio
 async def test_protect_event_detail(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")
-    stub_managers(monkeypatch, {
-        ("protect", "event_manager", "list_events"): [
-            {"id": "evt1", "type": "motion", "camera_id": "cam1", "start": 1000},
-        ],
-    })
-    body = await graphql_query(app, key, f'''{{
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "list_events"): [
+                {
+                    "id": "evt1",
+                    "type": "motion",
+                    "camera_id": "cam1",
+                    "start": 1000,
+                    "recognized_person_id": "face-group-1",
+                    "recognized_person_name": "Assigned Person",
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
         protect {{ event(controller: "{cid}", id: "evt1") {{
-            id type
+            id type recognizedPersonId recognizedPersonName
         }} }}
-    }}''')
+    }}''',
+    )
     assert body.get("errors") is None, body
     assert body["data"]["protect"]["event"]["id"] == "evt1"
     assert body["data"]["protect"]["event"]["type"] == "motion"
+    assert body["data"]["protect"]["event"]["recognizedPersonId"] == "face-group-1"
+    assert body["data"]["protect"]["event"]["recognizedPersonName"] == "Assigned Person"
 
 
 @pytest.mark.asyncio
 async def test_protect_event_thumbnail(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")
-    stub_managers(monkeypatch, {
-        ("protect", "event_manager", "get_event_thumbnail"): {
-            "event_id": "evt1",
-            "thumbnail_id": "thumb1",
-            "thumbnail_available": True,
-            "content_type": "image/jpeg",
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "get_event_thumbnail"): {
+                "event_id": "evt1",
+                "thumbnail_id": "thumb1",
+                "thumbnail_available": True,
+                "content_type": "image/jpeg",
+            },
         },
-    })
-    body = await graphql_query(app, key, f'''{{
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
         protect {{ eventThumbnail(controller: "{cid}", eventId: "evt1") {{
             eventId thumbnailAvailable contentType
         }} }}
-    }}''')
+    }}''',
+    )
     assert body.get("errors") is None, body
     assert body["data"]["protect"]["eventThumbnail"]["eventId"] == "evt1"
     assert body["data"]["protect"]["eventThumbnail"]["thumbnailAvailable"] is True
@@ -81,41 +118,63 @@ async def test_protect_event_thumbnail(tmp_path, monkeypatch):
 async def test_protect_smart_detections_list(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")
-    stub_managers(monkeypatch, {
-        ("protect", "event_manager", "list_smart_detections"): [
-            {"id": "sd1", "type": "person", "camera_id": "cam1", "start": 1000, "score": 90},
-            {"id": "sd2", "type": "vehicle", "camera_id": "cam1", "start": 2000, "score": 75},
-        ],
-    })
-    body = await graphql_query(app, key, f'''{{
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "list_smart_detections"): [
+                {
+                    "id": "sd1",
+                    "type": "face",
+                    "camera_id": "cam1",
+                    "start": 1000,
+                    "score": 90,
+                    "recognized_person_name": "Assigned Person",
+                },
+                {"id": "sd2", "type": "vehicle", "camera_id": "cam1", "start": 2000, "score": 75},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
         protect {{ smartDetections(controller: "{cid}", limit: 10) {{
-            items {{ id type score }}
+            items {{ id type score recognizedPersonName }}
         }} }}
-    }}''')
+    }}''',
+    )
     assert body.get("errors") is None, body
     items = body["data"]["protect"]["smartDetections"]["items"]
     assert len(items) == 2
     assert {it["id"] for it in items} == {"sd1", "sd2"}
+    assert next(it for it in items if it["id"] == "sd1")["recognizedPersonName"] == "Assigned Person"
 
 
 @pytest.mark.asyncio
 async def test_protect_alarm_status(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")
-    stub_managers(monkeypatch, {
-        ("protect", "alarm_manager", "get_arm_state"): {
-            "armed": True,
-            "status": "armed_away",
-            "active_profile_id": "prof1",
-            "active_profile_name": "Away",
-            "profile_count": 2,
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "alarm_manager", "get_arm_state"): {
+                "armed": True,
+                "status": "armed_away",
+                "active_profile_id": "prof1",
+                "active_profile_name": "Away",
+                "profile_count": 2,
+            },
         },
-    })
-    body = await graphql_query(app, key, f'''{{
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
         protect {{ alarmStatus(controller: "{cid}") {{
             armed status activeProfileName
         }} }}
-    }}''')
+    }}''',
+    )
     assert body.get("errors") is None, body
     result = body["data"]["protect"]["alarmStatus"]
     assert result["armed"] is True
@@ -127,20 +186,27 @@ async def test_protect_alarm_status(tmp_path, monkeypatch):
 async def test_protect_alarm_list_profiles(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")
-    stub_managers(monkeypatch, {
-        ("protect", "alarm_manager", "list_arm_profiles"): {
-            "profiles": [
-                {"id": "prof1", "name": "Away"},
-                {"id": "prof2", "name": "Home"},
-            ],
-            "count": 2,
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "alarm_manager", "list_arm_profiles"): {
+                "profiles": [
+                    {"id": "prof1", "name": "Away"},
+                    {"id": "prof2", "name": "Home"},
+                ],
+                "count": 2,
+            },
         },
-    })
-    body = await graphql_query(app, key, f'''{{
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
         protect {{ alarmProfiles(controller: "{cid}") {{
             count
         }} }}
-    }}''')
+    }}''',
+    )
     assert body.get("errors") is None, body
     result = body["data"]["protect"]["alarmProfiles"]
     assert result["count"] == 2

--- a/apps/api/tests/routes/resources/test_protect_events_system.py
+++ b/apps/api/tests/routes/resources/test_protect_events_system.py
@@ -8,19 +8,17 @@ Covers 9 endpoint families across 4 route modules:
   /protect/health, /protect/system-info, /viewers
 """
 
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 from httpx import ASGITransport, AsyncClient
-
-from unifi_core.exceptions import UniFiNotFoundError
-
 from unifi_api.auth.api_key import generate_key, hash_key
 from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
 from unifi_api.db.models import ApiKey, Base, Controller
 from unifi_api.server import create_app
+from unifi_core.exceptions import UniFiNotFoundError
 
 
 def _cfg(tmp_path):
@@ -40,17 +38,29 @@ async def _bootstrap(tmp_path, products="protect"):
     cid = str(uuid.uuid4())
     material = generate_key()
     async with sm() as session:
-        session.add(ApiKey(
-            id=str(uuid.uuid4()), prefix=material.prefix,
-            hash=hash_key(material.plaintext), scopes="read",
-            name="t", created_at=datetime.now(timezone.utc),
-        ))
-        session.add(Controller(
-            id=cid, name="P", base_url="https://x", product_kinds=products,
-            credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
-            verify_tls=False, is_default=True,
-            created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
-        ))
+        session.add(
+            ApiKey(
+                id=str(uuid.uuid4()),
+                prefix=material.prefix,
+                hash=hash_key(material.plaintext),
+                scopes="read",
+                name="t",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        session.add(
+            Controller(
+                id=cid,
+                name="P",
+                base_url="https://x",
+                product_kinds=products,
+                credentials_blob=cipher.encrypt(b'{"username":"u","password":"p","api_token":null}'),
+                verify_tls=False,
+                is_default=True,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
         await session.commit()
     return app, material.plaintext, cid
 
@@ -87,6 +97,8 @@ async def test_list_smart_detections_happy_path(tmp_path, monkeypatch) -> None:
             "score": 90,
             "smart_detect_types": ["person"],
             "camera_id": "cam-1",
+            "recognized_person_id": "face-group-1",
+            "recognized_person_name": "Assigned Person",
         }
         for i in range(3)
     ]
@@ -95,6 +107,7 @@ async def test_list_smart_detections_happy_path(tmp_path, monkeypatch) -> None:
         return fake_events
 
     from unifi_core.protect.managers.event_manager import EventManager
+
     monkeypatch.setattr(EventManager, "list_smart_detections", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -105,6 +118,7 @@ async def test_list_smart_detections_happy_path(tmp_path, monkeypatch) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert len(body["items"]) == 3
+    assert body["items"][0]["recognized_person_name"] == "Assigned Person"
     assert body["render_hint"]["kind"] == "event_log"
 
 
@@ -120,9 +134,13 @@ async def test_recent_events_happy_path(tmp_path, monkeypatch) -> None:
     _stub_connection(app, cid)
 
     def fake_buffer(self, *a, **kw):
-        return [{"id": "ev-1", "type": "motion"}, {"id": "ev-2", "type": "ring"}]
+        return [
+            {"id": "ev-1", "type": "motion", "recognized_person_name": "Assigned Person"},
+            {"id": "ev-2", "type": "ring"},
+        ]
 
     from unifi_core.protect.managers.event_manager import EventManager
+
     monkeypatch.setattr(EventManager, "get_recent_from_buffer", fake_buffer)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -135,6 +153,7 @@ async def test_recent_events_happy_path(tmp_path, monkeypatch) -> None:
     assert body["render_hint"]["kind"] == "detail"
     assert body["data"]["count"] == 2
     assert len(body["data"]["events"]) == 2
+    assert body["data"]["events"][0]["recognized_person_name"] == "Assigned Person"
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +174,10 @@ async def test_get_event_happy_path(tmp_path, monkeypatch) -> None:
         "end": 1700000010,
         "camera_id": "cam-1",
         "score": 88,
+        "recognized_person_id": "face-group-1",
+        "recognized_person_name": "Assigned Person",
+        "recognized_person_confidence": 94,
+        "detected_thumbnail_id": "crop-1",
     }
 
     async def fake(self, event_id):
@@ -162,6 +185,7 @@ async def test_get_event_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.event_manager import EventManager
+
     monkeypatch.setattr(EventManager, "get_event", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -172,6 +196,7 @@ async def test_get_event_happy_path(tmp_path, monkeypatch) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["data"]["id"] == "ev-1"
+    assert body["data"]["recognized_person_name"] == "Assigned Person"
     assert body["render_hint"]["kind"] == "detail"
 
 
@@ -185,6 +210,7 @@ async def test_get_event_404_via_unifi_not_found(tmp_path, monkeypatch) -> None:
         raise UniFiNotFoundError("event", event_id)
 
     from unifi_core.protect.managers.event_manager import EventManager
+
     monkeypatch.setattr(EventManager, "get_event", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -213,6 +239,7 @@ async def test_get_event_thumbnail_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.event_manager import EventManager
+
     monkeypatch.setattr(EventManager, "get_event_thumbnail", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -254,6 +281,7 @@ async def test_get_recording_status_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.recording_manager import RecordingManager
+
     monkeypatch.setattr(RecordingManager, "get_recording_status", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -307,6 +335,7 @@ async def test_list_liveviews_happy_path(tmp_path, monkeypatch) -> None:
         return fake_lvs
 
     from unifi_core.protect.managers.liveview_manager import LiveviewManager
+
     monkeypatch.setattr(LiveviewManager, "list_liveviews", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -344,6 +373,7 @@ async def test_get_liveview_filter_404(tmp_path, monkeypatch) -> None:
         return fake_lvs
 
     from unifi_core.protect.managers.liveview_manager import LiveviewManager
+
     monkeypatch.setattr(LiveviewManager, "list_liveviews", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -383,6 +413,7 @@ async def test_get_firmware_status_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.system_manager import SystemManager
+
     monkeypatch.setattr(SystemManager, "get_firmware_status", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -418,6 +449,7 @@ async def test_alarm_get_status_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.alarm_manager import AlarmManager
+
     monkeypatch.setattr(AlarmManager, "get_arm_state", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -446,6 +478,7 @@ async def test_alarm_list_profiles_happy_path(tmp_path, monkeypatch) -> None:
         return fake_profiles
 
     from unifi_core.protect.managers.alarm_manager import AlarmManager
+
     monkeypatch.setattr(AlarmManager, "list_arm_profiles", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -473,8 +506,11 @@ async def test_protect_health_happy_path(tmp_path, monkeypatch) -> None:
         "cpu": {"average_load": 12.5, "temperature_c": 50.0},
         "memory": {"available_bytes": 1, "free_bytes": 2, "total_bytes": 3},
         "storage": {
-            "available_bytes": 1, "size_bytes": 2, "used_bytes": 3,
-            "is_recycling": False, "type": "hdd",
+            "available_bytes": 1,
+            "size_bytes": 2,
+            "used_bytes": 3,
+            "is_recycling": False,
+            "type": "hdd",
         },
         "is_updating": False,
         "uptime_seconds": 3600,
@@ -484,6 +520,7 @@ async def test_protect_health_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.system_manager import SystemManager
+
     monkeypatch.setattr(SystemManager, "get_health", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -517,6 +554,7 @@ async def test_protect_system_info_happy_path(tmp_path, monkeypatch) -> None:
         return payload
 
     from unifi_core.protect.managers.system_manager import SystemManager
+
     monkeypatch.setattr(SystemManager, "get_system_info", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -562,6 +600,7 @@ async def test_list_viewers_happy_path(tmp_path, monkeypatch) -> None:
         return fake_viewers
 
     from unifi_core.protect.managers.system_manager import SystemManager
+
     monkeypatch.setattr(SystemManager, "list_viewers", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:

--- a/apps/api/tests/serializers/test_protect_events_recordings_liveviews.py
+++ b/apps/api/tests/serializers/test_protect_events_recordings_liveviews.py
@@ -117,6 +117,10 @@ def test_event_detail_serializer_shape() -> None:
         "smart_detect_types": ["person"],
         "camera_id": "cam1",
         "thumbnail_id": "thumb-1",
+        "recognized_person_id": "face-group-1",
+        "recognized_person_name": "Assigned Person",
+        "recognized_person_confidence": 94,
+        "detected_thumbnail_id": "crop-1",
     }
     out = Event.from_manager_output(sample).to_dict()
     assert out["id"] == "evt-1"
@@ -125,6 +129,10 @@ def test_event_detail_serializer_shape() -> None:
     assert out["camera"] == "cam1"
     assert out["thumbnail"] == "thumb-1"
     assert out["smart_detect_types"] == ["person"]
+    assert out["recognized_person_id"] == "face-group-1"
+    assert out["recognized_person_name"] == "Assigned Person"
+    assert out["recognized_person_confidence"] == 94
+    assert out["detected_thumbnail_id"] == "crop-1"
     assert Event.render_hint("detail")["kind"] == "detail"
     assert Event.render_hint("event_log")["sort_default"] == "start:desc"
 
@@ -177,13 +185,21 @@ def test_smart_detections_serializer_shape() -> None:
         "smart_detect_types": ["vehicle"],
         "camera_id": "cam1",
         "thumbnail_id": "thumb-2",
+        "recognized_person_id": "face-group-2",
+        "recognized_person_name": "Another Person",
+        "recognized_person_confidence": 91,
+        "detected_thumbnail_id": "crop-2",
     }
     out = SmartDetection.from_manager_output(sample).to_dict()
     assert out["id"] == "evt-2"
     assert out["smart_detect_types"] == ["vehicle"]
     assert out["camera"] == "cam1"
+    assert out["recognized_person_name"] == "Another Person"
+    assert out["recognized_person_confidence"] == 91
+    assert out["detected_thumbnail_id"] == "crop-2"
     assert SmartDetection.render_hint("event_log")["kind"] == "event_log"
     assert "smart_detect_types" in SmartDetection.render_hint("event_log")["display_columns"]
+    assert "recognized_person_name" in SmartDetection.render_hint("event_log")["display_columns"]
 
 
 def test_recent_events_serializer_passthrough() -> None:

--- a/apps/protect/src/unifi_protect_mcp/tools/events.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/events.py
@@ -56,7 +56,9 @@ def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
         "Query events from the NVR with optional filters. Returns events from "
         "the Protect controller's database via REST API. Supports filtering by "
         "time range, event type (motion, smartDetectZone, ring, etc.), camera ID, "
-        "and result limit. For real-time buffer events use protect_recent_events."
+        "and result limit. Face events include recognized Known Face identity "
+        "fields when Protect provides them. For real-time buffer events use "
+        "protect_recent_events."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -116,7 +118,8 @@ async def protect_list_events(
     name="protect_get_event",
     description=(
         "Get detailed information for a single event by ID. Returns event type, "
-        "camera, timestamps, score, smart detection types, and thumbnail info."
+        "camera, timestamps, score, smart detection types, thumbnail info, and "
+        "recognized Known Face identity fields when Protect provides them."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -177,7 +180,9 @@ async def protect_get_event_thumbnail(
         "List smart detection events (person, vehicle, animal, package, etc.) "
         "with optional filters. Filters by detection type, camera, confidence "
         "score, and time range. Only returns events above the minimum confidence "
-        "threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE)."
+        "threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE). "
+        "Face detections include recognized Known Face identity fields when "
+        "Protect provides them."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -248,8 +253,9 @@ async def protect_list_smart_detections(
         "Get recent events from the in-memory websocket buffer. This is fast "
         "(no API call) and returns events received via the real-time websocket "
         "stream. Supports filtering by event_type, camera_id, min_confidence, "
-        "and limit. Use this for real-time monitoring; use protect_list_events "
-        "for historical queries."
+        "and limit. Face events include recognized Known Face identity fields "
+        "when Protect provides them. Use this for real-time monitoring; use "
+        "protect_list_events for historical queries."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -364,7 +364,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get detailed information for a single event by ID. Returns event type, camera, timestamps, score, smart detection types, and thumbnail info.",
+      "description": "Get detailed information for a single event by ID. Returns event type, camera, timestamps, score, smart detection types, thumbnail info, and recognized Known Face identity fields when Protect provides them.",
       "name": "protect_get_event",
       "schema": {
         "input": {
@@ -539,7 +539,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Query events from the NVR with optional filters. Returns events from the Protect controller's database via REST API. Supports filtering by time range, event type (motion, smartDetectZone, ring, etc.), camera ID, and result limit. For real-time buffer events use protect_recent_events.",
+      "description": "Query events from the NVR with optional filters. Returns events from the Protect controller's database via REST API. Supports filtering by time range, event type (motion, smartDetectZone, ring, etc.), camera ID, and result limit. Face events include recognized Known Face identity fields when Protect provides them. For real-time buffer events use protect_recent_events.",
       "name": "protect_list_events",
       "schema": {
         "input": {
@@ -689,7 +689,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List smart detection events (person, vehicle, animal, package, etc.) with optional filters. Filters by detection type, camera, confidence score, and time range. Only returns events above the minimum confidence threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE).",
+      "description": "List smart detection events (person, vehicle, animal, package, etc.) with optional filters. Filters by detection type, camera, confidence score, and time range. Only returns events above the minimum confidence threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE). Face detections include recognized Known Face identity fields when Protect provides them.",
       "name": "protect_list_smart_detections",
       "schema": {
         "input": {
@@ -890,7 +890,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by event_type, camera_id, min_confidence, and limit. Use this for real-time monitoring; use protect_list_events for historical queries.",
+      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by event_type, camera_id, min_confidence, and limit. Face events include recognized Known Face identity fields when Protect provides them. Use this for real-time monitoring; use protect_list_events for historical queries.",
       "name": "protect_recent_events",
       "schema": {
         "input": {

--- a/apps/protect/tests/unit/test_event_manager.py
+++ b/apps/protect/tests/unit/test_event_manager.py
@@ -26,6 +26,8 @@ def _make_event(**overrides) -> MagicMock:
     ev.category = overrides.get("category", "motion")
     ev.sub_category = overrides.get("sub_category", None)
     ev.is_favorite = overrides.get("is_favorite", False)
+    ev.metadata = overrides.get("metadata", None)
+    ev.get_detected_thumbnail = MagicMock(return_value=overrides.get("detected_thumbnail", None))
     ev.model = overrides.get("model", ModelType.EVENT)
     ev.save_device = AsyncMock()
     return ev
@@ -45,6 +47,7 @@ def _make_connection_manager(events=None) -> MagicMock:
     cm.client.get_events = AsyncMock(return_value=events or [])
     cm.client.get_event = AsyncMock()
     cm.client.get_event_thumbnail = AsyncMock()
+    cm.client.api_request = AsyncMock(return_value={"groups": []})
     cm.client.subscribe_websocket = MagicMock(return_value=MagicMock())  # unsub callable
     return cm
 
@@ -314,6 +317,41 @@ class TestEventManagerGetEvent:
         cm.client.get_event.assert_awaited_once_with("evt-123")
 
     @pytest.mark.asyncio
+    async def test_backfills_recognition_metadata_from_list_path(self):
+        detail_event = _make_event(
+            id="evt-123",
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.FACE],
+            metadata={"detectedThumbnails": [{"type": "face", "croppedId": "detail-crop"}]},
+        )
+        list_event = _make_event(
+            id="evt-123",
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.FACE],
+            metadata={
+                "detectedThumbnails": [
+                    {
+                        "type": "face",
+                        "croppedId": "list-crop",
+                        "group": {"id": "face-group-1", "matchedName": "Assigned Person", "confidence": 94},
+                    }
+                ]
+            },
+        )
+        cm = _make_connection_manager()
+        cm.client.get_event = AsyncMock(return_value=detail_event)
+        cm.client.get_events = AsyncMock(return_value=[list_event])
+        mgr = EventManager(cm)
+
+        result = await mgr.get_event("evt-123")
+
+        assert result["recognized_person_id"] == "face-group-1"
+        assert result["recognized_person_name"] == "Assigned Person"
+        assert result["recognized_person_confidence"] == 94
+        assert result["detected_thumbnail_id"] == "list-crop"
+        cm.client.get_events.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_not_found(self):
         cm = _make_connection_manager()
         cm.client.get_event = AsyncMock(side_effect=Exception("404 Not Found"))
@@ -431,6 +469,45 @@ class TestEventManagerListSmartDetections:
         results = await mgr.list_smart_detections(camera_id="cam-001")
         assert len(results) == 1
 
+    @pytest.mark.asyncio
+    async def test_known_face_name_join(self):
+        events = [
+            _make_event(
+                id="sd-1",
+                type=EventType.SMART_DETECT,
+                score=90,
+                smart_detect_types=[SmartDetectObjectType.FACE],
+                metadata={
+                    "detectedThumbnails": [
+                        {
+                            "type": "face",
+                            "croppedId": "crop-1",
+                            "group": {"id": "face-group-1", "confidence": 88},
+                        }
+                    ]
+                },
+            )
+        ]
+        cm = _make_connection_manager(events=events)
+        cm.client.api_request = AsyncMock(
+            return_value={
+                "groups": [
+                    {
+                        "id": "face-group-1",
+                        "name": "Assigned Person",
+                        "matchedName": "Assigned Person",
+                    }
+                ]
+            }
+        )
+        mgr = EventManager(cm)
+
+        results = await mgr.list_smart_detections(detection_type="face", min_confidence=0)
+
+        assert results[0]["recognized_person_id"] == "face-group-1"
+        assert results[0]["recognized_person_name"] == "Assigned Person"
+        cm.client.api_request.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # REST API: acknowledge_event
@@ -510,6 +587,85 @@ class TestEventToDict:
         assert d["is_favorite"] is True
         assert d["start"] is not None
         assert d["end"] is not None
+
+    def test_face_recognition_metadata_from_detected_thumbnail(self):
+        cm = _make_connection_manager()
+        mgr = EventManager(cm)
+        group = MagicMock()
+        group.id = "face-group-1"
+        group.name = "Lobby Person"
+        group.matched_name = "Assigned Person"
+        group.confidence = 94
+        thumbnail = MagicMock()
+        thumbnail.type = "face"
+        thumbnail.thumbnail_id = None
+        thumbnail.thumbnailId = None
+        thumbnail.cropped_id = "crop-1"
+        thumbnail.clock_best_wall = datetime(2026, 3, 16, 12, 0, tzinfo=timezone.utc)
+        thumbnail.confidence = 88
+        thumbnail.group = group
+        metadata = MagicMock()
+        metadata.detected_thumbnails = [thumbnail]
+        event = _make_event(
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.FACE],
+            metadata=metadata,
+        )
+
+        d = mgr._event_to_dict(event)
+
+        assert d["recognized_person_id"] == "face-group-1"
+        assert d["recognized_person_name"] == "Assigned Person"
+        assert d["recognized_person_confidence"] == 94
+        assert d["detected_thumbnail_id"] == "crop-1"
+
+    def test_face_recognition_uses_group_id_without_name(self):
+        cm = _make_connection_manager()
+        mgr = EventManager(cm)
+        metadata = {
+            "detectedThumbnails": [
+                {
+                    "type": "face",
+                    "croppedId": "crop-2",
+                    "group": {"id": "face-group-2", "confidence": 81},
+                }
+            ]
+        }
+        event = _make_event(
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.FACE],
+            metadata=metadata,
+        )
+
+        d = mgr._event_to_dict(event)
+
+        assert d["recognized_person_id"] == "face-group-2"
+        assert d["recognized_person_confidence"] == 81
+        assert "recognized_person_name" not in d
+        assert d["detected_thumbnail_id"] == "crop-2"
+
+    def test_non_face_recognition_group_is_not_reported_as_person(self):
+        cm = _make_connection_manager()
+        mgr = EventManager(cm)
+        metadata = {
+            "detectedThumbnails": [
+                {
+                    "type": "licensePlate",
+                    "croppedId": "plate-crop",
+                    "group": {"id": "plate-group", "matchedName": "ABC123", "confidence": 99},
+                }
+            ]
+        }
+        event = _make_event(
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.LICENSE_PLATE],
+            metadata=metadata,
+        )
+
+        d = mgr._event_to_dict(event)
+
+        assert "recognized_person_id" not in d
+        assert "recognized_person_name" not in d
 
     def test_event_with_no_end(self):
         cm = _make_connection_manager()

--- a/apps/protect/tests/unit/test_event_tools.py
+++ b/apps/protect/tests/unit/test_event_tools.py
@@ -101,10 +101,21 @@ class TestProtectGetEvent:
     async def test_success(self, mock_event_manager):
         from unifi_protect_mcp.tools.events import protect_get_event
 
-        mock_event_manager.get_event = AsyncMock(return_value={"id": "evt-123", "type": "motion", "score": 85})
+        mock_event_manager.get_event = AsyncMock(
+            return_value={
+                "id": "evt-123",
+                "type": "smartDetectZone",
+                "score": 85,
+                "recognized_person_id": "face-group-1",
+                "recognized_person_name": "Assigned Person",
+                "recognized_person_confidence": 94,
+                "detected_thumbnail_id": "crop-1",
+            }
+        )
         result = await protect_get_event("evt-123")
         assert result["success"] is True
         assert result["data"]["id"] == "evt-123"
+        assert result["data"]["recognized_person_name"] == "Assigned Person"
 
     @pytest.mark.asyncio
     async def test_not_found(self, mock_event_manager):
@@ -186,12 +197,20 @@ class TestProtectListSmartDetections:
 
         mock_event_manager.list_smart_detections = AsyncMock(
             return_value=[
-                {"id": "sd-1", "type": "smartDetectZone", "score": 90, "smart_detect_types": ["person"]},
+                {
+                    "id": "sd-1",
+                    "type": "smartDetectZone",
+                    "score": 90,
+                    "smart_detect_types": ["face"],
+                    "recognized_person_id": "face-group-1",
+                    "recognized_person_name": "Assigned Person",
+                },
             ]
         )
         result = await protect_list_smart_detections()
         assert result["success"] is True
         assert result["data"]["count"] == 1
+        assert result["data"]["detections"][0]["recognized_person_id"] == "face-group-1"
 
     @pytest.mark.asyncio
     async def test_with_filters(self, mock_event_manager):
@@ -231,7 +250,7 @@ class TestProtectRecentEvents:
         from unifi_protect_mcp.tools.events import protect_recent_events
 
         mock_event_manager.get_recent_from_buffer.return_value = [
-            {"id": "evt-1", "type": "motion"},
+            {"id": "evt-1", "type": "motion", "recognized_person_name": "Assigned Person"},
             {"id": "evt-2", "type": "ring"},
         ]
         mock_event_manager.buffer_size = 10
@@ -240,6 +259,7 @@ class TestProtectRecentEvents:
         assert result["data"]["count"] == 2
         assert result["data"]["source"] == "websocket_buffer"
         assert result["data"]["buffer_size"] == 10
+        assert result["data"]["events"][0]["recognized_person_name"] == "Assigned Person"
 
     @pytest.mark.asyncio
     async def test_with_filters(self, mock_event_manager):

--- a/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable
 
 from uiprotect.data import Event, EventType, ModelType, SmartDetectObjectType, WSAction, WSSubscriptionMessage
@@ -18,6 +18,41 @@ from uiprotect.data import Event, EventType, ModelType, SmartDetectObjectType, W
 from unifi_core.exceptions import UniFiNotFoundError
 
 logger = logging.getLogger(__name__)
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _get_any(obj: Any, *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        value = _get(obj, key)
+        if value is not None:
+            return value
+    return default
+
+
+def _stringify(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _enum_values(values: list[Any] | None) -> list[str]:
+    return [t.value if hasattr(t, "value") else str(t) for t in (values or [])]
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +243,151 @@ class EventManager:
         except Exception:
             return None
 
+    def _detected_thumbnails(self, event: Event) -> list[Any]:
+        """Return detected-thumbnail metadata without fetching image bytes."""
+        thumbnails: list[Any] = []
+        metadata = _get(event, "metadata")
+        raw_thumbnails = _get_any(metadata, "detected_thumbnails", "detectedThumbnails")
+        if isinstance(raw_thumbnails, list):
+            thumbnails.extend(raw_thumbnails)
+
+        get_detected_thumbnail = getattr(event, "get_detected_thumbnail", None)
+        if callable(get_detected_thumbnail):
+            try:
+                best_thumbnail = get_detected_thumbnail()
+            except Exception:
+                best_thumbnail = None
+            if best_thumbnail is not None and not any(best_thumbnail is thumb for thumb in thumbnails):
+                thumbnails.append(best_thumbnail)
+        return [thumb for thumb in thumbnails if thumb is not None]
+
+    def _face_recognition_fields(self, event: Event) -> dict[str, Any]:
+        """Extract recognized-face identity metadata from detected thumbnails."""
+        thumbnails = self._detected_thumbnails(event)
+        if not thumbnails:
+            return {}
+
+        smart_detect_types = set(_enum_values(_get(event, "smart_detect_types")))
+        face_thumbnails = [thumb for thumb in thumbnails if _get(thumb, "type") == "face"]
+        candidates = face_thumbnails or (thumbnails if "face" in smart_detect_types else [])
+        if not candidates:
+            return {}
+
+        def _score(thumb: Any) -> tuple[int, int, int, int]:
+            group = _get(thumb, "group")
+            name = _get_any(group, "matched_name", "matchedName", "name") or _get_any(
+                thumb, "matched_name", "matchedName", "name"
+            )
+            group_id = _get_any(group, "id", "group_id", "groupId") or _get_any(thumb, "group_id", "groupId")
+            confidence = _coerce_int(
+                _get_any(group, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+                or _get_any(thumb, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+            )
+            clock_best_wall = _get_any(thumb, "clock_best_wall", "clockBestWall")
+            return (
+                1 if name else 0,
+                1 if group_id else 0,
+                1 if clock_best_wall else 0,
+                confidence or 0,
+            )
+
+        thumbnail = max(candidates, key=_score)
+        group = _get(thumbnail, "group")
+        recognized_person_id = _stringify(
+            _get_any(group, "id", "group_id", "groupId") or _get_any(thumbnail, "group_id", "groupId")
+        )
+        recognized_person_name = _get_any(group, "matched_name", "matchedName", "name") or _get_any(
+            thumbnail, "matched_name", "matchedName", "name"
+        )
+        recognized_person_confidence = _coerce_int(
+            _get_any(group, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+            or _get_any(thumbnail, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+        )
+        detected_thumbnail_id = _stringify(
+            _get_any(thumbnail, "thumbnail_id", "thumbnailId", "cropped_id", "croppedId", "id")
+        )
+
+        fields: dict[str, Any] = {}
+        if recognized_person_id:
+            fields["recognized_person_id"] = recognized_person_id
+        if recognized_person_name:
+            fields["recognized_person_name"] = str(recognized_person_name)
+        if recognized_person_confidence is not None:
+            fields["recognized_person_confidence"] = recognized_person_confidence
+        if detected_thumbnail_id:
+            fields["detected_thumbnail_id"] = detected_thumbnail_id
+        return fields
+
+    async def _lookup_event_recognition_fields(self, event: Event) -> dict[str, Any]:
+        """Fetch the same face event from the list/search path when detail drops group metadata."""
+        if "face" not in set(_enum_values(_get(event, "smart_detect_types"))):
+            return {}
+
+        kwargs: dict[str, Any] = {
+            "limit": 100,
+            "sorting": "desc",
+            "types": [EventType.SMART_DETECT, EventType.SMART_DETECT_LINE],
+            "smart_detect_types": [SmartDetectObjectType.FACE],
+        }
+        if event.start:
+            kwargs["start"] = event.start - timedelta(seconds=5)
+            end = event.end or event.start
+            kwargs["end"] = end + timedelta(minutes=1)
+
+        try:
+            events: list[Event] = await self._cm.client.get_events(**kwargs)
+        except Exception:
+            logger.debug("[event-mgr] Unable to backfill recognition metadata for event %s", event.id, exc_info=True)
+            return {}
+
+        for candidate in events:
+            if candidate.id == event.id:
+                return self._face_recognition_fields(candidate)
+        return {}
+
+    async def _known_face_names_by_id(self) -> dict[str, str]:
+        """Map Known Face group IDs to assigned names using the recognition directory."""
+        try:
+            data = await self._cm.client.api_request(
+                "recognition/face/groups",
+                method="get",
+                params={"hasName": True, "page": 1, "pageSize": 1000000},
+            )
+        except Exception:
+            logger.debug("[event-mgr] Unable to load Known Face names for event enrichment", exc_info=True)
+            return {}
+
+        groups = data.get("groups") if isinstance(data, dict) else None
+        if not isinstance(groups, list):
+            return {}
+
+        names: dict[str, str] = {}
+        for group in groups:
+            group_id = _stringify(_get(group, "id"))
+            name = _get_any(group, "matched_name", "matchedName", "name")
+            if group_id and name:
+                names[group_id] = str(name)
+        return names
+
+    async def _apply_known_face_names(self, events: list[dict[str, Any]]) -> None:
+        """Fill recognized_person_name from Known Faces when events only expose group IDs."""
+        missing_name_ids = {
+            event["recognized_person_id"]
+            for event in events
+            if event.get("recognized_person_id") and not event.get("recognized_person_name")
+        }
+        if not missing_name_ids:
+            return
+
+        names = await self._known_face_names_by_id()
+        if not names:
+            return
+
+        for event in events:
+            group_id = event.get("recognized_person_id")
+            if group_id in missing_name_ids and names.get(group_id):
+                event["recognized_person_name"] = names[group_id]
+
     def _event_to_dict(self, event: Event, compact: bool = False) -> dict[str, Any]:
         """Convert a uiprotect ``Event`` object to a serialisable dict.
 
@@ -223,10 +403,9 @@ class EventManager:
             "start": event.start.isoformat() if event.start else None,
             "end": event.end.isoformat() if event.end else None,
             "score": event.score,
-            "smart_detect_types": [
-                t.value if isinstance(t, SmartDetectObjectType) else str(t) for t in (event.smart_detect_types or [])
-            ],
+            "smart_detect_types": _enum_values(event.smart_detect_types),
         }
+        result.update(self._face_recognition_fields(event))
         if not compact:
             result["thumbnail_id"] = event.thumbnail_id
             result["category"] = event.category
@@ -318,6 +497,7 @@ class EventManager:
                 continue
             results.append(self._event_to_dict(ev, compact=compact))
 
+        await self._apply_known_face_names(results)
         return results
 
     async def get_event(self, event_id: str) -> dict[str, Any]:
@@ -329,7 +509,11 @@ class EventManager:
             event: Event = await self._cm.client.get_event(event_id)
         except Exception as exc:
             raise UniFiNotFoundError("event", event_id) from exc
-        return self._event_to_dict(event)
+        result = self._event_to_dict(event)
+        if not result.get("recognized_person_id") and not result.get("recognized_person_name"):
+            result.update(await self._lookup_event_recognition_fields(event))
+        await self._apply_known_face_names([result])
+        return result
 
     async def get_event_thumbnail(
         self,
@@ -438,6 +622,7 @@ class EventManager:
                 continue
             results.append(self._event_to_dict(ev, compact=compact))
 
+        await self._apply_known_face_names(results)
         return results
 
     async def acknowledge_event(self, event_id: str) -> dict[str, Any]:

--- a/packages/unifi-core/src/unifi_core/protect/models/events.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/events.py
@@ -17,13 +17,43 @@ class Event(BaseModel):
     """Canonical Protect event row (list + detail share this shape, read-only)."""
 
     id: Optional[str] = Field(default=None, description="Event UUID", json_schema_extra={"mutable": False})
-    type: Optional[str] = Field(default=None, description="Event type (motion, smartDetectZone, ring, etc.)", json_schema_extra={"mutable": False})
+    type: Optional[str] = Field(
+        default=None,
+        description="Event type (motion, smartDetectZone, ring, etc.)",
+        json_schema_extra={"mutable": False},
+    )
     start: Optional[str] = Field(default=None, description="ISO start timestamp", json_schema_extra={"mutable": False})
     end: Optional[str] = Field(default=None, description="ISO end timestamp", json_schema_extra={"mutable": False})
-    score: Optional[int] = Field(default=None, description="Detection confidence score (0-100)", json_schema_extra={"mutable": False})
-    smart_detect_types: List[str] = Field(default_factory=list, description="Smart detection sub-types (person, vehicle, etc.)", json_schema_extra={"mutable": False})
-    camera: Optional[str] = Field(default=None, description="Camera UUID this event belongs to", json_schema_extra={"mutable": False})
-    thumbnail: Optional[str] = Field(default=None, description="Thumbnail ID for this event", json_schema_extra={"mutable": False})
+    score: Optional[int] = Field(
+        default=None, description="Detection confidence score (0-100)", json_schema_extra={"mutable": False}
+    )
+    smart_detect_types: List[str] = Field(
+        default_factory=list,
+        description="Smart detection sub-types (person, vehicle, etc.)",
+        json_schema_extra={"mutable": False},
+    )
+    camera: Optional[str] = Field(
+        default=None, description="Camera UUID this event belongs to", json_schema_extra={"mutable": False}
+    )
+    thumbnail: Optional[str] = Field(
+        default=None, description="Thumbnail ID for this event", json_schema_extra={"mutable": False}
+    )
+    recognized_person_id: Optional[str] = Field(
+        default=None, description="Recognized Known Face group UUID when present", json_schema_extra={"mutable": False}
+    )
+    recognized_person_name: Optional[str] = Field(
+        default=None,
+        description="Recognized Known Face display name when present",
+        json_schema_extra={"mutable": False},
+    )
+    recognized_person_confidence: Optional[int] = Field(
+        default=None, description="Known Face match confidence when present", json_schema_extra={"mutable": False}
+    )
+    detected_thumbnail_id: Optional[str] = Field(
+        default=None,
+        description="Detected thumbnail/crop reference ID when present",
+        json_schema_extra={"mutable": False},
+    )
 
 
 class SmartDetection(BaseModel):
@@ -34,26 +64,70 @@ class SmartDetection(BaseModel):
     """
 
     id: Optional[str] = Field(default=None, description="Event UUID", json_schema_extra={"mutable": False})
-    type: Optional[str] = Field(default=None, description="Event type (smartDetectZone)", json_schema_extra={"mutable": False})
+    type: Optional[str] = Field(
+        default=None, description="Event type (smartDetectZone)", json_schema_extra={"mutable": False}
+    )
     start: Optional[str] = Field(default=None, description="ISO start timestamp", json_schema_extra={"mutable": False})
     end: Optional[str] = Field(default=None, description="ISO end timestamp", json_schema_extra={"mutable": False})
-    score: Optional[int] = Field(default=None, description="Detection confidence score (0-100)", json_schema_extra={"mutable": False})
-    smart_detect_types: List[str] = Field(default_factory=list, description="Smart detection sub-types (person, vehicle, etc.)", json_schema_extra={"mutable": False})
-    camera: Optional[str] = Field(default=None, description="Camera UUID this event belongs to", json_schema_extra={"mutable": False})
-    thumbnail: Optional[str] = Field(default=None, description="Thumbnail ID for this event", json_schema_extra={"mutable": False})
+    score: Optional[int] = Field(
+        default=None, description="Detection confidence score (0-100)", json_schema_extra={"mutable": False}
+    )
+    smart_detect_types: List[str] = Field(
+        default_factory=list,
+        description="Smart detection sub-types (person, vehicle, etc.)",
+        json_schema_extra={"mutable": False},
+    )
+    camera: Optional[str] = Field(
+        default=None, description="Camera UUID this event belongs to", json_schema_extra={"mutable": False}
+    )
+    thumbnail: Optional[str] = Field(
+        default=None, description="Thumbnail ID for this event", json_schema_extra={"mutable": False}
+    )
+    recognized_person_id: Optional[str] = Field(
+        default=None, description="Recognized Known Face group UUID when present", json_schema_extra={"mutable": False}
+    )
+    recognized_person_name: Optional[str] = Field(
+        default=None,
+        description="Recognized Known Face display name when present",
+        json_schema_extra={"mutable": False},
+    )
+    recognized_person_confidence: Optional[int] = Field(
+        default=None, description="Known Face match confidence when present", json_schema_extra={"mutable": False}
+    )
+    detected_thumbnail_id: Optional[str] = Field(
+        default=None,
+        description="Detected thumbnail/crop reference ID when present",
+        json_schema_extra={"mutable": False},
+    )
 
 
 class EventThumbnail(BaseModel):
     """Thumbnail metadata for a Protect event (read-only)."""
 
-    event_id: Optional[str] = Field(default=None, description="Event UUID this thumbnail belongs to", json_schema_extra={"mutable": False})
-    thumbnail_id: Optional[str] = Field(default=None, description="Thumbnail asset ID", json_schema_extra={"mutable": False})
-    thumbnail_available: Optional[bool] = Field(default=None, description="Whether the thumbnail is available", json_schema_extra={"mutable": False})
-    image_base64: Optional[str] = Field(default=None, description="Base64-encoded JPEG thumbnail data", json_schema_extra={"mutable": False})
-    content_type: Optional[str] = Field(default=None, description="MIME type of the thumbnail (e.g. image/jpeg)", json_schema_extra={"mutable": False})
-    message: Optional[str] = Field(default=None, description="Status or error message", json_schema_extra={"mutable": False})
-    url: Optional[str] = Field(default=None, description="URL to the thumbnail resource", json_schema_extra={"mutable": False})
-    size_bytes: Optional[int] = Field(default=None, description="Thumbnail size in bytes", json_schema_extra={"mutable": False})
+    event_id: Optional[str] = Field(
+        default=None, description="Event UUID this thumbnail belongs to", json_schema_extra={"mutable": False}
+    )
+    thumbnail_id: Optional[str] = Field(
+        default=None, description="Thumbnail asset ID", json_schema_extra={"mutable": False}
+    )
+    thumbnail_available: Optional[bool] = Field(
+        default=None, description="Whether the thumbnail is available", json_schema_extra={"mutable": False}
+    )
+    image_base64: Optional[str] = Field(
+        default=None, description="Base64-encoded JPEG thumbnail data", json_schema_extra={"mutable": False}
+    )
+    content_type: Optional[str] = Field(
+        default=None, description="MIME type of the thumbnail (e.g. image/jpeg)", json_schema_extra={"mutable": False}
+    )
+    message: Optional[str] = Field(
+        default=None, description="Status or error message", json_schema_extra={"mutable": False}
+    )
+    url: Optional[str] = Field(
+        default=None, description="URL to the thumbnail resource", json_schema_extra={"mutable": False}
+    )
+    size_bytes: Optional[int] = Field(
+        default=None, description="Thumbnail size in bytes", json_schema_extra={"mutable": False}
+    )
 
 
 MUTABLE_FIELDS = frozenset()
@@ -95,6 +169,14 @@ def _coerce_id(raw: Any, key: str) -> Optional[str]:
     return str(value)
 
 
+def _get_any(raw: Any, *keys: str) -> Any:
+    for key in keys:
+        value = _get(raw, key)
+        if value is not None:
+            return value
+    return None
+
+
 def from_controller(raw: Any) -> Event:
     """Build an Event from a uiprotect / manager dict or object."""
     sdt = _get(raw, "smart_detect_types")
@@ -113,6 +195,10 @@ def from_controller(raw: Any) -> Event:
         smart_detect_types=sdt,
         camera=camera,
         thumbnail=thumbnail,
+        recognized_person_id=_get(raw, "recognized_person_id"),
+        recognized_person_name=_get(raw, "recognized_person_name"),
+        recognized_person_confidence=_get(raw, "recognized_person_confidence"),
+        detected_thumbnail_id=_get_any(raw, "detected_thumbnail_id", "detectedThumbnailId"),
     )
 
 
@@ -134,6 +220,10 @@ def smart_detection_from_controller(raw: Any) -> SmartDetection:
         smart_detect_types=sdt,
         camera=camera,
         thumbnail=thumbnail,
+        recognized_person_id=_get(raw, "recognized_person_id"),
+        recognized_person_name=_get(raw, "recognized_person_name"),
+        recognized_person_confidence=_get(raw, "recognized_person_confidence"),
+        detected_thumbnail_id=_get_any(raw, "detected_thumbnail_id", "detectedThumbnailId"),
     )
 
 

--- a/packages/unifi-core/tests/protect/models/test_events.py
+++ b/packages/unifi-core/tests/protect/models/test_events.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from unifi_core.protect.models.events import (
-    Event,
-    SmartDetection,
-    EventThumbnail,
     MUTABLE_FIELDS,
     READ_ONLY_FIELDS,
+    Event,
+    EventThumbnail,
+    SmartDetection,
     from_controller,
     smart_detection_from_controller,
     thumbnail_from_controller,
@@ -52,6 +52,10 @@ class TestFromController:
             "smart_detect_types": ["person"],
             "camera": "cam-001",
             "thumbnail": "thumb-001",
+            "recognized_person_id": "face-group-1",
+            "recognized_person_name": "Assigned Person",
+            "recognized_person_confidence": 94,
+            "detected_thumbnail_id": "crop-1",
         }
         evt = from_controller(raw)
         assert evt.id == "evt-001"
@@ -62,6 +66,10 @@ class TestFromController:
         assert evt.smart_detect_types == ["person"]
         assert evt.camera == "cam-001"
         assert evt.thumbnail == "thumb-001"
+        assert evt.recognized_person_id == "face-group-1"
+        assert evt.recognized_person_name == "Assigned Person"
+        assert evt.recognized_person_confidence == 94
+        assert evt.detected_thumbnail_id == "crop-1"
 
     def test_missing_fields_default_to_none_or_empty(self) -> None:
         evt = from_controller({"id": "evt-002"})
@@ -123,6 +131,10 @@ class TestFromController:
         evt = from_controller({"id": "evt-012", "smart_detect_types": ["person", "vehicle"]})
         assert evt.smart_detect_types == ["person", "vehicle"]
 
+    def test_detected_thumbnail_id_camel_case(self) -> None:
+        evt = from_controller({"id": "evt-013", "detectedThumbnailId": "crop-camel"})
+        assert evt.detected_thumbnail_id == "crop-camel"
+
 
 class TestSmartDetectionFromController:
     def test_full_dict(self) -> None:
@@ -135,6 +147,10 @@ class TestSmartDetectionFromController:
             "smart_detect_types": ["person", "animal"],
             "camera": "cam-002",
             "thumbnail": "thumb-002",
+            "recognized_person_id": "face-group-2",
+            "recognized_person_name": "Another Person",
+            "recognized_person_confidence": 91,
+            "detected_thumbnail_id": "crop-2",
         }
         sd = smart_detection_from_controller(raw)
         assert isinstance(sd, SmartDetection)
@@ -146,6 +162,10 @@ class TestSmartDetectionFromController:
         assert sd.smart_detect_types == ["person", "animal"]
         assert sd.camera == "cam-002"
         assert sd.thumbnail == "thumb-002"
+        assert sd.recognized_person_id == "face-group-2"
+        assert sd.recognized_person_name == "Another Person"
+        assert sd.recognized_person_confidence == 91
+        assert sd.detected_thumbnail_id == "crop-2"
 
     def test_missing_fields_default_to_none_or_empty(self) -> None:
         sd = smart_detection_from_controller({"id": "sd-002"})


### PR DESCRIPTION
## Summary

Enriches existing Protect event outputs with Known Face recognition metadata when UniFi Protect provides face group data.

Refs #234.
Closes #236.

## Scope

- Extract recognized face metadata from `metadata.detectedThumbnails` / `get_detected_thumbnail()` without fetching image bytes
- Add optional `recognized_person_id`, `recognized_person_name`, `recognized_person_confidence`, and `detected_thumbnail_id` fields to core Protect event models
- Backfill `protect_get_event` identity metadata from the list/search event path when the detail endpoint drops group metadata
- Join recognized group IDs to the Known Faces directory so named faces surface as `recognized_person_name` when configured
- Preserve the fields through MCP tools, REST, GraphQL, OpenAPI, SDL, docs, and tests

## Live validation

- `protect_list_smart_detections(detection_type=face, min_confidence=0, limit=100)` returned 100 face detections; all had recognized IDs and 38 had joined Known Face names on the live controller
- `protect_get_event` on a sampled face event returned recognized ID, joined name, confidence, and detected thumbnail reference
- Standard live smoke harness passed for `protect_list_smart_detections`; `protect_get_event` remains skipped by the generic harness because it cannot auto-discover an event ID

## Validation

- `make pre-commit`
- `uv run --package unifi-api-server pytest apps/api/tests -q`
- `uv run python scripts/live_smoke.py --server protect --phase readonly --tool protect_list_smart_detections --tool protect_get_event --report-dir live-smoke-results`
