### PR TITLE
feat: add OpenClaw plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "unifi@privatly.net"
   },
   "metadata": {
-    "description": "UniFi MCP plugins — manage Ubiquiti UniFi infrastructure from Claude Code"
+    "description": "UniFi MCP plugins — manage Ubiquiti UniFi infrastructure from Claude Code, Codex, and OpenClaw"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Install via the plugin marketplace — includes the MCP server, an agent skill, 
 ```
 /plugin marketplace add sirkirby/unifi-mcp
 /plugin install unifi-network@unifi-plugins
-/unifi-network:setup
+/unifi-network:unifi-network-setup
 ```
 
 Repeat for Protect or Access if needed:
@@ -61,7 +61,7 @@ Repeat for Protect or Access if needed:
 /plugin install unifi-access@unifi-plugins
 ```
 
-Each plugin's `/setup` command walks you through connecting to your controller and configuring permissions.
+Each plugin's setup command walks you through connecting to your controller and configuring permissions.
 
 ### Codex
 
@@ -73,9 +73,34 @@ codex plugin marketplace add sirkirby/unifi-mcp
 
 Launch `codex`, run `/plugins`, open the UniFi MCP marketplace, and install `unifi-network`, `unifi-protect`, or `unifi-access`. After installing, ask Codex to run the plugin's setup skill, for example:
 
-> Use the UniFi Network setup skill to configure this for Codex.
+> Use the `unifi-network-setup` skill to configure this for Codex.
 
 The setup skill registers the MCP server with `codex mcp add`, stores the selected environment values in Codex's MCP configuration, and keeps the same preview-before-confirm safety model as Claude Code.
+
+### OpenClaw
+
+OpenClaw can install the same UniFi plugin bundles from the marketplace and map their skills plus MCP server definitions into embedded Pi sessions:
+
+```bash
+openclaw plugins install unifi-network --marketplace https://github.com/sirkirby/unifi-mcp
+openclaw gateway restart
+```
+
+Then run the matching setup skill from OpenClaw (`unifi-network-setup`, `unifi-protect-setup`, or `unifi-access-setup`), or configure the server directly:
+
+```bash
+openclaw mcp set unifi-network '{
+  "command": "uvx",
+  "args": ["--python-preference", "system", "unifi-network-mcp@latest"],
+  "env": {
+    "UNIFI_NETWORK_HOST": "192.168.1.1",
+    "UNIFI_NETWORK_USERNAME": "admin",
+    "UNIFI_NETWORK_PASSWORD": "your-password"
+  }
+}'
+```
+
+Repeat with `unifi-protect` or `unifi-access` as needed. Restart the OpenClaw Gateway after changing MCP server configuration.
 
 ### Other MCP clients
 
@@ -205,9 +230,9 @@ packages/
   unifi-mcp-shared/ # Shared MCP patterns (permissions, tools, diagnostics, config)
   unifi-mcp-relay/  # Cloud relay sidecar (bridges local servers to Cloudflare Worker)
 plugins/
-  unifi-network/    # Claude Code/Codex plugin: MCP server + agent skills + setup
-  unifi-protect/    # Claude Code/Codex plugin: MCP server + agent skills + setup
-  unifi-access/     # Claude Code/Codex plugin: MCP server + setup
+  unifi-network/    # Claude Code/Codex/OpenClaw plugin: MCP server + agent skills + setup
+  unifi-protect/    # Claude Code/Codex/OpenClaw plugin: MCP server + agent skills + setup
+  unifi-access/     # Claude Code/Codex/OpenClaw plugin: MCP server + setup
 skills/
   _shared/          # Shared utilities for skill scripts (MCP client, config)
 docs/               # Ecosystem-level documentation

--- a/docs/index.html
+++ b/docs/index.html
@@ -115,6 +115,7 @@
       <span class="item"><svg class="glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 18 0 9 9 0 0 0-18 0z"/><path d="M9 12l2 2 4-4"/></svg>Gemini CLI</span>
       <span class="item"><svg class="glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h12"/></svg>opencode</span>
       <span class="item"><svg class="glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12c5-8 15-8 20 0M2 12c5 8 15 8 20 0"/><circle cx="12" cy="12" r="3"/></svg>Codex CLI</span>
+      <span class="item"><svg class="glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5h16v10H4z"/><path d="M8 19h8M12 15v4"/><path d="M8 9h8M8 12h5"/></svg>OpenClaw</span>
       <span class="item"><svg class="glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/></svg>n8n / Zapier</span>
       <span class="item"><svg class="glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h7v7H4zM13 4h7v7h-7zM4 13h7v7H4zM13 13h7v7h-7z"/></svg>Custom agents</span>
     </div>
@@ -539,6 +540,10 @@
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 1l6 3v4c0 4-3 6.5-6 7-3-.5-6-3-6-7V4l6-3z"/></svg>
           Claude Code
         </button>
+        <button role="tab" id="tab-openclaw" aria-selected="false" aria-controls="panel-openclaw" onclick="switchTab('openclaw')">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="12" height="8"/><path d="M5 14h6M8 11v3"/><path d="M5 6h6M5 8.5h4"/></svg>
+          OpenClaw
+        </button>
         <button role="tab" id="tab-uvx" aria-selected="false" aria-controls="panel-uvx" onclick="switchTab('uvx')">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h12v8H2z"/><path d="M5 7l2 1-2 1M9 9h2"/></svg>
           uvx
@@ -566,7 +571,16 @@
 <span class="k">/plugin</span> install <span class="s">unifi-network@unifi-plugins</span>
 
 <span class="c"># 3. Run the guided setup</span>
-<span class="k">/unifi-network:setup</span></code></pre>
+<span class="k">/unifi-network:unifi-network-setup</span></code></pre>
+      </div>
+      <div role="tabpanel" id="panel-openclaw" class="install-panel" hidden>
+        <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+<pre><code><span class="c"># Install the same UniFi bundle marketplace in OpenClaw</span>
+openclaw plugins install <span class="s">unifi-network</span> --marketplace <span class="s">https://github.com/sirkirby/unifi-mcp</span>
+openclaw gateway restart
+
+<span class="c"># The unifi-network-setup skill can configure this, or register MCP directly:</span>
+openclaw mcp set <span class="s">unifi-network</span> <span class="v">'{"command":"uvx","args":["--python-preference","system","unifi-network-mcp@latest"],"env":{"UNIFI_NETWORK_HOST":"192.168.1.1","UNIFI_NETWORK_USERNAME":"admin","UNIFI_NETWORK_PASSWORD":"your-password"}}'</span></code></pre>
       </div>
       <div role="tabpanel" id="panel-uvx" class="install-panel" hidden>
         <button class="copy-btn" onclick="copyCode(this)">Copy</button>

--- a/plugins/unifi-access/scripts/check-prereqs.sh
+++ b/plugins/unifi-access/scripts/check-prereqs.sh
@@ -11,7 +11,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --target)
       if [ $# -lt 2 ]; then
-        echo "ERROR: --target requires claude or codex" >&2
+        echo "ERROR: --target requires claude, codex, or openclaw" >&2
         exit 1
       fi
       TARGET="$2"
@@ -39,9 +39,9 @@ PLUGIN_NAME="${1:-unifi plugin}"
 SETTINGS_FILE=".claude/settings.local.json"
 
 case "$TARGET" in
-  claude|codex) ;;
+  claude|codex|openclaw) ;;
   *)
-    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude, codex, or openclaw." >&2
     exit 1
     ;;
 esac
@@ -88,7 +88,7 @@ if [ "$TARGET" = "claude" ]; then
   else
     echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
   fi
-else
+elif [ "$TARGET" = "codex" ]; then
   if command -v codex >/dev/null 2>&1; then
     codex_version=$(codex --version 2>&1 | head -1)
     echo "  [OK]   codex found: $codex_version"
@@ -103,6 +103,32 @@ else
     echo "  [FAIL] codex CLI not found on PATH"
     echo "         Codex setup registers the MCP server with 'codex mcp add'."
     echo "         Install or open Codex, then re-run setup."
+    errors=$((errors + 1))
+  fi
+else
+  if command -v openclaw >/dev/null 2>&1; then
+    openclaw_version=$(openclaw --version 2>&1 | head -1)
+    echo "  [OK]   openclaw found: $openclaw_version"
+    if openclaw mcp list >/dev/null 2>&1; then
+      echo "  [OK]   openclaw mcp list succeeded"
+    else
+      echo "  [WARN] openclaw is installed, but 'openclaw mcp list' failed"
+      echo "         Setup may still work, but confirm OpenClaw config is valid."
+      warnings=$((warnings + 1))
+    fi
+  else
+    echo "  [FAIL] openclaw CLI not found on PATH"
+    echo "         OpenClaw setup registers the MCP server with 'openclaw mcp set'."
+    echo "         Install OpenClaw, then re-run setup."
+    errors=$((errors + 1))
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python_version=$(python3 --version 2>&1 | head -1)
+    echo "  [OK]   python3 found: $python_version"
+  else
+    echo "  [FAIL] python3 not found on PATH"
+    echo "         OpenClaw setup uses python3 to build MCP JSON without shell-escaping bugs."
     errors=$((errors + 1))
   fi
 fi
@@ -137,8 +163,10 @@ fi
 if [ "$TARGET" = "claude" ]; then
   echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
   echo "         After setup, run /plugin and confirm the plugin shows enabled."
-else
+elif [ "$TARGET" = "codex" ]; then
   echo "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+else
+  echo "  [INFO] After setup, restart the OpenClaw Gateway so MCP server changes are loaded."
 fi
 
 echo ""

--- a/plugins/unifi-access/scripts/set-env.sh
+++ b/plugins/unifi-access/scripts/set-env.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Configure UniFi MCP client environment.
 # Usage:
-#   set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
+#   set-env.sh [--target claude|codex|openclaw] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
 #
 # Claude target: merges environment variables into .claude/settings.local.json.
 # Codex target: registers/replaces the MCP server with `codex mcp add --env`.
+# OpenClaw target: registers/replaces the MCP server with `openclaw mcp set`.
 #
 # Bash 3.2 compatible for stock macOS.
 
@@ -17,7 +18,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --target)
       if [ $# -lt 2 ]; then
-        echo "ERROR: --target requires claude or codex" >&2
+        echo "ERROR: --target requires claude, codex, or openclaw" >&2
         exit 1
       fi
       TARGET="$2"
@@ -46,14 +47,14 @@ while [ $# -gt 0 ]; do
 done
 
 if [ $# -eq 0 ]; then
-  echo "Usage: set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
+  echo "Usage: set-env.sh [--target claude|codex|openclaw] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
   exit 1
 fi
 
 case "$TARGET" in
-  claude|codex) ;;
+  claude|codex|openclaw) ;;
   *)
-    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude, codex, or openclaw." >&2
     exit 1
     ;;
 esac
@@ -212,7 +213,71 @@ write_codex_config() {
   echo "Restart Codex so the updated MCP server configuration is loaded."
 }
 
+build_openclaw_json() {
+  package_pin="$1"
+  shift
+
+  python3 - "$package_pin" "$@" <<'PY'
+import json
+import sys
+
+package_pin = sys.argv[1]
+env = {}
+for item in sys.argv[2:]:
+    key, value = item.split("=", 1)
+    env[key] = value
+
+print(
+    json.dumps(
+        {
+            "command": "uvx",
+            "args": ["--python-preference", "system", package_pin],
+            "env": env,
+        },
+        separators=(",", ":"),
+    )
+)
+PY
+}
+
+write_openclaw_config() {
+  package_pin="$(detect_package_pin)"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would replace OpenClaw MCP server '$PLUGIN_NAME' with:"
+    printf '  openclaw mcp set %q ' "$PLUGIN_NAME"
+    printf "'{\"command\":\"uvx\",\"args\":[\"--python-preference\",\"system\",\"%s\"],\"env\":{...}}'" "$package_pin"
+    echo ""
+    echo ""
+    echo "Environment values:"
+    print_values "$@"
+    return
+  fi
+
+  if ! command -v openclaw >/dev/null 2>&1; then
+    echo "ERROR: openclaw CLI not found on PATH. Install OpenClaw, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v uvx >/dev/null 2>&1; then
+    echo "ERROR: uvx not found on PATH. Install uv, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 not found on PATH. It is required to build the OpenClaw MCP JSON config safely." >&2
+    exit 1
+  fi
+
+  mcp_json="$(build_openclaw_json "$package_pin" "$@")"
+  openclaw mcp set "$PLUGIN_NAME" "$mcp_json"
+  echo ""
+  echo "Configured OpenClaw MCP server '$PLUGIN_NAME' with $package_pin."
+  echo "Restart the OpenClaw Gateway so the updated MCP server configuration is loaded."
+}
+
 case "$TARGET" in
   claude) write_claude_settings "$@" ;;
   codex) write_codex_config "$@" ;;
+  openclaw) write_openclaw_config "$@" ;;
 esac

--- a/plugins/unifi-access/skills/unifi-access-setup/SKILL.md
+++ b/plugins/unifi-access/skills/unifi-access-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: setup
-description: Configure the UniFi Access MCP server for Claude Code or Codex — set controller host, credentials, API key, and permissions
+name: unifi-access-setup
+description: Configure the UniFi Access MCP server for Claude Code, Codex, or OpenClaw — set controller host, credentials, API key, and permissions
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
@@ -13,6 +13,7 @@ Walk the user through configuring their UniFi Access controller connection. Ask 
 Use the client target that matches the current agent runtime:
 - Claude Code: `claude`
 - Codex: `codex`
+- OpenClaw: `openclaw`
 
 If the runtime is unclear, ask which client to configure. For questions, use the platform's blocking question tool when available (`AskUserQuestion` in Claude Code, `request_user_input` in Codex). If no blocking question tool is available, ask in chat with numbered options and wait for the user's reply.
 
@@ -22,14 +23,14 @@ On macOS and Linux, resolve setup scripts relative to this skill file:
 
 When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
 
-On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable.
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable.
 
 ## Step 0: Check Prerequisites
 
 Before asking for credentials, run:
 
 ```bash
-bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex> "unifi-access"
+bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex|openclaw> "unifi-access"
 ```
 
 If the script exits non-zero, stop and report the error. Do not proceed to credentials.
@@ -38,7 +39,7 @@ If the script exits non-zero, stop and report the error. Do not proceed to crede
 
 Ask: "What is your UniFi controller's IP address or hostname?" Example: `192.168.1.1`.
 
-If another UniFi MCP server is already configured, ask whether Access is on the same controller. For Claude, existing values may be in `.claude/settings.local.json`. For Codex, existing values may be visible through `codex mcp list` and `codex mcp get <server>`.
+If another UniFi MCP server is already configured, ask whether Access is on the same controller. For Claude, existing values may be in `.claude/settings.local.json`. For Codex, existing values may be visible through `codex mcp list` and `codex mcp get <server>`. For OpenClaw, existing values may be visible through `openclaw mcp list` and `openclaw mcp show <server>`.
 
 ## Step 2: Authentication
 
@@ -80,7 +81,7 @@ Collect any selected policy variables. Use the existing `UNIFI_POLICY_ACCESS_<CA
 On macOS/Linux, run the target-aware setup script with only values the user provided or selected:
 
 ```bash
-bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex|openclaw> \
   UNIFI_ACCESS_HOST=<host> \
   UNIFI_ACCESS_API_KEY=<api-key> \
   UNIFI_ACCESS_USERNAME=<username> \
@@ -90,7 +91,7 @@ bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
 Add optional values and policy variables to the same command, for example:
 
 ```bash
-bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex|openclaw> \
   UNIFI_ACCESS_HOST=<host> \
   UNIFI_ACCESS_API_KEY=<api-key> \
   UNIFI_ACCESS_USERNAME=<username> \
@@ -102,6 +103,7 @@ bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
 The script handles the client-specific write:
 - Claude target: merges env vars into `.claude/settings.local.json`
 - Codex target: replaces the `unifi-access` MCP server via `codex mcp add --env ... -- uvx ...`
+- OpenClaw target: replaces the `unifi-access` MCP server via `openclaw mcp set ...`
 
 ## Step 6: Final Message
 
@@ -112,3 +114,7 @@ For Claude Code, tell the user:
 For Codex, tell the user:
 
 "Codex MCP server `unifi-access` configured. Restart Codex so the updated MCP server is loaded."
+
+For OpenClaw, tell the user:
+
+"OpenClaw MCP server `unifi-access` configured. Restart the OpenClaw Gateway so the updated MCP server is loaded."

--- a/plugins/unifi-access/skills/unifi-access/SKILL.md
+++ b/plugins/unifi-access/skills/unifi-access/SKILL.md
@@ -63,7 +63,7 @@ Access has two independent auth paths:
 
 Either can work independently. For full functionality, configure both. If mutations fail with auth errors, the user needs username+password (API key alone is not enough for write operations).
 
-To configure, run `/unifi-access:setup` or set env vars manually:
+To configure, run `/unifi-access:unifi-access-setup` or set env vars manually:
 ```
 UNIFI_ACCESS_HOST=192.168.1.1
 UNIFI_ACCESS_API_KEY=your-api-key

--- a/plugins/unifi-network/scripts/check-prereqs.sh
+++ b/plugins/unifi-network/scripts/check-prereqs.sh
@@ -11,7 +11,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --target)
       if [ $# -lt 2 ]; then
-        echo "ERROR: --target requires claude or codex" >&2
+        echo "ERROR: --target requires claude, codex, or openclaw" >&2
         exit 1
       fi
       TARGET="$2"
@@ -39,9 +39,9 @@ PLUGIN_NAME="${1:-unifi plugin}"
 SETTINGS_FILE=".claude/settings.local.json"
 
 case "$TARGET" in
-  claude|codex) ;;
+  claude|codex|openclaw) ;;
   *)
-    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude, codex, or openclaw." >&2
     exit 1
     ;;
 esac
@@ -88,7 +88,7 @@ if [ "$TARGET" = "claude" ]; then
   else
     echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
   fi
-else
+elif [ "$TARGET" = "codex" ]; then
   if command -v codex >/dev/null 2>&1; then
     codex_version=$(codex --version 2>&1 | head -1)
     echo "  [OK]   codex found: $codex_version"
@@ -103,6 +103,32 @@ else
     echo "  [FAIL] codex CLI not found on PATH"
     echo "         Codex setup registers the MCP server with 'codex mcp add'."
     echo "         Install or open Codex, then re-run setup."
+    errors=$((errors + 1))
+  fi
+else
+  if command -v openclaw >/dev/null 2>&1; then
+    openclaw_version=$(openclaw --version 2>&1 | head -1)
+    echo "  [OK]   openclaw found: $openclaw_version"
+    if openclaw mcp list >/dev/null 2>&1; then
+      echo "  [OK]   openclaw mcp list succeeded"
+    else
+      echo "  [WARN] openclaw is installed, but 'openclaw mcp list' failed"
+      echo "         Setup may still work, but confirm OpenClaw config is valid."
+      warnings=$((warnings + 1))
+    fi
+  else
+    echo "  [FAIL] openclaw CLI not found on PATH"
+    echo "         OpenClaw setup registers the MCP server with 'openclaw mcp set'."
+    echo "         Install OpenClaw, then re-run setup."
+    errors=$((errors + 1))
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python_version=$(python3 --version 2>&1 | head -1)
+    echo "  [OK]   python3 found: $python_version"
+  else
+    echo "  [FAIL] python3 not found on PATH"
+    echo "         OpenClaw setup uses python3 to build MCP JSON without shell-escaping bugs."
     errors=$((errors + 1))
   fi
 fi
@@ -137,8 +163,10 @@ fi
 if [ "$TARGET" = "claude" ]; then
   echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
   echo "         After setup, run /plugin and confirm the plugin shows enabled."
-else
+elif [ "$TARGET" = "codex" ]; then
   echo "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+else
+  echo "  [INFO] After setup, restart the OpenClaw Gateway so MCP server changes are loaded."
 fi
 
 echo ""

--- a/plugins/unifi-network/scripts/set-env.sh
+++ b/plugins/unifi-network/scripts/set-env.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Configure UniFi MCP client environment.
 # Usage:
-#   set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
+#   set-env.sh [--target claude|codex|openclaw] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
 #
 # Claude target: merges environment variables into .claude/settings.local.json.
 # Codex target: registers/replaces the MCP server with `codex mcp add --env`.
+# OpenClaw target: registers/replaces the MCP server with `openclaw mcp set`.
 #
 # Bash 3.2 compatible for stock macOS.
 
@@ -17,7 +18,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --target)
       if [ $# -lt 2 ]; then
-        echo "ERROR: --target requires claude or codex" >&2
+        echo "ERROR: --target requires claude, codex, or openclaw" >&2
         exit 1
       fi
       TARGET="$2"
@@ -46,14 +47,14 @@ while [ $# -gt 0 ]; do
 done
 
 if [ $# -eq 0 ]; then
-  echo "Usage: set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
+  echo "Usage: set-env.sh [--target claude|codex|openclaw] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
   exit 1
 fi
 
 case "$TARGET" in
-  claude|codex) ;;
+  claude|codex|openclaw) ;;
   *)
-    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude, codex, or openclaw." >&2
     exit 1
     ;;
 esac
@@ -212,7 +213,71 @@ write_codex_config() {
   echo "Restart Codex so the updated MCP server configuration is loaded."
 }
 
+build_openclaw_json() {
+  package_pin="$1"
+  shift
+
+  python3 - "$package_pin" "$@" <<'PY'
+import json
+import sys
+
+package_pin = sys.argv[1]
+env = {}
+for item in sys.argv[2:]:
+    key, value = item.split("=", 1)
+    env[key] = value
+
+print(
+    json.dumps(
+        {
+            "command": "uvx",
+            "args": ["--python-preference", "system", package_pin],
+            "env": env,
+        },
+        separators=(",", ":"),
+    )
+)
+PY
+}
+
+write_openclaw_config() {
+  package_pin="$(detect_package_pin)"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would replace OpenClaw MCP server '$PLUGIN_NAME' with:"
+    printf '  openclaw mcp set %q ' "$PLUGIN_NAME"
+    printf "'{\"command\":\"uvx\",\"args\":[\"--python-preference\",\"system\",\"%s\"],\"env\":{...}}'" "$package_pin"
+    echo ""
+    echo ""
+    echo "Environment values:"
+    print_values "$@"
+    return
+  fi
+
+  if ! command -v openclaw >/dev/null 2>&1; then
+    echo "ERROR: openclaw CLI not found on PATH. Install OpenClaw, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v uvx >/dev/null 2>&1; then
+    echo "ERROR: uvx not found on PATH. Install uv, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 not found on PATH. It is required to build the OpenClaw MCP JSON config safely." >&2
+    exit 1
+  fi
+
+  mcp_json="$(build_openclaw_json "$package_pin" "$@")"
+  openclaw mcp set "$PLUGIN_NAME" "$mcp_json"
+  echo ""
+  echo "Configured OpenClaw MCP server '$PLUGIN_NAME' with $package_pin."
+  echo "Restart the OpenClaw Gateway so the updated MCP server configuration is loaded."
+}
+
 case "$TARGET" in
   claude) write_claude_settings "$@" ;;
   codex) write_codex_config "$@" ;;
+  openclaw) write_openclaw_config "$@" ;;
 esac

--- a/plugins/unifi-network/skills/firewall-auditor/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-auditor/SKILL.md
@@ -18,7 +18,7 @@ There is no Python script doing the audit for you. There is no HTTP sidecar. You
 
 ## Required MCP Server
 
-This skill requires the `unifi-network` MCP server. If `unifi_tool_index` is unavailable, stop and direct the user to `/setup`.
+This skill requires the `unifi-network` MCP server. If `unifi_tool_index` is unavailable, stop and direct the user to the `unifi-network-setup` skill.
 
 ---
 

--- a/plugins/unifi-network/skills/firewall-manager/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-manager/SKILL.md
@@ -18,7 +18,7 @@ There are no helper scripts in this skill — only references and tools. You dri
 
 ## Required MCP Server
 
-This skill requires the `unifi-network` MCP server. Verify with `unifi_tool_index`. If it's unavailable, direct the user to `/setup`.
+This skill requires the `unifi-network` MCP server. Verify with `unifi_tool_index`. If it's unavailable, direct the user to the `unifi-network-setup` skill.
 
 ---
 
@@ -26,7 +26,7 @@ This skill requires the `unifi-network` MCP server. Verify with `unifi_tool_inde
 
 Before doing anything else:
 
-- Confirm `UNIFI_NETWORK_HOST` (or `UNIFI_HOST`) is set. If not: *"UNIFI_NETWORK_HOST is not configured. Please run `/setup` before using this skill."*
+- Confirm `UNIFI_NETWORK_HOST` (or `UNIFI_HOST`) is set. If not: *"UNIFI_NETWORK_HOST is not configured. Please run the `unifi-network-setup` skill before using this skill."*
 - Verify the server responds by calling `unifi_tool_index`.
 
 ---
@@ -205,7 +205,7 @@ For a comprehensive scored audit, use the **firewall-auditor** skill instead.
 
 ## 8. Manual fallback
 
-When you cannot reach the MCP server (network issue, server crash), there is no fallback that mutates the controller — there's nothing to mutate against. Tell the user the server is unreachable and direct them to `/setup` for diagnosis.
+When you cannot reach the MCP server (network issue, server crash), there is no fallback that mutates the controller — there's nothing to mutate against. Tell the user the server is unreachable and direct them to the `unifi-network-setup` skill for diagnosis.
 
 The "manual procedure" sections of older versions of this skill assumed a separate HTTP transport that no longer exists. Removed for simplicity.
 

--- a/plugins/unifi-network/skills/network-health-check/SKILL.md
+++ b/plugins/unifi-network/skills/network-health-check/SKILL.md
@@ -10,7 +10,7 @@ description: Run a UniFi network health check — diagnose device status, connec
 Before running a health check, verify the MCP server is configured:
 
 - Check that `UNIFI_NETWORK_HOST` is set in the environment.
-- If it is not set or the connection fails, stop and direct the user to `/setup` to configure the UniFi Network MCP server.
+- If it is not set or the connection fails, stop and direct the user to the `unifi-network-setup` skill to configure the UniFi Network MCP server.
 - Use `unifi_tool_index` to confirm available tools. If no UniFi tools are listed, the server is not connected.
 
 ## Health Check Procedure

--- a/plugins/unifi-network/skills/unifi-network-setup/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: setup
-description: Configure the UniFi Network MCP server for Claude Code or Codex — set controller host, credentials, and permissions
+name: unifi-network-setup
+description: Configure the UniFi Network MCP server for Claude Code, Codex, or OpenClaw — set controller host, credentials, and permissions
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
@@ -13,6 +13,7 @@ Walk the user through configuring their UniFi Network controller connection. Ask
 Use the client target that matches the current agent runtime:
 - Claude Code: `claude`
 - Codex: `codex`
+- OpenClaw: `openclaw`
 
 If the runtime is unclear, ask which client to configure. For questions, use the platform's blocking question tool when available (`AskUserQuestion` in Claude Code, `request_user_input` in Codex). If no blocking question tool is available, ask in chat with numbered options and wait for the user's reply.
 
@@ -22,14 +23,14 @@ On macOS and Linux, resolve setup scripts relative to this skill file:
 
 When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
 
-On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable.
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable.
 
 ## Step 0: Check Prerequisites
 
 Before asking for credentials, run:
 
 ```bash
-bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex> "unifi-network"
+bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex|openclaw> "unifi-network"
 ```
 
 If the script exits non-zero, stop and report the error. Do not proceed to credentials.
@@ -73,7 +74,7 @@ Collect any selected policy variables. Use the existing `UNIFI_POLICY_NETWORK_<C
 On macOS/Linux, run the target-aware setup script with only values the user provided or selected:
 
 ```bash
-bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex|openclaw> \
   UNIFI_NETWORK_HOST=<host> \
   UNIFI_NETWORK_USERNAME=<username> \
   UNIFI_NETWORK_PASSWORD=<password>
@@ -82,7 +83,7 @@ bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
 Add optional values and policy variables to the same command, for example:
 
 ```bash
-bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex|openclaw> \
   UNIFI_NETWORK_HOST=<host> \
   UNIFI_NETWORK_USERNAME=<username> \
   UNIFI_NETWORK_PASSWORD=<password> \
@@ -93,6 +94,7 @@ bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
 The script handles the client-specific write:
 - Claude target: merges env vars into `.claude/settings.local.json`
 - Codex target: replaces the `unifi-network` MCP server via `codex mcp add --env ... -- uvx ...`
+- OpenClaw target: replaces the `unifi-network` MCP server via `openclaw mcp set ...`
 
 ## Step 6: Final Message
 
@@ -103,3 +105,7 @@ For Claude Code, tell the user:
 For Codex, tell the user:
 
 "Codex MCP server `unifi-network` configured. Restart Codex so the updated MCP server is loaded."
+
+For OpenClaw, tell the user:
+
+"OpenClaw MCP server `unifi-network` configured. Restart the OpenClaw Gateway so the updated MCP server is loaded."

--- a/plugins/unifi-network/skills/unifi-network/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network/SKILL.md
@@ -69,7 +69,7 @@ Additional enriched fields: `upgradable` (bool), `connection_network` (VLAN name
 
 Username and password are **required** (local admin credentials, not Ubiquiti SSO). API key support exists but is **experimental** — limited to read-only operations and a subset of tools.
 
-To configure, run `/unifi-network:setup` or set env vars manually:
+To configure, run `/unifi-network:unifi-network-setup` or set env vars manually:
 ```
 UNIFI_NETWORK_HOST=192.168.1.1
 UNIFI_NETWORK_USERNAME=admin

--- a/plugins/unifi-protect/scripts/check-prereqs.sh
+++ b/plugins/unifi-protect/scripts/check-prereqs.sh
@@ -11,7 +11,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --target)
       if [ $# -lt 2 ]; then
-        echo "ERROR: --target requires claude or codex" >&2
+        echo "ERROR: --target requires claude, codex, or openclaw" >&2
         exit 1
       fi
       TARGET="$2"
@@ -39,9 +39,9 @@ PLUGIN_NAME="${1:-unifi plugin}"
 SETTINGS_FILE=".claude/settings.local.json"
 
 case "$TARGET" in
-  claude|codex) ;;
+  claude|codex|openclaw) ;;
   *)
-    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude, codex, or openclaw." >&2
     exit 1
     ;;
 esac
@@ -88,7 +88,7 @@ if [ "$TARGET" = "claude" ]; then
   else
     echo "  [OK]   $SETTINGS_FILE does not exist yet (will be created)"
   fi
-else
+elif [ "$TARGET" = "codex" ]; then
   if command -v codex >/dev/null 2>&1; then
     codex_version=$(codex --version 2>&1 | head -1)
     echo "  [OK]   codex found: $codex_version"
@@ -103,6 +103,32 @@ else
     echo "  [FAIL] codex CLI not found on PATH"
     echo "         Codex setup registers the MCP server with 'codex mcp add'."
     echo "         Install or open Codex, then re-run setup."
+    errors=$((errors + 1))
+  fi
+else
+  if command -v openclaw >/dev/null 2>&1; then
+    openclaw_version=$(openclaw --version 2>&1 | head -1)
+    echo "  [OK]   openclaw found: $openclaw_version"
+    if openclaw mcp list >/dev/null 2>&1; then
+      echo "  [OK]   openclaw mcp list succeeded"
+    else
+      echo "  [WARN] openclaw is installed, but 'openclaw mcp list' failed"
+      echo "         Setup may still work, but confirm OpenClaw config is valid."
+      warnings=$((warnings + 1))
+    fi
+  else
+    echo "  [FAIL] openclaw CLI not found on PATH"
+    echo "         OpenClaw setup registers the MCP server with 'openclaw mcp set'."
+    echo "         Install OpenClaw, then re-run setup."
+    errors=$((errors + 1))
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python_version=$(python3 --version 2>&1 | head -1)
+    echo "  [OK]   python3 found: $python_version"
+  else
+    echo "  [FAIL] python3 not found on PATH"
+    echo "         OpenClaw setup uses python3 to build MCP JSON without shell-escaping bugs."
     errors=$((errors + 1))
   fi
 fi
@@ -137,8 +163,10 @@ fi
 if [ "$TARGET" = "claude" ]; then
   echo "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
   echo "         After setup, run /plugin and confirm the plugin shows enabled."
-else
+elif [ "$TARGET" = "codex" ]; then
   echo "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+else
+  echo "  [INFO] After setup, restart the OpenClaw Gateway so MCP server changes are loaded."
 fi
 
 echo ""

--- a/plugins/unifi-protect/scripts/set-env.sh
+++ b/plugins/unifi-protect/scripts/set-env.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Configure UniFi MCP client environment.
 # Usage:
-#   set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
+#   set-env.sh [--target claude|codex|openclaw] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ...
 #
 # Claude target: merges environment variables into .claude/settings.local.json.
 # Codex target: registers/replaces the MCP server with `codex mcp add --env`.
+# OpenClaw target: registers/replaces the MCP server with `openclaw mcp set`.
 #
 # Bash 3.2 compatible for stock macOS.
 
@@ -17,7 +18,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --target)
       if [ $# -lt 2 ]; then
-        echo "ERROR: --target requires claude or codex" >&2
+        echo "ERROR: --target requires claude, codex, or openclaw" >&2
         exit 1
       fi
       TARGET="$2"
@@ -46,14 +47,14 @@ while [ $# -gt 0 ]; do
 done
 
 if [ $# -eq 0 ]; then
-  echo "Usage: set-env.sh [--target claude|codex] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
+  echo "Usage: set-env.sh [--target claude|codex|openclaw] [--dry-run] KEY1=VALUE1 KEY2=VALUE2 ..." >&2
   exit 1
 fi
 
 case "$TARGET" in
-  claude|codex) ;;
+  claude|codex|openclaw) ;;
   *)
-    echo "ERROR: Unsupported target '$TARGET'. Expected claude or codex." >&2
+    echo "ERROR: Unsupported target '$TARGET'. Expected claude, codex, or openclaw." >&2
     exit 1
     ;;
 esac
@@ -212,7 +213,71 @@ write_codex_config() {
   echo "Restart Codex so the updated MCP server configuration is loaded."
 }
 
+build_openclaw_json() {
+  package_pin="$1"
+  shift
+
+  python3 - "$package_pin" "$@" <<'PY'
+import json
+import sys
+
+package_pin = sys.argv[1]
+env = {}
+for item in sys.argv[2:]:
+    key, value = item.split("=", 1)
+    env[key] = value
+
+print(
+    json.dumps(
+        {
+            "command": "uvx",
+            "args": ["--python-preference", "system", package_pin],
+            "env": env,
+        },
+        separators=(",", ":"),
+    )
+)
+PY
+}
+
+write_openclaw_config() {
+  package_pin="$(detect_package_pin)"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "Would replace OpenClaw MCP server '$PLUGIN_NAME' with:"
+    printf '  openclaw mcp set %q ' "$PLUGIN_NAME"
+    printf "'{\"command\":\"uvx\",\"args\":[\"--python-preference\",\"system\",\"%s\"],\"env\":{...}}'" "$package_pin"
+    echo ""
+    echo ""
+    echo "Environment values:"
+    print_values "$@"
+    return
+  fi
+
+  if ! command -v openclaw >/dev/null 2>&1; then
+    echo "ERROR: openclaw CLI not found on PATH. Install OpenClaw, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v uvx >/dev/null 2>&1; then
+    echo "ERROR: uvx not found on PATH. Install uv, then re-run setup." >&2
+    exit 1
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 not found on PATH. It is required to build the OpenClaw MCP JSON config safely." >&2
+    exit 1
+  fi
+
+  mcp_json="$(build_openclaw_json "$package_pin" "$@")"
+  openclaw mcp set "$PLUGIN_NAME" "$mcp_json"
+  echo ""
+  echo "Configured OpenClaw MCP server '$PLUGIN_NAME' with $package_pin."
+  echo "Restart the OpenClaw Gateway so the updated MCP server configuration is loaded."
+}
+
 case "$TARGET" in
   claude) write_claude_settings "$@" ;;
   codex) write_codex_config "$@" ;;
+  openclaw) write_openclaw_config "$@" ;;
 esac

--- a/plugins/unifi-protect/skills/unifi-protect-setup/SKILL.md
+++ b/plugins/unifi-protect/skills/unifi-protect-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: setup
-description: Configure the UniFi Protect MCP server for Claude Code or Codex — set NVR host, credentials, and permissions
+name: unifi-protect-setup
+description: Configure the UniFi Protect MCP server for Claude Code, Codex, or OpenClaw — set NVR host, credentials, and permissions
 allowed-tools: Read, Bash, AskUserQuestion
 ---
 
@@ -13,6 +13,7 @@ Walk the user through configuring their UniFi Protect NVR connection. Ask one qu
 Use the client target that matches the current agent runtime:
 - Claude Code: `claude`
 - Codex: `codex`
+- OpenClaw: `openclaw`
 
 If the runtime is unclear, ask which client to configure. For questions, use the platform's blocking question tool when available (`AskUserQuestion` in Claude Code, `request_user_input` in Codex). If no blocking question tool is available, ask in chat with numbered options and wait for the user's reply.
 
@@ -22,14 +23,14 @@ On macOS and Linux, resolve setup scripts relative to this skill file:
 
 When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
 
-On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable.
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable.
 
 ## Step 0: Check Prerequisites
 
 Before asking for credentials, run:
 
 ```bash
-bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex> "unifi-protect"
+bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex|openclaw> "unifi-protect"
 ```
 
 If the script exits non-zero, stop and report the error. Do not proceed to credentials.
@@ -38,7 +39,7 @@ If the script exits non-zero, stop and report the error. Do not proceed to crede
 
 Ask: "What is your UniFi controller's IP address or hostname?" Example: `192.168.1.1`.
 
-If another UniFi MCP server is already configured, ask whether Protect is on the same controller. For Claude, existing values may be in `.claude/settings.local.json`. For Codex, existing values may be visible through `codex mcp list` and `codex mcp get <server>`.
+If another UniFi MCP server is already configured, ask whether Protect is on the same controller. For Claude, existing values may be in `.claude/settings.local.json`. For Codex, existing values may be visible through `codex mcp list` and `codex mcp get <server>`. For OpenClaw, existing values may be visible through `openclaw mcp list` and `openclaw mcp show <server>`.
 
 ## Step 2: Credentials
 
@@ -73,7 +74,7 @@ Collect any selected policy variables. Use the existing `UNIFI_POLICY_PROTECT_<C
 On macOS/Linux, run the target-aware setup script with only values the user provided or selected:
 
 ```bash
-bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex|openclaw> \
   UNIFI_PROTECT_HOST=<host> \
   UNIFI_PROTECT_USERNAME=<username> \
   UNIFI_PROTECT_PASSWORD=<password>
@@ -82,7 +83,7 @@ bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
 Add optional values and policy variables to the same command, for example:
 
 ```bash
-bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
+bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex|openclaw> \
   UNIFI_PROTECT_HOST=<host> \
   UNIFI_PROTECT_USERNAME=<username> \
   UNIFI_PROTECT_PASSWORD=<password> \
@@ -93,6 +94,7 @@ bash <path-to-plugin>/scripts/set-env.sh --target <claude|codex> \
 The script handles the client-specific write:
 - Claude target: merges env vars into `.claude/settings.local.json`
 - Codex target: replaces the `unifi-protect` MCP server via `codex mcp add --env ... -- uvx ...`
+- OpenClaw target: replaces the `unifi-protect` MCP server via `openclaw mcp set ...`
 
 ## Step 5: Final Message
 
@@ -103,3 +105,7 @@ For Claude Code, tell the user:
 For Codex, tell the user:
 
 "Codex MCP server `unifi-protect` configured. Restart Codex so the updated MCP server is loaded."
+
+For OpenClaw, tell the user:
+
+"OpenClaw MCP server `unifi-protect` configured. Restart the OpenClaw Gateway so the updated MCP server is loaded."

--- a/plugins/unifi-protect/skills/unifi-protect/SKILL.md
+++ b/plugins/unifi-protect/skills/unifi-protect/SKILL.md
@@ -67,7 +67,7 @@ All tools return: `{"success": true, "data": ...}`, `{"success": false, "error":
 
 Username and password are **required** (local admin credentials, not Ubiquiti SSO). API key support exists but is **experimental** — limited to read-only operations and a subset of tools.
 
-To configure, run `/unifi-protect:setup` or set env vars manually:
+To configure, run `/unifi-protect:unifi-protect-setup` or set env vars manually:
 ```
 UNIFI_PROTECT_HOST=192.168.1.1
 UNIFI_PROTECT_USERNAME=admin

--- a/scripts/smoke-plugin-setup.sh
+++ b/scripts/smoke-plugin-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Smoke test the plugin setup scripts (check-prereqs.sh, set-env.sh) for all
-# three Claude Code plugins.
+# three UniFi MCP plugin bundles.
 #
 # Run with the system bash to specifically pin macOS bash 3.2 compatibility:
 #   /bin/bash scripts/smoke-plugin-setup.sh
@@ -187,6 +187,54 @@ ec=$?
 set -e
 assert "bad input exits non-zero" "$ec" "1"
 assert_contains "bad input names the offending arg" "$out" "notakeyvalue"
+
+# 3f. OpenClaw dry-run emits the expected registry command without leaking secrets
+rm -rf "$work" && mkdir "$work" && cd "$work"
+set +e
+out=$(/bin/bash "$SETENV" --target openclaw --dry-run \
+  UNIFI_NETWORK_HOST=10.0.0.1 \
+  UNIFI_NETWORK_USERNAME=admin \
+  UNIFI_NETWORK_PASSWORD=hunter2secret 2>&1)
+ec=$?
+set -e
+assert "openclaw dry-run exits 0" "$ec" "0"
+assert_contains "openclaw dry-run uses mcp set" "$out" "openclaw mcp set unifi-network"
+assert_contains "openclaw dry-run uses uvx command" "$out" '"command":"uvx"'
+assert_contains "openclaw dry-run masks password" "$out" "hu***et"
+assert_not_contains "openclaw dry-run hides raw password" "$out" "hunter2secret"
+
+# 3g. OpenClaw target writes valid MCP JSON through the CLI
+rm -rf "$work" && mkdir -p "$work/bin" && cd "$work"
+cat > "$work/bin/uvx" <<'SH'
+#!/bin/sh
+echo "uvx 0.0.0"
+SH
+cat > "$work/bin/openclaw" <<'SH'
+#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "set" ]; then
+  printf '%s\n' "$3" > "$OPENCLAW_CAPTURE_NAME"
+  printf '%s\n' "$4" > "$OPENCLAW_CAPTURE_JSON"
+  exit 0
+fi
+echo "openclaw 0.0.0"
+SH
+chmod +x "$work/bin/uvx" "$work/bin/openclaw"
+set +e
+out=$(PATH="$work/bin:$PATH" OPENCLAW_CAPTURE_NAME="$work/name.txt" OPENCLAW_CAPTURE_JSON="$work/mcp.json" /bin/bash "$SETENV" --target openclaw \
+  UNIFI_NETWORK_HOST=10.0.0.1 \
+  UNIFI_NETWORK_USERNAME=admin \
+  UNIFI_NETWORK_PASSWORD=hunter2secret 2>&1)
+ec=$?
+set -e
+assert "openclaw write exits 0" "$ec" "0"
+got_name=$(cat "$work/name.txt")
+assert "openclaw write targets plugin name" "$got_name" "unifi-network"
+assert_file_valid_json "openclaw write produces valid MCP JSON" "$work/mcp.json"
+got_command=$(python3 -c "import json; print(json.load(open('mcp.json'))['command'])")
+assert "openclaw JSON uses uvx command" "$got_command" "uvx"
+got_host=$(python3 -c "import json; print(json.load(open('mcp.json'))['env']['UNIFI_NETWORK_HOST'])")
+assert "openclaw JSON includes host env" "$got_host" "10.0.0.1"
+assert_not_contains "openclaw write stdout hides raw password" "$out" "hunter2secret"
 
 # --- 4. Bash version this test ran under (informational) ---
 echo ""


### PR DESCRIPTION
## Summary

Adds first-class OpenClaw support to the existing UniFi MCP plugin bundles without converting them to native OpenClaw plugins.

- adds `--target openclaw` to the shared setup scripts for Network, Protect, and Access
- writes OpenClaw MCP server definitions through `openclaw mcp set` using the existing `uvx --python-preference system` package launch path
- updates setup skills, README, docs landing page, and marketplace copy to include OpenClaw
- gives each setup skill a globally unique bundle skill name so OpenClaw can publish all three plugins together without skill-name collisions
- extends plugin smoke tests to cover OpenClaw dry-run output, mocked writes, valid MCP JSON, and secret masking

## Why

OpenClaw now supports Codex/Claude bundle layouts directly. Keeping UniFi MCP on the bundle path lets OpenClaw consume the existing skills and `.mcp.json` MCP definitions while preserving the narrower bundle trust boundary.

## Validation

- OpenClaw 2026.5.12 real CLI smoke:
  - `openclaw plugins marketplace list /Users/chris/Repos/unifi-mcp --json` discovers `unifi-network`, `unifi-protect`, and `unifi-access`
  - isolated `openclaw plugins install <plugin> --marketplace /Users/chris/Repos/unifi-mcp --force` loads each plugin as `Format: bundle`, `Bundle format: codex`, with `skills, mcpServers` capabilities
  - `openclaw skills list` publishes `unifi-network-setup`, `unifi-protect-setup`, and `unifi-access-setup` with no plugin skill-name collisions
  - `plugins/unifi-network/scripts/set-env.sh --target openclaw ...` writes valid MCP JSON through real `openclaw mcp set`; special-character env values round-trip through `openclaw mcp show --json`
  - isolated `check-prereqs.sh --target openclaw` passes for Network, Protect, and Access
- `/bin/bash scripts/smoke-plugin-setup.sh` — 36 assertions passed
- `python3 scripts/generate_skill_references.py --check`
- `git diff --check`
- browser smoke of the docs OpenClaw install tab via local HTTP server
- `make pre-commit`