### PR TITLE
feat: add Codex plugin support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,44 @@
+{
+  "name": "unifi-plugins",
+  "interface": {
+    "displayName": "UniFi MCP"
+  },
+  "plugins": [
+    {
+      "name": "unifi-network",
+      "source": {
+        "source": "local",
+        "path": "./plugins/unifi-network"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    },
+    {
+      "name": "unifi-protect",
+      "source": {
+        "source": "local",
+        "path": "./plugins/unifi-protect"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    },
+    {
+      "name": "unifi-access",
+      "source": {
+        "source": "local",
+        "path": "./plugins/unifi-access"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/.github/workflows/bump-plugin-versions.yml
+++ b/.github/workflows/bump-plugin-versions.yml
@@ -50,17 +50,39 @@ jobs:
           git tag --list "v*.*.*" --sort=-version:refname | head -1 | sed 's|^v||'
         }
 
-        update_plugin_version() {
-          local plugin_json="$1"
+        update_json_version() {
+          local json_file="$1"
           local version="$2"
 
-          if [ -z "$version" ] || [ ! -f "$plugin_json" ]; then
+          if [ -z "$version" ] || [ ! -f "$json_file" ]; then
             return
           fi
 
-          current=$(python3 -c "import json; print(json.load(open('${plugin_json}'))['version'])")
+          current=$(python3 -c "import json; print(json.load(open('${json_file}')).get('version', ''))")
           if [ "$current" = "$version" ]; then
-            echo "  $plugin_json already at $version"
+            echo "  $json_file already at $version"
+            return
+          fi
+
+          python3 -c "
+        import json, sys
+        pj = sys.argv[1]
+        ver = sys.argv[2]
+        with open(pj) as f:
+            data = json.load(f)
+        data['version'] = ver
+        with open(pj, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.write('\n')
+        " "$json_file" "$version"
+          echo "  $json_file: $current -> $version"
+        }
+
+        update_mcp_package_pin() {
+          local json_file="$1"
+          local version="$2"
+
+          if [ -z "$version" ] || [ ! -f "$json_file" ]; then
             return
           fi
 
@@ -70,7 +92,6 @@ jobs:
         ver = sys.argv[2]
         with open(pj) as f:
             data = json.load(f)
-        data['version'] = ver
         pkg_pin = re.compile(r'^(unifi-[a-z]+-mcp)==')
         for server in data.get('mcpServers', {}).values():
             args = server.get('args', [])
@@ -84,8 +105,22 @@ jobs:
         with open(pj, 'w') as f:
             json.dump(data, f, indent=2)
             f.write('\n')
-        " "$plugin_json" "$version"
-          echo "  $plugin_json: $current -> $version"
+        " "$json_file" "$version"
+          echo "  $json_file package pin -> $version"
+        }
+
+        update_plugin_version() {
+          local plugin_dir="$1"
+          local version="$2"
+
+          if [ -z "$version" ]; then
+            return
+          fi
+
+          update_json_version "$plugin_dir/.claude-plugin/plugin.json" "$version"
+          update_json_version "$plugin_dir/.codex-plugin/plugin.json" "$version"
+          update_mcp_package_pin "$plugin_dir/.claude-plugin/plugin.json" "$version"
+          update_mcp_package_pin "$plugin_dir/.mcp.json" "$version"
         }
 
         NETWORK_VERSION=$(get_version "network")
@@ -106,10 +141,10 @@ jobs:
         echo "  Shared:  ${SHARED_VERSION:-not tagged}"
         echo "  Relay:   ${RELAY_VERSION:-not tagged}"
 
-        # Update plugin.json versions
-        update_plugin_version "plugins/unifi-network/.claude-plugin/plugin.json" "$NETWORK_VERSION"
-        update_plugin_version "plugins/unifi-protect/.claude-plugin/plugin.json" "$PROTECT_VERSION"
-        update_plugin_version "plugins/unifi-access/.claude-plugin/plugin.json" "$ACCESS_VERSION"
+        # Update Claude/Codex plugin manifests and MCP package pins
+        update_plugin_version "plugins/unifi-network" "$NETWORK_VERSION"
+        update_plugin_version "plugins/unifi-protect" "$PROTECT_VERSION"
+        update_plugin_version "plugins/unifi-access" "$ACCESS_VERSION"
 
         # Regenerate server.json manifests for MCP Registry
         if [ -n "$NETWORK_VERSION" ]; then

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Repeat for Protect or Access if needed:
 
 Each plugin's `/setup` command walks you through connecting to your controller and configuring permissions.
 
+### Codex
+
+Register the UniFi MCP marketplace, then install the plugins from Codex's `/plugins` UI:
+
+```bash
+codex plugin marketplace add sirkirby/unifi-mcp
+```
+
+Launch `codex`, run `/plugins`, open the UniFi MCP marketplace, and install `unifi-network`, `unifi-protect`, or `unifi-access`. After installing, ask Codex to run the plugin's setup skill, for example:
+
+> Use the UniFi Network setup skill to configure this for Codex.
+
+The setup skill registers the MCP server with `codex mcp add`, stores the selected environment values in Codex's MCP configuration, and keeps the same preview-before-confirm safety model as Claude Code.
+
 ### Other MCP clients
 
 Run the servers directly:
@@ -191,9 +205,9 @@ packages/
   unifi-mcp-shared/ # Shared MCP patterns (permissions, tools, diagnostics, config)
   unifi-mcp-relay/  # Cloud relay sidecar (bridges local servers to Cloudflare Worker)
 plugins/
-  unifi-network/    # Claude Code plugin: MCP server + agent skills + setup
-  unifi-protect/    # Claude Code plugin: MCP server + agent skills + setup
-  unifi-access/     # Claude Code plugin: MCP server + setup
+  unifi-network/    # Claude Code/Codex plugin: MCP server + agent skills + setup
+  unifi-protect/    # Claude Code/Codex plugin: MCP server + agent skills + setup
+  unifi-access/     # Claude Code/Codex plugin: MCP server + setup
 skills/
   _shared/          # Shared utilities for skill scripts (MCP client, config)
 docs/               # Ecosystem-level documentation

--- a/apps/access/README.md
+++ b/apps/access/README.md
@@ -27,7 +27,17 @@ Then run the interactive setup to configure your controller connection:
 /unifi-access:setup
 ```
 
-This walks you through connecting to your Access controller, explains the dual-auth system (API key for reads, username/password for mutations), and configures permissions — then writes everything to `.claude/settings.json`. If you already have other UniFi plugins configured on the same controller, the setup will detect and reuse those credentials. Restart Claude Code after setup to connect.
+This walks you through connecting to your Access controller, explains the dual-auth system (API key for reads, username/password for mutations), and configures permissions — then writes everything to `.claude/settings.local.json`. If you already have other UniFi plugins configured on the same controller, the setup will detect and reuse those credentials. Restart Claude Code after setup to connect.
+
+### Codex
+
+Register the marketplace, then install `unifi-access` from Codex's `/plugins` UI:
+
+```bash
+codex plugin marketplace add sirkirby/unifi-mcp
+```
+
+After installing, ask Codex to use the UniFi Access setup skill. The setup flow registers the MCP server with `codex mcp add`, stores your controller environment values in Codex's MCP configuration, and prompts you to restart Codex.
 
 ### PyPI / Docker
 

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -24,7 +24,17 @@ Then run the interactive setup to configure your controller connection:
 /unifi-network:setup
 ```
 
-This walks you through entering your controller host, credentials, and permission preferences — then writes everything to `.claude/settings.json` so it persists across sessions. Restart Claude Code after setup to connect.
+This walks you through entering your controller host, credentials, and permission preferences — then writes everything to `.claude/settings.local.json` so it persists across sessions. Restart Claude Code after setup to connect.
+
+### Codex
+
+Register the marketplace, then install `unifi-network` from Codex's `/plugins` UI:
+
+```bash
+codex plugin marketplace add sirkirby/unifi-mcp
+```
+
+After installing, ask Codex to use the UniFi Network setup skill. The setup flow registers the MCP server with `codex mcp add`, stores your controller environment values in Codex's MCP configuration, and prompts you to restart Codex.
 
 ### PyPI / Docker
 

--- a/apps/protect/README.md
+++ b/apps/protect/README.md
@@ -27,7 +27,17 @@ Then run the interactive setup to configure your controller connection:
 /unifi-protect:setup
 ```
 
-This walks you through entering your controller host, credentials, and permission preferences — then writes everything to `.claude/settings.json` so it persists across sessions. If you already have the Network plugin configured on the same controller, the setup will detect and reuse those credentials. Restart Claude Code after setup to connect.
+This walks you through entering your controller host, credentials, and permission preferences — then writes everything to `.claude/settings.local.json` so it persists across sessions. If you already have the Network plugin configured on the same controller, the setup will detect and reuse those credentials. Restart Claude Code after setup to connect.
+
+### Codex
+
+Register the marketplace, then install `unifi-protect` from Codex's `/plugins` UI:
+
+```bash
+codex plugin marketplace add sirkirby/unifi-mcp
+```
+
+After installing, ask Codex to use the UniFi Protect setup skill. The setup flow registers the MCP server with `codex mcp add`, stores your controller environment values in Codex's MCP configuration, and prompts you to restart Codex.
 
 ### PyPI / Docker
 

--- a/plugins/unifi-access/.codex-plugin/plugin.json
+++ b/plugins/unifi-access/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "unifi-access",
+  "version": "0.2.9",
+  "description": "UniFi Access MCP server — manage door locks, credentials, visitors, and access policies",
+  "author": {
+    "name": "sirkirby",
+    "url": "https://github.com/sirkirby"
+  },
+  "homepage": "https://github.com/sirkirby/unifi-mcp",
+  "repository": "https://github.com/sirkirby/unifi-mcp",
+  "license": "MIT",
+  "keywords": [
+    "unifi",
+    "access",
+    "doors",
+    "credentials",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "UniFi Access",
+    "shortDescription": "Manage UniFi Access doors, credentials, visitors, and policies",
+    "longDescription": "Use UniFi Access MCP tools and skills in Codex to inspect doors, credentials, visitors, and access events, then apply safe preview-before-confirm mutations against a UniFi Access controller.",
+    "developerName": "sirkirby",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/sirkirby/unifi-mcp",
+    "defaultPrompt": [
+      "Set up UniFi Access MCP for Codex",
+      "Show door access events today",
+      "Audit expiring access credentials"
+    ],
+    "brandColor": "#006FFF",
+    "screenshots": []
+  }
+}

--- a/plugins/unifi-access/.mcp.json
+++ b/plugins/unifi-access/.mcp.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "unifi-access": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--python-preference",
+        "system",
+        "unifi-access-mcp==0.2.9"
+      ],
+      "env": {
+        "UNIFI_HOST": "${UNIFI_ACCESS_HOST:-}",
+        "UNIFI_USERNAME": "${UNIFI_ACCESS_USERNAME:-}",
+        "UNIFI_PASSWORD": "${UNIFI_ACCESS_PASSWORD:-}",
+        "UNIFI_PORT": "${UNIFI_ACCESS_PORT:-443}",
+        "UNIFI_VERIFY_SSL": "${UNIFI_ACCESS_VERIFY_SSL:-false}",
+        "UNIFI_ACCESS_HOST": "${UNIFI_ACCESS_HOST:-}",
+        "UNIFI_ACCESS_USERNAME": "${UNIFI_ACCESS_USERNAME:-}",
+        "UNIFI_ACCESS_PASSWORD": "${UNIFI_ACCESS_PASSWORD:-}",
+        "UNIFI_ACCESS_API_KEY": "${UNIFI_ACCESS_API_KEY:-}",
+        "UNIFI_ACCESS_PORT": "${UNIFI_ACCESS_PORT:-443}",
+        "UNIFI_ACCESS_API_PORT": "${UNIFI_ACCESS_API_PORT:-12445}",
+        "UNIFI_ACCESS_VERIFY_SSL": "${UNIFI_ACCESS_VERIFY_SSL:-false}",
+        "UNIFI_TOOL_REGISTRATION_MODE": "${UNIFI_TOOL_REGISTRATION_MODE:-lazy}"
+      }
+    }
+  }
+}

--- a/plugins/unifi-access/scripts/check-prereqs.sh
+++ b/plugins/unifi-access/scripts/check-prereqs.sh
@@ -1,21 +1,57 @@
 #!/bin/bash
 # Pre-flight check for unifi-* plugin setup.
-# Verifies uvx is installed and any existing settings file is valid JSON.
-# Run this BEFORE asking the user for credentials so silent failures get caught early.
-# Bash 3.2 compatible (works on stock macOS /bin/bash).
+# Verifies uvx and client-specific setup prerequisites before credentials are collected.
+# Bash 3.2 compatible for stock macOS.
 
 set -e
+
+TARGET="claude"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --target requires claude or codex" >&2
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: Unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 PLUGIN_NAME="${1:-unifi plugin}"
 SETTINGS_FILE=".claude/settings.local.json"
 
+case "$TARGET" in
+  claude|codex) ;;
+  *)
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    exit 1
+    ;;
+esac
+
 errors=0
 warnings=0
 
-echo "Checking prerequisites for $PLUGIN_NAME..."
+echo "Checking prerequisites for $PLUGIN_NAME ($TARGET)..."
 echo ""
 
-# 1. uvx — required to launch the MCP server
 if command -v uvx >/dev/null 2>&1; then
   uvx_version=$(uvx --version 2>&1 | head -1)
   echo "  [OK]   uvx found: $uvx_version"
@@ -34,45 +70,52 @@ else
   errors=$((errors + 1))
 fi
 
-# 2. existing settings.local.json must be valid JSON before we touch it
-if [ -f "$SETTINGS_FILE" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-      echo "  [OK]   $SETTINGS_FILE is valid JSON"
+if [ "$TARGET" = "claude" ]; then
+  if [ -f "$SETTINGS_FILE" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
+        echo "  [OK]   $SETTINGS_FILE is valid JSON"
+      else
+        echo "  [FAIL] $SETTINGS_FILE exists but is not valid JSON"
+        echo "         Fix or move it aside before continuing — setup will not"
+        echo "         clobber a malformed settings file."
+        errors=$((errors + 1))
+      fi
     else
-      echo "  [FAIL] $SETTINGS_FILE exists but is not valid JSON"
-      echo "         Fix or move it aside before continuing — setup will not"
-      echo "         clobber a malformed settings file."
-      errors=$((errors + 1))
+      echo "  [WARN] python3 not available — cannot validate $SETTINGS_FILE"
+      warnings=$((warnings + 1))
     fi
   else
-    echo "  [WARN] python3 not available — cannot validate $SETTINGS_FILE"
-    warnings=$((warnings + 1))
+    echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
   fi
 else
-  echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
+  if command -v codex >/dev/null 2>&1; then
+    codex_version=$(codex --version 2>&1 | head -1)
+    echo "  [OK]   codex found: $codex_version"
+    if codex mcp list >/dev/null 2>&1; then
+      echo "  [OK]   codex mcp list succeeded"
+    else
+      echo "  [WARN] codex is installed, but 'codex mcp list' failed"
+      echo "         Setup may still work, but confirm Codex is authenticated."
+      warnings=$((warnings + 1))
+    fi
+  else
+    echo "  [FAIL] codex CLI not found on PATH"
+    echo "         Codex setup registers the MCP server with 'codex mcp add'."
+    echo "         Install or open Codex, then re-run setup."
+    errors=$((errors + 1))
+  fi
 fi
 
-# 3. macOS interpreter selection
-# The MCP server's outbound network capability depends on which Python
-# interpreter uvx selects. macOS only grants network access to interpreters
-# that carry the com.apple.security.network.client entitlement — system and
-# Homebrew Python builds do; uv's managed standalone Python builds do not.
-# An entitlement-less interpreter will start the server cleanly, register
-# tools, and silently fail every outbound call with errno 65.
-#
-# plugin.json passes `--python-preference system` so uvx picks an entitled
-# interpreter when one is present; this check confirms one actually is and
-# warns when uv would fall back to its managed build.
 if [ "$(uname -s)" = "Darwin" ] && command -v uv >/dev/null 2>&1; then
   selected_py=$(uv python find --python-preference system 2>/dev/null || true)
   case "$selected_py" in
     */.local/share/uv/python/*)
       echo "  [WARN] uv would fall back to its managed Python on this Mac:"
       echo "           $selected_py"
-      echo "         macOS will not grant outbound network to that interpreter,"
-      echo "         so every controller call returns 'Not connected to"
-      echo "         controller' even though the server starts cleanly."
+      echo "         macOS may not grant outbound network to that interpreter,"
+      echo "         so controller calls can return 'Not connected to controller'"
+      echo "         even though the server starts cleanly."
       echo ""
       echo "         Install a system Python so uvx can use it, e.g."
       echo "           brew install python@3.13"
@@ -91,9 +134,12 @@ if [ "$(uname -s)" = "Darwin" ] && command -v uv >/dev/null 2>&1; then
   esac
 fi
 
-# 4. plugin enablement — there's no programmatic check, just remind the user
-echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
-echo "         After setup, run /plugin and confirm the plugin shows enabled."
+if [ "$TARGET" = "claude" ]; then
+  echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
+  echo "         After setup, run /plugin and confirm the plugin shows enabled."
+else
+  echo "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+fi
 
 echo ""
 if [ $errors -gt 0 ]; then

--- a/plugins/unifi-access/scripts/set-env.sh
+++ b/plugins/unifi-access/scripts/set-env.sh
@@ -1,22 +1,63 @@
 #!/bin/bash
-# Merge environment variables into .claude/settings.local.json
-# Usage: set-env.sh KEY1=VALUE1 KEY2=VALUE2 ...
+# Configure UniFi MCP client environment.
+# Usage:
+#   set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
 #
-# Creates .claude/settings.local.json if it doesn't exist.
-# Merges into existing "env" object without overwriting other keys.
-# Pure bash + sed — no python3, jq, or other dependencies required.
-# Compatible with bash 3.2 (the version shipped on macOS).
+# Claude target: merges environment variables into .claude/settings.local.json.
+# Codex target: registers/replaces the MCP server with `codex mcp add --env`.
+#
+# Bash 3.2 compatible for stock macOS.
 
 set -e
 
-SETTINGS_FILE=".claude/settings.local.json"
+TARGET="claude"
+DRY_RUN="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --target requires claude or codex" >&2
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: Unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ $# -eq 0 ]; then
-  echo "Usage: set-env.sh KEY1=VALUE1 KEY2=VALUE2 ..." >&2
+  echo "Usage: set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
   exit 1
 fi
 
-# Validate every argument up front so we fail fast on bad input.
+case "$TARGET" in
+  claude|codex) ;;
+  *)
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    exit 1
+    ;;
+esac
+
 for arg in "$@"; do
   if [[ "$arg" != *"="* ]]; then
     echo "ERROR: Invalid argument '$arg'. Expected KEY=VALUE format." >&2
@@ -24,71 +65,154 @@ for arg in "$@"; do
   fi
 done
 
-mkdir -p "$(dirname "$SETTINGS_FILE")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_NAME="$(basename "$PLUGIN_ROOT")"
 
-# Refuse to clobber a malformed settings file — fix it first.
-if [ -f "$SETTINGS_FILE" ] && command -v python3 >/dev/null 2>&1; then
-  if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-    echo "ERROR: $SETTINGS_FILE is not valid JSON. Fix or move it aside, then re-run." >&2
-    exit 1
-  fi
-fi
+detect_package_pin() {
+  for manifest in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.mcp.json"; do
+    if [ -f "$manifest" ]; then
+      pin=$(grep -Eo 'unifi-[a-z]+-mcp==[0-9][^"]*' "$manifest" | head -1 || true)
+      if [ -n "$pin" ]; then
+        echo "$pin"
+        return
+      fi
+    fi
+  done
 
-# Read existing settings or start with an empty env object
-if [ -f "$SETTINGS_FILE" ]; then
-  existing=$(cat "$SETTINGS_FILE")
-else
-  existing='{ "env": {} }'
-fi
+  case "$PLUGIN_NAME" in
+    unifi-network) echo "unifi-network-mcp@latest" ;;
+    unifi-protect) echo "unifi-protect-mcp@latest" ;;
+    unifi-access) echo "unifi-access-mcp@latest" ;;
+    *)
+      echo "ERROR: Could not infer MCP package for $PLUGIN_NAME" >&2
+      exit 1
+      ;;
+  esac
+}
 
-# Ensure "env" key exists — if the file has no env block, wrap it
-if ! echo "$existing" | grep -q '"env"'; then
-  existing=$(echo "$existing" | sed 's/}[[:space:]]*$/,\n  "env": {}\n}/')
-fi
-
-# For each KEY=VALUE arg, either update the existing key or insert it
-for arg in "$@"; do
-  key="${arg%%=*}"
-  value="${arg#*=}"
-  escaped_value=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g; s/&/\\&/g')
-
-  if echo "$existing" | grep -q "\"$key\""; then
-    existing=$(echo "$existing" | sed "s|\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$key\": \"$escaped_value\"|")
-  else
-    existing=$(echo "$existing" | sed "s|\"env\"[[:space:]]*:[[:space:]]*{|\"env\": {\n    \"$key\": \"$escaped_value\",|")
-  fi
-done
-
-# Clean up any trailing commas before closing braces (invalid JSON)
-existing=$(echo "$existing" | sed 's/,[[:space:]]*}/\n  }/g')
-
-# Write atomically via a temp file so a malformed result never replaces a good file.
-tmp_file="${SETTINGS_FILE}.tmp.$$"
-echo "$existing" > "$tmp_file"
-
-# Validate the result before swapping in. If python3 isn't available, skip validation —
-# the user can still recover from .tmp file if something goes wrong.
-if command -v python3 >/dev/null 2>&1; then
-  if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp_file" 2>/dev/null; then
-    echo "ERROR: produced invalid JSON. Likely cause: a special character in a value broke" >&2
-    echo "       sed-based escaping. Bad output left at $tmp_file for inspection." >&2
-    echo "       Original $SETTINGS_FILE was not modified." >&2
-    exit 1
-  fi
-fi
-mv "$tmp_file" "$SETTINGS_FILE"
-
-# Report what was set (mask sensitive values)
-for arg in "$@"; do
-  key="${arg%%=*}"
-  value="${arg#*=}"
+mask_value() {
+  key="$1"
+  value="$2"
   if [ ${#value} -gt 4 ] && [[ ! "$key" =~ _(HOST|PORT|SITE)$ ]] && [ "$value" != "true" ] && [ "$value" != "false" ]; then
-    display="${value:0:2}***${value: -2}"
+    echo "${value:0:2}***${value: -2}"
   else
-    display="$value"
+    echo "$value"
   fi
-  echo "  $key = $display"
-done
+}
 
-echo ""
-echo "Saved to $SETTINGS_FILE"
+print_values() {
+  for arg in "$@"; do
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    display="$(mask_value "$key" "$value")"
+    echo "  $key = $display"
+  done
+}
+
+write_claude_settings() {
+  SETTINGS_FILE=".claude/settings.local.json"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would merge these values into $SETTINGS_FILE:"
+    print_values "$@"
+    return
+  fi
+
+  mkdir -p "$(dirname "$SETTINGS_FILE")"
+
+  if [ -f "$SETTINGS_FILE" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
+      echo "ERROR: $SETTINGS_FILE is not valid JSON. Fix or move it aside, then re-run." >&2
+      exit 1
+    fi
+  fi
+
+  if [ -f "$SETTINGS_FILE" ]; then
+    existing=$(cat "$SETTINGS_FILE")
+  else
+    existing='{ "env": {} }'
+  fi
+
+  if ! echo "$existing" | grep -q '"env"'; then
+    existing=$(echo "$existing" | sed 's/}[[:space:]]*$/,\n  "env": {}\n}/')
+  fi
+
+  for arg in "$@"; do
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    escaped_value=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g; s/&/\\&/g')
+
+    if echo "$existing" | grep -q "\"$key\""; then
+      existing=$(echo "$existing" | sed "s|\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$key\": \"$escaped_value\"|")
+    else
+      existing=$(echo "$existing" | sed "s|\"env\"[[:space:]]*:[[:space:]]*{|\"env\": {\n    \"$key\": \"$escaped_value\",|")
+    fi
+  done
+
+  existing=$(echo "$existing" | sed 's/,[[:space:]]*}/\n  }/g')
+
+  tmp_file="${SETTINGS_FILE}.tmp.$$"
+  echo "$existing" > "$tmp_file"
+
+  if command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp_file" 2>/dev/null; then
+      echo "ERROR: produced invalid JSON. Bad output left at $tmp_file for inspection." >&2
+      echo "       Original $SETTINGS_FILE was not modified." >&2
+      exit 1
+    fi
+  fi
+
+  mv "$tmp_file" "$SETTINGS_FILE"
+  print_values "$@"
+  echo ""
+  echo "Saved to $SETTINGS_FILE"
+}
+
+write_codex_config() {
+  package_pin="$(detect_package_pin)"
+
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "ERROR: codex CLI not found on PATH. Install or open Codex, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v uvx >/dev/null 2>&1; then
+    echo "ERROR: uvx not found on PATH. Install uv, then re-run setup." >&2
+    exit 1
+  fi
+
+  cmd=(mcp add "$PLUGIN_NAME")
+  for arg in "$@"; do
+    cmd+=(--env "$arg")
+  done
+  cmd+=(-- uvx --python-preference system "$package_pin")
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would replace Codex MCP server '$PLUGIN_NAME' with:"
+    printf '  codex mcp add %q' "$PLUGIN_NAME"
+    for arg in "$@"; do
+      key="${arg%%=*}"
+      value="${arg#*=}"
+      display="$(mask_value "$key" "$value")"
+      printf ' --env %q' "$key=$display"
+    done
+    printf ' -- uvx --python-preference system %q' "$package_pin"
+    echo ""
+    echo ""
+    echo "Environment values:"
+    print_values "$@"
+    return
+  fi
+
+  codex mcp remove "$PLUGIN_NAME" >/dev/null 2>&1 || true
+  codex "${cmd[@]}"
+  echo ""
+  echo "Configured Codex MCP server '$PLUGIN_NAME' with $package_pin."
+  echo "Restart Codex so the updated MCP server configuration is loaded."
+}
+
+case "$TARGET" in
+  claude) write_claude_settings "$@" ;;
+  codex) write_codex_config "$@" ;;
+esac

--- a/plugins/unifi-access/skills/setup/SKILL.md
+++ b/plugins/unifi-access/skills/setup/SKILL.md
@@ -1,114 +1,114 @@
 ---
 name: setup
-description: Configure the UniFi Access MCP server — set controller host, credentials, and permissions
+description: Configure the UniFi Access MCP server for Claude Code or Codex — set controller host, credentials, API key, and permissions
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
 # Set Up UniFi Access MCP Server
 
-Walk the user through configuring their UniFi Access controller connection. **Ask each question one at a time using AskUserQuestion. Wait for the answer before proceeding.**
+Walk the user through configuring their UniFi Access controller connection. Ask one question at a time and wait for the answer before continuing.
+
+## Interaction Rules
+
+Use the client target that matches the current agent runtime:
+- Claude Code: `claude`
+- Codex: `codex`
+
+If the runtime is unclear, ask which client to configure. For questions, use the platform's blocking question tool when available (`AskUserQuestion` in Claude Code, `request_user_input` in Codex). If no blocking question tool is available, ask in chat with numbered options and wait for the user's reply.
+
+On macOS and Linux, resolve setup scripts relative to this skill file:
+- `../../scripts/check-prereqs.sh`
+- `../../scripts/set-env.sh`
+
+When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
+
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable.
 
 ## Step 0: Check Prerequisites
 
-Before asking the user for any credentials, run the prereq check so the most common silent failures (missing `uvx`, malformed existing settings) are caught up front:
+Before asking for credentials, run:
 
-**macOS / Linux:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-prereqs.sh "unifi-access"
+bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex> "unifi-access"
 ```
 
-**Windows:** PowerShell setups can skip this step — `uvx` availability is checked when the MCP server first launches. Just remind the user to install `uv` if it's missing.
-
-If the script exits non-zero, **stop and report the error to the user**. Do not proceed to credentials. The script's output already explains what to fix.
+If the script exits non-zero, stop and report the error. Do not proceed to credentials.
 
 ## Step 1: Controller Host
 
-Ask: "What is your UniFi controller's IP address or hostname?" (e.g., 192.168.1.1)
+Ask: "What is your UniFi controller's IP address or hostname?" Example: `192.168.1.1`.
 
-If the user already has Network or Protect configured (check `.claude/settings.local.json` for existing `UNIFI_*` env vars), ask: "Is Access on the same controller?" If yes, use the same host.
+If another UniFi MCP server is already configured, ask whether Access is on the same controller. For Claude, existing values may be in `.claude/settings.local.json`. For Codex, existing values may be visible through `codex mcp list` and `codex mcp get <server>`.
 
 ## Step 2: Authentication
 
-Access uses dual authentication — explain this to the user:
+Access supports two auth paths:
+- API key for read-oriented Access API calls
+- Local proxy session with username and password for mutations and broader tool coverage
 
-"UniFi Access has two auth paths:
-- **API key** (port 12445) — for read-only operations (listing doors, events, devices)
-- **Username + password** (port 443) — required for mutations (lock/unlock, credentials, visitors)
+Ask whether the user wants API key only, username/password only, or both. Recommend both when they want full Access management.
 
-You can configure one or both."
+For username/password, ask for:
+1. Username, using a local admin account, not a Ubiquiti SSO account
+2. Password
 
-Ask: "Which auth paths do you want to set up?"
+For API key, ask for the key and include `UNIFI_ACCESS_API_KEY`.
 
-Options:
-- "API key only" — read-only access to Access data
-- "Username and password only" — full access including mutations
-- "Both" — recommended for full flexibility
+At least one auth path is required.
 
-## Step 3: Collect Credentials
+## Step 3: Optional Settings
 
-Based on their choice, ask for API key and/or username+password (one question at a time).
+Ask whether to use defaults or customize:
+- Defaults: controller port `443`, Access API port `12445`, SSL verification `false`, lazy tool loading
+- Customize: ask for controller port, API port, SSL verification, and tool registration mode
 
 ## Step 4: Permission Configuration
 
-Ask: "Do you want to enable any write permissions? By default, ALL mutations are disabled for Access (door lock/unlock, credentials, visitors)."
+Ask whether to enable write permissions. By default, Access mutations are disabled for credentials, visitors, policies, and door controls.
 
 Options:
-- "Read-only for now" — can view doors, events, users but not control anything
-- "Enable door control" — lock/unlock doors
-- "Enable credential management" — create/revoke NFC, PIN, mobile credentials
-- "Enable visitor management" — create/delete visitor passes
-- "Enable all" — door control + credentials + visitors + device reboot
-- "Custom" — ask which categories to enable
+- Read-only for now
+- Enable visitor and credential management
+- Enable door operations
+- Enable all Access write permissions except delete operations
+- Custom categories
+
+Collect any selected policy variables. Use the existing `UNIFI_POLICY_ACCESS_<CATEGORY>_<ACTION>=true` format.
 
 ## Step 5: Write Configuration
 
-Use the appropriate script for the user's platform to write all collected values to `.claude/settings.local.json`. Check the platform from your environment info. On **Windows** use `set-env.ps1`, on **macOS/Linux** use `set-env.sh`:
+On macOS/Linux, run the target-aware setup script with only values the user provided or selected:
 
-**macOS / Linux:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-env.sh \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
   UNIFI_ACCESS_HOST=<host> \
   UNIFI_ACCESS_API_KEY=<api-key> \
   UNIFI_ACCESS_USERNAME=<username> \
   UNIFI_ACCESS_PASSWORD=<password>
 ```
 
-**Windows:**
-```powershell
-powershell -ExecutionPolicy Bypass -File "${CLAUDE_PLUGIN_ROOT}/scripts/set-env.ps1" UNIFI_ACCESS_HOST=<host> UNIFI_ACCESS_API_KEY=<api-key> UNIFI_ACCESS_USERNAME=<username> UNIFI_ACCESS_PASSWORD=<password>
-```
+Add optional values and policy variables to the same command, for example:
 
-If the host and credentials are the same as existing shared `UNIFI_*` vars, use the shared prefix instead to avoid duplication.
-
-If permissions were enabled, also pass those:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-env.sh \
-  UNIFI_POLICY_ACCESS_DOORS_UPDATE=true \
-  UNIFI_POLICY_ACCESS_CREDENTIALS_CREATE=true \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+  UNIFI_ACCESS_HOST=<host> \
+  UNIFI_ACCESS_API_KEY=<api-key> \
+  UNIFI_ACCESS_USERNAME=<username> \
+  UNIFI_ACCESS_PASSWORD=<password> \
+  UNIFI_ACCESS_API_PORT=12445 \
   UNIFI_POLICY_ACCESS_VISITORS_CREATE=true
 ```
 
-Permission variables by option:
-- **Door control:** `UNIFI_POLICY_ACCESS_DOORS_UPDATE=true`
-- **Credential management:** `UNIFI_POLICY_ACCESS_CREDENTIALS_CREATE=true`, `UNIFI_POLICY_ACCESS_CREDENTIALS_DELETE=true`
-- **Visitor management:** `UNIFI_POLICY_ACCESS_VISITORS_CREATE=true`, `UNIFI_POLICY_ACCESS_VISITORS_DELETE=true`
-- **Enable all:** all of the above + `UNIFI_POLICY_ACCESS_DEVICES_UPDATE=true`, `UNIFI_POLICY_ACCESS_POLICIES_UPDATE=true`
+The script handles the client-specific write:
+- Claude target: merges env vars into `.claude/settings.local.json`
+- Codex target: replaces the `unifi-access` MCP server via `codex mcp add --env ... -- uvx ...`
 
-## Step 6: Verify and Restart
+## Step 6: Final Message
 
-Tell the user:
+For Claude Code, tell the user:
 
-"Configuration saved to `.claude/settings.local.json`. Restart Claude Code (or run `/reload-plugins`) to connect the MCP server.
+"Configuration saved to `.claude/settings.local.json`. Restart Claude Code or run `/reload-plugins`, then confirm the plugin is enabled with `/plugin`."
 
-**After restart, run `/mcp` to verify.** You should see `unifi-access` listed as connected, with a tool count next to it.
+For Codex, tell the user:
 
-If it's missing or shows 0 tools, the server failed to start. Diagnose in this order:
-
-1. `/plugin` — confirm the plugin shows **enabled** (not just installed). If only installed, enable it and re-run `/reload-plugins`.
-2. `which uvx` — if it returns nothing, install `uv` (`curl -LsSf https://astral.sh/uv/install.sh | sh`), restart your shell, then restart Claude Code.
-3. `claude --debug` (in a fresh shell) — surfaces MCP server startup errors. Look for `unifi-access` in the output and report any error to the maintainer.
-4. Verify the credentials by running the same `uvx unifi-access-mcp` command manually with the same env vars to see if it can reach your controller.
-
-Once `/mcp` shows the server connected, the UniFi Access tools will be available."
-
-Show a summary table of what was configured, noting which auth paths are active and what permissions are enabled.
+"Codex MCP server `unifi-access` configured. Restart Codex so the updated MCP server is loaded."

--- a/plugins/unifi-network/.codex-plugin/plugin.json
+++ b/plugins/unifi-network/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "unifi-network",
+  "version": "0.17.1",
+  "description": "UniFi Network MCP server — manage network devices, clients, firewall, VPN, and more",
+  "author": {
+    "name": "sirkirby",
+    "url": "https://github.com/sirkirby"
+  },
+  "homepage": "https://github.com/sirkirby/unifi-mcp",
+  "repository": "https://github.com/sirkirby/unifi-mcp",
+  "license": "MIT",
+  "keywords": [
+    "unifi",
+    "network",
+    "firewall",
+    "wifi",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "UniFi Network",
+    "shortDescription": "Manage UniFi Network devices, clients, firewall, VPN, and WiFi",
+    "longDescription": "Use UniFi Network MCP tools and skills in Codex to inspect clients and devices, audit health, manage firewall and routing changes, and apply safe preview-before-confirm mutations against a UniFi Network Controller.",
+    "developerName": "sirkirby",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/sirkirby/unifi-mcp",
+    "defaultPrompt": [
+      "Set up UniFi Network MCP for Codex",
+      "Show my UniFi Network health",
+      "Audit my UniFi firewall rules"
+    ],
+    "brandColor": "#006FFF",
+    "screenshots": []
+  }
+}

--- a/plugins/unifi-network/.mcp.json
+++ b/plugins/unifi-network/.mcp.json
@@ -1,0 +1,28 @@
+{
+  "mcpServers": {
+    "unifi-network": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--python-preference",
+        "system",
+        "unifi-network-mcp==0.17.1"
+      ],
+      "env": {
+        "UNIFI_HOST": "${UNIFI_NETWORK_HOST:-}",
+        "UNIFI_USERNAME": "${UNIFI_NETWORK_USERNAME:-}",
+        "UNIFI_PASSWORD": "${UNIFI_NETWORK_PASSWORD:-}",
+        "UNIFI_PORT": "${UNIFI_NETWORK_PORT:-443}",
+        "UNIFI_SITE": "${UNIFI_NETWORK_SITE:-default}",
+        "UNIFI_VERIFY_SSL": "${UNIFI_NETWORK_VERIFY_SSL:-false}",
+        "UNIFI_NETWORK_HOST": "${UNIFI_NETWORK_HOST:-}",
+        "UNIFI_NETWORK_USERNAME": "${UNIFI_NETWORK_USERNAME:-}",
+        "UNIFI_NETWORK_PASSWORD": "${UNIFI_NETWORK_PASSWORD:-}",
+        "UNIFI_NETWORK_PORT": "${UNIFI_NETWORK_PORT:-443}",
+        "UNIFI_NETWORK_SITE": "${UNIFI_NETWORK_SITE:-default}",
+        "UNIFI_NETWORK_VERIFY_SSL": "${UNIFI_NETWORK_VERIFY_SSL:-false}",
+        "UNIFI_TOOL_REGISTRATION_MODE": "${UNIFI_TOOL_REGISTRATION_MODE:-lazy}"
+      }
+    }
+  }
+}

--- a/plugins/unifi-network/scripts/check-prereqs.sh
+++ b/plugins/unifi-network/scripts/check-prereqs.sh
@@ -1,21 +1,57 @@
 #!/bin/bash
 # Pre-flight check for unifi-* plugin setup.
-# Verifies uvx is installed and any existing settings file is valid JSON.
-# Run this BEFORE asking the user for credentials so silent failures get caught early.
-# Bash 3.2 compatible (works on stock macOS /bin/bash).
+# Verifies uvx and client-specific setup prerequisites before credentials are collected.
+# Bash 3.2 compatible for stock macOS.
 
 set -e
+
+TARGET="claude"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --target requires claude or codex" >&2
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: Unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 PLUGIN_NAME="${1:-unifi plugin}"
 SETTINGS_FILE=".claude/settings.local.json"
 
+case "$TARGET" in
+  claude|codex) ;;
+  *)
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    exit 1
+    ;;
+esac
+
 errors=0
 warnings=0
 
-echo "Checking prerequisites for $PLUGIN_NAME..."
+echo "Checking prerequisites for $PLUGIN_NAME ($TARGET)..."
 echo ""
 
-# 1. uvx — required to launch the MCP server
 if command -v uvx >/dev/null 2>&1; then
   uvx_version=$(uvx --version 2>&1 | head -1)
   echo "  [OK]   uvx found: $uvx_version"
@@ -34,45 +70,52 @@ else
   errors=$((errors + 1))
 fi
 
-# 2. existing settings.local.json must be valid JSON before we touch it
-if [ -f "$SETTINGS_FILE" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-      echo "  [OK]   $SETTINGS_FILE is valid JSON"
+if [ "$TARGET" = "claude" ]; then
+  if [ -f "$SETTINGS_FILE" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
+        echo "  [OK]   $SETTINGS_FILE is valid JSON"
+      else
+        echo "  [FAIL] $SETTINGS_FILE exists but is not valid JSON"
+        echo "         Fix or move it aside before continuing — setup will not"
+        echo "         clobber a malformed settings file."
+        errors=$((errors + 1))
+      fi
     else
-      echo "  [FAIL] $SETTINGS_FILE exists but is not valid JSON"
-      echo "         Fix or move it aside before continuing — setup will not"
-      echo "         clobber a malformed settings file."
-      errors=$((errors + 1))
+      echo "  [WARN] python3 not available — cannot validate $SETTINGS_FILE"
+      warnings=$((warnings + 1))
     fi
   else
-    echo "  [WARN] python3 not available — cannot validate $SETTINGS_FILE"
-    warnings=$((warnings + 1))
+    echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
   fi
 else
-  echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
+  if command -v codex >/dev/null 2>&1; then
+    codex_version=$(codex --version 2>&1 | head -1)
+    echo "  [OK]   codex found: $codex_version"
+    if codex mcp list >/dev/null 2>&1; then
+      echo "  [OK]   codex mcp list succeeded"
+    else
+      echo "  [WARN] codex is installed, but 'codex mcp list' failed"
+      echo "         Setup may still work, but confirm Codex is authenticated."
+      warnings=$((warnings + 1))
+    fi
+  else
+    echo "  [FAIL] codex CLI not found on PATH"
+    echo "         Codex setup registers the MCP server with 'codex mcp add'."
+    echo "         Install or open Codex, then re-run setup."
+    errors=$((errors + 1))
+  fi
 fi
 
-# 3. macOS interpreter selection
-# The MCP server's outbound network capability depends on which Python
-# interpreter uvx selects. macOS only grants network access to interpreters
-# that carry the com.apple.security.network.client entitlement — system and
-# Homebrew Python builds do; uv's managed standalone Python builds do not.
-# An entitlement-less interpreter will start the server cleanly, register
-# tools, and silently fail every outbound call with errno 65.
-#
-# plugin.json passes `--python-preference system` so uvx picks an entitled
-# interpreter when one is present; this check confirms one actually is and
-# warns when uv would fall back to its managed build.
 if [ "$(uname -s)" = "Darwin" ] && command -v uv >/dev/null 2>&1; then
   selected_py=$(uv python find --python-preference system 2>/dev/null || true)
   case "$selected_py" in
     */.local/share/uv/python/*)
       echo "  [WARN] uv would fall back to its managed Python on this Mac:"
       echo "           $selected_py"
-      echo "         macOS will not grant outbound network to that interpreter,"
-      echo "         so every controller call returns 'Not connected to"
-      echo "         controller' even though the server starts cleanly."
+      echo "         macOS may not grant outbound network to that interpreter,"
+      echo "         so controller calls can return 'Not connected to controller'"
+      echo "         even though the server starts cleanly."
       echo ""
       echo "         Install a system Python so uvx can use it, e.g."
       echo "           brew install python@3.13"
@@ -91,9 +134,12 @@ if [ "$(uname -s)" = "Darwin" ] && command -v uv >/dev/null 2>&1; then
   esac
 fi
 
-# 4. plugin enablement — there's no programmatic check, just remind the user
-echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
-echo "         After setup, run /plugin and confirm the plugin shows enabled."
+if [ "$TARGET" = "claude" ]; then
+  echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
+  echo "         After setup, run /plugin and confirm the plugin shows enabled."
+else
+  echo "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+fi
 
 echo ""
 if [ $errors -gt 0 ]; then

--- a/plugins/unifi-network/scripts/set-env.sh
+++ b/plugins/unifi-network/scripts/set-env.sh
@@ -1,22 +1,63 @@
 #!/bin/bash
-# Merge environment variables into .claude/settings.local.json
-# Usage: set-env.sh KEY1=VALUE1 KEY2=VALUE2 ...
+# Configure UniFi MCP client environment.
+# Usage:
+#   set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
 #
-# Creates .claude/settings.local.json if it doesn't exist.
-# Merges into existing "env" object without overwriting other keys.
-# Pure bash + sed — no python3, jq, or other dependencies required.
-# Compatible with bash 3.2 (the version shipped on macOS).
+# Claude target: merges environment variables into .claude/settings.local.json.
+# Codex target: registers/replaces the MCP server with `codex mcp add --env`.
+#
+# Bash 3.2 compatible for stock macOS.
 
 set -e
 
-SETTINGS_FILE=".claude/settings.local.json"
+TARGET="claude"
+DRY_RUN="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --target requires claude or codex" >&2
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: Unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ $# -eq 0 ]; then
-  echo "Usage: set-env.sh KEY1=VALUE1 KEY2=VALUE2 ..." >&2
+  echo "Usage: set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
   exit 1
 fi
 
-# Validate every argument up front so we fail fast on bad input.
+case "$TARGET" in
+  claude|codex) ;;
+  *)
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    exit 1
+    ;;
+esac
+
 for arg in "$@"; do
   if [[ "$arg" != *"="* ]]; then
     echo "ERROR: Invalid argument '$arg'. Expected KEY=VALUE format." >&2
@@ -24,71 +65,154 @@ for arg in "$@"; do
   fi
 done
 
-mkdir -p "$(dirname "$SETTINGS_FILE")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_NAME="$(basename "$PLUGIN_ROOT")"
 
-# Refuse to clobber a malformed settings file — fix it first.
-if [ -f "$SETTINGS_FILE" ] && command -v python3 >/dev/null 2>&1; then
-  if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-    echo "ERROR: $SETTINGS_FILE is not valid JSON. Fix or move it aside, then re-run." >&2
-    exit 1
-  fi
-fi
+detect_package_pin() {
+  for manifest in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.mcp.json"; do
+    if [ -f "$manifest" ]; then
+      pin=$(grep -Eo 'unifi-[a-z]+-mcp==[0-9][^"]*' "$manifest" | head -1 || true)
+      if [ -n "$pin" ]; then
+        echo "$pin"
+        return
+      fi
+    fi
+  done
 
-# Read existing settings or start with an empty env object
-if [ -f "$SETTINGS_FILE" ]; then
-  existing=$(cat "$SETTINGS_FILE")
-else
-  existing='{ "env": {} }'
-fi
+  case "$PLUGIN_NAME" in
+    unifi-network) echo "unifi-network-mcp@latest" ;;
+    unifi-protect) echo "unifi-protect-mcp@latest" ;;
+    unifi-access) echo "unifi-access-mcp@latest" ;;
+    *)
+      echo "ERROR: Could not infer MCP package for $PLUGIN_NAME" >&2
+      exit 1
+      ;;
+  esac
+}
 
-# Ensure "env" key exists — if the file has no env block, wrap it
-if ! echo "$existing" | grep -q '"env"'; then
-  existing=$(echo "$existing" | sed 's/}[[:space:]]*$/,\n  "env": {}\n}/')
-fi
-
-# For each KEY=VALUE arg, either update the existing key or insert it
-for arg in "$@"; do
-  key="${arg%%=*}"
-  value="${arg#*=}"
-  escaped_value=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g; s/&/\\&/g')
-
-  if echo "$existing" | grep -q "\"$key\""; then
-    existing=$(echo "$existing" | sed "s|\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$key\": \"$escaped_value\"|")
-  else
-    existing=$(echo "$existing" | sed "s|\"env\"[[:space:]]*:[[:space:]]*{|\"env\": {\n    \"$key\": \"$escaped_value\",|")
-  fi
-done
-
-# Clean up any trailing commas before closing braces (invalid JSON)
-existing=$(echo "$existing" | sed 's/,[[:space:]]*}/\n  }/g')
-
-# Write atomically via a temp file so a malformed result never replaces a good file.
-tmp_file="${SETTINGS_FILE}.tmp.$$"
-echo "$existing" > "$tmp_file"
-
-# Validate the result before swapping in. If python3 isn't available, skip validation —
-# the user can still recover from .tmp file if something goes wrong.
-if command -v python3 >/dev/null 2>&1; then
-  if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp_file" 2>/dev/null; then
-    echo "ERROR: produced invalid JSON. Likely cause: a special character in a value broke" >&2
-    echo "       sed-based escaping. Bad output left at $tmp_file for inspection." >&2
-    echo "       Original $SETTINGS_FILE was not modified." >&2
-    exit 1
-  fi
-fi
-mv "$tmp_file" "$SETTINGS_FILE"
-
-# Report what was set (mask sensitive values)
-for arg in "$@"; do
-  key="${arg%%=*}"
-  value="${arg#*=}"
+mask_value() {
+  key="$1"
+  value="$2"
   if [ ${#value} -gt 4 ] && [[ ! "$key" =~ _(HOST|PORT|SITE)$ ]] && [ "$value" != "true" ] && [ "$value" != "false" ]; then
-    display="${value:0:2}***${value: -2}"
+    echo "${value:0:2}***${value: -2}"
   else
-    display="$value"
+    echo "$value"
   fi
-  echo "  $key = $display"
-done
+}
 
-echo ""
-echo "Saved to $SETTINGS_FILE"
+print_values() {
+  for arg in "$@"; do
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    display="$(mask_value "$key" "$value")"
+    echo "  $key = $display"
+  done
+}
+
+write_claude_settings() {
+  SETTINGS_FILE=".claude/settings.local.json"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would merge these values into $SETTINGS_FILE:"
+    print_values "$@"
+    return
+  fi
+
+  mkdir -p "$(dirname "$SETTINGS_FILE")"
+
+  if [ -f "$SETTINGS_FILE" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
+      echo "ERROR: $SETTINGS_FILE is not valid JSON. Fix or move it aside, then re-run." >&2
+      exit 1
+    fi
+  fi
+
+  if [ -f "$SETTINGS_FILE" ]; then
+    existing=$(cat "$SETTINGS_FILE")
+  else
+    existing='{ "env": {} }'
+  fi
+
+  if ! echo "$existing" | grep -q '"env"'; then
+    existing=$(echo "$existing" | sed 's/}[[:space:]]*$/,\n  "env": {}\n}/')
+  fi
+
+  for arg in "$@"; do
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    escaped_value=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g; s/&/\\&/g')
+
+    if echo "$existing" | grep -q "\"$key\""; then
+      existing=$(echo "$existing" | sed "s|\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$key\": \"$escaped_value\"|")
+    else
+      existing=$(echo "$existing" | sed "s|\"env\"[[:space:]]*:[[:space:]]*{|\"env\": {\n    \"$key\": \"$escaped_value\",|")
+    fi
+  done
+
+  existing=$(echo "$existing" | sed 's/,[[:space:]]*}/\n  }/g')
+
+  tmp_file="${SETTINGS_FILE}.tmp.$$"
+  echo "$existing" > "$tmp_file"
+
+  if command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp_file" 2>/dev/null; then
+      echo "ERROR: produced invalid JSON. Bad output left at $tmp_file for inspection." >&2
+      echo "       Original $SETTINGS_FILE was not modified." >&2
+      exit 1
+    fi
+  fi
+
+  mv "$tmp_file" "$SETTINGS_FILE"
+  print_values "$@"
+  echo ""
+  echo "Saved to $SETTINGS_FILE"
+}
+
+write_codex_config() {
+  package_pin="$(detect_package_pin)"
+
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "ERROR: codex CLI not found on PATH. Install or open Codex, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v uvx >/dev/null 2>&1; then
+    echo "ERROR: uvx not found on PATH. Install uv, then re-run setup." >&2
+    exit 1
+  fi
+
+  cmd=(mcp add "$PLUGIN_NAME")
+  for arg in "$@"; do
+    cmd+=(--env "$arg")
+  done
+  cmd+=(-- uvx --python-preference system "$package_pin")
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would replace Codex MCP server '$PLUGIN_NAME' with:"
+    printf '  codex mcp add %q' "$PLUGIN_NAME"
+    for arg in "$@"; do
+      key="${arg%%=*}"
+      value="${arg#*=}"
+      display="$(mask_value "$key" "$value")"
+      printf ' --env %q' "$key=$display"
+    done
+    printf ' -- uvx --python-preference system %q' "$package_pin"
+    echo ""
+    echo ""
+    echo "Environment values:"
+    print_values "$@"
+    return
+  fi
+
+  codex mcp remove "$PLUGIN_NAME" >/dev/null 2>&1 || true
+  codex "${cmd[@]}"
+  echo ""
+  echo "Configured Codex MCP server '$PLUGIN_NAME' with $package_pin."
+  echo "Restart Codex so the updated MCP server configuration is loaded."
+}
+
+case "$TARGET" in
+  claude) write_claude_settings "$@" ;;
+  codex) write_codex_config "$@" ;;
+esac

--- a/plugins/unifi-network/skills/firewall-auditor/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-auditor/SKILL.md
@@ -71,7 +71,8 @@ The `fix` block is optional but include it whenever the benchmark reference show
 Pipe the findings through the scoring CLI. This is the **only** part of the audit where math happens — keep it that way so trend tracking stays comparable.
 
 ```bash
-echo '{"findings": [...]}' | "${CLAUDE_PLUGIN_ROOT}/skills/firewall-auditor/scripts/unifi-firewall-score"
+# Resolve scripts/unifi-firewall-score relative to this skill directory.
+echo '{"findings": [...]}' | "<firewall-auditor-skill-dir>/scripts/unifi-firewall-score"
 ```
 
 The CLI returns:
@@ -94,10 +95,10 @@ Do not compute the score yourself. The CLI is stable across versions; your arith
 
 ### 4. Append to history
 
-Maintain a single audit history file at `${UNIFI_SKILLS_STATE_DIR:-$HOME/.claude/unifi-skills}/audit-history.json`. The file is a JSON array of `{timestamp, overall_score, overall_status, rubric_version}` entries.
+Maintain a single audit history file at `${UNIFI_SKILLS_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/unifi-mcp/skills}/audit-history.json`. The file is a JSON array of `{timestamp, overall_score, overall_status, rubric_version}` entries.
 
 ```bash
-STATE_DIR="${UNIFI_SKILLS_STATE_DIR:-$HOME/.claude/unifi-skills}"
+STATE_DIR="${UNIFI_SKILLS_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/unifi-mcp/skills}"
 mkdir -p "$STATE_DIR"
 HIST="$STATE_DIR/audit-history.json"
 [ -f "$HIST" ] || echo "[]" > "$HIST"

--- a/plugins/unifi-network/skills/firewall-manager/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-manager/SKILL.md
@@ -44,7 +44,7 @@ Gather state via three parallel tool calls:
 Combine the results into one JSON document and write it to disk:
 
 ```bash
-STATE_DIR="${UNIFI_SKILLS_STATE_DIR:-$HOME/.claude/unifi-skills}/firewall-snapshots"
+STATE_DIR="${UNIFI_SKILLS_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/unifi-mcp/skills}/firewall-snapshots"
 mkdir -p "$STATE_DIR"
 SNAPSHOT="$STATE_DIR/firewall_$(date -u +%Y%m%dT%H%M%SZ).json"
 # Write the combined JSON ($SNAPSHOT_JSON below is what you composed from the three tool results):

--- a/plugins/unifi-network/skills/setup/SKILL.md
+++ b/plugins/unifi-network/skills/setup/SKILL.md
@@ -1,121 +1,105 @@
 ---
 name: setup
-description: Configure the UniFi Network MCP server — set controller host, credentials, and permissions
+description: Configure the UniFi Network MCP server for Claude Code or Codex — set controller host, credentials, and permissions
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
 # Set Up UniFi Network MCP Server
 
-Walk the user through configuring their UniFi Network controller connection. **Ask each question one at a time using AskUserQuestion. Wait for the answer before proceeding.**
+Walk the user through configuring their UniFi Network controller connection. Ask one question at a time and wait for the answer before continuing.
+
+## Interaction Rules
+
+Use the client target that matches the current agent runtime:
+- Claude Code: `claude`
+- Codex: `codex`
+
+If the runtime is unclear, ask which client to configure. For questions, use the platform's blocking question tool when available (`AskUserQuestion` in Claude Code, `request_user_input` in Codex). If no blocking question tool is available, ask in chat with numbered options and wait for the user's reply.
+
+On macOS and Linux, resolve setup scripts relative to this skill file:
+- `../../scripts/check-prereqs.sh`
+- `../../scripts/set-env.sh`
+
+When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
+
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable.
 
 ## Step 0: Check Prerequisites
 
-Before asking the user for any credentials, run the prereq check so the most common silent failures (missing `uvx`, malformed existing settings) are caught up front:
+Before asking for credentials, run:
 
-**macOS / Linux:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-prereqs.sh "unifi-network"
+bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex> "unifi-network"
 ```
 
-**Windows:** PowerShell setups can skip this step — `uvx` availability is checked when the MCP server first launches. Just remind the user to install `uv` if it's missing.
-
-If the script exits non-zero, **stop and report the error to the user**. Do not proceed to credentials. The script's output already explains what to fix (install `uv`, repair `.claude/settings.local.json`, etc.).
+If the script exits non-zero, stop and report the error. Do not proceed to credentials.
 
 ## Step 1: Controller Host
 
-Ask: "What is your UniFi controller's IP address or hostname?" (e.g., 192.168.1.1)
+Ask: "What is your UniFi controller's IP address or hostname?" Example: `192.168.1.1`.
 
 ## Step 2: Credentials
 
 Ask for:
-1. Username (local admin account — **not** a Ubiquiti SSO account)
+1. Username, using a local admin account, not a Ubiquiti SSO account
 2. Password
 
-Username and password are **required**. These must be local admin credentials on the UniFi controller.
+Username and password are required.
 
-### Optional: API Key
+### Optional API Key
 
-After collecting credentials, mention:
+After collecting username and password, explain that UniFi API key support is experimental and limited to read-only operations and a subset of tools. Ask whether to configure an API key too.
 
-"UniFi also supports API keys, but API key auth is **experimental** — it's limited to read-only operations and a subset of tools. Ubiquiti is still expanding API key support. Would you also like to configure an API key?"
+If yes, ask for the API key and include `UNIFI_NETWORK_API_KEY`. If no, skip it.
 
-If yes, ask for the API key string and include it as `UNIFI_NETWORK_API_KEY` in the configuration. If no, skip it.
+## Step 3: Optional Settings
 
-## Step 4: Optional Settings
+Ask whether to use defaults or customize:
+- Defaults: port `443`, site `default`, SSL verification `false`, lazy tool loading
+- Customize: ask for port, site, SSL verification, and tool registration mode
 
-Ask: "Any additional settings to configure?"
+## Step 4: Permission Configuration
 
-Options:
-- "Use defaults" — port 443, site 'default', SSL verification off, lazy tool loading
-- "Customize" — ask about each: port, site name, SSL verification, tool registration mode
+Ask whether to enable write permissions:
+- Read-only for now
+- Enable common write permissions: firewall, port forwards, QoS, traffic routes, VPN clients
+- Enable all write permissions except delete operations
+- Custom categories
 
-## Step 5: Permission Configuration
+Collect any selected policy variables. Use the existing `UNIFI_POLICY_NETWORK_<CATEGORY>_<ACTION>=true` format.
 
-Ask: "Do you want to enable any write permissions? By default, the server is read-only for high-risk categories."
+## Step 5: Write Configuration
 
-Options:
-- "Read-only for now" — skip, can be configured later
-- "Enable common write permissions" — enable firewall, port forwards, QoS, traffic routes, VPN clients
-- "Enable all write permissions" — enable everything except delete operations
-- "Custom" — ask which categories to enable
+On macOS/Linux, run the target-aware setup script with only values the user provided or selected:
 
-## Step 6: Write Configuration
-
-Use the appropriate script for the user's platform to write all collected values to `.claude/settings.local.json`. The script handles creating the file, merging into existing env vars, and masking sensitive values in output.
-
-Check the platform from your environment info. On **Windows** use `set-env.ps1`, on **macOS/Linux** use `set-env.sh`:
-
-**macOS / Linux:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-env.sh \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
   UNIFI_NETWORK_HOST=<host> \
   UNIFI_NETWORK_USERNAME=<username> \
   UNIFI_NETWORK_PASSWORD=<password>
 ```
 
-**Windows:**
-```powershell
-powershell -ExecutionPolicy Bypass -File "${CLAUDE_PLUGIN_ROOT}/scripts/set-env.ps1" UNIFI_NETWORK_HOST=<host> UNIFI_NETWORK_USERNAME=<username> UNIFI_NETWORK_PASSWORD=<password>
-```
+Add optional values and policy variables to the same command, for example:
 
-Only pass variables the user provided values for. Use the `UNIFI_NETWORK_` prefix so it doesn't conflict with other server plugins.
-
-If permissions were enabled, also pass those (same script, separate call):
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-env.sh \
-  UNIFI_POLICY_NETWORK_FIREWALL_POLICIES_CREATE=true \
-  UNIFI_POLICY_NETWORK_FIREWALL_POLICIES_UPDATE=true \
-  UNIFI_POLICY_NETWORK_PORT_FORWARDS_CREATE=true \
-  UNIFI_POLICY_NETWORK_PORT_FORWARDS_UPDATE=true
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+  UNIFI_NETWORK_HOST=<host> \
+  UNIFI_NETWORK_USERNAME=<username> \
+  UNIFI_NETWORK_PASSWORD=<password> \
+  UNIFI_NETWORK_API_KEY=<api-key> \
+  UNIFI_POLICY_NETWORK_FIREWALL_UPDATE=true
 ```
 
-Common permission variables for "enable all write":
-- `UNIFI_POLICY_NETWORK_NETWORKS_CREATE=true`, `UNIFI_POLICY_NETWORK_NETWORKS_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_WLANS_CREATE=true`, `UNIFI_POLICY_NETWORK_WLANS_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_DEVICES_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_CLIENTS_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_FIREWALL_POLICIES_CREATE=true`, `UNIFI_POLICY_NETWORK_FIREWALL_POLICIES_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_PORT_FORWARDS_CREATE=true`, `UNIFI_POLICY_NETWORK_PORT_FORWARDS_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_TRAFFIC_ROUTES_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_QOS_RULES_CREATE=true`, `UNIFI_POLICY_NETWORK_QOS_RULES_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_VPN_CLIENTS_UPDATE=true`
-- `UNIFI_POLICY_NETWORK_ROUTES_CREATE=true`, `UNIFI_POLICY_NETWORK_ROUTES_UPDATE=true`
+The script handles the client-specific write:
+- Claude target: merges env vars into `.claude/settings.local.json`
+- Codex target: replaces the `unifi-network` MCP server via `codex mcp add --env ... -- uvx ...`
 
-## Step 7: Verify and Restart
+## Step 6: Final Message
 
-Tell the user:
+For Claude Code, tell the user:
 
-"Configuration saved to `.claude/settings.local.json`. Restart Claude Code (or run `/reload-plugins`) to connect the MCP server.
+"Configuration saved to `.claude/settings.local.json`. Restart Claude Code or run `/reload-plugins`, then confirm the plugin is enabled with `/plugin`."
 
-**After restart, run `/mcp` to verify.** You should see `unifi-network` listed as connected, with a tool count next to it.
+For Codex, tell the user:
 
-If it's missing or shows 0 tools, the server failed to start. Diagnose in this order:
-
-1. `/plugin` — confirm the plugin shows **enabled** (not just installed). If only installed, enable it and re-run `/reload-plugins`.
-2. `which uvx` — if it returns nothing, install `uv` (`curl -LsSf https://astral.sh/uv/install.sh | sh`), restart your shell, then restart Claude Code.
-3. `claude --debug` (in a fresh shell) — surfaces MCP server startup errors. Look for `unifi-network` in the output and report any error to the maintainer.
-4. Verify the credentials by running the same `uvx unifi-network-mcp` command manually with the same env vars to see if it can reach your controller.
-
-Once `/mcp` shows the server connected, the UniFi tools (`unifi_execute`, `unifi_tool_index`, etc.) will be available."
-
-Show a summary table of what was configured.
+"Codex MCP server `unifi-network` configured. Restart Codex so the updated MCP server is loaded."

--- a/plugins/unifi-protect/.codex-plugin/plugin.json
+++ b/plugins/unifi-protect/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "unifi-protect",
+  "version": "0.3.10",
+  "description": "UniFi Protect MCP server — manage security cameras, NVR, recordings, and smart detections",
+  "author": {
+    "name": "sirkirby",
+    "url": "https://github.com/sirkirby"
+  },
+  "homepage": "https://github.com/sirkirby/unifi-mcp",
+  "repository": "https://github.com/sirkirby/unifi-mcp",
+  "license": "MIT",
+  "keywords": [
+    "unifi",
+    "protect",
+    "cameras",
+    "nvr",
+    "security",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "UniFi Protect",
+    "shortDescription": "Manage UniFi Protect cameras, events, recordings, and detections",
+    "longDescription": "Use UniFi Protect MCP tools and skills in Codex to inspect cameras and events, summarize security activity, review recordings, and apply safe preview-before-confirm device mutations against a UniFi Protect controller.",
+    "developerName": "sirkirby",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/sirkirby/unifi-mcp",
+    "defaultPrompt": [
+      "Set up UniFi Protect MCP for Codex",
+      "Show recent Protect events",
+      "Summarize camera activity today"
+    ],
+    "brandColor": "#006FFF",
+    "screenshots": []
+  }
+}

--- a/plugins/unifi-protect/.mcp.json
+++ b/plugins/unifi-protect/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "unifi-protect": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--python-preference",
+        "system",
+        "unifi-protect-mcp==0.3.10"
+      ],
+      "env": {
+        "UNIFI_HOST": "${UNIFI_PROTECT_HOST:-}",
+        "UNIFI_USERNAME": "${UNIFI_PROTECT_USERNAME:-}",
+        "UNIFI_PASSWORD": "${UNIFI_PROTECT_PASSWORD:-}",
+        "UNIFI_PORT": "${UNIFI_PROTECT_PORT:-443}",
+        "UNIFI_VERIFY_SSL": "${UNIFI_PROTECT_VERIFY_SSL:-false}",
+        "UNIFI_PROTECT_HOST": "${UNIFI_PROTECT_HOST:-}",
+        "UNIFI_PROTECT_USERNAME": "${UNIFI_PROTECT_USERNAME:-}",
+        "UNIFI_PROTECT_PASSWORD": "${UNIFI_PROTECT_PASSWORD:-}",
+        "UNIFI_PROTECT_PORT": "${UNIFI_PROTECT_PORT:-443}",
+        "UNIFI_PROTECT_VERIFY_SSL": "${UNIFI_PROTECT_VERIFY_SSL:-false}",
+        "UNIFI_TOOL_REGISTRATION_MODE": "${UNIFI_TOOL_REGISTRATION_MODE:-lazy}"
+      }
+    }
+  }
+}

--- a/plugins/unifi-protect/scripts/check-prereqs.sh
+++ b/plugins/unifi-protect/scripts/check-prereqs.sh
@@ -1,21 +1,57 @@
 #!/bin/bash
 # Pre-flight check for unifi-* plugin setup.
-# Verifies uvx is installed and any existing settings file is valid JSON.
-# Run this BEFORE asking the user for credentials so silent failures get caught early.
-# Bash 3.2 compatible (works on stock macOS /bin/bash).
+# Verifies uvx and client-specific setup prerequisites before credentials are collected.
+# Bash 3.2 compatible for stock macOS.
 
 set -e
+
+TARGET="claude"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --target requires claude or codex" >&2
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: Unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 PLUGIN_NAME="${1:-unifi plugin}"
 SETTINGS_FILE=".claude/settings.local.json"
 
+case "$TARGET" in
+  claude|codex) ;;
+  *)
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    exit 1
+    ;;
+esac
+
 errors=0
 warnings=0
 
-echo "Checking prerequisites for $PLUGIN_NAME..."
+echo "Checking prerequisites for $PLUGIN_NAME ($TARGET)..."
 echo ""
 
-# 1. uvx — required to launch the MCP server
 if command -v uvx >/dev/null 2>&1; then
   uvx_version=$(uvx --version 2>&1 | head -1)
   echo "  [OK]   uvx found: $uvx_version"
@@ -34,45 +70,52 @@ else
   errors=$((errors + 1))
 fi
 
-# 2. existing settings.local.json must be valid JSON before we touch it
-if [ -f "$SETTINGS_FILE" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-      echo "  [OK]   $SETTINGS_FILE is valid JSON"
+if [ "$TARGET" = "claude" ]; then
+  if [ -f "$SETTINGS_FILE" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+      if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
+        echo "  [OK]   $SETTINGS_FILE is valid JSON"
+      else
+        echo "  [FAIL] $SETTINGS_FILE exists but is not valid JSON"
+        echo "         Fix or move it aside before continuing — setup will not"
+        echo "         clobber a malformed settings file."
+        errors=$((errors + 1))
+      fi
     else
-      echo "  [FAIL] $SETTINGS_FILE exists but is not valid JSON"
-      echo "         Fix or move it aside before continuing — setup will not"
-      echo "         clobber a malformed settings file."
-      errors=$((errors + 1))
+      echo "  [WARN] python3 not available — cannot validate $SETTINGS_FILE"
+      warnings=$((warnings + 1))
     fi
   else
-    echo "  [WARN] python3 not available — cannot validate $SETTINGS_FILE"
-    warnings=$((warnings + 1))
+    echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
   fi
 else
-  echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
+  if command -v codex >/dev/null 2>&1; then
+    codex_version=$(codex --version 2>&1 | head -1)
+    echo "  [OK]   codex found: $codex_version"
+    if codex mcp list >/dev/null 2>&1; then
+      echo "  [OK]   codex mcp list succeeded"
+    else
+      echo "  [WARN] codex is installed, but 'codex mcp list' failed"
+      echo "         Setup may still work, but confirm Codex is authenticated."
+      warnings=$((warnings + 1))
+    fi
+  else
+    echo "  [FAIL] codex CLI not found on PATH"
+    echo "         Codex setup registers the MCP server with 'codex mcp add'."
+    echo "         Install or open Codex, then re-run setup."
+    errors=$((errors + 1))
+  fi
 fi
 
-# 3. macOS interpreter selection
-# The MCP server's outbound network capability depends on which Python
-# interpreter uvx selects. macOS only grants network access to interpreters
-# that carry the com.apple.security.network.client entitlement — system and
-# Homebrew Python builds do; uv's managed standalone Python builds do not.
-# An entitlement-less interpreter will start the server cleanly, register
-# tools, and silently fail every outbound call with errno 65.
-#
-# plugin.json passes `--python-preference system` so uvx picks an entitled
-# interpreter when one is present; this check confirms one actually is and
-# warns when uv would fall back to its managed build.
 if [ "$(uname -s)" = "Darwin" ] && command -v uv >/dev/null 2>&1; then
   selected_py=$(uv python find --python-preference system 2>/dev/null || true)
   case "$selected_py" in
     */.local/share/uv/python/*)
       echo "  [WARN] uv would fall back to its managed Python on this Mac:"
       echo "           $selected_py"
-      echo "         macOS will not grant outbound network to that interpreter,"
-      echo "         so every controller call returns 'Not connected to"
-      echo "         controller' even though the server starts cleanly."
+      echo "         macOS may not grant outbound network to that interpreter,"
+      echo "         so controller calls can return 'Not connected to controller'"
+      echo "         even though the server starts cleanly."
       echo ""
       echo "         Install a system Python so uvx can use it, e.g."
       echo "           brew install python@3.13"
@@ -91,9 +134,12 @@ if [ "$(uname -s)" = "Darwin" ] && command -v uv >/dev/null 2>&1; then
   esac
 fi
 
-# 4. plugin enablement — there's no programmatic check, just remind the user
-echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
-echo "         After setup, run /plugin and confirm the plugin shows enabled."
+if [ "$TARGET" = "claude" ]; then
+  echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
+  echo "         After setup, run /plugin and confirm the plugin shows enabled."
+else
+  echo "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+fi
 
 echo ""
 if [ $errors -gt 0 ]; then

--- a/plugins/unifi-protect/scripts/set-env.sh
+++ b/plugins/unifi-protect/scripts/set-env.sh
@@ -1,22 +1,63 @@
 #!/bin/bash
-# Merge environment variables into .claude/settings.local.json
-# Usage: set-env.sh KEY1=VALUE1 KEY2=VALUE2 ...
+# Configure UniFi MCP client environment.
+# Usage:
+#   set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
 #
-# Creates .claude/settings.local.json if it doesn't exist.
-# Merges into existing "env" object without overwriting other keys.
-# Pure bash + sed — no python3, jq, or other dependencies required.
-# Compatible with bash 3.2 (the version shipped on macOS).
+# Claude target: merges environment variables into .claude/settings.local.json.
+# Codex target: registers/replaces the MCP server with `codex mcp add --env`.
+#
+# Bash 3.2 compatible for stock macOS.
 
 set -e
 
-SETTINGS_FILE=".claude/settings.local.json"
+TARGET="claude"
+DRY_RUN="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --target)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --target requires claude or codex" >&2
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: Unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [ $# -eq 0 ]; then
-  echo "Usage: set-env.sh KEY1=VALUE1 KEY2=VALUE2 ..." >&2
+  echo "Usage: set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
   exit 1
 fi
 
-# Validate every argument up front so we fail fast on bad input.
+case "$TARGET" in
+  claude|codex) ;;
+  *)
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    exit 1
+    ;;
+esac
+
 for arg in "$@"; do
   if [[ "$arg" != *"="* ]]; then
     echo "ERROR: Invalid argument '$arg'. Expected KEY=VALUE format." >&2
@@ -24,71 +65,154 @@ for arg in "$@"; do
   fi
 done
 
-mkdir -p "$(dirname "$SETTINGS_FILE")"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_NAME="$(basename "$PLUGIN_ROOT")"
 
-# Refuse to clobber a malformed settings file — fix it first.
-if [ -f "$SETTINGS_FILE" ] && command -v python3 >/dev/null 2>&1; then
-  if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
-    echo "ERROR: $SETTINGS_FILE is not valid JSON. Fix or move it aside, then re-run." >&2
-    exit 1
-  fi
-fi
+detect_package_pin() {
+  for manifest in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.mcp.json"; do
+    if [ -f "$manifest" ]; then
+      pin=$(grep -Eo 'unifi-[a-z]+-mcp==[0-9][^"]*' "$manifest" | head -1 || true)
+      if [ -n "$pin" ]; then
+        echo "$pin"
+        return
+      fi
+    fi
+  done
 
-# Read existing settings or start with an empty env object
-if [ -f "$SETTINGS_FILE" ]; then
-  existing=$(cat "$SETTINGS_FILE")
-else
-  existing='{ "env": {} }'
-fi
+  case "$PLUGIN_NAME" in
+    unifi-network) echo "unifi-network-mcp@latest" ;;
+    unifi-protect) echo "unifi-protect-mcp@latest" ;;
+    unifi-access) echo "unifi-access-mcp@latest" ;;
+    *)
+      echo "ERROR: Could not infer MCP package for $PLUGIN_NAME" >&2
+      exit 1
+      ;;
+  esac
+}
 
-# Ensure "env" key exists — if the file has no env block, wrap it
-if ! echo "$existing" | grep -q '"env"'; then
-  existing=$(echo "$existing" | sed 's/}[[:space:]]*$/,\n  "env": {}\n}/')
-fi
-
-# For each KEY=VALUE arg, either update the existing key or insert it
-for arg in "$@"; do
-  key="${arg%%=*}"
-  value="${arg#*=}"
-  escaped_value=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g; s/&/\\&/g')
-
-  if echo "$existing" | grep -q "\"$key\""; then
-    existing=$(echo "$existing" | sed "s|\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$key\": \"$escaped_value\"|")
-  else
-    existing=$(echo "$existing" | sed "s|\"env\"[[:space:]]*:[[:space:]]*{|\"env\": {\n    \"$key\": \"$escaped_value\",|")
-  fi
-done
-
-# Clean up any trailing commas before closing braces (invalid JSON)
-existing=$(echo "$existing" | sed 's/,[[:space:]]*}/\n  }/g')
-
-# Write atomically via a temp file so a malformed result never replaces a good file.
-tmp_file="${SETTINGS_FILE}.tmp.$$"
-echo "$existing" > "$tmp_file"
-
-# Validate the result before swapping in. If python3 isn't available, skip validation —
-# the user can still recover from .tmp file if something goes wrong.
-if command -v python3 >/dev/null 2>&1; then
-  if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp_file" 2>/dev/null; then
-    echo "ERROR: produced invalid JSON. Likely cause: a special character in a value broke" >&2
-    echo "       sed-based escaping. Bad output left at $tmp_file for inspection." >&2
-    echo "       Original $SETTINGS_FILE was not modified." >&2
-    exit 1
-  fi
-fi
-mv "$tmp_file" "$SETTINGS_FILE"
-
-# Report what was set (mask sensitive values)
-for arg in "$@"; do
-  key="${arg%%=*}"
-  value="${arg#*=}"
+mask_value() {
+  key="$1"
+  value="$2"
   if [ ${#value} -gt 4 ] && [[ ! "$key" =~ _(HOST|PORT|SITE)$ ]] && [ "$value" != "true" ] && [ "$value" != "false" ]; then
-    display="${value:0:2}***${value: -2}"
+    echo "${value:0:2}***${value: -2}"
   else
-    display="$value"
+    echo "$value"
   fi
-  echo "  $key = $display"
-done
+}
 
-echo ""
-echo "Saved to $SETTINGS_FILE"
+print_values() {
+  for arg in "$@"; do
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    display="$(mask_value "$key" "$value")"
+    echo "  $key = $display"
+  done
+}
+
+write_claude_settings() {
+  SETTINGS_FILE=".claude/settings.local.json"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would merge these values into $SETTINGS_FILE:"
+    print_values "$@"
+    return
+  fi
+
+  mkdir -p "$(dirname "$SETTINGS_FILE")"
+
+  if [ -f "$SETTINGS_FILE" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$SETTINGS_FILE" 2>/dev/null; then
+      echo "ERROR: $SETTINGS_FILE is not valid JSON. Fix or move it aside, then re-run." >&2
+      exit 1
+    fi
+  fi
+
+  if [ -f "$SETTINGS_FILE" ]; then
+    existing=$(cat "$SETTINGS_FILE")
+  else
+    existing='{ "env": {} }'
+  fi
+
+  if ! echo "$existing" | grep -q '"env"'; then
+    existing=$(echo "$existing" | sed 's/}[[:space:]]*$/,\n  "env": {}\n}/')
+  fi
+
+  for arg in "$@"; do
+    key="${arg%%=*}"
+    value="${arg#*=}"
+    escaped_value=$(printf '%s' "$value" | sed 's/\\/\\\\/g; s/"/\\"/g; s/&/\\&/g')
+
+    if echo "$existing" | grep -q "\"$key\""; then
+      existing=$(echo "$existing" | sed "s|\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$key\": \"$escaped_value\"|")
+    else
+      existing=$(echo "$existing" | sed "s|\"env\"[[:space:]]*:[[:space:]]*{|\"env\": {\n    \"$key\": \"$escaped_value\",|")
+    fi
+  done
+
+  existing=$(echo "$existing" | sed 's/,[[:space:]]*}/\n  }/g')
+
+  tmp_file="${SETTINGS_FILE}.tmp.$$"
+  echo "$existing" > "$tmp_file"
+
+  if command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$tmp_file" 2>/dev/null; then
+      echo "ERROR: produced invalid JSON. Bad output left at $tmp_file for inspection." >&2
+      echo "       Original $SETTINGS_FILE was not modified." >&2
+      exit 1
+    fi
+  fi
+
+  mv "$tmp_file" "$SETTINGS_FILE"
+  print_values "$@"
+  echo ""
+  echo "Saved to $SETTINGS_FILE"
+}
+
+write_codex_config() {
+  package_pin="$(detect_package_pin)"
+
+  if ! command -v codex >/dev/null 2>&1; then
+    echo "ERROR: codex CLI not found on PATH. Install or open Codex, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v uvx >/dev/null 2>&1; then
+    echo "ERROR: uvx not found on PATH. Install uv, then re-run setup." >&2
+    exit 1
+  fi
+
+  cmd=(mcp add "$PLUGIN_NAME")
+  for arg in "$@"; do
+    cmd+=(--env "$arg")
+  done
+  cmd+=(-- uvx --python-preference system "$package_pin")
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would replace Codex MCP server '$PLUGIN_NAME' with:"
+    printf '  codex mcp add %q' "$PLUGIN_NAME"
+    for arg in "$@"; do
+      key="${arg%%=*}"
+      value="${arg#*=}"
+      display="$(mask_value "$key" "$value")"
+      printf ' --env %q' "$key=$display"
+    done
+    printf ' -- uvx --python-preference system %q' "$package_pin"
+    echo ""
+    echo ""
+    echo "Environment values:"
+    print_values "$@"
+    return
+  fi
+
+  codex mcp remove "$PLUGIN_NAME" >/dev/null 2>&1 || true
+  codex "${cmd[@]}"
+  echo ""
+  echo "Configured Codex MCP server '$PLUGIN_NAME' with $package_pin."
+  echo "Restart Codex so the updated MCP server configuration is loaded."
+}
+
+case "$TARGET" in
+  claude) write_claude_settings "$@" ;;
+  codex) write_codex_config "$@" ;;
+esac

--- a/plugins/unifi-protect/skills/setup/SKILL.md
+++ b/plugins/unifi-protect/skills/setup/SKILL.md
@@ -1,104 +1,105 @@
 ---
 name: setup
-description: Configure the UniFi Protect MCP server — set NVR host, credentials, and permissions
+description: Configure the UniFi Protect MCP server for Claude Code or Codex — set NVR host, credentials, and permissions
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
 # Set Up UniFi Protect MCP Server
 
-Walk the user through configuring their UniFi Protect NVR connection. **Ask each question one at a time using AskUserQuestion. Wait for the answer before proceeding.**
+Walk the user through configuring their UniFi Protect NVR connection. Ask one question at a time and wait for the answer before continuing.
+
+## Interaction Rules
+
+Use the client target that matches the current agent runtime:
+- Claude Code: `claude`
+- Codex: `codex`
+
+If the runtime is unclear, ask which client to configure. For questions, use the platform's blocking question tool when available (`AskUserQuestion` in Claude Code, `request_user_input` in Codex). If no blocking question tool is available, ask in chat with numbered options and wait for the user's reply.
+
+On macOS and Linux, resolve setup scripts relative to this skill file:
+- `../../scripts/check-prereqs.sh`
+- `../../scripts/set-env.sh`
+
+When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
+
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable.
 
 ## Step 0: Check Prerequisites
 
-Before asking the user for any credentials, run the prereq check so the most common silent failures (missing `uvx`, malformed existing settings) are caught up front:
+Before asking for credentials, run:
 
-**macOS / Linux:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-prereqs.sh "unifi-protect"
+bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex> "unifi-protect"
 ```
 
-**Windows:** PowerShell setups can skip this step — `uvx` availability is checked when the MCP server first launches. Just remind the user to install `uv` if it's missing.
-
-If the script exits non-zero, **stop and report the error to the user**. Do not proceed to credentials. The script's output already explains what to fix.
+If the script exits non-zero, stop and report the error. Do not proceed to credentials.
 
 ## Step 1: Controller Host
 
-Ask: "What is your UniFi controller's IP address or hostname?" (e.g., 192.168.1.1)
+Ask: "What is your UniFi controller's IP address or hostname?" Example: `192.168.1.1`.
 
-If the user already has a Network server configured (check for `UNIFI_NETWORK_HOST` or `UNIFI_HOST` in `.claude/settings.local.json`), ask: "Is Protect on the same controller as your Network server?" If yes, use the same host.
+If another UniFi MCP server is already configured, ask whether Protect is on the same controller. For Claude, existing values may be in `.claude/settings.local.json`. For Codex, existing values may be visible through `codex mcp list` and `codex mcp get <server>`.
 
 ## Step 2: Credentials
 
-If the user already has Network credentials configured with the shared `UNIFI_` prefix, mention they can reuse those. Only set `UNIFI_PROTECT_` prefixed variables if the credentials differ from the shared ones.
+If the user already configured shared `UNIFI_*` credentials for another UniFi server, mention they can reuse those credentials. Only set `UNIFI_PROTECT_*` values when Protect credentials differ.
 
 Ask for:
-1. Username (local admin account — **not** a Ubiquiti SSO account)
+1. Username, using a local admin account, not a Ubiquiti SSO account
 2. Password
 
-Username and password are **required**. These must be local admin credentials on the UniFi controller.
+Username and password are required.
 
-### Optional: API Key
+### Optional API Key
 
-After collecting credentials, mention:
+After collecting username and password, explain that UniFi API key support is experimental and limited to read-only operations and a subset of tools. Ask whether to configure an API key too.
 
-"UniFi also supports API keys, but API key auth is **experimental** — it's limited to read-only operations and a subset of tools. Ubiquiti is still expanding API key support. Would you also like to configure an API key?"
+If yes, ask for the API key and include `UNIFI_PROTECT_API_KEY`. If no, skip it.
 
-If yes, ask for the API key string and include it as `UNIFI_PROTECT_API_KEY` in the configuration. If no, skip it.
+## Step 3: Permission Configuration
 
-## Step 4: Permission Configuration
-
-Ask: "Do you want to enable any write permissions? By default, ALL mutations are disabled for Protect (camera settings, recording control, PTZ, reboots)."
+Ask whether to enable write permissions. By default, Protect mutations are disabled for camera settings, recording control, PTZ, and reboots.
 
 Options:
-- "Read-only for now" — safest, can view everything but change nothing
-- "Enable camera management" — camera settings, recording toggle, PTZ, reboot
-- "Enable all device management" — cameras + lights + chimes
-- "Custom" — ask which categories to enable
+- Read-only for now
+- Enable camera management
+- Enable all device management
+- Custom categories
 
-## Step 5: Write Configuration
+Collect any selected policy variables. Use the existing `UNIFI_POLICY_PROTECT_<CATEGORY>_<ACTION>=true` format.
 
-Use the appropriate script for the user's platform to write all collected values to `.claude/settings.local.json`. Check the platform from your environment info. On **Windows** use `set-env.ps1`, on **macOS/Linux** use `set-env.sh`:
+## Step 4: Write Configuration
 
-**macOS / Linux:**
+On macOS/Linux, run the target-aware setup script with only values the user provided or selected:
+
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-env.sh \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
   UNIFI_PROTECT_HOST=<host> \
   UNIFI_PROTECT_USERNAME=<username> \
   UNIFI_PROTECT_PASSWORD=<password>
 ```
 
-**Windows:**
-```powershell
-powershell -ExecutionPolicy Bypass -File "${CLAUDE_PLUGIN_ROOT}/scripts/set-env.ps1" UNIFI_PROTECT_HOST=<host> UNIFI_PROTECT_USERNAME=<username> UNIFI_PROTECT_PASSWORD=<password>
-```
+Add optional values and policy variables to the same command, for example:
 
-If the host and credentials are the same as existing shared `UNIFI_*` vars, use the shared prefix instead (same script, different keys).
-
-If permissions were enabled, also pass those:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/set-env.sh \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+  UNIFI_PROTECT_HOST=<host> \
+  UNIFI_PROTECT_USERNAME=<username> \
+  UNIFI_PROTECT_PASSWORD=<password> \
+  UNIFI_PROTECT_API_KEY=<api-key> \
   UNIFI_POLICY_PROTECT_CAMERAS_UPDATE=true
 ```
 
-Permission variables by option:
-- **Camera management:** `UNIFI_POLICY_PROTECT_CAMERAS_UPDATE=true`
-- **All device management:** `UNIFI_POLICY_PROTECT_CAMERAS_UPDATE=true`, `UNIFI_POLICY_PROTECT_LIGHTS_UPDATE=true`, `UNIFI_POLICY_PROTECT_CHIMES_UPDATE=true`
+The script handles the client-specific write:
+- Claude target: merges env vars into `.claude/settings.local.json`
+- Codex target: replaces the `unifi-protect` MCP server via `codex mcp add --env ... -- uvx ...`
 
-## Step 6: Verify and Restart
+## Step 5: Final Message
 
-Tell the user:
+For Claude Code, tell the user:
 
-"Configuration saved to `.claude/settings.local.json`. Restart Claude Code (or run `/reload-plugins`) to connect the MCP server.
+"Configuration saved to `.claude/settings.local.json`. Restart Claude Code or run `/reload-plugins`, then confirm the plugin is enabled with `/plugin`."
 
-**After restart, run `/mcp` to verify.** You should see `unifi-protect` listed as connected, with a tool count next to it.
+For Codex, tell the user:
 
-If it's missing or shows 0 tools, the server failed to start. Diagnose in this order:
-
-1. `/plugin` — confirm the plugin shows **enabled** (not just installed). If only installed, enable it and re-run `/reload-plugins`.
-2. `which uvx` — if it returns nothing, install `uv` (`curl -LsSf https://astral.sh/uv/install.sh | sh`), restart your shell, then restart Claude Code.
-3. `claude --debug` (in a fresh shell) — surfaces MCP server startup errors. Look for `unifi-protect` in the output and report any error to the maintainer.
-4. Verify the credentials by running the same `uvx unifi-protect-mcp` command manually with the same env vars to see if it can reach your controller.
-
-Once `/mcp` shows the server connected, the UniFi Protect tools will be available."
-
-Show a summary table of what was configured.
+"Codex MCP server `unifi-protect` configured. Restart Codex so the updated MCP server is loaded."


### PR DESCRIPTION
## Summary

- Add Codex marketplace metadata and per-plugin `.codex-plugin` manifests for Network, Protect, and Access.
- Add per-plugin `.mcp.json` files so Codex can discover the same uvx-backed MCP servers as Claude Code.
- Make setup/prereq scripts target-aware: Claude writes `.claude/settings.local.json`; Codex registers MCP servers with `codex mcp add`.
- Update setup skills and docs so the post-install setup flow is portable across Claude Code and Codex.
- Extend plugin version sync so Claude manifests, Codex manifests, and `.mcp.json` package pins stay aligned after releases.

## Notes

Codex setup intentionally keeps the plugin flow on stdio for now. HTTP MCP remains a future option, but this avoids local port conflicts and daemon lifecycle complexity for session-scoped plugin installs.

## Test Results

Post-rebase on latest `origin/main`:

- `make pre-commit` ✅
  - format, manifest generation, skill reference sync, server manifest generation, lint, and package/app test suites completed successfully.
- `python3 scripts/generate_skill_references.py --check` ✅
  - Network: 169 tools / 21 categories
  - Protect: 40 tools / 8 categories
  - Access: 29 tools / 7 categories
- JSON validation ✅
  - `.agents/plugins/marketplace.json`
  - all new `.codex-plugin/plugin.json` files
  - all new `.mcp.json` files
  - existing Claude marketplace/plugin manifests
- Shell validation ✅
  - `bash -n` for all updated `set-env.sh` and `check-prereqs.sh` scripts.
- Isolated Codex marketplace smoke ✅
  - `CODEX_HOME=<tmp> codex plugin marketplace add /Users/chris/Repos/unifi-mcp`
  - Result: marketplace `unifi-plugins` added and temp Codex config written.
- Isolated Codex MCP setup smoke ✅
  - Network registered with `uvx --python-preference system unifi-network-mcp==0.17.1`, no CWD pinned.
  - Protect registered with `uvx --python-preference system unifi-protect-mcp==0.3.10`, no CWD pinned.
  - Access registered with `uvx --python-preference system unifi-access-mcp==0.2.9`, no CWD pinned.
- Isolated Claude setup smoke ✅
  - Access setup wrote valid temp `.claude/settings.local.json` with expected `env` keys.
- `git diff --check` ✅
