### PR TITLE
fix: align MCP protocol revision terminology

### DIFF
--- a/.agents/skills/add-tool-category/SKILL.md
+++ b/.agents/skills/add-tool-category/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: myco:add-tool-category
-description: >
-  Use this skill whenever adding a new UniFi resource type as a supported tool category
-  — creating a manager, tool layer, schemas, tests, and wiring everything into the
-  manifest and CI. Activates for any PR or task that introduces a new manager class
-  (managers/{resource}_manager.py), new tool module (tools/{resource}.py), or new
-  UniFi subsystem support, even if the user only asks to "add support for X" without
-  specifying each step. Covers: manager class with CRUD + lru_cache factory, 405
-  endpoint workarounds, pydantic model definition in unifi-core, tool layer
-  with preview/confirm flow and correct ToolAnnotations, test file requirements (both
-  layers), V2 API response unwrapping, manifest regeneration, test_scaffold.py CI
-  registration, and Protect-package naming conventions.
+description: >-
+  Use this skill whenever adding a new UniFi resource type as a supported tool
+  category — creating a manager, tool layer, schemas, tests, and wiring
+  everything into the manifest and CI. Activates for any PR or task that
+  introduces a new manager class (managers/{resource}_manager.py), new tool
+  module (tools/{resource}.py), or new UniFi subsystem support, even if the
+  user only asks to "add support for X" without specifying each step. Covers:
+  manager class with CRUD + lru_cache factory, 405 endpoint workarounds, V2
+  API response unwrapping, schema definition and validator registry wiring,
+  tool layer with preview/confirm flow and correct ToolAnnotations, test file
+  requirements (both layers), manifest regeneration, test_scaffold.py CI
+  registration, Protect-package naming conventions, critical endpoint patterns,
+  typed action input models for non-CRUD action tools, and
+  DISPATCH_ARG_TRANSLATORS API-layer registration for action dispatcher.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -232,6 +235,57 @@ async def handle_dns_record_create(args: dict | None = None) -> str:
 
 **Preview/confirm flow:** All mutating tools (create, update, delete) must present a preview and require explicit confirmation before executing. Follow the established pattern in `tools/dns.py`.
 
+## Step 4.5 — Typed Action Input Models for Non-CRUD Action Tools
+
+If your resource includes action tools (non-CRUD operations like "arm", "disarm", "toggle" state), define typed input models to enable full schema discovery and validation. This pattern is critical for action dispatcher integration (Step 8).
+
+**File:** `packages/unifi-core/src/unifi_core/<server>/models/_actions.py`
+
+Define a Pydantic model class for each action tool's input schema:
+
+```python
+from pydantic import BaseModel, Field
+from typing import Optional
+
+# Example for an alarm manager with arm/disarm/toggle actions
+class AlarmArmInput(BaseModel):
+    """Input schema for the alarm_arm action tool."""
+    alarm_id: str = Field(..., description="The unique ID of the alarm to arm")
+    override_armed_status: Optional[bool] = Field(
+        None, description="If true, arm even if already armed"
+    )
+
+class AlarmDisarmInput(BaseModel):
+    """Input schema for the alarm_disarm action tool."""
+    alarm_id: str
+    require_confirmation: Optional[bool] = Field(
+        None, description="Require user confirmation before disarming"
+    )
+
+class AlarmToggleInput(BaseModel):
+    """Input schema for the alarm_toggle action tool."""
+    alarm_id: str
+```
+
+Then, in the tool module, reference these models in the tool's `inputSchema`:
+
+```python
+from unifi_core.protect.models._actions import AlarmArmInput
+
+def get_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="protect_alarm_arm",
+            description="Arm the alarm system.",
+            inputSchema=AlarmArmInput.model_json_schema(),
+            annotations=ToolAnnotations(destructiveHint=False),
+        ),
+        # ... more tools
+    ]
+```
+
+Action tools with explicit typed models are discoverable by the action dispatcher (Step 8) and participate in schema validation without requiring a Pydantic base model for the resource itself.
+
 ## Step 5 — Write Tests for Both Layers
 
 Both test files are required. PRs missing either are blocked at review.
@@ -270,16 +324,47 @@ The registration string must match the key used in `CATEGORY_MAP` (see Step 7). 
 ## Step 7 — Regenerate the Manifest
 
 ```bash
-make manifest
+make generate
 ```
 
-This regenerates `CATEGORY_MAP` and `TOOL_MODULE_MAP` entries. After running:
+This regenerates the manifest and validates your new category against CI gates. The build output includes:
+
+1. Tool count summary — verify your new tools are included.
+2. Validator registry check — ensures all Pydantic models register correctly.
+3. Category membership — confirms your new manager is discoverable.
+
+After running:
 
 1. Verify your new category appears in the manifest header.
 2. Confirm the tool count in the manifest header incremented by the number of tools you added.
-3. Commit the updated manifest along with the rest of your changes.
+3. Commit the updated manifest files along with the rest of your changes.
 
 **Do this before opening the PR.** A stale manifest causes tool-count assertion failures in CI.
+
+For build/check cycles, use `make check-generated` to validate without regenerating, and `make ci` to run the full pre-commit gate locally.
+
+## Step 8 — Register in Action Dispatcher (API-Layer Only)
+
+If your new category includes action tools (non-CRUD operations like arm, disarm, toggle) **and** the unifi-api layer needs to support those tools, register a `DISPATCH_ARG_TRANSLATORS` entry in the action dispatcher service.
+
+**File:** `apps/api/src/unifi_api/services/dispatch_overrides.py`
+
+```python
+from unifi_core.protect.models._actions import AlarmArmInput, AlarmDisarmInput
+from unifi_core.protect.managers.alarm_manager import get_alarm_manager
+
+DISPATCH_ARG_TRANSLATORS = {
+    # ... existing entries
+    "protect_alarm_arm": lambda args, ctx: AlarmArmInput(**args).model_dump(),
+    "protect_alarm_disarm": lambda args, ctx: AlarmDisarmInput(**args).model_dump(),
+}
+```
+
+This registration allows the `/v1/actions/` endpoint to validate and translate caller arguments before passing them to the tool handler. Without this registration, action tools via `/v1/actions/` will fail with a silent arg-shape mismatch (TypeError) that unit tests do not catch.
+
+**Scope:** Only action tools (arm, disarm, toggle, etc.) need `DISPATCH_ARG_TRANSLATORS` entries. CRUD tools (create, read, update, delete) do not use the action dispatcher.
+
+**Reference:** `apps/api/src/unifi_api/services/dispatch_overrides.py` and `extend-unifi-api` skill, Procedure C.
 
 ## Naming Conventions
 
@@ -299,7 +384,9 @@ Manager class: `{Resource}Manager` (PascalCase). Factory function: `get_{resourc
 
 **V2 list wrapping on single-resource fetches** — V2 responses can return a list even for single-object fetches. Always check `isinstance(response, list)` before returning from `get_by_id`. The list branch must come before the dict branch.
 
-**Manifest must be committed** — `make manifest` output is not auto-generated in CI. The regenerated manifest file must be in the PR commit.
+**Manifest must be committed** — `make generate` output is not auto-generated in CI. The regenerated manifest files must be in the PR commit.
+
+**Make target restructure** — The build toolchain now uses `make generate` (replaces `make manifest`), `make check-generated` for validation-only runs, and `make ci` for full pre-commit gate execution. Update any scripts or automation that reference the old `make manifest` target.
 
 **Silent creation failures exist** — The controller sometimes returns 200 on a malformed POST without creating the resource. Check for missing required fields before looking for a network or auth issue.
 
@@ -310,3 +397,5 @@ Manager class: `{Resource}Manager` (PascalCase). Factory function: `get_{resourc
 **Firewall policy required fields** — zone-based firewall policies require `schedule: {"mode": "ALWAYS"}` on all policies (even ALLOW), and `create_allow_respond: False` on BLOCK/REJECT policies. Omitting these causes silent non-creation or controller errors.
 
 **Firmware-version field variation** — Some response fields behave differently across firmware versions. If a bug report describes unexpected field values and the reporter is on a specific firmware version, treat firmware variation as a likely cause before assuming a code bug. Request the firmware version string and a sample of the affected response payload for diagnosis.
+
+**Action dispatcher arg-shape mismatch** — Without a registered `DISPATCH_ARG_TRANSLATORS` entry, action tools invoked via `/v1/actions/` fail silently with TypeError when the LLM produces argument names that don't match the API caller's expectation. Always test action tools both via MCP and via the `/v1/actions/` endpoint (if applicable) before merging. Live smoke testing catches this failure class when unit tests miss it.

--- a/.agents/skills/claude-plugin-config-transport/SKILL.md
+++ b/.agents/skills/claude-plugin-config-transport/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: myco:claude-plugin-config-transport
-description: |
-  Activate when working on Claude plugin configuration, MCP transport
-  behavior, or plugin release mechanics in unifi-mcp. Covers: keeping
-  UNIFI_MCP_HTTP_FORCE at its safe default in apps/*/config/config.yaml
-  for all three apps (network, protect, access); the stdio-primary
-  transport pattern in transport.py and why asyncio.wait(FIRST_COMPLETED)
-  must not be reintroduced; local development with claude --plugin-dir
-  and its marketplace-cache blind spot; running check-prereqs.sh before
-  plugin setup; writing Bash 3.2-compatible shell scripts for plugins/;
-  and issuing no-op patch releases when only plugin config or scripts
-  change. Apply even if the user doesn't explicitly mention transport
-  races — activate whenever plugin behavior, MCP tool availability, or
+description: >-
+  Activate when working on Claude plugin configuration, MCP transport behavior,
+  or plugin release mechanics in unifi-mcp. Covers: keeping UNIFI_MCP_HTTP_FORCE
+  at its safe default in apps/*/config/config.yaml for all three apps (network,
+  protect, access); the stdio-primary transport pattern in transport.py and why
+  asyncio.wait(FIRST_COMPLETED) must not be reintroduced; local development
+  with claude --plugin-dir and its marketplace-cache blind spot; running
+  check-prereqs.sh before plugin setup; writing Bash 3.2-compatible shell
+  scripts for plugins/; multi-target plugin support for Claude and Codex
+  targets; and issuing no-op patch releases when only plugin config or scripts
+  change. Apply even if the user doesn't explicitly mention transport races —
+  activate whenever plugin behavior, MCP tool availability, or
   plugin-scoped shell scripts are being modified.
 managed_by: myco
 user-invocable: true
@@ -20,14 +20,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Claude Plugin Configuration and Transport Stability
 
-This skill covers the full lifecycle of Claude MCP plugin integration
-in unifi-mcp: from configuring transport flags correctly, through
-understanding the asyncio transport architecture that keeps MCP tools
-available, to verifying plugin setup, writing portable shell scripts,
-and publishing plugin-only releases. The procedures share a common
-prerequisite — understanding the uvx launch context — because a wrong
-flag can trigger a transport race that silently drops all MCP tools
-with no visible error.
+This skill covers the full lifecycle of Claude MCP plugin integration in unifi-mcp: from configuring transport flags correctly, through understanding the asyncio transport architecture that keeps MCP tools available, to verifying plugin setup, writing portable shell scripts, and publishing plugin-only releases. The procedures share a common prerequisite — understanding the uvx launch context — because a wrong flag can trigger a transport race that silently drops all MCP tools with no visible error.
 
 **Relevant files:**
 - `apps/network/src/unifi_network_mcp/config/config.yaml`
@@ -37,29 +30,19 @@ with no visible error.
 - `plugins/unifi-protect/scripts/set-env.sh`, `plugins/unifi-protect/scripts/check-prereqs.sh`
 - `plugins/unifi-access/scripts/set-env.sh`, `plugins/unifi-access/scripts/check-prereqs.sh`
 - `packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py`
+- `.agents/plugins/marketplace.json` (multi-target plugin registry)
+- `.codex-plugin/` (Codex-specific manifest directory, PR #246)
 
 ## Prerequisites
 
 Before modifying any plugin configuration or transport code:
 
-1. **Understand the uvx launch context.** When Claude launches a plugin
-   via `uvx`, the plugin process is not PID 1. This distinction controls
-   which transport path activates inside `transport.py` and whether HTTP
-   transport will be enabled. The PID check is in `resolve_http_config()`
-   in `transport.py`.
-2. **Know all three app directories.** Transport and HTTP config changes
-   almost always need to be reflected in `apps/network/`, `apps/protect/`,
-   and `apps/access/` in parallel. Partial application leaves inconsistent
-   behavior.
-3. **Know all three plugin directories.** Script and setup changes apply to
-   `plugins/unifi-network/`, `plugins/unifi-protect/`, and
-   `plugins/unifi-access/`. Applying to only one or two creates
-   inconsistent behavior that is nearly impossible for users to diagnose.
-4. **Hold the current MCP shared package version.** Plugin versions are
-   slaved to MCP package tags; know the current tag before planning a
-   release (see Procedure F).
-5. **Run `check-prereqs.sh` first** (see Procedure D) before activating
-   any plugin setup change in a live environment.
+1. **Understand the uvx launch context.** When Claude launches a plugin via `uvx`, the plugin process is not PID 1. This distinction controls which transport path activates inside `transport.py` and whether HTTP transport will be enabled. The PID check is in `resolve_http_config()` in `transport.py`.
+2. **Know all three app directories.** Transport and HTTP config changes almost always need to be reflected in `apps/network/`, `apps/protect/`, and `apps/access/` in parallel. Partial application leaves inconsistent behavior.
+3. **Know all three plugin directories.** Script and setup changes apply to `plugins/unifi-network/`, `plugins/unifi-protect/`, and `plugins/unifi-access/`. Applying to only one or two creates inconsistent behavior that is nearly impossible for users to diagnose.
+4. **Know the multi-target plugin registry.** As of PR #246, unifi-mcp supports both Claude and Codex targets. Plugin configuration, version sync, and release procedures must account for target-specific manifests.
+5. **Hold the current MCP shared package version.** Plugin versions are slaved to MCP package tags; know the current tag before planning a release (see Procedure F).
+6. **Run `check-prereqs.sh` first** (see Procedure D) before activating any plugin setup change in a live environment.
 
 ---
 
@@ -67,8 +50,7 @@ Before modifying any plugin configuration or transport code:
 
 ### Where the flag lives
 
-`UNIFI_MCP_HTTP_FORCE` is an environment variable consumed by each app's
-`config.yaml`. It maps to the `http.force` config key:
+`UNIFI_MCP_HTTP_FORCE` is an environment variable consumed by each app's `config.yaml`. It maps to the `http.force` config key:
 
 ```yaml
 # apps/network/src/unifi_network_mcp/config/config.yaml  (same pattern in protect, access)
@@ -78,39 +60,26 @@ http:
   transport: ${oc.env:UNIFI_MCP_HTTP_TRANSPORT,streamable-http}
 ```
 
-**The safe default is `false` (or unset).** Never set `UNIFI_MCP_HTTP_FORCE=true`
-in a uvx-launched context (non-PID-1). Setting it to `true` forces an
-HTTP bind attempt that is unavailable in the uvx sandbox.
+**The safe default is `false` (or unset).** Never set `UNIFI_MCP_HTTP_FORCE=true` in a uvx-launched context (non-PID-1). Setting it to `true` forces an HTTP bind attempt that is unavailable in the uvx sandbox.
 
 ### Why `UNIFI_MCP_HTTP_FORCE=true` silently destroys all MCP tools
 
-The failure chain when `UNIFI_MCP_HTTP_FORCE=true` in a uvx-launched
-(non-PID-1) context:
+The failure chain when `UNIFI_MCP_HTTP_FORCE=true` in a uvx-launched (non-PID-1) context:
 
 1. HTTP bind is unavailable in the uvx sandbox.
-2. `run_http()` in `transport.py` catches the `SystemExit` from the
-   failed bind and **returns normally** — no exception propagates.
-3. The pre-fix `asyncio.wait(FIRST_COMPLETED)` implementation saw the
-   HTTP task as "done" and interpreted normal return as success.
-4. FIRST_COMPLETED cancelled the stdio task (the only transport Claude
-   Code actually uses).
-5. **All MCP tools disappeared silently.** Claude showed no error; the
-   tools were simply gone.
+2. `run_http()` in `transport.py` catches the `SystemExit` from the failed bind and **returns normally** — no exception propagates.
+3. The pre-fix `asyncio.wait(FIRST_COMPLETED)` implementation saw the HTTP task as "done" and interpreted normal return as success.
+4. FIRST_COMPLETED cancelled the stdio task (the only transport Claude actually uses).
+5. **All MCP tools disappeared silently.** Claude showed no error; the tools were simply gone.
 
-This was the root cause of Issue #200, fixed in PR #202. The fix
-required changes in two places: the config flag handling AND the
-asyncio transport pattern (see Procedure B).
+This was the root cause of Issue #200, fixed in PR #202. The fix required changes in two places: the config flag handling AND the asyncio transport pattern (see Procedure B).
 
 ### Checklist when changing HTTP transport config
 
-- [ ] Change applied in all three: `apps/network/`, `apps/protect/`,
-      `apps/access/` config.yaml files
-- [ ] `UNIFI_MCP_HTTP_FORCE` value is `false` (or the env var is unset)
-      for all uvx-launched contexts
-- [ ] No environment variable injection is setting it to `true` in the
-      plugin setup path
-- [ ] A no-op patch release is planned if config is the only change
-      (see Procedure F)
+- [ ] Change applied in all three: `apps/network/`, `apps/protect/`, `apps/access/` config.yaml files
+- [ ] `UNIFI_MCP_HTTP_FORCE` value is `false` (or the env var is unset) for all uvx-launched contexts
+- [ ] No environment variable injection is setting it to `true` in the plugin setup path
+- [ ] A no-op patch release is planned if config is the only change (see Procedure F)
 
 ---
 
@@ -118,11 +87,7 @@ asyncio transport pattern (see Procedure B).
 
 ### The current safe pattern in `transport.py`
 
-The current implementation in
-`packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py` uses
-stdio as the **primary control flow** — it runs to completion. HTTP
-runs as a **cancellable background task**. An HTTP failure must never
-cancel stdio.
+The current implementation in `packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py` uses stdio as the **primary control flow** — it runs to completion. HTTP runs as a **cancellable background task**. An HTTP failure must never cancel stdio. This pattern extends to **all transport targets** including Codex (PR #246).
 
 ```python
 # SAFE — current implementation (run_transports function)
@@ -140,9 +105,7 @@ finally:
             pass
 ```
 
-`run_http()` catches its own `SystemExit` internally (port-bind
-failures from uvicorn), so a failed HTTP transport returns normally
-rather than propagating. Stdio lifecycle is unaffected.
+`run_http()` catches its own `SystemExit` internally (port-bind failures from uvicorn), so a failed HTTP transport returns normally rather than propagating. Stdio lifecycle is unaffected. This design assumes the transport target (Claude, Codex) uses stdio as the primary transport and HTTP as optional.
 
 ### What NOT to do — the pre-fix anti-pattern
 
@@ -158,30 +121,20 @@ for task in pending:
     task.cancel()  # cancels stdio if http_task "succeeds" silently
 ```
 
-`asyncio.wait(FIRST_COMPLETED)` is unsafe when any task can "succeed"
-by swallowing its own error. A task that catches an exception internally
-and returns `None` looks identical to a task that completed successfully.
-This was the pre-#202 implementation — it is described in the docstring
-of `run_transports()` as "the previous implementation."
+`asyncio.wait(FIRST_COMPLETED)` is unsafe when any task can "succeed" by swallowing its own error. A task that catches an exception internally and returns `None` looks identical to a task that completed successfully. This was the pre-#202 implementation — it is described in the docstring of `run_transports()` as "the previous implementation."
 
 **Design rules for transport code:**
 - Stdio EOF / client disconnect is the authoritative shutdown signal.
-- Never use `FIRST_COMPLETED` across transport tasks where either task
-  can swallow errors.
-- Use explicit exception inspection or a sentinel flag to distinguish
-  "HTTP successfully bound and serving" from "HTTP failed silently."
+- Never use `FIRST_COMPLETED` across transport tasks where either task can swallow errors.
+- Use explicit exception inspection or a sentinel flag to distinguish "HTTP successfully bound and serving" from "HTTP failed silently."
 - HTTP errors must not propagate to the stdio lifecycle.
 
 ### Regression test strategy
 
 Two-layer verification after any transport change:
 
-1. **Mock race test** — unit test that forces `run_http()` to catch and
-   swallow a `SystemExit`, then asserts that the stdio task was **not**
-   cancelled and ran to completion.
-2. **E2E repro** — bind a TCP listener on the HTTP port before launching
-   the plugin so the HTTP bind fails, then verify MCP tools remain
-   available throughout the stdio session.
+1. **Mock race test** — unit test that forces `run_http()` to catch and swallow a `SystemExit`, then asserts that the stdio task was **not** cancelled and ran to completion.
+2. **E2E repro** — bind a TCP listener on the HTTP port before launching the plugin so the HTTP bind fails, then verify MCP tools remain available throughout the stdio session.
 
 ---
 
@@ -193,16 +146,11 @@ Two-layer verification after any transport change:
 claude --plugin-dir <path/to/plugins/unifi-network>
 ```
 
-This loads the plugin directly from the local directory, bypassing the
-marketplace install step. It is the correct flag for iterating on plugin
-scripts or skills without publishing a release.
+This loads the plugin directly from the local directory, bypassing the marketplace install step. It is the correct flag for iterating on plugin scripts or skills without publishing a release.
 
 ### The marketplace cache blind spot
 
-`--plugin-dir` does **not** deactivate a marketplace-installed version
-of the same plugin. If a marketplace-installed version has a conflicting
-config cached, it may take precedence over the local-dir version, or
-the two configs may interfere with each other in unpredictable ways.
+`--plugin-dir` does **not** deactivate a marketplace-installed version of the same plugin. If a marketplace-installed version has a conflicting config cached, it may take precedence over the local-dir version, or the two configs may interfere with each other in unpredictable ways.
 
 **To confirm the correct plugin is active:**
 
@@ -221,11 +169,9 @@ ls plugins/unifi-network/scripts/
 
 ### What `--plugin-dir` does NOT substitute for
 
-- A **marketplace install test** — always do a final end-to-end test
-  through the marketplace path before shipping a release.
+- A **marketplace install test** — always do a final end-to-end test through the marketplace path before shipping a release.
 - The `check-prereqs.sh` pre-flight (Procedure D).
-- Version verification — the plugin version shown in Claude may reflect
-  the marketplace-installed version, not the local-dir version.
+- Version verification — the plugin version shown in Claude may reflect the marketplace-installed version, not the local-dir version.
 
 ---
 
@@ -233,11 +179,7 @@ ls plugins/unifi-network/scripts/
 
 ### What it does
 
-`plugins/unifi-*/scripts/check-prereqs.sh` validates required
-environment variables and system state before plugin activation. It
-catches missing credentials and misconfigured endpoints before they
-produce cryptic user-facing failures. The scripts explicitly state
-Bash 3.2 compatibility.
+`plugins/unifi-*/scripts/check-prereqs.sh` validates required environment variables and system state before plugin activation. It catches missing credentials and misconfigured endpoints before they produce cryptic user-facing failures. The scripts explicitly state Bash 3.2 compatibility.
 
 ### When to run it
 
@@ -249,14 +191,11 @@ bash plugins/unifi-protect/scripts/check-prereqs.sh
 bash plugins/unifi-access/scripts/check-prereqs.sh
 ```
 
-Run each separately — the three plugins can have different prerequisite
-sets. A failure in `unifi-protect` does not imply a failure in
-`unifi-network`.
+Run each separately — the three plugins can have different prerequisite sets. A failure in `unifi-protect` does not imply a failure in `unifi-network`.
 
 ### Adding new prerequisites
 
-When a plugin gains a new required environment variable or system
-dependency, add a check to `check-prereqs.sh` in the **same PR**:
+When a plugin gains a new required environment variable or system dependency, add a check to `check-prereqs.sh` in the **same PR**:
 
 ```bash
 # Pattern for a required variable with a helpful error message
@@ -272,9 +211,7 @@ if ! command -v my-tool >/dev/null 2>&1; then
 fi
 ```
 
-Do not rely on the plugin process itself to surface missing
-prerequisites — process-level errors are much harder to diagnose than
-a clean pre-flight failure with a human-readable message.
+Do not rely on the plugin process itself to surface missing prerequisites — process-level errors are much harder to diagnose than a clean pre-flight failure with a human-readable message.
 
 ---
 
@@ -282,16 +219,9 @@ a clean pre-flight failure with a human-readable message.
 
 ### The constraint
 
-macOS ships `/bin/bash` at version **3.2** (circa 2007). Homebrew may
-install a newer `bash`, but users run plugin scripts without Homebrew
-in their PATH. Any script in `plugins/` must work against the system
-shell. This constraint is documented in each `check-prereqs.sh`:
-"Bash 3.2 compatible (works on stock macOS /bin/bash)."
+macOS ships `/bin/bash` at version **3.2** (circa 2007). Homebrew may install a newer `bash`, but users run plugin scripts without Homebrew in their PATH. Any script in `plugins/` must work against the system shell. This constraint is documented in each `check-prereqs.sh`: "Bash 3.2 compatible (works on stock macOS /bin/bash)."
 
-**`declare -A` (associative arrays) is bash 4+ only.** Using it in
-any `plugins/*/scripts/*.sh` causes a silent no-op or `unbound variable`
-error on macOS. The `set-env.sh` scripts use sed-based manipulation
-instead of associative arrays for exactly this reason (fixed in PR #202).
+**`declare -A` (associative arrays) is bash 4+ only.** Using it in any `plugins/*/scripts/*.sh` causes a silent no-op or `unbound variable` error on macOS. The `set-env.sh` scripts use sed-based manipulation instead of associative arrays for exactly this reason (fixed in PR #202).
 
 ### POSIX-compatible alternatives for new scripts
 
@@ -324,8 +254,7 @@ NETWORK_PORT="${NETWORK_PORT:-443}"
 
 ### Verification rule for new plugin scripts
 
-Every new shell script added to `plugins/` must be tested against the
-**system bash**, not Homebrew bash:
+Every new shell script added to `plugins/` must be tested against the **system bash**, not Homebrew bash:
 
 ```bash
 # Syntax check
@@ -335,44 +264,61 @@ Every new shell script added to `plugins/` must be tested against the
 /bin/bash plugins/unifi-network/scripts/my-new-script.sh
 ```
 
-If CI runs on Linux, add a macOS job or test locally — Linux bash is
-almost always 4+, so CI will not catch 3.2 incompatibilities.
+If CI runs on Linux, add a macOS job or test locally — Linux bash is almost always 4+, so CI will not catch 3.2 incompatibilities.
 
 ---
 
-## Procedure F: Plugin Version Sync — No-Op Patch Releases
+## Procedure F: Plugin Version Sync — No-Op Patch Releases and Multi-Target Registry
 
 ### The versioning contract
 
-Plugin versions are **strictly slaved** to MCP package release tags.
-The version referenced in plugin config must match a tagged MCP package
-version published to PyPI. There is no independent plugin version number.
+Plugin versions are **strictly slaved** to MCP package release tags. The version referenced in plugin config must match a tagged MCP package version published to PyPI. There is no independent plugin version number.
+
+### Multi-target plugin registry (PR #246)
+
+As of PR #246, unifi-mcp supports **both Claude and Codex** as plugin targets. The multi-target registry lives in `.agents/plugins/marketplace.json`:
+
+```json
+{
+  "claude": {
+    "plugins": [
+      {"name": "unifi-network", "version": "1.2.3"},
+      {"name": "unifi-protect", "version": "1.2.3"},
+      {"name": "unifi-access", "version": "1.2.3"}
+    ]
+  },
+  "codex": {
+    "plugins": [
+      {"name": "unifi-network", "version": "1.2.3"},
+      {"name": "unifi-protect", "version": "1.2.3"},
+      {"name": "unifi-access", "version": "1.2.3"}
+    ]
+  }
+}
+```
+
+When a version bump is released, all target registries must be updated in the same commit. Codex-specific manifests are in `.codex-plugin/` and must be synchronized with the main app configs.
 
 ### When only plugin config or scripts change
 
-If a PR modifies only plugin manifests or scripts (no Python code
-changes in `shared/`), the correct release mechanism is a
-**no-op patch release**:
+If a PR modifies only plugin manifests or scripts (no Python code changes in `shared/`), the correct release mechanism is a **no-op patch release**:
 
-1. Bump the patch version in
-   `packages/unifi-mcp-shared/pyproject.toml`
-   (e.g., `1.2.3` → `1.2.4`).
+1. Bump the patch version in `packages/unifi-mcp-shared/pyproject.toml` (e.g., `1.2.3` → `1.2.4`).
 2. Commit, tag, and push:
    ```bash
    git tag v1.2.4
    git push origin v1.2.4
    ```
-3. Wait for the release pipeline to publish the wheel to PyPI. The
-   Python wheel is functionally identical to the prior version — the
-   bump exists solely to create a version anchor the plugin can reference.
-4. Update the version field in all three apps' config to `"1.2.4"`.
-5. Do **not** update the plugin version before the PyPI step completes
-   (PyPI ordering gate — see `monorepo-release-pipeline` skill).
+3. Wait for the release pipeline to publish the wheel to PyPI. The Python wheel is functionally identical to the prior version — the bump exists solely to create a version anchor the plugin can reference.
+4. Update the version field in **all target registries** in `.agents/plugins/marketplace.json` (both Claude and Codex).
+5. Update the version field in **all three apps'** config to `"1.2.4"`:
+   - `apps/network/src/unifi_network_mcp/config/config.yaml`
+   - `apps/protect/src/unifi_protect_mcp/config/config.yaml`
+   - `apps/access/src/unifi_access_mcp/config/config.yaml`
+6. Update Codex-specific manifests in `.codex-plugin/plugin.json` if transport-level changes were made.
+7. Do **not** update the plugin version before the PyPI step completes (PyPI ordering gate — see `monorepo-release-pipeline` skill).
 
-**Never skip the release for plugin-only changes.** Without a new tag,
-the plugin version field cannot advance, the config change has no
-anchored release identity, and existing users stay pinned to the cached
-old config until a tagged release forces cache invalidation.
+**Never skip the release for plugin-only changes.** Without a new tag, the plugin version field cannot advance, the config change has no anchored release identity, and existing users stay pinned to the cached old config until a tagged release forces cache invalidation.
 
 ### Change-type reference
 
@@ -382,6 +328,8 @@ old config until a tagged release forces cache invalidation.
 | HTTP transport config change only | Yes | No-op patch |
 | `check-prereqs.sh` or `set-env.sh` change | Yes | No-op patch |
 | Plugin skill SKILL.md change | Yes | No-op patch |
+| Codex manifest or `.codex-plugin/` change | Yes | No-op patch |
+| Multi-target registry (.agents/plugins/marketplace.json) change | Yes | No-op patch |
 | README / docs only | No | — |
 
 ---
@@ -390,36 +338,28 @@ old config until a tagged release forces cache invalidation.
 
 ### Silent tool loss is the hardest failure mode to diagnose
 
-When all MCP tools disappear after a plugin or transport change, the
-natural instinct is to check credentials or network connectivity.
-**Check `UNIFI_MCP_HTTP_FORCE` (is it set to `true` somewhere?) and
-the transport pattern in `transport.py` first.** The stdio cancellation
-failure surfaces no error to Claude or the user — tools simply stop
-appearing in the tool list.
+When all MCP tools disappear after a plugin or transport change, the natural instinct is to check credentials or network connectivity. **Check `UNIFI_MCP_HTTP_FORCE` (is it set to `true` somewhere?) and the transport pattern in `transport.py` first.** The stdio cancellation failure surfaces no error to Claude or the user — tools simply stop appearing in the tool list.
 
 ### Both layers must be fixed together
 
 The Issue #200 / PR #202 fix required changes in two places:
-- `apps/*/config/config.yaml` — ensure `UNIFI_MCP_HTTP_FORCE` is not
-  forced to `true` in non-PID-1 contexts
-- `transport.py` — the stdio-primary pattern prevents a swallowed HTTP
-  failure from cancelling stdio
+- `apps/*/config/config.yaml` — ensure `UNIFI_MCP_HTTP_FORCE` is not forced to `true` in non-PID-1 contexts
+- `transport.py` — the stdio-primary pattern prevents a swallowed HTTP failure from cancelling stdio
 
-If you are investigating a transport issue, always audit both the
-config flag injection path and the asyncio pattern before concluding
-the fix is complete.
+If you are investigating a transport issue, always audit both the config flag injection path and the asyncio pattern before concluding the fix is complete.
 
 ### Three-app and three-plugin parity is non-negotiable
 
-Config changes to HTTP transport behavior must be applied to all three
-apps (`network`, `protect`, `access`). Script changes must be applied
-to all three plugin directories (`unifi-network`, `unifi-protect`,
-`unifi-access`). Partial application produces inconsistent behavior
-depending on which app/plugin the user has installed.
+Config changes to HTTP transport behavior must be applied to all three apps (`network`, `protect`, `access`). Script changes must be applied to all three plugin directories (`unifi-network`, `unifi-protect`, `unifi-access`). Partial application produces inconsistent behavior depending on which app/plugin the user has installed.
 
 ### `--plugin-dir` local tests are necessary but not sufficient
 
-A passing local test with `--plugin-dir` does not guarantee the
-marketplace-installed version behaves the same way. Always do a final
-marketplace-path test before shipping, especially after config or
-script changes.
+A passing local test with `--plugin-dir` does not guarantee the marketplace-installed version behaves the same way. Always do a final marketplace-path test before shipping, especially after config or script changes.
+
+### OpenClaw bundle pattern — Codex-specific gotcha
+
+The Codex plugin uses the OpenClaw bundle pattern (decision-e7099071) where transport initialization is bundled with Codex-specific config loading. Changes to transport.py may require parallel changes to `.codex-plugin/` initialization code. Test both Claude and Codex transport paths after any transport change.
+
+### Skill-dir naming collision — Manifest registration gotcha
+
+The `.agents/skills/*/` directory structure can collide with plugin name patterns if not carefully scoped. Plugin skill manifests registered in `.agents/plugins/*/skills/*/` must use fully qualified names (e.g., `unifi-mcp:skill-name`) to avoid colliding with agent-owned skills. Always verify that a new plugin skill manifest's fully qualified name does not collide with existing agent or plugin skill names (gotcha-b2b7f4d9).

--- a/.agents/skills/shared-package-extension/SKILL.md
+++ b/.agents/skills/shared-package-extension/SKILL.md
@@ -6,7 +6,7 @@ description: |
   protocol changes, or bumping workspace dependency versions across the monorepo.
   Covers four recurring procedures: (1) DI-only rule for shared-package entrypoints
   to avoid circular-import blast radius across all three app servers; (2) the
-  "connectivity primitive or MCP layer?" scope gate for placing new capability in
+  \"connectivity primitive or MCP layer?\" scope gate for placing new capability in
   the right package; (3) manual relay protocol sync to discovery.py and protocol.py
   when shared-package protocol changes, because those files do not import from the
   shared package and won't pick up changes automatically; (4) lockstep pyproject.toml
@@ -56,7 +56,7 @@ def register_meta_tools(
     get_tools_fn,        # injected by the calling app server
     get_server_info_fn,  # injected by the calling app server
 ):
-    """Register meta tools. App-specific behavior provided via DI parameters."""
+    \"\"\"Register meta tools. App-specific behavior provided via DI parameters.\"\"\"
     ...
 ```
 
@@ -83,16 +83,16 @@ from unifi_network_mcp.config import get_config  # ← circular; breaks all thre
    parameters or `typing.Protocol` types defined in the shared package.
 2. Verify no app imports slipped in:
    ```bash
-   grep -r "from unifi_network_mcp\|from unifi_protect_mcp\|from unifi_access_mcp" \
+   grep -r \"from unifi_network_mcp\\|from unifi_protect_mcp\\|from unifi_access_mcp\" \\
        packages/unifi-mcp-shared/
    ```
    Any hit is a bug — replace with an injected parameter.
 3. Wire the injection at each app-server call site.
 4. Confirm no circular import across all three servers:
    ```bash
-   python -c "import unifi_network_mcp"
-   python -c "import unifi_protect_mcp"
-   python -c "import unifi_access_mcp"
+   python -c \"import unifi_network_mcp\"
+   python -c \"import unifi_protect_mcp\"
+   python -c \"import unifi_access_mcp\"
    ```
 
 **Tip:** For complex injected hooks, prefer a `typing.Protocol` over a bare
@@ -103,7 +103,7 @@ rather than failing at runtime.
 
 Before adding new capability to either package, apply this decision test:
 
-> **"Is this a connectivity primitive or an MCP layer concern?"**
+> **\"Is this a connectivity primitive or an MCP layer concern?\"**
 
 | Belongs in `unifi-core` | Belongs in `unifi-mcp-shared` |
 |---|---|
@@ -120,7 +120,7 @@ Before adding new capability to either package, apply this decision test:
 2. Does the code coordinate MCP protocol concerns (permissions, tool registration,
    confirmations, config loading)? → `unifi-mcp-shared`
 3. Does the code reference MCP types (`mcp`, `FastMCP`, tool decorators)? → `unifi-mcp-shared`
-4. Still unclear? Ask: "Would this be useful in a non-MCP CLI that calls the UniFi API?"
+4. Still unclear? Ask: \"Would this be useful in a non-MCP CLI that calls the UniFi API?\"
    - Yes → `unifi-core`
    - No → `unifi-mcp-shared`
 
@@ -136,8 +136,8 @@ Arrows flow left-to-right only. No package imports from anything to its right in
 this chain. Check with:
 
 ```bash
-grep -r "from unifi_mcp_shared\|import unifi_mcp_shared" packages/unifi-core/
-grep -r "from unifi_network_mcp\|from unifi_protect_mcp\|from unifi_access_mcp" \
+grep -r \"from unifi_mcp_shared\\|import unifi_mcp_shared\" packages/unifi-core/
+grep -r \"from unifi_network_mcp\\|from unifi_protect_mcp\\|from unifi_access_mcp\" \\
     packages/unifi-mcp-shared/ packages/unifi-core/
 ```
 
@@ -172,7 +172,7 @@ client using the new protocol connects through a relay running the old one.
    verification you performed in the PR.
 
 **PR checklist trigger:** Any PR modifying the shared-package protocol must include a
-"relay sync" section confirming `discovery.py` and `protocol.py` were reviewed and
+\"relay sync\" section confirming `discovery.py` and `protocol.py` were reviewed and
 updated if necessary. Community PR reviewers: look for this section.
 
 ## Procedure D: Workspace Dependency Version Alignment
@@ -204,8 +204,8 @@ the dependency ranges embedded in the wheel metadata.
 2. Identify which downstream packages are being released because they use that new upstream code.
 3. Update only those downstream dependency ranges:
    ```toml
-   "unifi-core[protect]>=0.4,<0.5"
-   "unifi-mcp-shared>=0.5,<0.6"
+   \"unifi-core[protect]>=0.4,<0.5\"
+   \"unifi-mcp-shared>=0.5,<0.6\"
    ```
 4. From the repo root, run `uv lock --check` to validate workspace constraints resolve cleanly.
 5. Commit dependency-bound changes before creating local release tags.
@@ -225,8 +225,18 @@ review on every protocol-touching PR is the only protection.
 
 **Dependency ranges are release artifacts.** A downstream release can publish
 successfully while still installing an older upstream package if its wheel metadata
-allows only the old line. Use `rg "unifi-core|unifi-mcp-shared" apps/ packages/` to
+allows only the old line. Use `rg \"unifi-core|unifi-mcp-shared\" apps/ packages/` to
 audit ranges before tagging coordinated releases.
+
+**Tag staggering is mandatory for coordinated releases.** When releasing both
+`unifi-core` and dependent packages (e.g., `unifi-mcp-shared`, `apps/network`):
+1. Tag `unifi-core` first — CI publishes to PyPI.
+2. Wait 30 seconds for PyPI CDN sync.
+3. Update downstream dependency pins to the new `unifi-core` version.
+4. Tag downstream packages in dependency order (shared before apps).
+This prevents CI from failing on \"version not found\" errors. A batched tag push
+(tagging all at once) guarantees downstream failures because PyPI won't have the
+upstream version yet when their CI runs.
 
 **DI parameters document the contract.** When a new shared entrypoint accepts injected
 callables, name the parameters descriptively (`get_tools_fn`, `permission_checker`) and

--- a/.agents/skills/two-tier-tool-discovery/SKILL.md
+++ b/.agents/skills/two-tier-tool-discovery/SKILL.md
@@ -42,10 +42,10 @@ FastMCP maps `tools/call` arguments to Python function parameters **by name**. T
 **Wrong — registering `tool_index_handler` directly with `@tool_decorator` would silently drop all named arguments:**
 ```python
 # If this were registered directly with @tool_decorator, args would always
-# be None — no caller sends {"args": {...}}, so FastMCP never populates it.
+# be None — no caller sends {\"args\": {...}}, so FastMCP never populates it.
 async def tool_index_handler(args: dict | None = None) -> dict:
-    category = args.get("category") if args else None  # args is always None
-    search = args.get("search") if args else None       # never reached
+    category = args.get(\"category\") if args else None  # args is always None
+    search = args.get(\"search\") if args else None       # never reached
 ```
 
 **Correct — the actual pattern: a thin named-param wrapper delegates to the backend:**
@@ -58,20 +58,20 @@ async def _tool_index_wrapper(
 ) -> dict:
     args = {}
     if category is not None:
-        args["category"] = category
+        args[\"category\"] = category
     if search is not None:
-        args["search"] = search
+        args[\"search\"] = search
     if include_schemas:
-        args["include_schemas"] = include_schemas
+        args[\"include_schemas\"] = include_schemas
     return await tool_index_handler(args or None)
 
 # In tool_index.py — the backend:
 async def tool_index_handler(args: dict | None = None) -> dict:
     args = args or {}
     return get_tool_index(
-        category=args.get("category"),
-        search=args.get("search"),
-        include_schemas=bool(args.get("include_schemas", False)),
+        category=args.get(\"category\"),
+        search=args.get(\"search\"),
+        include_schemas=bool(args.get(\"include_schemas\", False)),
     )
 ```
 
@@ -82,7 +82,7 @@ This rule applies to every handler in `tool_index.py`: the FastMCP-facing functi
 1. Open `apps/*/src/*/tool_index.py` where the wrapper and handler reside.
 2. Add the new parameter to the FastMCP-registered wrapper function's signature with a sensible default (preserves backwards compatibility for callers that omit it).
 3. In the wrapper, add the new param to the `args` dict it assembles before calling `tool_index_handler`.
-4. Open each backend `tool_index_handler` — in each app's `tool_index.py` and the shared `packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py`. In each, add `args.get("new_param")` and thread it into the `get_tool_index()` call.
+4. Open each backend `tool_index_handler` — in each app's `tool_index.py` and the shared `packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py`. In each, add `args.get(\"new_param\")` and thread it into the `get_tool_index()` call.
 5. In `get_tool_index()` (shared `tool_index.py`), implement the actual filtering/shaping logic.
 6. Update the `register_tool()` call's `input_schema` in the app's `tool_index.py` to document the new parameter for schema-aware callers.
 7. Start the local server and call `tool_index` with and without the new parameter to confirm correct behavior in both modes.
@@ -134,15 +134,32 @@ Every parameter added to the local tool discovery layer must be mirrored in the 
 
 `plugins/*/skills/*/SKILL.md` files are **agent-readable invocation manifests**. Agents read these at runtime to learn what parameters a tool accepts. A stale manifest causes agents to call `tool_index` with wrong or missing parameters — treat this with the same urgency as a code bug, not as documentation.
 
+The manifest location varies by runtime environment:
+
+- **Local monorepo development**: `.agents/plugins/*/skills/*/SKILL.md`
+- **OpenClaw distributed agent**: `~/.codex-plugin/myco/skills/*/SKILL.md` (OpenClaw globally-unique skill directories)
+- **Claude desktop plugin**: `.agents/plugins/*/skills/*/SKILL.md` (mirrored from monorepo)
+- **Codespark / other runtimes**: `~/.agents/plugins/*/skills/*/SKILL.md` (XDG-compliant home paths)
+
+When `tool_index` parameters change, all four paths must be synchronized to ensure all runtimes reflect the new behavior.
+
 ### Steps
 
-1. After any parameter change to `tool_index`, find all SKILL.md files that reference it:
+1. After any parameter change to `tool_index`, find all SKILL.md files that reference it across all runtime paths:
    ```bash
-   grep -rl "tool_index" plugins/*/skills/*/SKILL.md
+   # Local monorepo
+   grep -rl \"tool_index\" .agents/plugins/*/skills/*/SKILL.md
+
+   # OpenClaw
+   grep -rl \"tool_index\" ~/.codex-plugin/myco/skills/*/SKILL.md 2>/dev/null || true
+
+   # XDG home paths
+   grep -rl \"tool_index\" ~/.agents/plugins/*/skills/*/SKILL.md 2>/dev/null || true
    ```
 2. For each matching SKILL.md, update the parameter list and invocation examples to match the new handler signature.
 3. If a SKILL.md describes the output shape, update that section too if tier behavior changed.
 4. Include SKILL.md updates in the **same PR** as the code change — they are runtime artifacts, not documentation that can lag behind.
+5. After merge, verify that OpenClaw and XDG-path deploys are triggered (see `bump-plugin-versions.yml`).
 
 In PR #145, 7 SKILL.md files across `plugins/unifi-network/skills/*/`, `plugins/unifi-protect/skills/*/`, and `plugins/unifi-access/skills/*/` were swept as part of the handler change. Missing even one leaves a stranded manifest that will mislead future agents.
 
@@ -158,6 +175,22 @@ Adding optional parameters to the tool discovery layer is a **minor** semver bum
 4. The Worker npm package is published separately via OIDC trusted publishing, triggered by a version tag on the Worker repo. Coordinate release order:
    - Publish shared package (PyPI) first
    - Update Worker dependency, tag the Worker release, CI publishes to npm
+
+### Plugin Version Sync via `bump-plugin-versions.yml`
+
+The monorepo CI uses `bump-plugin-versions.yml` to synchronize SKILL.md manifests across all four runtime environments (monorepo, OpenClaw, Claude desktop, XDG paths). When `tool_index` parameter or behavior changes:
+
+1. Ensure all SKILL.md files updated in Procedure D include the new parameter documentation.
+2. Merge the PR to `main`.
+3. The CI job `bump-plugin-versions.yml` automatically:
+   - Detects changed SKILL.md files in the merged commit
+   - Increments the manifest version field
+   - Pushes updates to OpenClaw registry and XDG-path caches
+   - Triggers Claude plugin regeneration if needed
+4. Monitor the CI job to confirm all manifest types (monorepo, OpenClaw, Claude, XDG) received the update.
+5. If a manifest type fails to sync, manually trigger `bump-plugin-versions.yml` with the failed type as input.
+
+This ensures agents across all runtimes see the same tool discovery behavior.
 
 ## Cross-Cutting Gotchas
 

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/protocol.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/protocol.py
@@ -1,9 +1,10 @@
 """MCP protocol abstraction layer.
 
-Provides a version-aware adapter for the FastMCP tool decorator, enabling
-dual-track migration when MCP SDK v2 arrives. Today this is a passthrough
-to FastMCP v1. When v2 ships, a v2 adapter can be added here without
-touching any tool modules.
+Provides a revision-aware adapter for the FastMCP tool decorator, enabling
+date-versioned MCP spec alignment without touching individual tool modules.
+Today this is a passthrough for the currently supported MCP protocol
+revision. If a future MCP revision requires SDK or registration changes, a
+revision-specific adapter can be added here.
 
 The adapter sits at Layer 1 of the decorator chain:
 
@@ -21,15 +22,52 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
-# Known protocol versions. "v2" is recognized but not yet implemented.
-_KNOWN_VERSIONS = {"v1", "v2"}
+DEFAULT_MCP_PROTOCOL_REVISION = "2025-11-25"
+
+_KNOWN_REVISIONS = frozenset({DEFAULT_MCP_PROTOCOL_REVISION})
+_LEGACY_PROTOCOL_VERSION_ALIASES = {
+    "v1": DEFAULT_MCP_PROTOCOL_REVISION,
+}
+
+
+def _normalize_protocol_revision(value: str) -> str:
+    raw_value = value.strip()
+    if raw_value in _LEGACY_PROTOCOL_VERSION_ALIASES:
+        return _LEGACY_PROTOCOL_VERSION_ALIASES[raw_value]
+
+    if raw_value.startswith("v"):
+        raise ValueError(
+            f"Unsupported MCP protocol version alias: '{raw_value}'. "
+            f"Use date-based MCP protocol revisions such as '{DEFAULT_MCP_PROTOCOL_REVISION}'."
+        )
+
+    return raw_value
+
+
+def get_protocol_revision() -> str:
+    """Read the MCP protocol revision from environment.
+
+    ``UNIFI_MCP_PROTOCOL_REVISION`` is the canonical setting. The legacy
+    ``UNIFI_MCP_PROTOCOL_VERSION=v1`` setting remains supported as a
+    compatibility alias for the current default revision.
+    """
+    configured_revision = os.environ.get("UNIFI_MCP_PROTOCOL_REVISION")
+    if configured_revision is not None:
+        return _normalize_protocol_revision(configured_revision)
+
+    legacy_version = os.environ.get("UNIFI_MCP_PROTOCOL_VERSION")
+    if legacy_version is not None:
+        return _normalize_protocol_revision(legacy_version)
+
+    return DEFAULT_MCP_PROTOCOL_REVISION
 
 
 def get_protocol_version() -> str:
-    """Read the MCP protocol version from environment.
+    """Read the deprecated legacy MCP protocol version setting.
 
-    Returns "v1" by default. Set UNIFI_MCP_PROTOCOL_VERSION=v2 to
-    switch when v2 support is added.
+    New code should use ``get_protocol_revision()``. This helper remains so
+    callers that inspect ``UNIFI_MCP_PROTOCOL_VERSION`` continue to see the
+    historical ``v1`` default.
     """
     return os.environ.get("UNIFI_MCP_PROTOCOL_VERSION", "v1").strip()
 
@@ -37,34 +75,42 @@ def get_protocol_version() -> str:
 def create_mcp_tool_adapter(
     fastmcp_tool_decorator: Callable[..., Any],
     *,
+    protocol_revision: str | None = None,
     protocol_version: str | None = None,
 ) -> Callable[..., Any]:
-    """Wrap the FastMCP tool decorator with protocol-version awareness.
+    """Wrap the FastMCP tool decorator with protocol-revision awareness.
 
     Args:
         fastmcp_tool_decorator: The raw FastMCP ``server.tool`` decorator.
-        protocol_version: Override version (default: from env var).
+        protocol_revision: Override MCP spec revision (default: from env var).
+        protocol_version: Deprecated compatibility override. ``v1`` maps to
+            the current default protocol revision.
 
     Returns:
         A decorator with the same signature as ``server.tool``.
-        In v1 mode, this is a direct passthrough (zero overhead).
+        For the current revision, this is a direct passthrough (zero overhead).
 
     Raises:
-        ValueError: If the protocol version is unknown or not yet implemented.
+        ValueError: If the protocol revision is unknown or unsupported.
     """
-    version = protocol_version or get_protocol_version()
+    if protocol_revision is not None and protocol_version is not None:
+        raise ValueError("Pass either protocol_revision or protocol_version, not both.")
 
-    if version not in _KNOWN_VERSIONS:
-        raise ValueError(f"Unsupported protocol version: '{version}'. Known versions: {sorted(_KNOWN_VERSIONS)}")
+    if protocol_revision is not None:
+        revision = _normalize_protocol_revision(protocol_revision)
+    elif protocol_version is not None:
+        revision = _normalize_protocol_revision(protocol_version)
+    else:
+        revision = get_protocol_revision()
 
-    if version == "v1":
-        logger.debug("[protocol] Using MCP v1 adapter (passthrough)")
-        return fastmcp_tool_decorator
-
-    if version == "v2":
+    if revision not in _KNOWN_REVISIONS:
         raise ValueError(
-            "MCP protocol v2 is not yet implemented. Set UNIFI_MCP_PROTOCOL_VERSION=v1 or remove the variable."
+            f"Unsupported MCP protocol revision: '{revision}'. Known revisions: {sorted(_KNOWN_REVISIONS)}"
         )
 
+    if revision == DEFAULT_MCP_PROTOCOL_REVISION:
+        logger.debug("[protocol] Using MCP %s adapter (passthrough)", revision)
+        return fastmcp_tool_decorator
+
     # Unreachable, but satisfies type checkers
-    raise ValueError(f"Unhandled protocol version: {version}")
+    raise ValueError(f"Unhandled MCP protocol revision: {revision}")

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
@@ -78,7 +78,8 @@ async def run_transports(
     port: int,
     http_transport: str,
     logger: logging.Logger,
-    protocol_version: str = "v1",
+    protocol_revision: str = "2025-11-25",
+    protocol_version: str | None = None,
 ) -> None:
     """Run stdio (always) and optionally HTTP, with stdio as the primary.
 
@@ -96,9 +97,9 @@ async def run_transports(
     ``SystemExit`` raised by uvicorn on port-bind failures is caught inside
     ``run_http`` so it does not propagate.
     """
-    # Future: when MCP SDK v2 changes the transport API, branch here:
-    # if protocol_version == "v2":
-    #     return await _run_transports_v2(server, ...)
+    # Future: if a date-versioned MCP revision changes the transport API,
+    # branch here on protocol_revision. protocol_version remains accepted as a
+    # deprecated compatibility keyword for older callers.
 
     async def run_stdio() -> None:
         logger.info("Starting FastMCP stdio server ...")

--- a/packages/unifi-mcp-shared/tests/test_protocol.py
+++ b/packages/unifi-mcp-shared/tests/test_protocol.py
@@ -5,20 +5,45 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from unifi_mcp_shared.protocol import create_mcp_tool_adapter, get_protocol_version
+from unifi_mcp_shared.protocol import (
+    DEFAULT_MCP_PROTOCOL_REVISION,
+    create_mcp_tool_adapter,
+    get_protocol_revision,
+    get_protocol_version,
+)
+
+
+class TestGetProtocolRevision:
+    """Test protocol revision resolution from env vars."""
+
+    def test_default_is_current_supported_revision(self):
+        assert get_protocol_revision() == DEFAULT_MCP_PROTOCOL_REVISION
+
+    def test_reads_from_revision_env(self, monkeypatch):
+        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_REVISION", "2025-11-25")
+        assert get_protocol_revision() == "2025-11-25"
+
+    def test_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_REVISION", "  2025-11-25  ")
+        assert get_protocol_revision() == "2025-11-25"
+
+    def test_revision_env_takes_precedence_over_legacy_version_env(self, monkeypatch):
+        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_REVISION", "2025-11-25")
+        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_VERSION", "v1")
+        assert get_protocol_revision() == "2025-11-25"
+
+    def test_legacy_v1_env_alias_maps_to_current_revision(self, monkeypatch):
+        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_VERSION", "v1")
+        assert get_protocol_revision() == DEFAULT_MCP_PROTOCOL_REVISION
 
 
 class TestGetProtocolVersion:
-    """Test protocol version resolution from env var."""
+    """Test deprecated protocol version compatibility helper."""
 
-    def test_default_is_v1(self):
+    def test_default_legacy_version_is_v1(self):
         assert get_protocol_version() == "v1"
 
-    def test_reads_from_env(self, monkeypatch):
-        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_VERSION", "v2")
-        assert get_protocol_version() == "v2"
-
-    def test_strips_whitespace(self, monkeypatch):
+    def test_reads_legacy_version_env(self, monkeypatch):
         monkeypatch.setenv("UNIFI_MCP_PROTOCOL_VERSION", "  v1  ")
         assert get_protocol_version() == "v1"
 
@@ -26,23 +51,37 @@ class TestGetProtocolVersion:
 class TestCreateMcpToolAdapter:
     """Test the tool decorator adapter factory."""
 
-    def test_v1_returns_original_decorator(self):
+    def test_current_revision_returns_original_decorator(self):
+        mock_decorator = MagicMock(name="fastmcp_tool_decorator")
+        adapter = create_mcp_tool_adapter(mock_decorator, protocol_revision="2025-11-25")
+        assert adapter is mock_decorator
+
+    def test_legacy_v1_version_alias_returns_original_decorator(self):
         mock_decorator = MagicMock(name="fastmcp_tool_decorator")
         adapter = create_mcp_tool_adapter(mock_decorator, protocol_version="v1")
         assert adapter is mock_decorator
 
-    def test_unsupported_version_raises(self):
+    def test_unsupported_revision_raises(self):
         mock_decorator = MagicMock()
-        with pytest.raises(ValueError, match="Unsupported protocol version"):
-            create_mcp_tool_adapter(mock_decorator, protocol_version="v99")
+        with pytest.raises(ValueError, match="Unsupported MCP protocol revision"):
+            create_mcp_tool_adapter(mock_decorator, protocol_revision="2026-06-18")
 
-    def test_v2_raises_not_implemented(self):
+    def test_v2_version_alias_raises(self):
         mock_decorator = MagicMock()
-        with pytest.raises(ValueError, match="not yet implemented"):
+        with pytest.raises(ValueError, match="Use date-based MCP protocol revisions"):
             create_mcp_tool_adapter(mock_decorator, protocol_version="v2")
 
-    def test_default_version_uses_env(self, monkeypatch):
-        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_VERSION", "v1")
+    def test_conflicting_revision_and_version_overrides_raise(self):
+        mock_decorator = MagicMock()
+        with pytest.raises(ValueError, match="Pass either protocol_revision or protocol_version"):
+            create_mcp_tool_adapter(
+                mock_decorator,
+                protocol_revision="2025-11-25",
+                protocol_version="v1",
+            )
+
+    def test_default_revision_uses_env(self, monkeypatch):
+        monkeypatch.setenv("UNIFI_MCP_PROTOCOL_REVISION", "2025-11-25")
         mock_decorator = MagicMock()
         adapter = create_mcp_tool_adapter(mock_decorator)
         assert adapter is mock_decorator

--- a/packages/unifi-mcp-shared/tests/test_transport.py
+++ b/packages/unifi-mcp-shared/tests/test_transport.py
@@ -58,6 +58,20 @@ class TestRunTransports:
         mock_server.run_streamable_http_async.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_legacy_protocol_version_keyword_is_accepted(self, mock_server):
+        """The deprecated protocol_version keyword remains accepted for compatibility."""
+        await run_transports(
+            server=mock_server,
+            http_enabled=False,
+            host="0.0.0.0",
+            port=3000,
+            http_transport="streamable-http",
+            logger=logging.getLogger("test"),
+            protocol_version="v1",
+        )
+        mock_server.run_stdio_async.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_pid1_skips_stdio_runs_http_only(self, mock_server):
         """When PID is 1 (Docker container), skip stdio and run HTTP only."""
         with patch("unifi_mcp_shared.transport.os.getpid", return_value=1):


### PR DESCRIPTION
## Summary
- replace MCP v1/v2 terminology in the shared adapter with date-versioned protocol revision handling
- add `UNIFI_MCP_PROTOCOL_REVISION` as the canonical setting while keeping `UNIFI_MCP_PROTOCOL_VERSION=v1` and `protocol_version="v1"` as compatibility aliases
- reject unofficial `v2` aliases with guidance to use MCP protocol revisions
- carry forward skill-reference/check cleanup captured in this branch

## Compatibility
- Default behavior remains a FastMCP passthrough.
- Legacy `get_protocol_version()` still returns `v1`.
- Legacy `UNIFI_MCP_PROTOCOL_VERSION=v1` maps to `2025-11-25`.
- `run_transports(..., protocol_version="v1")` remains accepted as a deprecated keyword.

## Verification
- `make pre-commit`
- `make shared-test`
- `git diff --check`

No live smoke test was run because this does not touch controller-facing behavior, tool schemas, manager calls, or live registration behavior.

Closes #249
