### PR TITLE
feat: harden Protect known face discovery

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1293,7 +1293,7 @@ type ProtectQuery {
   snapshot(controller: ID!, id: ID!, width: Int = null, height: Int = null): Snapshot
 
   """List assigned Protect Known Faces / named face recognition groups."""
-  knownFaces(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, orderBy: String! = "name", orderDirection: String! = "asc"): KnownFacePage!
+  knownFaces(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownFacePage!
 
   """List paired Protect chimes (paginated)."""
   chimes(controller: ID!, limit: Int! = 50, cursor: String = null): ChimePage!

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1694,6 +1694,7 @@ No native ``protect_get_liveview`` tool — filter from LIST.
 - `cursor` (query)
 - `min_confidence` (query)
 - `include_interest` (query)
+- `group_types` (query)
 - `order_by` (query)
 - `order_direction` (query)
 - `controller` (query)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -11692,6 +11692,27 @@
             }
           },
           {
+            "description": "Explicit recognition group types to list. Supported values: known, interest, unknown. When set, this overrides include_interest.",
+            "in": "query",
+            "name": "group_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit recognition group types to list. Supported values: known, interest, unknown. When set, this overrides include_interest.",
+              "title": "Group Types"
+            }
+          },
+          {
             "in": "query",
             "name": "order_by",
             "required": false,

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -232,12 +232,14 @@ async def _fetch_known_faces(
     controller: str,
     min_confidence: int,
     include_interest: bool,
+    group_types: list[str] | None,
     order_by: str,
     order_direction: str,
 ) -> list:
+    group_types_key = ",".join(group_types) if group_types else ""
     key = (
         f"protect/known-faces/{controller}/{min_confidence}/"
-        f"{include_interest}/{order_by}/{order_direction}"
+        f"{include_interest}/{group_types_key}/{order_by}/{order_direction}"
     )
 
     async def _do() -> list:
@@ -252,6 +254,7 @@ async def _fetch_known_faces(
                 page_size=1000,
                 min_confidence=min_confidence,
                 include_interest=include_interest,
+                group_types=group_types,
                 order_by=order_by,
                 order_direction=order_direction,
             )
@@ -764,6 +767,7 @@ class ProtectQuery:
         cursor: str | None = None,
         min_confidence: int = 30,
         include_interest: bool = True,
+        group_types: list[str] | None = None,
         order_by: str = "name",
         order_direction: str = "asc",
     ) -> KnownFacePage:
@@ -773,6 +777,7 @@ class ProtectQuery:
             str(controller),
             min_confidence,
             include_interest,
+            group_types,
             order_by,
             order_direction,
         )

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1282,7 +1282,7 @@ type ProtectQuery {
   snapshot(controller: ID!, id: ID!, width: Int = null, height: Int = null): Snapshot
 
   """List assigned Protect Known Faces / named face recognition groups."""
-  knownFaces(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, orderBy: String! = "name", orderDirection: String! = "asc"): KnownFacePage!
+  knownFaces(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownFacePage!
 
   """List paired Protect chimes (paginated)."""
   chimes(controller: ID!, limit: Int! = 50, cursor: String = null): ChimePage!

--- a/apps/api/src/unifi_api/routes/resources/protect/recognition.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recognition.py
@@ -46,6 +46,13 @@ async def list_known_faces(
     cursor: str | None = Query(None),
     min_confidence: int = Query(30, ge=0, le=100),
     include_interest: bool = Query(True),
+    group_types: list[str] | None = Query(
+        None,
+        description=(
+            "Explicit recognition group types to list. Supported values: known, interest, unknown. "
+            "When set, this overrides include_interest."
+        ),
+    ),
     order_by: str = Query("name"),
     order_direction: str = Query("asc"),
 ) -> dict:
@@ -64,6 +71,7 @@ async def list_known_faces(
             page_size=1000,
             min_confidence=min_confidence,
             include_interest=include_interest,
+            group_types=group_types,
             order_by=order_by,
             order_direction=order_direction,
         )

--- a/apps/api/tests/graphql/fixtures/protect/test_recognition.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_recognition.py
@@ -38,7 +38,7 @@ async def test_protect_known_faces_list(tmp_path, monkeypatch):
         app,
         key,
         f'''{{
-        protect {{ knownFaces(controller: "{cid}", limit: 10) {{
+        protect {{ knownFaces(controller: "{cid}", limit: 10, groupTypes: ["unknown"]) {{
             items {{ id name matchedName detectionsCount lastDetectedAt }}
         }} }}
     }}''',

--- a/apps/api/tests/routes/resources/test_protect_resources.py
+++ b/apps/api/tests/routes/resources/test_protect_resources.py
@@ -1,11 +1,10 @@
 """Protect resource endpoints — happy paths, capability mismatch, 404."""
 
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 from httpx import ASGITransport, AsyncClient
-
 from unifi_api.auth.api_key import generate_key, hash_key
 from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
@@ -193,6 +192,44 @@ async def test_list_known_faces_happy_path(tmp_path, monkeypatch) -> None:
     assert {item["matched_name"] for item in body["items"]} == {"Person 1", "Person 2"}
     assert body["next_cursor"] is not None
     assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_known_faces_group_types_filter(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    calls: list[dict] = []
+
+    async def fake_list(self, *a, **kw):
+        calls.append(kw)
+        return {
+            "faces": [
+                {
+                    "id": "face-427",
+                    "type": "face",
+                    "detections_count": 14,
+                    "metadata": {},
+                }
+            ],
+            "count": 1,
+            "links": {},
+        }
+
+    from unifi_core.protect.managers.recognition_manager import RecognitionManager
+    monkeypatch.setattr(RecognitionManager, "list_known_faces", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/known-faces?controller={cid}&group_types=unknown",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["items"][0]["id"] == "face-427"
+    assert calls[0]["group_types"] == ["unknown"]
 
 
 @pytest.mark.asyncio

--- a/apps/protect/src/unifi_protect_mcp/tools/recognition.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/recognition.py
@@ -1,7 +1,7 @@
 """Recognition tools for UniFi Protect MCP server."""
 
 import logging
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 @server.tool(
     name="protect_list_known_faces",
     description=(
-        "List assigned UniFi Protect Known Faces / named face recognition groups. "
+        "List UniFi Protect face recognition groups, including assigned Known Faces "
+        "by default and unlabeled groups when group_types includes unknown. "
         "Returns metadata and controller image references only; image bytes are not fetched."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
@@ -37,9 +38,21 @@ async def protect_list_known_faces(
     include_interest: Annotated[
         bool,
         Field(
-            description="When true, include Protect groups labeled as known or interest. When false, only known groups."
+            description=(
+                "Backward-compatible filter used when group_types is omitted. "
+                "When true, include known and interest groups. When false, only known groups."
+            )
         ),
     ] = True,
+    group_types: Annotated[
+        Optional[List[str]],
+        Field(
+            description=(
+                "Optional explicit recognition group types to list. Supported values: known, interest, unknown. "
+                "When set, this overrides include_interest."
+            )
+        ),
+    ] = None,
     order_by: Annotated[
         str,
         Field(description="Sort field: name, createdAt, firstDetectedAt, lastDetectedAt, or detectionsCount."),
@@ -62,6 +75,7 @@ async def protect_list_known_faces(
             page_size=page_size,
             min_confidence=min_confidence,
             include_interest=include_interest,
+            group_types=group_types,
             order_by=order_by,
             order_direction=order_direction,  # type: ignore[arg-type]
         )

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -578,13 +578,17 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List assigned UniFi Protect Known Faces / named face recognition groups. Returns metadata and controller image references only; image bytes are not fetched.",
+      "description": "List UniFi Protect face recognition groups, including assigned Known Faces by default and unlabeled groups when group_types includes unknown. Returns metadata and controller image references only; image bytes are not fetched.",
       "name": "protect_list_known_faces",
       "schema": {
         "input": {
           "properties": {
+            "group_types": {
+              "description": "Optional explicit recognition group types to list. Supported values: known, interest, unknown. When set, this overrides include_interest.",
+              "type": "array"
+            },
             "include_interest": {
-              "description": "When true, include Protect groups labeled as known or interest. When false, only known groups.",
+              "description": "Backward-compatible filter used when group_types is omitted. When true, include known and interest groups. When false, only known groups.",
               "type": "boolean"
             },
             "min_confidence": {

--- a/apps/protect/tests/unit/test_recognition.py
+++ b/apps/protect/tests/unit/test_recognition.py
@@ -76,6 +76,44 @@ class TestRecognitionManager:
         assert params["labels"] == "groupType:known"
 
     @pytest.mark.asyncio
+    async def test_list_known_faces_unknown_group_type(self, mock_cm):
+        from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+        mock_cm.client.api_request.return_value = {
+            "groups": [
+                {
+                    "id": "face-427",
+                    "name": None,
+                    "matchedName": None,
+                    "type": "face",
+                    "detectionsCount": 14,
+                    "metadata": {},
+                }
+            ],
+            "links": {"prev": None, "next": None},
+        }
+
+        result = await RecognitionManager(mock_cm).list_known_faces(group_types=["unknown"])
+
+        face = result["faces"][0]
+        assert face["id"] == "face-427"
+        assert "name" not in face
+        assert "matched_name" not in face
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert params["labels"] == "groupType:unknown"
+
+    @pytest.mark.asyncio
+    async def test_list_known_faces_mixed_group_types(self, mock_cm):
+        from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+        mock_cm.client.api_request.return_value = {"groups": [], "links": {}}
+
+        await RecognitionManager(mock_cm).list_known_faces(group_types=["known", "unknown", "known"])
+
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert params["labels"] == "groupType:known,groupType:unknown"
+
+    @pytest.mark.asyncio
     async def test_list_known_faces_validates_bounds(self, mock_cm):
         from unifi_core.protect.managers.recognition_manager import RecognitionManager
 
@@ -87,6 +125,10 @@ class TestRecognitionManager:
             await mgr.list_known_faces(min_confidence=101)
         with pytest.raises(ValueError, match="order_direction"):
             await mgr.list_known_faces(order_direction="sideways")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="group_types"):
+            await mgr.list_known_faces(group_types=["person"])  # type: ignore[list-item]
+        with pytest.raises(ValueError, match="at least one"):
+            await mgr.list_known_faces(group_types=[])
 
 
 @pytest.fixture
@@ -119,6 +161,33 @@ class TestProtectListKnownFacesTool:
             page_size=25,
             min_confidence=40,
             include_interest=True,
+            group_types=None,
+            order_by="name",
+            order_direction="asc",
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_group_types(self, mock_recognition_manager):
+        from unifi_protect_mcp.tools.recognition import protect_list_known_faces
+
+        mock_recognition_manager.list_known_faces = AsyncMock(
+            return_value={
+                "faces": [{"id": "face-427", "type": "face", "detections_count": 14}],
+                "count": 1,
+                "links": {},
+            }
+        )
+
+        result = await protect_list_known_faces(group_types=["unknown"])
+
+        assert result["success"] is True
+        assert result["data"]["faces"][0]["id"] == "face-427"
+        mock_recognition_manager.list_known_faces.assert_awaited_once_with(
+            page=None,
+            page_size=100,
+            min_confidence=30,
+            include_interest=True,
+            group_types=["unknown"],
             order_by="name",
             order_direction="asc",
         )

--- a/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
@@ -16,6 +16,27 @@ logger = logging.getLogger(__name__)
 
 _VALID_ORDER_BY = {"name", "createdAt", "firstDetectedAt", "lastDetectedAt", "detectionsCount"}
 _VALID_ORDER_DIRECTION = {"asc", "desc"}
+_VALID_GROUP_TYPES = {"known", "interest", "unknown"}
+
+
+def _build_group_labels(group_types: list[str] | None, include_interest: bool) -> str:
+    """Build Protect recognition group labels, preserving old defaults."""
+    if group_types is None:
+        selected = ["known", "interest"] if include_interest else ["known"]
+    else:
+        selected = []
+        for raw in group_types:
+            group_type = str(raw).strip().lower()
+            if not group_type:
+                continue
+            if group_type not in _VALID_GROUP_TYPES:
+                raise ValueError(f"group_types must contain only {sorted(_VALID_GROUP_TYPES)}")
+            if group_type not in selected:
+                selected.append(group_type)
+        if not selected:
+            raise ValueError("group_types must include at least one supported group type")
+
+    return ",".join(f"groupType:{group_type}" for group_type in selected)
 
 
 class RecognitionManager:
@@ -31,14 +52,17 @@ class RecognitionManager:
         page_size: int = 100,
         min_confidence: int = 30,
         include_interest: bool = True,
+        group_types: list[str] | None = None,
         order_by: str = "name",
         order_direction: Literal["asc", "desc"] = "asc",
     ) -> Dict[str, Any]:
-        """Return assigned/named face recognition groups.
+        """Return Protect face recognition groups.
 
         Uses the same private endpoint shape as the Protect UI's Known Faces
-        view. The response intentionally includes image reference paths only;
-        it never fetches or embeds image bytes.
+        view by default. Pass ``group_types`` to explicitly discover other
+        group types, such as unlabeled/unknown clusters. The response
+        intentionally includes image reference paths only; it never fetches
+        or embeds image bytes.
         """
         if page is not None and page < 1:
             raise ValueError("page must be greater than or equal to 1")
@@ -51,7 +75,7 @@ class RecognitionManager:
         if order_direction not in _VALID_ORDER_DIRECTION:
             raise ValueError("order_direction must be 'asc' or 'desc'")
 
-        labels = "groupType:known,groupType:interest" if include_interest else "groupType:known"
+        labels = _build_group_labels(group_types, include_interest)
         params: dict[str, Any] = {
             "labels": labels,
             "minConfidence": min_confidence,

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -195,7 +195,7 @@ Lists assigned UniFi Protect Known Faces / named face recognition groups. Read-o
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `protect_list_known_faces` | Read | List assigned UniFi Protect Known Faces / named face recognition groups. |
+| `protect_list_known_faces` | Read | List UniFi Protect face recognition groups, including assigned Known Faces by default and unlabeled groups when group_types includes unkn... |
 <!-- /AUTO:tools:recognition -->
 
 **Tips:**


### PR DESCRIPTION
## Summary

- Adds explicit `group_types` filtering to Protect Known Face discovery with supported values `known`, `interest`, and `unknown`.
- Preserves existing default behavior: `protect_list_known_faces` still queries known + interest groups unless callers pass `group_types` or set `include_interest=false`.
- Exposes the same filter through MCP, REST, and GraphQL surfaces, with generated manifest/docs/schema updates.
- Adds coverage for unlabeled/unknown group discovery and invalid group type validation.

Closes #243.

## Verification

- `make pre-commit`
- `make -C apps/protect test` — 348 passed
- `uv run --package unifi-api-server pytest apps/api/tests/routes/resources/test_protect_resources.py::test_list_known_faces_happy_path apps/api/tests/routes/resources/test_protect_resources.py::test_list_known_faces_group_types_filter apps/api/tests/graphql/fixtures/protect/test_recognition.py apps/api/tests/graphql/test_sdl_drift.py apps/api/tests/graphql/test_openapi_drift.py apps/api/tests/graphql/test_docs_drift.py apps/api/tests/graphql/test_openapi_docs_drift.py` — 7 passed
- `make check-generated`
- `uv run ruff check ...` on touched Python files
- `git diff --check`

## Live Smoke

Run from `/Users/chris/Repos/unifi-mcp-known-face-discovery` using the local `.env` credentials symlinked from the main checkout.

- `uv run --package unifi-protect-mcp python scripts/live_smoke.py --server protect --phase inventory --tool protect_list_known_faces --report-dir live-smoke-results`
- `uv run --package unifi-protect-mcp python scripts/live_smoke.py --server protect --phase readonly --tool protect_list_known_faces --report-dir live-smoke-results`
  - `protect_list_known_faces` seed: ok
  - `protect_list_known_faces` readonly: ok
- `uv run --package unifi-protect-mcp python scripts/live_smoke.py --server protect --phase readonly --report-dir live-smoke-results`
  - connected: true
  - records: 37 ok, 2 skipped heavy/streaming reads
  - pending approval: 0
  - created/cleaned resources: 0/0
- Custom sanitized live check for `recognition_manager.list_known_faces(group_types=["unknown"], page_size=10)`
  - connected: true
  - returned 10 unknown groups
  - first sampled row had metadata-only fields and no `name` / `matched_name`

Artifacts are intentionally ignored under `live-smoke-results/`.
