### PR TITLE
feat: move worker into monorepo

### DIFF
--- a/.agents/skills/monorepo-release-pipeline/SKILL.md
+++ b/.agents/skills/monorepo-release-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: myco:monorepo-release-pipeline
 description: >-
-  Covers the full release pipeline for the unifi-mcp Python monorepo: determining release scope by analyzing changed packages, scoping hatch-vcs version tag globs per package to prevent sibling-tag contamination, pushing tags in strict dependency order (unifi-core → unifi-mcp-shared → app servers → relay), configuring scripts/generate_release_notes.py path scoping per package, wiring per-package publish workflows for OIDC trusted publishing, coordinating cross-package version bumps in pyproject.toml, understanding app vs. library versioning and writeback behavior, and validating releases post-tag. Apply this skill when cutting any release, adding a new package, bumping unifi-core, or debugging a versioning or publish-workflow failure — even if the user does not explicitly ask about tag ordering or release notes.
+  Covers the full release pipeline for the unifi-mcp monorepo: determining release scope by analyzing changed packages, scoping hatch-vcs version tag globs per Python package to prevent sibling-tag contamination, pushing tags in strict dependency order (unifi-core → unifi-mcp-shared → app servers → relay → worker when needed), configuring scripts/generate_release_notes.py path scoping per package, wiring per-package publish workflows for OIDC trusted publishing, coordinating cross-package version bumps in pyproject.toml, understanding app vs. library versioning and writeback behavior, and validating releases post-tag. Apply this skill when cutting any release, adding a new package, bumping unifi-core, or debugging a versioning or publish-workflow failure — even if the user does not explicitly ask about tag ordering or release notes.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -9,11 +9,12 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Monorepo Release Pipeline
 
-The unifi-mcp repo ships seven independently versioned Python packages: `unifi-core`
+The unifi-mcp repo ships seven independently versioned Python packages plus the
+Node/TypeScript worker app: `unifi-core`
 and `unifi-mcp-shared` live under `packages/`; `unifi-mcp-network`, `unifi-mcp-protect`,
 `unifi-mcp-access`, and `unifi-api-server` live under `apps/`; `unifi-mcp-relay` lives under `packages/`
-alongside core and shared. Each has its own PyPI identity, tag namespace, publish
-workflow, and release-notes scope. Getting the release sequence wrong leaves downstream
+alongside core and shared; `unifi-mcp-worker` lives under `apps/worker/` and publishes to npm.
+Each has its own package identity, tag namespace, publish workflow, and release-notes scope. Getting the release sequence wrong leaves downstream
 packages referencing non-existent PyPI versions or produces contaminated release notes
 that bleed across package boundaries.
 
@@ -37,6 +38,7 @@ that bleed across package boundaries.
 | `unifi-mcp-access` | `apps/access/` | `access/v*` | `release-access.yml` |
 | `unifi-api-server` | `apps/api/` | `api/v*` | `release-api.yml` |
 | `unifi-mcp-relay` | `packages/unifi-mcp-relay/` | `relay/v*` | `release-relay.yml` |
+| `unifi-mcp-worker` | `apps/worker/` | `worker/v*` | `release-worker.yml` |
 
 When adding a new package, extend this table and the release-notes path configuration
 before pushing any tag.
@@ -66,7 +68,7 @@ git log --oneline network/v$(git tag -l 'network/v*' | sort -V | tail -1)..HEAD 
 | One app only (e.g., `apps/protect/`) | `protect/v*` only |
 | Multiple apps | One tag per changed app, in dependency order |
 | Plugin-only changes (manifest/config updates) | Patch release for cache invalidation (e.g., `network/v0.14.13` → `network/v0.14.14`) |
-| Worker (`~/Repos/unifi-mcp-worker`) | Tag in that repo (see Procedure F) |
+| Worker (`apps/worker/`) | `worker/v*` |
 
 ### Plugin-only Release and Cache Invalidation
 
@@ -327,10 +329,9 @@ git push origin relay/v0.1.0
 workflows simultaneously. The network workflow may start before the core package is
 indexed on PyPI (~2–5 minutes after the core workflow completes).
 
-**Worker repo:** `unifi-mcp-worker` (at `~/Repos/unifi-mcp-worker`) has a separate
-npm release flow using OIDC via GitHub Actions. Apply the same ordering principle:
-if the worker depends on a Python package version, confirm PyPI is updated before
-pushing the worker tag.
+**Worker app:** `apps/worker` has a separate npm release flow using OIDC via GitHub Actions.
+Apply the same ordering principle: if the worker depends on a Python package version or relay
+protocol behavior, confirm the upstream PyPI release is updated before pushing the `worker/v*` tag.
 
 ## Procedure G: generate_release_notes.py Path Configuration
 

--- a/.agents/skills/monorepo-release-pipeline/SKILL.md
+++ b/.agents/skills/monorepo-release-pipeline/SKILL.md
@@ -322,6 +322,10 @@ git push origin network/v0.14.13 protect/v0.3.5 access/v0.2.4 api/v0.2.1
 # Step 4 — relay
 git tag relay/v0.1.0
 git push origin relay/v0.1.0
+
+# Step 5 — worker, if relay/worker behavior changed
+git tag worker/v1.3.1
+git push origin worker/v1.3.1
 ```
 
 **Never batch tags across dependency levels.** Running

--- a/.agents/skills/two-tier-tool-discovery/SKILL.md
+++ b/.agents/skills/two-tier-tool-discovery/SKILL.md
@@ -24,9 +24,9 @@ The unifi-mcp project implements a meta-tool (`tool_index`) that lets agents and
 ## Prerequisites
 
 - **One-unified-server rule**: `tool_index` is a meta-tool that describes other tools. It must remain a single canonical entry point — do not add a second discovery handler in a plugin or subsystem, as this would fragment the index and break agents.
-- **Two source repos**:
+- **Two implementation surfaces**:
   - Local server: `apps/*/src/*/tool_index.py` (backend handler with FastMCP-registered wrapper) and `packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py` (shared handler)
-  - Worker cloud: `~/Repos/unifi-mcp-worker` (the Worker's `tool_index` handler)
+  - Worker cloud: `apps/worker/worker/src/` (the Worker's tool index and MCP handling code)
 - **Two-layer architecture**: The discovery system uses a named-param wrapper as the FastMCP-registered function, which delegates to a backend `tool_index_handler` via an assembled `args` dict. Both layers need updating when adding a new parameter.
 
 ## Procedure A: Adding or Modifying Parameters on the Tool Discovery Layer
@@ -120,15 +120,15 @@ Every parameter added to the local tool discovery layer must be mirrored in the 
 
 ### Steps
 
-1. After the local PR is merged, open `~/Repos/unifi-mcp-worker`.
-2. Locate the Worker's `tool_index` handler (the file analogous to the app's `tool_index.py`).
+1. In the same monorepo PR, inspect `apps/worker/worker/src/` for the Worker-side tool discovery and MCP handling path.
+2. Locate the Worker's `tool_index` handler or equivalent catalog-shaping code.
 3. Add the same parameter with the same signature and default. The same named-param wrapper pattern applies — use explicit named params in the FastMCP-registered function.
 4. Implement the same logic. If the Worker delegates to the shared package, ensure the shared package is published first (see Procedure E), then update the Worker's dependency pin.
-5. Open a PR to the Worker repo. In the PR description, reference the local PR so the connection is traceable.
-6. Close any open Worker issues that tracked the parity gap.
-7. Merge the Worker PR after the local PR is live.
+5. Add or update Worker tests in `apps/worker/worker/test/`, especially contract fixtures shared with the relay when protocol shape changes.
+6. Run `make worker-check` or root `make check` before opening the PR.
+7. Reference any Worker parity issue in the monorepo PR description so the connection is traceable.
 
-**Coordination order**: local merge → shared package publish → Worker dependency update → Worker PR → Worker merge.
+**Coordination order**: shared Python code changes and Worker parity changes land together in the monorepo PR; release order is still upstream Python packages first, then `worker/v*` if the Worker depends on newly released relay behavior.
 
 ## Procedure D: Updating SKILL.md Runtime Manifests
 
@@ -172,9 +172,9 @@ Adding optional parameters to the tool discovery layer is a **minor** semver bum
 1. Bump `packages/unifi-mcp-shared/pyproject.toml` (minor: `X.Y.Z` → `X.(Y+1).0`).
 2. Publish the shared package to PyPI via CI before opening the Worker PR.
 3. Update the Worker's dependency pin to the new shared package version.
-4. The Worker npm package is published separately via OIDC trusted publishing, triggered by a version tag on the Worker repo. Coordinate release order:
+4. The Worker npm package is published separately via OIDC trusted publishing, triggered by a `worker/v*` tag in this monorepo. Coordinate release order:
    - Publish shared package (PyPI) first
-   - Update Worker dependency, tag the Worker release, CI publishes to npm
+   - Confirm any relay protocol dependency is available, then tag the Worker release so CI publishes to npm
 
 ### Plugin Version Sync via `bump-plugin-versions.yml`
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,46 @@ updates:
         patterns:
           - "*"
 
+  # Worker CLI dependencies
+  - package-ecosystem: "npm"
+    directory: "/apps/worker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "worker"
+    groups:
+      worker-cli:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Cloudflare Worker dependencies
+  - package-ecosystem: "npm"
+    directory: "/apps/worker/worker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "worker"
+    groups:
+      worker-runtime:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # Docker base images
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -1,0 +1,198 @@
+name: "UniFi MCP Worker: Release (test → npm → GitHub Release)"
+
+# Triggered on worker/v* tags. The npm package still owns the Cloudflare
+# Worker source and CLI; the monorepo only changes the tag namespace and path.
+
+on:
+  push:
+    tags:
+      - 'worker/v*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-tag:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${REF_NAME#worker/v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION}"
+
+  test:
+    name: Run worker checks
+    runs-on: ubuntu-latest
+    needs: validate-tag
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            apps/worker/package-lock.json
+            apps/worker/worker/package-lock.json
+      - name: Set package version from tag
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+        working-directory: apps/worker
+      - name: Install CLI dependencies
+        run: npm ci --prefix apps/worker
+      - name: Install worker dependencies
+        run: npm ci --prefix apps/worker/worker
+      - name: Typecheck worker
+        run: npm run --prefix apps/worker/worker typecheck
+      - name: CLI tests
+        run: npm test --prefix apps/worker
+      - name: Worker tests
+        run: npm run --prefix apps/worker test:worker
+
+  pack:
+    name: Pack npm tarball
+    runs-on: ubuntu-latest
+    needs: [validate-tag, test]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/worker/package-lock.json
+      - name: Set package version from tag
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+        working-directory: apps/worker
+      - name: Install CLI dependencies
+        run: npm ci --prefix apps/worker
+      - name: Pack npm tarball
+        run: npm pack
+        working-directory: apps/worker
+      - name: Upload tarball for release
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-package
+          path: apps/worker/unifi-mcp-worker-*.tgz
+
+  publish-npm:
+    name: Publish to npmjs.org
+    runs-on: ubuntu-latest
+    needs: [validate-tag, test]
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: |
+            apps/worker/package-lock.json
+            apps/worker/worker/package-lock.json
+      - name: Set package version from tag
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+        working-directory: apps/worker
+      - name: Install CLI dependencies
+        run: npm ci --prefix apps/worker
+      - name: Install worker dependencies
+        run: npm ci --prefix apps/worker/worker
+      - name: Publish package
+        run: npx npm@latest publish --provenance --access public
+        working-directory: apps/worker
+      - name: Publish summary
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: |
+          echo "## Published to npmjs.org" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Package:** [unifi-mcp-worker](https://www.npmjs.com/package/unifi-mcp-worker)" >> "$GITHUB_STEP_SUMMARY"
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [validate-tag, pack, publish-npm]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: npm-package
+          path: dist/
+      - name: Generate path-scoped release notes
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: python3 scripts/generate_release_notes.py --tag "${REF_NAME}" --output /tmp/release-notes.md
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${REF_NAME#worker/v}"
+          if echo "${VERSION}" | grep -qE -- '-(rc|alpha|beta|dev)'; then
+            PRERELEASE_FLAG="--prerelease"
+          else
+            PRERELEASE_FLAG=""
+          fi
+          gh release create "${REF_NAME}" \
+            --title "UniFi MCP Worker v${VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            --latest=false \
+            --verify-tag \
+            ${PRERELEASE_FLAG} \
+            dist/*
+
+  sync-version:
+    name: Sync version to main
+    runs-on: ubuntu-latest
+    needs: [validate-tag, github-release]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.PUSH_TOKEN }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Update package version
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+        working-directory: apps/worker
+      - name: Commit version bump
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add apps/worker/package.json apps/worker/package-lock.json
+          if git diff --cached --quiet; then
+            echo "No worker version changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(worker): sync version to ${VERSION} [skip ci]"
+          git push

--- a/.github/workflows/test-worker.yml
+++ b/.github/workflows/test-worker.yml
@@ -1,0 +1,39 @@
+name: "Worker: Test"
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, develop]
+
+jobs:
+  test:
+    name: Test Worker CLI and Cloudflare Worker
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            apps/worker/package-lock.json
+            apps/worker/worker/package-lock.json
+
+      - name: Install CLI dependencies
+        run: npm ci --prefix apps/worker
+
+      - name: Install worker dependencies
+        run: npm ci --prefix apps/worker/worker
+
+      - name: Typecheck worker
+        run: npm run --prefix apps/worker/worker typecheck
+
+      - name: CLI tests
+        run: npm test --prefix apps/worker
+
+      - name: Worker tests
+        run: npm run --prefix apps/worker test:worker

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ apps/worker/worker/node_modules/
 apps/worker/dist/
 apps/worker/.wrangler/
 apps/worker/worker/.wrangler/
+!apps/worker/src/lib/
+!apps/worker/src/lib/*.mjs
 .dev.vars
 apps/worker/.dev.vars
 apps/worker/worker/.dev.vars

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,17 @@ ENV/
 logs/
 !apps/api/src/unifi_api/templates/admin/logs/
 
+# Node / Cloudflare Worker
+node_modules/
+apps/worker/node_modules/
+apps/worker/worker/node_modules/
+apps/worker/dist/
+apps/worker/.wrangler/
+apps/worker/worker/.wrangler/
+.dev.vars
+apps/worker/.dev.vars
+apps/worker/worker/.dev.vars
+
 # Cache
 .cache/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,7 @@ make pre-commit   # format + lint + sync-skills + test
 - Version is derived from git tags via `hatch-vcs`. MUST NOT manually edit version in `pyproject.toml`.
 - Before release tags, update downstream `pyproject.toml` dependency ranges when a downstream package requires newly tagged `unifi-core` or `unifi-mcp-shared` code; pip only installs versions allowed by the published wheel metadata.
 - Each app's `tools_manifest.json` MUST be regenerated (`make manifest`) and committed before release.
+- The Cloudflare worker lives in `apps/worker/` as a self-contained Node/TypeScript app. It is intentionally excluded from the uv workspace and released from `worker/v*` tags via npm; run `make worker-check` after worker or relay protocol changes.
 
 ## Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ make pre-commit   # format + lint + sync-skills + test
 - Version is derived from git tags via `hatch-vcs`. MUST NOT manually edit version in `pyproject.toml`.
 - Before release tags, update downstream `pyproject.toml` dependency ranges when a downstream package requires newly tagged `unifi-core` or `unifi-mcp-shared` code; pip only installs versions allowed by the published wheel metadata.
 - Each app's `tools_manifest.json` MUST be regenerated (`make manifest`) and committed before release.
-- The Cloudflare worker lives in `apps/worker/` as a self-contained Node/TypeScript app. It is intentionally excluded from the uv workspace and released from `worker/v*` tags via npm; run `make worker-check` after worker or relay protocol changes.
+- The Cloudflare worker lives in `apps/worker/` as a self-contained Node/TypeScript app. It is intentionally excluded from the uv workspace and released from `worker/v*` tags via npm; run `make worker-check` for focused worker changes and root `make check` before merging worker or relay protocol changes.
 
 ## Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - Python 3.13+
+- Node.js 22+ for the Cloudflare Worker app
 - [uv](https://docs.astral.sh/uv/) (package manager)
 
 ## Setup
@@ -23,6 +24,7 @@ This installs all workspace packages (apps + shared packages) in development mod
 | `apps/network/` | Network MCP server | `make test`, `make lint`, `make manifest` |
 | `apps/protect/` | Protect MCP server | `make test`, `make lint`, `make manifest` |
 | `apps/access/` | Access MCP server | `make test`, `make lint`, `make manifest` |
+| `apps/worker/` | Cloudflare Worker gateway + npm CLI | `make check` |
 | `packages/unifi-core/` | Shared connectivity | Tested via root `make core-test` |
 | `packages/unifi-mcp-shared/` | Shared MCP patterns | Tested via root `make shared-test` |
 
@@ -31,7 +33,7 @@ This installs all workspace packages (apps + shared packages) in development mod
 The root Makefile delegates to app/package Makefiles:
 
 ```bash
-make test              # Run ALL tests (core + shared + network + protect + access)
+make test              # Run ALL tests (core + shared + relay + worker + apps)
 make lint              # Lint all packages
 make format            # Format all packages
 make pre-commit        # Format + lint + test
@@ -39,6 +41,8 @@ make pre-commit        # Format + lint + test
 # Individual packages
 make core-test         # Run unifi-core tests
 make shared-test       # Run unifi-mcp-shared tests
+make relay-test        # Run unifi-mcp-relay tests
+make worker-check      # Run worker CLI tests + TypeScript checks
 make network-test      # Run network server tests
 make network-lint      # Lint network server
 make network-manifest  # Regenerate network tools manifest
@@ -183,11 +187,11 @@ Tests use `pytest-asyncio` for async support and `aioresponses` for HTTP mocking
 ## Release Process (Maintainers)
 
 1. Run `make pre-commit` from root.
-2. Determine release scope by package tag namespace (`core/v*`, `shared/v*`, `network/v*`, `protect/v*`, `access/v*`, `api/v*`, `relay/v*`).
+2. Determine release scope by package tag namespace (`core/v*`, `shared/v*`, `network/v*`, `protect/v*`, `access/v*`, `api/v*`, `relay/v*`, `worker/v*`).
 3. If a downstream package needs code from a newly released upstream package, update its `pyproject.toml` dependency range before tagging. For example, Protect/API releases that require new `unifi-core` models must allow the new `unifi-core` line.
 4. Run `uv lock --check` and commit any dependency-bound changes before creating local tags.
-5. Push tags in dependency order: `core` first, then `shared`, then app/API packages, then `relay`. Wait for each upstream package to appear on PyPI before pushing dependents.
-6. CI publishes to PyPI, builds Docker images where applicable, and creates GitHub Releases.
+5. Push tags in dependency order: `core` first, then `shared`, then app/API packages, then `relay`, then `worker` if the worker needs the released relay behavior. Wait for each upstream package to appear on PyPI before pushing dependents.
+6. CI publishes to PyPI or npm, builds Docker images where applicable, and creates GitHub Releases.
 
 ## Questions?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@
 ```bash
 git clone https://github.com/sirkirby/unifi-mcp.git
 cd unifi-mcp
-uv sync
+make sync
 ```
 
-This installs all workspace packages (apps + shared packages) in development mode.
+This installs all Python workspace packages in development mode plus the self-contained worker npm dependencies.
 
 ## Monorepo Layout
 
@@ -34,6 +34,9 @@ The root Makefile delegates to app/package Makefiles:
 
 ```bash
 make test              # Run ALL tests (core + shared + relay + worker + apps)
+make check             # Run format check + lint + generated drift checks + tests
+make build             # Build deployable artifacts, including the worker typecheck
+make sync              # Install Python workspace + worker npm dependencies
 make lint              # Lint all packages
 make format            # Format all packages
 make pre-commit        # Format + lint + test
@@ -42,6 +45,7 @@ make pre-commit        # Format + lint + test
 make core-test         # Run unifi-core tests
 make shared-test       # Run unifi-mcp-shared tests
 make relay-test        # Run unifi-mcp-relay tests
+make worker-build      # Install worker deps + typecheck the Worker app
 make worker-check      # Run worker CLI tests + TypeScript checks
 make network-test      # Run network server tests
 make network-lint      # Lint network server

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-.PHONY: help test lint format format-check format-fix manifest generate server-manifests skill-references \
+.PHONY: help sync build check test lint format format-check format-fix manifest generate server-manifests skill-references \
        check-skill-references check-generated pre-commit ci core-test shared-test \
-       relay-test worker-install worker-test worker-typecheck worker-check docker-relay sync \
+       relay-test worker-install worker-test worker-typecheck worker-build worker-check docker-relay \
        docker-build docker-up docker-down docker-logs
 
 help:
 	@echo "UniFi MCP Ecosystem — Top-Level Commands"
 	@echo ""
 	@echo "  make sync           Sync uv workspace (install/update all packages)"
+	@echo "  make build          Build all deployable artifacts"
+	@echo "  make check          Run full lint + drift + test checks"
 	@echo "  make test           Run all tests (core + shared + all apps)"
 	@echo "  make lint           Lint the full workspace"
 	@echo "  make format         Format the full workspace"
@@ -27,10 +29,15 @@ help:
 	@echo ""
 	@echo "  make core-test      Run unifi-core tests only"
 	@echo "  make shared-test    Run unifi-mcp-shared tests only"
+	@echo "  make worker-build   Install worker deps + typecheck Worker app"
 	@echo "  make worker-check   Run worker CLI tests + TypeScript checks"
 
-sync:
+sync: worker-install
 	uv sync --all-packages
+
+build: docker-build worker-build
+
+check: format-check lint check-generated test worker-typecheck
 
 core-test:
 	uv run --package unifi-core pytest packages/unifi-core/tests -v
@@ -92,15 +99,16 @@ worker-typecheck: worker-install
 worker-test: worker-install
 	npm run --prefix apps/worker test:all
 
-worker-check: worker-install
-	$(MAKE) -C apps/worker check
+worker-build: worker-typecheck
+
+worker-check: worker-typecheck worker-test
 
 docker-relay:
 	docker build -f packages/unifi-mcp-relay/Dockerfile -t unifi-mcp-relay .
 
-pre-commit: format generate lint test check-generated
+pre-commit: format generate lint test check-generated worker-typecheck
 
-ci: format-check lint check-generated test
+ci: check
 
 docker-build:
 	docker compose -f docker/docker-compose.yml build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help test lint format format-check format-fix manifest generate server-manifests skill-references \
        check-skill-references check-generated pre-commit ci core-test shared-test \
-       relay-test docker-relay sync docker-build docker-up docker-down docker-logs
+       relay-test worker-install worker-test worker-typecheck worker-check docker-relay sync \
+       docker-build docker-up docker-down docker-logs
 
 help:
 	@echo "UniFi MCP Ecosystem — Top-Level Commands"
@@ -26,6 +27,7 @@ help:
 	@echo ""
 	@echo "  make core-test      Run unifi-core tests only"
 	@echo "  make shared-test    Run unifi-mcp-shared tests only"
+	@echo "  make worker-check   Run worker CLI tests + TypeScript checks"
 
 sync:
 	uv sync --all-packages
@@ -36,7 +38,7 @@ core-test:
 shared-test:
 	uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -v
 
-test: core-test shared-test relay-test
+test: core-test shared-test relay-test worker-test
 	$(MAKE) -C apps/network test
 	$(MAKE) -C apps/protect test
 	$(MAKE) -C apps/access test
@@ -79,6 +81,19 @@ check-generated: check-skill-references
 
 relay-test:
 	uv run --package unifi-mcp-relay pytest packages/unifi-mcp-relay/tests -v
+
+worker-install:
+	npm ci --prefix apps/worker
+	npm ci --prefix apps/worker/worker
+
+worker-typecheck: worker-install
+	npm run --prefix apps/worker/worker typecheck
+
+worker-test: worker-install
+	npm run --prefix apps/worker test:all
+
+worker-check: worker-install
+	$(MAKE) -C apps/worker check
 
 docker-relay:
 	docker build -f packages/unifi-mcp-relay/Dockerfile -t unifi-mcp-relay .

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,281 +1,104 @@
-# Quick Start Guide - v0.2.0
+# Quick Start
 
-## 🚀 New in v0.2.0: Lazy Tool Loading is Now Default!
+UniFi MCP ships independent MCP servers for Network, Protect, and Access, plus optional cloud relay components for cloud-hosted agents.
 
-Save 96% on tokens with automatic on-demand tool loading - **active by default!**
+## Install A Server
 
----
-
-## Installation
+For the Network server:
 
 ```bash
-# Clone
-git clone https://github.com/sirkirby/unifi-network-mcp.git
-cd unifi-network-mcp
-
-# Install
-uv sync
-
-# Configure
-cat > .env << EOF
-UNIFI_HOST=192.168.1.1
-UNIFI_USERNAME=admin
-UNIFI_PASSWORD=password
-# UNIFI_TOOL_REGISTRATION_MODE=lazy  # This is the default - no need to set!
-EOF
+uvx unifi-network-mcp@latest
 ```
 
----
-
-## Configuration Modes
-
-### 🎯 Lazy Mode (DEFAULT) ⭐⭐⭐
-
-**Active by default in v0.2.0!**
-
-**Best for:** Claude Desktop, production LLMs, most users
-
-**Config:**
-```json
-{
-  "env": {
-    // No need to set UNIFI_TOOL_REGISTRATION_MODE - defaults to "lazy"!
-  }
-}
-```
-
-**Benefits:**
-- 96% token savings
-- Tools load automatically when called
-- Seamless UX
-- **Active by default - no configuration needed!**
-
-### Eager Mode
-
-**Best for:** Dev console, automation, upgrading from v0.1.x
-
-**Config:**
-```json
-{
-  "env": {
-    "UNIFI_TOOL_REGISTRATION_MODE": "eager"
-  }
-}
-```
-
-**Benefits:**
-- All tools immediately available
-- No lazy loading overhead
-- Previous default behavior (v0.1.x)
-
-### Meta-Only Mode
-
-**Best for:** Maximum control
-
-**Config:**
-```json
-{
-  "env": {
-    "UNIFI_TOOL_REGISTRATION_MODE": "meta_only"
-  }
-}
-```
-
-**Benefits:**
-- 96% token savings
-- Manual tool discovery via `unifi_tool_index`
-
----
-
-## Quick Test
+For Protect or Access:
 
 ```bash
-# Test with dev console
-uv run python devtools/dev_console.py
-
-# Test with Python examples
-uv run python examples/python/query_tool_index.py
-uv run python examples/python/use_async_jobs.py
-uv run python examples/python/programmatic_client.py
-
-# Run tests
-uv run pytest tests/test_async_jobs.py -v
+uvx unifi-protect-mcp@latest
+uvx unifi-access-mcp@latest
 ```
 
----
+Configure the server with environment variables:
 
-## Claude Desktop Setup
-
-**1. Edit config:**
 ```bash
-# macOS
-nano ~/Library/Application\ Support/Claude/claude_desktop_config.json
-
-# Windows
-notepad %APPDATA%\Claude\claude_desktop_config.json
+export UNIFI_HOST=192.168.1.1
+export UNIFI_USERNAME=admin
+export UNIFI_PASSWORD=password
 ```
 
-**2. Add server (lazy mode - default, recommended):**
+Lazy tool registration is the default. You normally do not need to set `UNIFI_TOOL_REGISTRATION_MODE`.
+
+## Claude Desktop
+
+Example Network server configuration:
+
 ```json
 {
   "mcpServers": {
-    "unifi": {
-      "command": "uv",
-      "args": [
-        "--directory",
-        "/path/to/unifi-network-mcp",
-        "run",
-        "python",
-        "-m",
-        "src.main"
-      ],
+    "unifi-network": {
+      "command": "uvx",
+      "args": ["unifi-network-mcp@latest"],
       "env": {
         "UNIFI_HOST": "192.168.1.1",
         "UNIFI_USERNAME": "admin",
         "UNIFI_PASSWORD": "password"
-        // UNIFI_TOOL_REGISTRATION_MODE defaults to "lazy"
       }
     }
   }
 }
 ```
 
-**OR: Add server (eager mode - for v0.1.x compatibility):**
-```json
-{
-  "mcpServers": {
-    "unifi": {
-      "command": "uv",
-      "args": [
-        "--directory",
-        "/path/to/unifi-network-mcp",
-        "run",
-        "python",
-        "-m",
-        "src.main"
-      ],
-      "env": {
-        "UNIFI_HOST": "192.168.1.1",
-        "UNIFI_USERNAME": "admin",
-        "UNIFI_PASSWORD": "password",
-        "UNIFI_TOOL_REGISTRATION_MODE": "eager"
-      }
-    }
-  }
-}
+Then restart Claude Desktop and ask for your available UniFi tools or devices.
+
+## Source Checkout
+
+For local development:
+
+```bash
+git clone https://github.com/sirkirby/unifi-mcp.git
+cd unifi-mcp
+make sync
+make check
 ```
 
-**3. Restart Claude Desktop**
+`make sync` installs the Python workspace plus the self-contained worker npm dependencies. `make check` runs formatting checks, linting, generated artifact drift checks, Python tests, worker tests, and the worker TypeScript typecheck.
 
-**4. Test:**
-- Ask: "What UniFi tools are available?"
-- Ask: "Show me my wireless clients"
-- Ask: "List all my devices"
+Run the Network server from the checkout:
 
----
-
-## Token Savings
-
-| Mode | Initial Tokens | After Query | Savings | Status |
-|------|----------------|-------------|---------|--------|
-| **lazy** (default) | **225** | **225** | **96%** | ⭐ **DEFAULT** |
-| meta_only | 225 | 525 | 89% | |
-| eager (v0.1.x) | 5,000 | 5,000 | 0% | Legacy |
-
----
-
-## Key Features
-
-### 1. Tool Index
-```python
-# Get all available tools with schemas
-await server.call_tool("unifi_tool_index", {})
+```bash
+uv run --package unifi-network-mcp unifi-network-mcp
 ```
 
-### 2. Tool Execution
-```python
-# Single execution (returns result directly)
-result = await server.call_tool("unifi_execute", {
-    "tool": "unifi_list_clients",
-    "arguments": {}
-})
+## Optional Cloud Relay
 
-# Batch execution (parallel, returns job IDs)
-batch = await server.call_tool("unifi_batch", {
-    "operations": [
-        {"tool": "unifi_get_client_details", "arguments": {"mac": "aa:bb:cc:dd:ee:ff"}},
-        {"tool": "unifi_get_device_details", "arguments": {"mac": "11:22:33:44:55:66"}}
-    ]
-})
+Use the relay when a cloud-hosted agent needs to reach MCP servers running on your local network without opening inbound ports.
 
-# Check batch status
-status = await server.call_tool("unifi_batch_status", {
-    "jobIds": [job["jobId"] for job in batch["jobs"]]
-})
+Deploy the Cloudflare Worker gateway:
+
+```bash
+npm install -g unifi-mcp-worker
+unifi-mcp-worker install
 ```
 
-### 3. Lazy Loading
-```python
-# Tools load automatically when called
-result = await server.call_tool("unifi_list_devices", {})
-# → Devices module loads on-demand
-# → Tool executes normally
-# → Cached for future calls
+Then run the local relay sidecar:
+
+```bash
+pip install unifi-mcp-relay
+export UNIFI_RELAY_URL=https://your-worker.workers.dev
+export UNIFI_RELAY_TOKEN=your-relay-token
+export UNIFI_RELAY_LOCATION_NAME="Home Lab"
+unifi-mcp-relay
 ```
 
----
-
-## Troubleshooting
-
-### Issue: "I upgraded to v0.2.0 and now I only see 3 tools instead of 67!"
-
-**Explanation:** Lazy mode is now the default! Tools are loaded automatically when called.
-
-**Solution 1 (Recommended):** Just use the tools normally - they'll load on-demand:
-- Ask Claude: "List my UniFi devices"
-- The `unifi_list_devices` tool loads automatically
-- All subsequent calls are instant
-
-**Solution 2:** Restore v0.1.x behavior (eager mode):
-```json
-{
-  "env": {
-    "UNIFI_TOOL_REGISTRATION_MODE": "eager"
-  }
-}
-```
-
-### Issue: "Unclosed client session"
-**Fix:** Upgrade to v0.2.0 (fixed in dev console)
-
-### Issue: Meta-tools not visible in dev console
-**Fix:** Upgrade to v0.2.0 (now registered properly)
-
-### Issue: Tools not loading in lazy mode
-**Check logs:**
-```
-🔄 Lazy-loading tool 'tool_name' from 'module_path'
-✅ Tool 'tool_name' loaded successfully
-```
-
-If missing, verify your server is running v0.2.0 or later.
-
----
+See [apps/worker](apps/worker/) and [packages/unifi-mcp-relay](packages/unifi-mcp-relay/) for relay details.
 
 ## More Documentation
 
-- **Full README:** [README.md](README.md)
-- **Lazy Loading Guide:** [docs/LAZY_TOOL_LOADING.md](docs/LAZY_TOOL_LOADING.md)
-- **Context Optimization:** [CONTEXT_OPTIMIZATION_SUMMARY.md](CONTEXT_OPTIMIZATION_SUMMARY.md)
-- **Testing Guide:** [TESTING_GUIDE.md](TESTING_GUIDE.md)
-
----
+- [README.md](README.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/cross-product.md](docs/cross-product.md)
 
 ## Support
 
-- **Issues:** https://github.com/sirkirby/unifi-network-mcp/issues
-- **Discussions:** https://github.com/sirkirby/unifi-network-mcp/discussions
-
----
-
-**Enjoy 96% token savings with lazy mode!** 🎉
+- [Issues](https://github.com/sirkirby/unifi-mcp/issues)
+- [Discussions](https://github.com/sirkirby/unifi-mcp/discussions)

--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ Each Python server in `apps/` is an independent package that depends on the shar
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 
+## Development
+
+```bash
+make sync   # Install Python workspace + worker npm dependencies
+make check  # Format check + lint + generated drift checks + tests + worker typecheck
+make build  # Build deployable artifacts, including worker typecheck
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, including how to work with the monorepo, run tests, and submit PRs.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 [![PyPI - Access](https://img.shields.io/pypi/v/unifi-access-mcp)](https://pypi.org/project/unifi-access-mcp/)
 [![PyPI - Relay](https://img.shields.io/pypi/v/unifi-mcp-relay)](https://pypi.org/project/unifi-mcp-relay/)
 [![PyPI - API Server](https://img.shields.io/pypi/v/unifi-api-server)](https://pypi.org/project/unifi-api-server/)
+[![npm - Worker](https://img.shields.io/npm/v/unifi-mcp-worker)](https://www.npmjs.com/package/unifi-mcp-worker)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
 
@@ -27,7 +28,7 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 | Component | Status | Package |
 |-----------|--------|---------|
 | [Relay Sidecar](packages/unifi-mcp-relay/) | Beta | [`unifi-mcp-relay`](https://pypi.org/project/unifi-mcp-relay/) |
-| [Worker Gateway](https://github.com/sirkirby/unifi-mcp-worker) | Beta | [`unifi-mcp-worker`](https://www.npmjs.com/package/unifi-mcp-worker) (CLI) |
+| [Worker Gateway](apps/worker/) | Beta | [`unifi-mcp-worker`](https://www.npmjs.com/package/unifi-mcp-worker) (CLI) |
 
 The relay bridges your local MCP servers to a Cloudflare Worker, letting cloud agents access your UniFi tools without exposing local ports. Supports multi-location with annotation-based fan-out for read-only tools. Deploy the worker with `npm install -g unifi-mcp-worker && unifi-mcp-worker install`, then see the [relay README](packages/unifi-mcp-relay/) for connecting your local servers.
 
@@ -225,6 +226,7 @@ apps/
   network/          # UniFi Network MCP server (stable, 169 tools)
   protect/          # UniFi Protect MCP server (beta, 43 tools)
   access/           # UniFi Access MCP server (beta, 29 tools)
+  worker/           # Cloudflare Worker gateway + npm CLI
 packages/
   unifi-core/       # Shared UniFi connectivity (auth, detection, retry)
   unifi-mcp-shared/ # Shared MCP patterns (permissions, tools, diagnostics, config)
@@ -238,7 +240,7 @@ skills/
 docs/               # Ecosystem-level documentation
 ```
 
-Each server in `apps/` is an independent Python package that depends on the shared packages. The shared packages ensure consistent behavior across all servers — same permission model, same confirmation flow, same lazy tool loading.
+Each Python server in `apps/` is an independent package that depends on the shared packages. `apps/worker/` is intentionally separate: it is a self-contained TypeScript/Node app for the Cloudflare Worker gateway and npm CLI. Keeping it in this repo lets relay protocol changes and worker contract tests move together.
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,7 @@
 | unifi-protect-mcp | Latest release (beta) |
 | unifi-access-mcp | Latest release (beta) |
 | unifi-mcp-relay | Latest release (beta) |
+| unifi-mcp-worker | Latest release (beta) |
 
 Only the latest release of each package receives security patches. We recommend always running the most recent version.
 
@@ -42,7 +43,7 @@ Reporters will be credited in the security advisory and CHANGELOG unless they re
 
 ## Security Model
 
-unifi-network-mcp is designed with a **secure-by-default** posture:
+UniFi MCP is designed with a **secure-by-default** posture:
 
 ### Local-First Authentication
 
@@ -97,7 +98,7 @@ We recommend running at least these controller versions for security and API com
 - MCP server code (`apps/network/`, `apps/protect/`, `apps/access/`)
 - Shared packages (`packages/unifi-core/`, `packages/unifi-mcp-shared/`)
 - Relay sidecar (`packages/unifi-mcp-relay/`)
-- Cloudflare Worker relay (`worker/`)
+- Cloudflare Worker relay and CLI (`apps/worker/`)
 - Claude Code plugins (`plugins/`)
 
 ### Out of Scope

--- a/apps/worker/.gitignore
+++ b/apps/worker/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+worker/node_modules/
+dist/
+worker/.wrangler/
+.dev.vars
+worker/.dev.vars
+.env
+*.log
+
+# Myco managed (machine-specific)
+.agents/skills/myco
+.agents/skills/myco-curate
+.agents/skills/rules
+.wrangler/

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -1,0 +1,172 @@
+# AGENTS.md — UniFi MCP Relay Worker
+
+> Worker app rules. These rules apply inside `apps/worker/` in addition to the
+> repository root `AGENTS.md`.
+
+---
+
+## 1. Project Identity
+
+**UniFi MCP Relay Worker** is a CLI + Cloudflare Worker that relays MCP (Model Context Protocol) tool calls between cloud AI agents and locally-hosted UniFi MCP servers through a secure WebSocket relay.
+
+Two workspaces live in one repo:
+
+| Workspace | Language | Path | Purpose |
+|-----------|----------|------|---------|
+| **CLI** | Plain ESM (`.mjs`) | `bin/`, `src/`, `test/` | Deploys/manages the Worker via Wrangler |
+| **Worker** | TypeScript (strict) | `worker/` | Cloudflare Worker + Durable Object relay |
+
+---
+
+## 2. Non-Goals
+
+- This is NOT a general-purpose MCP framework. Do not add plugin systems, extensibility hooks, or abstract base classes.
+- This is NOT a UniFi controller. The relay forwards tool calls — it MUST NOT implement UniFi business logic.
+- Do not add a build/transpile step to the CLI. It ships as plain `.mjs` — no TypeScript, no bundler.
+- Do not merge the CLI and Worker `node_modules`. They are intentionally separate (`npm ci` at root and `cd worker && npm ci`).
+
+---
+
+## 3. Architecture Invariants
+
+### 3.1 Workspace Boundary
+
+- CLI code MUST be plain ESM in `.mjs` files under `src/` and `bin/`.
+- Worker code MUST be TypeScript in `.ts` files under `worker/src/`.
+- The CLI MUST NOT import from `worker/`. The Worker MUST NOT import from `src/`.
+
+### 3.2 Worker Structure
+
+- `worker/src/index.ts` — HTTP fetch handler and routing. All inbound requests enter here.
+- `worker/src/relay-object.ts` — Durable Object (`RelayObject`). All persistent state and WebSocket management lives here.
+- `worker/src/mcp-handler.ts` — MCP JSON-RPC dispatch. Pure function, no side effects beyond calling the `RelayStub` interface.
+- `worker/src/auth.ts` — Token generation, hashing, and validation. All auth primitives live here.
+- `worker/src/types.ts` — All TypeScript interfaces and protocol constants. Shared types MUST be defined here, not inline.
+
+New Worker source files SHOULD be added to `worker/src/` only when they represent a clearly distinct concern. Do not fragment into deep directory trees.
+
+### 3.3 CLI Structure
+
+- `bin/cli.mjs` — Entry point. Parses args and dispatches to command modules. MUST NOT contain business logic.
+- `src/commands/*.mjs` — One file per CLI command. Each MUST export a `run(options)` function.
+- `src/lib/*.mjs` — Shared utilities (config, API helpers, Wrangler wrappers, display, tokens, prerequisites).
+
+### 3.4 Authentication
+
+- All endpoints except `/health` MUST require Bearer token authentication.
+- Token comparison MUST use the constant-time `timingSafeEqual` function from `worker/src/auth.ts`.
+- Relay tokens MUST be stored as SHA-256 hashes (via `hashToken`), never plaintext.
+- The CLI config file (`~/.unifi-mcp-worker/config.json`) MUST be written with mode `0o600` and its directory with `0o700`.
+
+### 3.5 Protocol
+
+- The relay uses JSON-RPC 2.0 for the MCP interface (POST `/mcp`).
+- WebSocket messages between relay clients and the Durable Object use the typed message format defined in `worker/src/types.ts` (`InboundMessage`, `OutboundMessage`).
+- Protocol constants (`PROTOCOL_VERSION`, `TOOL_CALL_TIMEOUT_MS`, etc.) MUST be defined in `worker/src/types.ts`, not hardcoded elsewhere.
+
+### 3.6 Durable Object
+
+- The relay uses a singleton Durable Object (`env.RELAY.idFromName("singleton")`).
+- The Durable Object uses SQLite for persistent location/token storage (configured in `wrangler.toml` via `new_sqlite_classes`).
+- Meta-tools (`unifi_tool_index`, `unifi_execute`, `unifi_batch`, `unifi_location_timeline`) are defined in `relay-object.ts` and handled by the relay itself — they MUST NOT be forwarded to relay clients.
+
+### 3.7 Dependencies
+
+- The CLI has minimal runtime dependencies (`prompts`, `chalk`). Do not add heavy dependencies without justification.
+- The Worker has zero runtime dependencies — only `devDependencies` for types, TypeScript, Vitest, and Wrangler.
+- Worker MUST NOT add runtime `dependencies`. Cloudflare Workers bundle everything at deploy time; only `devDependencies` are appropriate.
+
+---
+
+## 4. Golden Paths
+
+### 4.1 Add a New CLI Command
+
+1. Create `src/commands/<name>.mjs` exporting `async function run(options) { ... }`.
+2. Register the command in the `COMMANDS` map in `bin/cli.mjs`.
+3. Add `--help` text for the command in the help string in `bin/cli.mjs`.
+4. Add any new flags to the `parseArgs` options in `bin/cli.mjs`.
+5. Add tests at `test/cli/<name>.test.mjs` using `node:test` and `node:assert/strict`.
+6. Run `make check` to verify.
+
+### 4.2 Add a New Worker Endpoint
+
+1. Add the route handler in `worker/src/index.ts` following the existing `if (url.pathname === ...)` pattern.
+2. All authenticated routes MUST call `validateBearerToken` before proceeding.
+3. Add tests at `worker/test/<module>.test.ts` using Vitest.
+4. Run `make check` to verify.
+
+### 4.3 Add a New Meta-Tool
+
+1. Define the `ToolInfo` constant in `worker/src/relay-object.ts` alongside the existing `META_TOOL_*` constants.
+2. Add it to the `META_TOOLS` array.
+3. Add the handler case in the Durable Object's tool dispatch logic.
+4. Add tests at `worker/test/relay-object.test.ts`.
+5. Run `make check` to verify.
+
+### 4.4 Add a New Type or Interface
+
+1. All shared types MUST go in `worker/src/types.ts`.
+2. Import types with `import type { ... }` (not value imports) when used only for type checking.
+3. Run `cd worker && npm run typecheck` to verify.
+
+### 4.5 Modify Authentication Logic
+
+1. All auth functions live in `worker/src/auth.ts`.
+2. Token comparison MUST remain constant-time. Do not introduce early-return comparisons.
+3. Tests at `worker/test/auth.test.ts` MUST cover both positive and negative cases.
+
+---
+
+## 5. Quality Gates
+
+Before considering work complete, the following MUST pass:
+
+```bash
+make check
+```
+
+This runs:
+
+| Step | Command | What it verifies |
+|------|---------|-----------------|
+| Typecheck | `cd worker && npm run typecheck` | Worker TypeScript compiles with `--strict --noEmit` |
+| CLI tests | `npm test` | `node --test test/cli/*.test.mjs` |
+| Worker tests | `npm run test:worker` | `cd worker && vitest run` |
+
+### Test Conventions
+
+- **CLI tests** MUST use `node:test` (`describe`, `it`) and `node:assert/strict`. No third-party test runners.
+- **Worker tests** MUST use Vitest (`describe`, `it`, `expect`).
+- Test files MUST mirror source files: `src/lib/foo.mjs` -> `test/cli/foo.test.mjs`, `worker/src/bar.ts` -> `worker/test/bar.test.ts`.
+- Tests MUST NOT depend on network access, running workers, or real Cloudflare infrastructure.
+
+### CI
+
+CI runs on Node 22, ubuntu-latest. The pipeline is:
+
+1. `npm ci` + `cd worker && npm ci`
+2. `cd worker && npm run typecheck`
+3. `npm test`
+4. `npm run test:worker`
+
+If CI fails, the PR MUST NOT be merged.
+
+---
+
+## 6. Release Process
+
+Releases are tag-triggered. Do NOT manually edit `package.json` version on `main`.
+
+1. Create and push a namespaced semver tag from the monorepo root: `git tag worker/v1.2.3 && git push origin worker/v1.2.3`
+2. CI validates, tests, packs, creates a GitHub Release, and publishes to npm with provenance.
+3. A post-publish job syncs the version back to `main` (`chore: sync version to X.Y.Z [skip ci]`).
+
+---
+
+## 7. Security Considerations
+
+- Secrets (`AGENT_TOKEN`, `ADMIN_TOKEN`, relay tokens) MUST NEVER appear in logs, error messages, or test output.
+- The `.dev.vars` and `.env` files are gitignored and MUST remain so.
+- Config files written to disk MUST use restrictive permissions (`0o600` for files, `0o700` for directories).
+- Token generation MUST use `crypto.getRandomValues` (32 bytes, URL-safe base64).

--- a/apps/worker/Makefile
+++ b/apps/worker/Makefile
@@ -1,0 +1,24 @@
+.PHONY: check build test typecheck install dev
+
+# Install all dependencies
+install:
+	npm ci
+	cd worker && npm ci
+
+# Typecheck the worker TypeScript
+typecheck:
+	cd worker && npm run typecheck
+
+# Run all tests (CLI + worker)
+test:
+	npm run test:all
+
+# Run typecheck + all tests (mirrors CI)
+check: typecheck test
+
+# Install deps + typecheck (no deploy)
+build: install typecheck
+
+# Install CLI globally from local source for development
+dev:
+	npm install -g .

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,0 +1,211 @@
+# UniFi MCP Relay Worker
+
+A Cloudflare Worker that enables cloud agents to access locally-hosted UniFi MCP servers via a secure relay gateway.
+
+---
+
+## How It Works
+
+Cloud agents communicate with your local UniFi MCP server through a two-leg relay:
+
+```
+Cloud Agent (Claude, n8n, etc.)
+        |  HTTPS POST /mcp  (Bearer AGENT_TOKEN)
+        v
+Cloudflare Worker  ──────────────────────────────────  Durable Object (RelayObject)
+                                                                |
+                                              WebSocket (WSS) /ws  (relay_token)
+                                                                |
+                                                   unifi-mcp-relay (local network)
+                                                                |
+                                                    UniFi MCP Server (stdio/HTTP)
+```
+
+The Durable Object persists location registrations in SQLite and maintains live WebSocket connections to one or more relay clients. When a tool call arrives from a cloud agent, the worker routes it to the appropriate relay client and streams the result back.
+
+**Multi-location support:** Multiple relay clients can connect simultaneously, each representing a different physical location (home lab, branch office, customer site). Read-only tool calls are automatically fanned out to all connected locations and results are aggregated. Write operations require an explicit `__location` argument to target a specific site — useful for MSP workflows.
+
+---
+
+## Quick Start
+
+### Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sirkirby/unifi-mcp/main/apps/worker/install.sh | bash
+```
+
+Or install the CLI directly:
+
+```bash
+npm install -g unifi-mcp-worker
+unifi-mcp-worker install
+```
+
+The CLI will:
+1. Check prerequisites (Node.js, Wrangler)
+2. Deploy the worker to your Cloudflare account
+3. Generate and set authentication tokens
+4. Display your tokens and next steps
+
+### Upgrade
+
+```bash
+unifi-mcp-worker upgrade
+```
+
+### Add a Location
+
+```bash
+unifi-mcp-worker add-location
+```
+
+### Manage Tokens
+
+```bash
+unifi-mcp-worker rotate-tokens
+unifi-mcp-worker status
+```
+
+### Remove
+
+```bash
+unifi-mcp-worker destroy
+```
+
+---
+
+## Configuration Reference
+
+### Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `AGENT_TOKEN` | Bearer token required by cloud agents calling the `/mcp` endpoint |
+| `ADMIN_TOKEN` | Bearer token required for admin API calls (`/api/*`) |
+
+Secrets are set automatically by the CLI and can be rotated with `unifi-mcp-worker rotate-tokens`.
+
+### Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TOOL_REGISTRATION_MODE` | `lazy` | Tool registration mode sent to relay clients. `lazy` registers only meta-tools (~200 tokens); `eager` registers all tools upfront (~5,000 tokens) |
+
+Variables are set in `wrangler.toml` under `[vars]` or overridden via the Cloudflare dashboard.
+
+---
+
+## API Reference
+
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| `/health` | GET | None | Health check — returns `{"status":"ok"}` |
+| `/mcp` | POST | `AGENT_TOKEN` | MCP JSON-RPC endpoint for cloud agents |
+| `/ws` | GET | `relay_token` | WebSocket upgrade for relay client connections |
+| `/api/locations` | GET | `ADMIN_TOKEN` | List registered locations and connection status |
+| `/api/locations/token` | POST | `ADMIN_TOKEN` | Generate a relay token for a new location |
+
+### MCP Endpoint
+
+The `/mcp` endpoint accepts standard MCP JSON-RPC requests:
+
+```bash
+curl -X POST https://your-worker.workers.dev/mcp \
+  -H "Authorization: Bearer <agent-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+### Built-in Meta-Tools
+
+The relay always exposes these meta-tools regardless of registration mode:
+
+| Tool | Purpose |
+|------|---------|
+| `unifi_tool_index` | List all available UniFi tools with optional category or search filter |
+| `unifi_execute` | Execute any UniFi tool by name; use `__location` to target a specific site |
+| `unifi_batch` | Execute multiple UniFi tools in a single request |
+| `unifi_location_timeline` | Query a unified event timeline across connected locations and products |
+
+---
+
+## Token Management
+
+The CLI manages tokens automatically during `install` and `rotate-tokens`. You can also manage tokens manually via the admin API:
+
+```bash
+curl -X POST https://your-worker.workers.dev/api/locations/token \
+  -H "Authorization: Bearer <admin-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"location_name": "Home Lab"}'
+```
+
+Response:
+
+```json
+{
+  "location_id": "a1b2c3d4-...",
+  "location_name": "Home Lab",
+  "token": "<relay-token>"
+}
+```
+
+Store the `token` value securely — it is only returned once. Provide it to `unifi-mcp-relay` as `UNIFI_MCP_RELAY_TOKEN` (see [unifi-mcp](https://github.com/sirkirby/unifi-mcp) for relay client configuration).
+
+### List Registered Locations
+
+```bash
+unifi-mcp-worker status
+```
+
+Or via the admin API:
+
+```bash
+curl https://your-worker.workers.dev/api/locations \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+Response includes `connected: true/false` indicating whether the relay client WebSocket is currently active.
+
+---
+
+## Connecting Cloud Agents
+
+Point any MCP-compatible client at the worker URL:
+
+- **Endpoint:** `https://your-worker.workers.dev/mcp`
+- **Auth:** `Authorization: Bearer <agent-token>`
+- **Transport:** HTTP POST (standard MCP JSON-RPC)
+
+Compatible clients include Claude connectors, ChatGPT plugins, n8n MCP nodes, and any platform that supports the MCP protocol over HTTP.
+
+### Multi-Location Writes
+
+When multiple relay clients are connected, write operations require a `__location` argument passed to `unifi_execute`:
+
+```json
+{
+  "tool_name": "block_client",
+  "arguments": { "mac": "aa:bb:cc:dd:ee:ff" },
+  "__location": "a1b2c3d4-..."
+}
+```
+
+Read-only operations (tools with `readOnlyHint: true`) are automatically fanned out to all connected locations and results are returned as an aggregated response.
+
+---
+
+## Security
+
+- **Timing-safe token comparison** — all token validation uses constant-time comparison to prevent timing attacks
+- **SHA-256 hashed storage** — relay tokens are stored as hashes in SQLite; the plaintext is never persisted
+- **Per-location isolation** — each relay client is identified by its own relay token and location ID; locations cannot access each other's data
+- **HTTPS/WSS transport** — all traffic is encrypted in transit; Cloudflare terminates TLS at the edge
+- **No credentials in config** — tokens and secrets are managed via the CLI or `wrangler secret put`, never committed to source
+
+---
+
+## Related
+
+- [unifi-mcp](https://github.com/sirkirby/unifi-mcp) — source repository for this worker, the UniFi MCP servers, and the `unifi-mcp-relay` client

--- a/apps/worker/bin/cli.mjs
+++ b/apps/worker/bin/cli.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { parseArgs } from "node:util";
+
+const COMMANDS = {
+  install: () => import("../src/commands/install.mjs"),
+  upgrade: () => import("../src/commands/upgrade.mjs"),
+  "add-location": () => import("../src/commands/add-location.mjs"),
+  "rotate-tokens": () => import("../src/commands/rotate-tokens.mjs"),
+  status: () => import("../src/commands/status.mjs"),
+  destroy: () => import("../src/commands/destroy.mjs"),
+  observability: () => import("../src/commands/observability.mjs"),
+};
+
+const { values, positionals } = parseArgs({
+  allowPositionals: true,
+  options: {
+    version: { type: "boolean", short: "v" },
+    help: { type: "boolean", short: "h" },
+    "non-interactive": { type: "boolean" },
+    yes: { type: "boolean", short: "y" },
+    "worker-name": { type: "string" },
+    "location-name": { type: "string" },
+    "worker-url": { type: "string" },
+    "admin-token": { type: "string" },
+    token: { type: "string" },
+    force: { type: "boolean", short: "f" },
+    enable: { type: "boolean" },
+    disable: { type: "boolean" },
+    observability: { type: "boolean" },
+  },
+});
+
+if (values.version) {
+  const { readFileSync } = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const { join, dirname } = await import("node:path");
+  const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  console.log(pkg.version);
+  process.exit(0);
+}
+
+const command = positionals[0];
+
+if (values.help || !command) {
+  console.log(`
+Usage: unifi-mcp-worker <command> [options]
+
+Commands:
+  install         Deploy the Cloudflare Worker and generate tokens
+  upgrade         Redeploy the latest worker code
+  add-location    Add a new location (generates a relay token)
+  rotate-tokens   Rotate agent, admin, or relay tokens
+  status          Show deployment info and token summary
+  destroy         Remove the worker and clean up
+  observability   Show or toggle Workers Logs observability
+
+Options:
+  --version, -v          Show CLI version
+  --help, -h             Show this help
+  --non-interactive      Disable interactive prompts (requires flags for all values)
+  --yes, -y              Skip confirmation prompts
+  --worker-name <name>   Worker name (default: unifi-mcp-relay)
+  --location-name <name> Location name (default: Home Lab)
+  --worker-url <url>     Worker URL (for add-location, rotate-tokens)
+  --admin-token <token>  Admin token override
+  --token <type>         Token to rotate: agent, admin, relay, all
+  --force, -f            Overwrite existing config on install
+  --enable               Enable observability (for observability command)
+  --disable              Disable observability (for observability command)
+  --observability        Enable observability during install
+`);
+  process.exit(0);
+}
+
+if (!COMMANDS[command]) {
+  console.error(`Unknown command: ${command}`);
+  console.error(`Run 'unifi-mcp-worker --help' for available commands.`);
+  process.exit(1);
+}
+
+const mod = await COMMANDS[command]();
+await mod.run(values);

--- a/apps/worker/install.sh
+++ b/apps/worker/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND="${1:-install}"
+
+echo ""
+echo "  UniFi MCP Worker CLI"
+echo ""
+
+# Check Node.js
+if ! command -v node &>/dev/null; then
+    echo "  Error: Node.js is required but not installed."
+    echo "  Install it from https://nodejs.org/ or via your package manager:"
+    echo "    brew install node      (macOS)"
+    echo "    apt install nodejs     (Debian/Ubuntu)"
+    echo "    winget install Volta   (Windows)"
+    echo ""
+    exit 1
+fi
+
+# Check minimum Node version (18+)
+NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+    echo "  Error: Node.js 18+ required. Found: $(node -v)"
+    echo "  Update from https://nodejs.org/"
+    exit 1
+fi
+
+echo "  Node.js $(node -v) detected."
+
+# Install or update the CLI
+if command -v unifi-mcp-worker &>/dev/null; then
+    echo "  Updating unifi-mcp-worker CLI..."
+    npm install -g unifi-mcp-worker@latest --silent 2>/dev/null || npm install -g unifi-mcp-worker@latest
+else
+    echo "  Installing unifi-mcp-worker CLI..."
+    npm install -g unifi-mcp-worker --silent 2>/dev/null || npm install -g unifi-mcp-worker
+fi
+
+echo ""
+
+# Run the requested command, passing through any additional args
+shift 2>/dev/null || true
+unifi-mcp-worker "$COMMAND" "$@"

--- a/apps/worker/package-lock.json
+++ b/apps/worker/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "unifi-mcp-worker",
+  "version": "1.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unifi-mcp-worker",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "unifi-mcp-worker": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "unifi-mcp-worker",
+  "version": "1.3.0",
+  "description": "CLI to deploy and manage the UniFi MCP Cloudflare Worker relay",
+  "type": "module",
+  "bin": {
+    "unifi-mcp-worker": "./bin/cli.mjs"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "worker/src/",
+    "worker/package.json",
+    "worker/package-lock.json",
+    "worker/wrangler.toml",
+    "worker/tsconfig.json",
+    "worker/vitest.config.ts",
+    "install.sh"
+  ],
+  "scripts": {
+    "test": "node --test test/cli/*.test.mjs",
+    "test:worker": "cd worker && npm test",
+    "test:all": "npm test && npm run test:worker"
+  },
+  "dependencies": {
+    "prompts": "^2.4.2",
+    "chalk": "^5.4.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sirkirby/unifi-mcp.git",
+    "directory": "apps/worker"
+  }
+}

--- a/apps/worker/src/commands/add-location.mjs
+++ b/apps/worker/src/commands/add-location.mjs
@@ -1,0 +1,92 @@
+// src/commands/add-location.mjs
+import prompts from "prompts";
+import { loadConfig, saveConfig } from "../lib/config.mjs";
+import { healthCheck, createLocationToken } from "../lib/api.mjs";
+import { showAddLocationSuccess, showError } from "../lib/display.mjs";
+
+export async function run(flags) {
+  const config = loadConfig();
+  if (!config) {
+    showError("No deployment found. Run 'unifi-mcp-worker install' first.");
+    process.exit(1);
+  }
+
+  let locationName, workerUrl, adminToken;
+
+  if (flags["non-interactive"]) {
+    locationName = flags["location-name"];
+    workerUrl = flags["worker-url"] || config.worker_url;
+    adminToken = flags["admin-token"] || config.admin_token;
+    if (!locationName) {
+      showError("--location-name is required in non-interactive mode.");
+      process.exit(1);
+    }
+  } else {
+    const answers = await prompts([
+      {
+        type: "text",
+        name: "locationName",
+        message: "Location name",
+        validate: (v) => (v ? true : "Location name is required"),
+      },
+      {
+        type: "text",
+        name: "workerUrl",
+        message: "Worker URL",
+        initial: config.worker_url,
+      },
+      {
+        type: "text",
+        name: "adminToken",
+        message: "Admin token",
+        initial: config.admin_token,
+      },
+    ]);
+    locationName = answers.locationName;
+    workerUrl = answers.workerUrl;
+    adminToken = answers.adminToken;
+  }
+
+  console.log("\nChecking worker health...");
+  const health = await healthCheck(workerUrl);
+  if (!health.ok) {
+    showError(`Worker not reachable at ${workerUrl}`);
+    console.error("  Check that:");
+    console.error("  - The URL is correct");
+    console.error("  - The worker is deployed (run 'unifi-mcp-worker status')");
+    console.error("  - Cloudflare is not experiencing issues");
+    if (health.error) console.error(`  Error: ${health.error}`);
+    process.exit(1);
+  }
+
+  try {
+    console.log(`Creating location "${locationName}"...`);
+    const loc = await createLocationToken(workerUrl, adminToken, locationName);
+
+    const existingIdx = config.locations.findIndex(
+      (l) => l.location_name === locationName
+    );
+    if (existingIdx >= 0) {
+      config.locations[existingIdx].relay_token = loc.relayToken;
+      config.locations[existingIdx].location_id = loc.locationId;
+    } else {
+      config.locations.push({
+        location_name: locationName,
+        relay_token: loc.relayToken,
+        location_id: loc.locationId,
+        created_at: new Date().toISOString(),
+      });
+    }
+
+    saveConfig(config);
+
+    showAddLocationSuccess({
+      locationName,
+      relayToken: loc.relayToken,
+      workerUrl,
+    });
+  } catch (err) {
+    showError(`Failed to create location: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/apps/worker/src/commands/destroy.mjs
+++ b/apps/worker/src/commands/destroy.mjs
@@ -1,0 +1,83 @@
+// src/commands/destroy.mjs
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import prompts from "prompts";
+import chalk from "chalk";
+import { loadConfig, deleteConfig } from "../lib/config.mjs";
+import { ensureWrangler, checkWranglerAuth, isGhAvailable } from "../lib/prerequisites.mjs";
+import { deleteWorker, login } from "../lib/wrangler.mjs";
+import { showError } from "../lib/display.mjs";
+
+const execFileAsync = promisify(execFile);
+
+export async function run(flags) {
+  const config = loadConfig();
+  if (!config) {
+    showError("No deployment found. Nothing to destroy.");
+    process.exit(1);
+  }
+
+  if (!flags.yes && !flags["non-interactive"]) {
+    const answer = await prompts({
+      type: "confirm",
+      name: "confirm",
+      message: `This will delete worker "${config.worker_name}" and all associated data. Are you sure?`,
+      initial: false,
+    });
+    if (!answer.confirm) {
+      console.log("Cancelled.");
+      process.exit(0);
+    }
+  }
+
+  const wranglerOk = await ensureWrangler();
+  if (!wranglerOk) process.exit(1);
+
+  const authed = await checkWranglerAuth();
+  if (!authed) {
+    console.log("You need to log in to Cloudflare.");
+    await login();
+  }
+
+  try {
+    console.log(`\nDeleting worker "${config.worker_name}"...`);
+    try {
+      await deleteWorker(config.worker_name);
+      console.log("Worker deleted.");
+    } catch (err) {
+      if (err.message.includes("does not exist") || err.message.includes("10090")) {
+        console.log(chalk.dim("  Worker already removed from Cloudflare. Cleaning up local config."));
+      } else {
+        throw err;
+      }
+    }
+
+    if (config.auto_update_repo) {
+      const ghOk = await isGhAvailable();
+      if (ghOk) {
+        let deleteRepo = flags.yes || flags["non-interactive"];
+        if (!deleteRepo) {
+          const answer = await prompts({
+            type: "confirm",
+            name: "deleteRepo",
+            message: `Delete auto-update repo "${config.auto_update_repo}"?`,
+            initial: false,
+          });
+          deleteRepo = answer.deleteRepo;
+        }
+        if (deleteRepo) {
+          await execFileAsync("gh", ["repo", "delete", config.auto_update_repo, "--yes"], {
+            timeout: 30_000,
+          });
+          console.log("Auto-update repo deleted.");
+        }
+      }
+    }
+
+    deleteConfig();
+    console.log(chalk.green("\n  Worker removed. Cloudflare account and local config cleaned up.\n"));
+  } catch (err) {
+    showError(`Destroy failed: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/apps/worker/src/commands/install.mjs
+++ b/apps/worker/src/commands/install.mjs
@@ -1,0 +1,169 @@
+// src/commands/install.mjs
+import prompts from "prompts";
+import { loadConfig, saveConfig, deleteConfig } from "../lib/config.mjs";
+import { generateToken } from "../lib/tokens.mjs";
+import { ensureWrangler, checkWranglerAuth } from "../lib/prerequisites.mjs";
+import { deploy, putSecret, login } from "../lib/wrangler.mjs";
+import { createLocationToken } from "../lib/api.mjs";
+import { showInstallSuccess, showError } from "../lib/display.mjs";
+
+export async function run(flags) {
+  const existing = loadConfig();
+  if (existing && !existing.setup_incomplete) {
+    if (flags.force) {
+      console.log("Overwriting existing config (--force).");
+      deleteConfig();
+    } else {
+      showError("A deployment already exists. Run 'unifi-mcp-worker status' to see it.");
+      showError("To start fresh, run 'unifi-mcp-worker destroy' first, or use 'unifi-mcp-worker install --force'.");
+      process.exit(1);
+    }
+  }
+
+  const wranglerOk = await ensureWrangler();
+  if (!wranglerOk) process.exit(1);
+
+  const authed = await checkWranglerAuth();
+  if (!authed) {
+    console.log("You need to log in to Cloudflare.");
+    await login();
+  }
+
+  const resuming = existing?.setup_incomplete;
+  const resumeFrom = resuming ? existing._resume_step || "deploy" : "deploy";
+
+  let workerName, locationName, customDomain, observability;
+
+  if (resuming) {
+    workerName = existing.worker_name;
+    customDomain = existing.custom_domain || null;
+    locationName = existing._location_name || flags["location-name"] || "Home Lab";
+    observability = existing.observability || false;
+    console.log(`Resuming install for "${workerName}" from ${resumeFrom} step...`);
+  } else if (flags["non-interactive"]) {
+    workerName = flags["worker-name"] || "unifi-mcp-relay";
+    locationName = flags["location-name"] || "Home Lab";
+    observability = flags.observability || false;
+  } else {
+    const answers = await prompts([
+      {
+        type: "text",
+        name: "workerName",
+        message: "Worker name",
+        initial: "unifi-mcp-relay",
+      },
+      {
+        type: "text",
+        name: "baseDomain",
+        message: "Base domain (leave blank for default *.workers.dev)",
+        initial: "",
+      },
+      {
+        type: "text",
+        name: "locationName",
+        message: "Location name for your first relay",
+        initial: "Home Lab",
+      },
+      {
+        type: "confirm",
+        name: "observability",
+        message: "Enable observability? (logs stored 7 days in Cloudflare dashboard)",
+        initial: false,
+      },
+    ]);
+    workerName = answers.workerName;
+    customDomain = answers.baseDomain ? `${answers.workerName}.${answers.baseDomain}` : null;
+    locationName = answers.locationName;
+    observability = answers.observability;
+  }
+
+  if (!workerName || !locationName) {
+    showError("Worker name and location name are required.");
+    process.exit(1);
+  }
+
+  const agentToken = resuming ? existing.agent_token : generateToken();
+  const adminToken = resuming ? existing.admin_token : generateToken();
+
+  try {
+    let workerUrl = existing?.worker_url;
+
+    if (resumeFrom === "deploy") {
+      console.log(`\nDeploying worker "${workerName}"...`);
+      const result = await deploy(workerName, { customDomain, observability });
+      workerUrl = result.workerUrl;
+      if (!workerUrl) {
+        workerUrl = `https://${workerName}.workers.dev`;
+      }
+      console.log(`Deployed to ${workerUrl}`);
+
+      saveConfig({
+        setup_incomplete: true,
+        _resume_step: "secrets",
+        _location_name: locationName,
+        worker_name: workerName,
+        worker_url: workerUrl,
+        custom_domain: customDomain || null,
+        observability,
+        agent_token: agentToken,
+        admin_token: adminToken,
+        locations: [],
+        created_at: new Date().toISOString(),
+      });
+    }
+
+    if (resumeFrom === "deploy" || resumeFrom === "secrets") {
+      console.log("Setting AGENT_TOKEN...");
+      await putSecret(workerName, "AGENT_TOKEN", agentToken);
+      console.log("Setting ADMIN_TOKEN...");
+      await putSecret(workerName, "ADMIN_TOKEN", adminToken);
+
+      const cfg = loadConfig();
+      cfg._resume_step = "location";
+      saveConfig(cfg);
+    }
+
+    if (resumeFrom === "deploy" || resumeFrom === "secrets" || resumeFrom === "location") {
+      console.log(`Creating location "${locationName}"...`);
+      await new Promise((r) => setTimeout(r, 3000));
+
+      const loc = await createLocationToken(
+        workerUrl || existing?.worker_url,
+        adminToken || existing?.admin_token,
+        locationName
+      );
+
+      saveConfig({
+        worker_name: workerName,
+        worker_url: workerUrl || existing?.worker_url,
+        custom_domain: customDomain || null,
+        observability,
+        agent_token: agentToken || existing?.agent_token,
+        admin_token: adminToken || existing?.admin_token,
+        locations: [
+          {
+            location_name: locationName,
+            relay_token: loc.relayToken,
+            location_id: loc.locationId,
+            created_at: new Date().toISOString(),
+          },
+        ],
+        auto_update_repo: null,
+        created_at: existing?.created_at || new Date().toISOString(),
+        last_upgraded: new Date().toISOString(),
+      });
+
+      showInstallSuccess({
+        workerUrl: workerUrl || existing?.worker_url,
+        agentToken: agentToken || existing?.agent_token,
+        adminToken: adminToken || existing?.admin_token,
+        relayToken: loc.relayToken,
+        locationName,
+      });
+    }
+  } catch (err) {
+    showError(`Install failed: ${err.message}`);
+    console.error("\nPartial state saved. Re-run 'unifi-mcp-worker install' to resume.");
+    process.exit(1);
+  }
+}

--- a/apps/worker/src/commands/observability.mjs
+++ b/apps/worker/src/commands/observability.mjs
@@ -1,0 +1,80 @@
+// src/commands/observability.mjs
+import chalk from "chalk";
+import prompts from "prompts";
+import { loadConfig, saveConfig } from "../lib/config.mjs";
+import { ensureWrangler, checkWranglerAuth } from "../lib/prerequisites.mjs";
+import { deploy, login } from "../lib/wrangler.mjs";
+import { showError } from "../lib/display.mjs";
+
+export async function run(flags) {
+  const config = loadConfig();
+  if (!config) {
+    showError("No deployment found. Run 'unifi-mcp-worker install' first.");
+    process.exit(1);
+  }
+
+  if (flags.enable && flags.disable) {
+    showError("Cannot use both --enable and --disable.");
+    process.exit(1);
+  }
+
+  // No flags — show current state
+  if (!flags.enable && !flags.disable) {
+    const state = config.observability ? chalk.green("Enabled") : chalk.dim("Disabled");
+    console.log(`\n  Observability: ${state}\n`);
+    return;
+  }
+
+  const enabling = !!flags.enable;
+  const current = !!config.observability;
+
+  if (enabling === current) {
+    console.log(`\n  Observability is already ${enabling ? "enabled" : "disabled"}.\n`);
+    return;
+  }
+
+  // Confirm before redeploying
+  if (!flags.yes && !flags["non-interactive"]) {
+    const answer = await prompts({
+      type: "confirm",
+      name: "proceed",
+      message: `This will ${enabling ? "enable" : "disable"} observability and redeploy the worker. Continue?`,
+      initial: false,
+    });
+    if (!answer.proceed) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  const wranglerOk = await ensureWrangler();
+  if (!wranglerOk) process.exit(1);
+
+  const authed = await checkWranglerAuth();
+  if (!authed) {
+    console.log("You need to log in to Cloudflare.");
+    await login();
+  }
+
+  try {
+    console.log(`\n${enabling ? "Enabling" : "Disabling"} observability for "${config.worker_name}"...`);
+    await deploy(config.worker_name, {
+      customDomain: config.custom_domain,
+      observability: enabling,
+    });
+
+    config.observability = enabling;
+    config.last_upgraded = new Date().toISOString();
+    saveConfig(config);
+
+    console.log(chalk.green(`\n  Observability ${enabling ? "enabled" : "disabled"} successfully.`));
+    if (enabling) {
+      console.log(chalk.dim("  Logs will appear in the Cloudflare dashboard within a few minutes.\n"));
+    } else {
+      console.log("");
+    }
+  } catch (err) {
+    showError(`Failed to update observability: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/apps/worker/src/commands/rotate-tokens.mjs
+++ b/apps/worker/src/commands/rotate-tokens.mjs
@@ -1,0 +1,114 @@
+// src/commands/rotate-tokens.mjs
+import prompts from "prompts";
+import chalk from "chalk";
+import { loadConfig, saveConfig } from "../lib/config.mjs";
+import { generateToken } from "../lib/tokens.mjs";
+import { ensureWrangler, checkWranglerAuth } from "../lib/prerequisites.mjs";
+import { putSecret, login } from "../lib/wrangler.mjs";
+import { createLocationToken } from "../lib/api.mjs";
+import { showError } from "../lib/display.mjs";
+
+export async function run(flags) {
+  const config = loadConfig();
+  if (!config) {
+    showError("No deployment found. Run 'unifi-mcp-worker install' first.");
+    process.exit(1);
+  }
+
+  let tokenType;
+
+  if (flags["non-interactive"] || flags.token) {
+    tokenType = flags.token || "agent";
+  } else {
+    const answer = await prompts({
+      type: "select",
+      name: "tokenType",
+      message: "Which token to rotate?",
+      choices: [
+        { title: "Agent token (cloud AI agents)", value: "agent" },
+        { title: "Admin token (location management)", value: "admin" },
+        { title: "Relay token (sidecar connection)", value: "relay" },
+        { title: "All (agent + admin)", value: "all" },
+      ],
+    });
+    tokenType = answer.tokenType;
+  }
+
+  try {
+    if (tokenType === "agent" || tokenType === "admin" || tokenType === "all") {
+      const wranglerOk = await ensureWrangler();
+      if (!wranglerOk) process.exit(1);
+
+      const authed = await checkWranglerAuth();
+      if (!authed) {
+        console.log("You need to log in to Cloudflare.");
+        await login();
+      }
+    }
+
+    if (tokenType === "agent" || tokenType === "all") {
+      const newToken = generateToken();
+      console.log("Rotating AGENT_TOKEN...");
+      await putSecret(config.worker_name, "AGENT_TOKEN", newToken);
+      config.agent_token = newToken;
+      console.log(chalk.green(`  New AGENT_TOKEN: ${newToken}`));
+      console.log(chalk.dim("  → Update your AI agent configuration with this token.\n"));
+    }
+
+    if (tokenType === "admin" || tokenType === "all") {
+      const newToken = generateToken();
+      console.log("Rotating ADMIN_TOKEN...");
+      await putSecret(config.worker_name, "ADMIN_TOKEN", newToken);
+      config.admin_token = newToken;
+      console.log(chalk.green(`  New ADMIN_TOKEN: ${newToken}`));
+      console.log(chalk.dim("  → Save this token for location management.\n"));
+    }
+
+    if (tokenType === "relay") {
+      if (!config.locations?.length) {
+        showError("No locations configured. Run 'unifi-mcp-worker add-location' first.");
+        process.exit(1);
+      }
+
+      let locationIdx;
+      if (config.locations.length === 1) {
+        locationIdx = 0;
+      } else if (flags["non-interactive"]) {
+        const name = flags["location-name"];
+        locationIdx = config.locations.findIndex((l) => l.location_name === name);
+        if (locationIdx < 0) {
+          showError(`Location "${name}" not found.`);
+          process.exit(1);
+        }
+      } else {
+        const answer = await prompts({
+          type: "select",
+          name: "locationIdx",
+          message: "Which location's relay token to rotate?",
+          choices: config.locations.map((l, i) => ({
+            title: l.location_name,
+            value: i,
+          })),
+        });
+        locationIdx = answer.locationIdx;
+      }
+
+      const location = config.locations[locationIdx];
+      console.log(`Rotating relay token for "${location.location_name}"...`);
+      const loc = await createLocationToken(
+        config.worker_url,
+        config.admin_token,
+        location.location_name
+      );
+      config.locations[locationIdx].relay_token = loc.relayToken;
+      console.log(chalk.green(`  New RELAY_TOKEN: ${loc.relayToken}`));
+      console.log(chalk.dim("  → Update your relay sidecar with this token.\n"));
+    }
+
+    saveConfig(config);
+    console.log(chalk.dim("Config updated."));
+  } catch (err) {
+    showError(`Token rotation failed: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/apps/worker/src/commands/status.mjs
+++ b/apps/worker/src/commands/status.mjs
@@ -1,0 +1,42 @@
+// src/commands/status.mjs
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import chalk from "chalk";
+import { loadConfig, getConfigDir } from "../lib/config.mjs";
+import { showStatus, showError } from "../lib/display.mjs";
+
+const execFileAsync = promisify(execFile);
+
+export async function run() {
+  const config = loadConfig();
+  if (!config) {
+    showError("No deployment found. Run 'unifi-mcp-worker install' first.");
+    process.exit(1);
+  }
+
+  showStatus(config);
+
+  const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
+  const currentVersion = JSON.parse(readFileSync(pkgPath, "utf8")).version;
+  console.log(`  CLI version: ${currentVersion}`);
+
+  try {
+    const { stdout } = await execFileAsync("npm", ["view", "unifi-mcp-worker", "version"], {
+      timeout: 10_000,
+    });
+    const latest = stdout.trim();
+    if (latest !== currentVersion) {
+      console.log(chalk.yellow(`  Update available: ${latest}`));
+      console.log(chalk.dim("  Run 'unifi-mcp-worker upgrade' to update.\n"));
+    } else {
+      console.log(chalk.green("  Up to date.\n"));
+    }
+  } catch {
+    console.log(chalk.dim("  Could not check for updates.\n"));
+  }
+
+  console.log(chalk.dim(`  Config: ${getConfigDir()}/config.json\n`));
+}

--- a/apps/worker/src/commands/upgrade.mjs
+++ b/apps/worker/src/commands/upgrade.mjs
@@ -1,0 +1,111 @@
+// src/commands/upgrade.mjs
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import prompts from "prompts";
+import chalk from "chalk";
+import { loadConfig, saveConfig } from "../lib/config.mjs";
+import { ensureWrangler, checkWranglerAuth } from "../lib/prerequisites.mjs";
+import { deploy, login } from "../lib/wrangler.mjs";
+import { showError } from "../lib/display.mjs";
+
+const execFileAsync = promisify(execFile);
+
+async function checkForUpdate() {
+  try {
+    const { stdout } = await execFileAsync("npm", ["view", "unifi-mcp-worker", "version"], {
+      timeout: 10_000,
+    });
+    const latest = stdout.trim();
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
+    const current = JSON.parse(readFileSync(pkgPath, "utf8")).version;
+    return { current, latest, needsUpdate: latest !== current };
+  } catch {
+    return { current: null, latest: null, needsUpdate: false };
+  }
+}
+
+export async function run(flags) {
+  const versionCheck = await checkForUpdate();
+  if (versionCheck.needsUpdate) {
+    console.log(
+      chalk.yellow(
+        `\n  CLI update available: ${versionCheck.current} → ${versionCheck.latest}`
+      )
+    );
+
+    let shouldUpdate = flags.yes || flags["non-interactive"];
+    if (!shouldUpdate) {
+      const answer = await prompts({
+        type: "confirm",
+        name: "update",
+        message: "Update CLI before upgrading worker?",
+        initial: true,
+      });
+      shouldUpdate = answer.update;
+    }
+
+    if (shouldUpdate) {
+      console.log("Updating CLI...");
+      await execFileAsync("npm", ["install", "-g", "unifi-mcp-worker@latest"], {
+        timeout: 120_000,
+      });
+      const { spawn } = await import("node:child_process");
+      const child = spawn("unifi-mcp-worker", ["upgrade", ...process.argv.slice(3)], {
+        stdio: "inherit",
+      });
+      child.on("close", (code) => process.exit(code));
+      return;
+    }
+  }
+
+  const wranglerOk = await ensureWrangler();
+  if (!wranglerOk) process.exit(1);
+
+  const authed = await checkWranglerAuth();
+  if (!authed) {
+    console.log("You need to log in to Cloudflare.");
+    await login();
+  }
+
+  const config = loadConfig();
+  let workerName;
+
+  if (config) {
+    workerName = config.worker_name;
+  } else if (flags["worker-name"]) {
+    workerName = flags["worker-name"];
+  } else if (flags["non-interactive"]) {
+    showError("No config found and --worker-name not provided.");
+    process.exit(1);
+  } else {
+    const answer = await prompts({
+      type: "text",
+      name: "workerName",
+      message: "Worker name to upgrade",
+      initial: "unifi-mcp-relay",
+    });
+    workerName = answer.workerName;
+  }
+
+  try {
+    console.log(`\nUpgrading worker "${workerName}"...`);
+    await deploy(workerName, {
+      customDomain: config?.custom_domain,
+      observability: config?.observability || false,
+    });
+
+    if (config) {
+      config.last_upgraded = new Date().toISOString();
+      saveConfig(config);
+    }
+
+    console.log(chalk.green("\n  Upgraded to latest version."));
+    console.log(chalk.dim("  Tokens and configuration unchanged.\n"));
+  } catch (err) {
+    showError(`Upgrade failed: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/apps/worker/src/lib/api.mjs
+++ b/apps/worker/src/lib/api.mjs
@@ -1,0 +1,46 @@
+export function buildLocationTokenRequest(workerUrl, adminToken, locationName) {
+  return {
+    url: `${workerUrl.replace(/\/$/, "")}/api/locations/token`,
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      "Content-Type": "application/json",
+    },
+    body: { location_name: locationName },
+  };
+}
+
+export function parseLocationTokenResponse(data) {
+  return {
+    relayToken: data.token || data.relay_token,
+    locationId: data.location_id,
+  };
+}
+
+export async function healthCheck(workerUrl) {
+  const url = `${workerUrl.replace(/\/$/, "")}/health`;
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    return { ok: res.ok, status: res.status };
+  } catch (err) {
+    return { ok: false, status: null, error: err.message };
+  }
+}
+
+export async function createLocationToken(workerUrl, adminToken, locationName) {
+  const req = buildLocationTokenRequest(workerUrl, adminToken, locationName);
+  const res = await fetch(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: JSON.stringify(req.body),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Admin API returned ${res.status}: ${text}`);
+  }
+
+  const data = await res.json();
+  return parseLocationTokenResponse(data);
+}

--- a/apps/worker/src/lib/config.mjs
+++ b/apps/worker/src/lib/config.mjs
@@ -1,0 +1,37 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const CONFIG_DIR = process.env.UNIFI_MCP_WORKER_CONFIG_DIR || join(homedir(), ".unifi-mcp-worker");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+const CURRENT_CONFIG_VERSION = 1;
+
+export function loadConfig() {
+  if (!existsSync(CONFIG_FILE)) return null;
+  const raw = readFileSync(CONFIG_FILE, "utf8");
+  return JSON.parse(raw);
+}
+
+export function saveConfig(data) {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
+  data.config_version = CURRENT_CONFIG_VERSION;
+  writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
+}
+
+export function deleteConfig() {
+  if (existsSync(CONFIG_FILE)) {
+    unlinkSync(CONFIG_FILE);
+  }
+}
+
+export function maskToken(token) {
+  if (!token) return "****";
+  const last4 = token.slice(-4);
+  return `****-${last4}`;
+}
+
+export function getConfigDir() {
+  return CONFIG_DIR;
+}

--- a/apps/worker/src/lib/display.mjs
+++ b/apps/worker/src/lib/display.mjs
@@ -1,0 +1,88 @@
+// src/lib/display.mjs
+import chalk from "chalk";
+import { maskToken } from "./config.mjs";
+
+export function showInstallSuccess({ workerUrl, agentToken, adminToken, relayToken, locationName }) {
+  console.log("");
+  console.log(chalk.green.bold("  Worker deployed successfully!"));
+  console.log("");
+  console.log(`  Worker URL: ${chalk.cyan(workerUrl)}`);
+  console.log("");
+  console.log(`  ${chalk.yellow("AGENT_TOKEN")}: ${agentToken}`);
+  console.log(`    ${chalk.dim("→ Configure this in your AI agent (Claude, ChatGPT, n8n)")}`);
+  console.log("");
+  console.log(`  ${chalk.yellow("ADMIN_TOKEN")}: ${adminToken}`);
+  console.log(`    ${chalk.dim("→ Save this — needed to manage locations")}`);
+  console.log(`    ${chalk.dim("  Recoverable from ~/.unifi-mcp-worker/config.json")}`);
+  console.log("");
+  console.log(`  ${chalk.yellow("RELAY_TOKEN")}: ${relayToken}`);
+  console.log(`    ${chalk.dim(`→ Configure in your relay sidecar for "${locationName}"`)}`);
+  console.log("");
+  console.log(chalk.bold("  Next steps:"));
+  console.log(`  1. Configure your relay sidecar with:`);
+  console.log(`     ${chalk.dim("UNIFI_RELAY_URL")}=${workerUrl}`);
+  console.log(`     ${chalk.dim("UNIFI_RELAY_TOKEN")}=${relayToken}`);
+  console.log(`     ${chalk.dim("UNIFI_RELAY_LOCATION_NAME")}=${locationName}`);
+  console.log(`  2. Configure your AI agent with:`);
+  console.log(`     ${chalk.dim("MCP URL")}: ${workerUrl}/mcp`);
+  console.log(`     ${chalk.dim("Auth")}: Bearer ${agentToken}`);
+  console.log("");
+}
+
+export function showStatus(config) {
+  console.log("");
+  console.log(chalk.bold("  UniFi MCP Worker Status"));
+  console.log("");
+  console.log(`  Worker:     ${config.worker_name} (${chalk.cyan(config.worker_url)})`);
+  if (config.custom_domain) {
+    console.log(`  Domain:     ${chalk.cyan(config.custom_domain)}`);
+  }
+  console.log(`  Locations:  ${config.locations?.length || 0}`);
+  console.log("");
+
+  if (config.locations?.length) {
+    for (const loc of config.locations) {
+      console.log(`    ${chalk.yellow(loc.location_name)} (${loc.location_id})`);
+      console.log(`      Relay token: ${maskToken(loc.relay_token)}`);
+    }
+    console.log("");
+  }
+
+  console.log(`  Agent token: ${maskToken(config.agent_token)}`);
+  console.log(`  Admin token: ${maskToken(config.admin_token)}`);
+  console.log("");
+
+  if (config.auto_update_repo) {
+    console.log(`  Auto-update: ${chalk.green("enabled")} (${config.auto_update_repo})`);
+  } else {
+    console.log(`  Auto-update: ${chalk.dim("disabled")}`);
+  }
+
+  if (config.observability) {
+    console.log(`  Observability: ${chalk.green("enabled")}`);
+  } else {
+    console.log(`  Observability: ${chalk.dim("disabled")}`);
+  }
+
+  if (config.last_upgraded) {
+    console.log(`  Last upgraded: ${config.last_upgraded}`);
+  }
+  console.log("");
+}
+
+export function showAddLocationSuccess({ locationName, relayToken, workerUrl }) {
+  console.log("");
+  console.log(chalk.green.bold(`  Location "${locationName}" created!`));
+  console.log("");
+  console.log(`  ${chalk.yellow("RELAY_TOKEN")}: ${relayToken}`);
+  console.log("");
+  console.log(`  Configure a relay sidecar for this location with:`);
+  console.log(`    ${chalk.dim("UNIFI_RELAY_URL")}=${workerUrl}`);
+  console.log(`    ${chalk.dim("UNIFI_RELAY_TOKEN")}=${relayToken}`);
+  console.log(`    ${chalk.dim("UNIFI_RELAY_LOCATION_NAME")}=${locationName}`);
+  console.log("");
+}
+
+export function showError(message) {
+  console.error(chalk.red(`  Error: ${message}`));
+}

--- a/apps/worker/src/lib/prerequisites.mjs
+++ b/apps/worker/src/lib/prerequisites.mjs
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export async function checkCommand(cmd, args = ["--version"]) {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, { timeout: 10_000 });
+    const version = stdout.trim().replace(/^v/, "");
+    return { available: true, version };
+  } catch {
+    return { available: false, version: null };
+  }
+}
+
+export function getNodeVersion() {
+  return parseInt(process.version.replace("v", "").split(".")[0], 10);
+}
+
+export async function ensureWrangler() {
+  const result = await checkCommand("wrangler", ["--version"]);
+  if (result.available) return true;
+
+  console.log("Wrangler not found. Installing...");
+  try {
+    await execFileAsync("npm", ["install", "-g", "wrangler"], { timeout: 120_000 });
+    return true;
+  } catch (err) {
+    console.error("Failed to install wrangler:", err.message);
+    console.error("Install manually: npm install -g wrangler");
+    return false;
+  }
+}
+
+export async function checkWranglerAuth() {
+  try {
+    const { stdout } = await execFileAsync("wrangler", ["whoami"], { timeout: 15_000 });
+    if (stdout.includes("not authenticated") || stdout.includes("not logged in")) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isGhAvailable() {
+  const result = await checkCommand("gh", ["--version"]);
+  return result.available;
+}

--- a/apps/worker/src/lib/tokens.mjs
+++ b/apps/worker/src/lib/tokens.mjs
@@ -1,0 +1,5 @@
+import { randomUUID } from "node:crypto";
+
+export function generateToken() {
+  return randomUUID();
+}

--- a/apps/worker/src/lib/wrangler.mjs
+++ b/apps/worker/src/lib/wrangler.mjs
@@ -1,0 +1,111 @@
+// src/lib/wrangler.mjs
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+
+function getWorkerDir() {
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  return join(cliDir, "..", "..", "worker");
+}
+
+/**
+ * Pure function: takes base wrangler.toml content and options,
+ * returns the modified TOML string for deploy.
+ */
+export function buildWranglerToml(originalToml, { customDomain, observability } = {}) {
+  let toml = originalToml;
+
+  if (customDomain) {
+    // Remove any existing [[routes]] blocks, then append the new one
+    toml = toml.replace(/\n*\[\[routes\]\]\n[^\[]*/g, "");
+    const routeBlock = `\n[[routes]]\npattern = "${customDomain}"\ncustom_domain = true\n`;
+    toml = toml.trimEnd() + "\n" + routeBlock;
+  }
+
+  if (observability) {
+    // Strip the [observability] block this function emits (canonical format only)
+    toml = toml.replace(/\n*\[observability\]\n(\[observability\.\w+\]\n)?[^\[]*/g, "");
+    const obsBlock = `\n[observability]\n[observability.logs]\nenabled = true\ninvocation_logs = true\n`;
+    toml = toml.trimEnd() + "\n" + obsBlock;
+  }
+
+  return toml;
+}
+
+export async function deploy(workerName, { customDomain, observability } = {}) {
+  const workerDir = getWorkerDir();
+  const wranglerToml = join(workerDir, "wrangler.toml");
+
+  // Install worker dependencies (including devDependencies — wrangler and
+  // @cloudflare/workers-types are devDeps needed for the build step)
+  await execFileAsync("npm", ["install"], {
+    cwd: workerDir,
+    timeout: 120_000,
+  });
+
+  const { readFileSync, writeFileSync } = await import("node:fs");
+  const originalToml = readFileSync(wranglerToml, "utf8");
+  const modifiedToml = buildWranglerToml(originalToml, { customDomain, observability });
+
+  if (modifiedToml !== originalToml) {
+    writeFileSync(wranglerToml, modifiedToml);
+  }
+
+  try {
+    const args = ["deploy", "--name", workerName];
+    const { stdout, stderr } = await execFileAsync("wrangler", args, {
+      cwd: workerDir,
+      timeout: 120_000,
+    });
+    // Parse the worker URL from wrangler output
+    const output = stdout + stderr;
+    const urlMatch = output.match(/https:\/\/[\w.-]+\.workers\.dev/);
+    const workerUrl = customDomain
+      ? `https://${customDomain}`
+      : urlMatch ? urlMatch[0] : null;
+    return { stdout, stderr, workerUrl };
+  } finally {
+    // Restore original wrangler.toml so the bundled source stays clean
+    writeFileSync(wranglerToml, originalToml);
+  }
+}
+
+export async function putSecret(workerName, secretName, secretValue) {
+  const workerDir = getWorkerDir();
+  return new Promise((resolve, reject) => {
+    const child = spawn("wrangler", ["secret", "put", secretName, "--name", workerName], {
+      cwd: workerDir,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.write(secretValue);
+    child.stdin.end();
+    let stderr = "";
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`wrangler secret put ${secretName} failed (code ${code}): ${stderr}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+export async function deleteWorker(workerName) {
+  const workerDir = getWorkerDir();
+  await execFileAsync("wrangler", ["delete", "--name", workerName, "--force"], {
+    cwd: workerDir,
+    timeout: 30_000,
+  });
+}
+
+export async function login() {
+  return new Promise((resolve, reject) => {
+    const child = spawn("wrangler", ["login"], { stdio: "inherit" });
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`wrangler login exited with code ${code}`));
+    });
+  });
+}

--- a/apps/worker/test/cli/api.test.mjs
+++ b/apps/worker/test/cli/api.test.mjs
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildLocationTokenRequest, parseLocationTokenResponse } from "../../src/lib/api.mjs";
+
+describe("api", () => {
+  it("builds location token request correctly", () => {
+    const req = buildLocationTokenRequest("https://relay.workers.dev", "admin-token-123", "Home Lab");
+    assert.equal(req.url, "https://relay.workers.dev/api/locations/token");
+    assert.equal(req.method, "POST");
+    assert.equal(req.headers.Authorization, "Bearer admin-token-123");
+    assert.deepEqual(req.body, { location_name: "Home Lab" });
+  });
+
+  it("strips trailing slash from worker URL", () => {
+    const req = buildLocationTokenRequest("https://relay.workers.dev/", "token", "Lab");
+    assert.equal(req.url, "https://relay.workers.dev/api/locations/token");
+  });
+
+  it("parses location token response with token field (worker format)", () => {
+    const result = parseLocationTokenResponse({
+      token: "tok-abc-123",
+      location_id: "loc_xyz",
+    });
+    assert.equal(result.relayToken, "tok-abc-123");
+    assert.equal(result.locationId, "loc_xyz");
+  });
+
+  it("parses location token response with relay_token field (spec format)", () => {
+    const result = parseLocationTokenResponse({
+      relay_token: "tok-abc-123",
+      location_id: "loc_xyz",
+    });
+    assert.equal(result.relayToken, "tok-abc-123");
+    assert.equal(result.locationId, "loc_xyz");
+  });
+});

--- a/apps/worker/test/cli/config.test.mjs
+++ b/apps/worker/test/cli/config.test.mjs
@@ -1,0 +1,54 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const createConfigModule = async (dir) => {
+  process.env.UNIFI_MCP_WORKER_CONFIG_DIR = dir;
+  const mod = await import(`../../src/lib/config.mjs?dir=${encodeURIComponent(dir)}`);
+  return mod;
+};
+
+describe("config", () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "unifi-mcp-worker-test-"));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.UNIFI_MCP_WORKER_CONFIG_DIR;
+  });
+
+  it("returns null when no config exists", async () => {
+    const { loadConfig } = await createConfigModule(join(tmpDir, "nonexistent"));
+    const config = loadConfig();
+    assert.equal(config, null);
+  });
+
+  it("saves and loads config with correct permissions", async () => {
+    const configDir = join(tmpDir, "save-test");
+    const { loadConfig, saveConfig } = await createConfigModule(configDir);
+    const data = {
+      config_version: 1,
+      worker_name: "test-worker",
+      worker_url: "https://test.workers.dev",
+      agent_token: "agent-123",
+      admin_token: "admin-456",
+      locations: [],
+    };
+    saveConfig(data);
+    const loaded = loadConfig();
+    assert.deepEqual(loaded.worker_name, "test-worker");
+    assert.deepEqual(loaded.config_version, 1);
+  });
+
+  it("masks tokens correctly", async () => {
+    const { maskToken } = await createConfigModule(join(tmpDir, "mask-test"));
+    assert.equal(maskToken("abcdef-1234-5678-90ab"), "****-90ab");
+    assert.equal(maskToken("short"), "****-hort");
+    assert.equal(maskToken(""), "****");
+  });
+});

--- a/apps/worker/test/cli/prerequisites.test.mjs
+++ b/apps/worker/test/cli/prerequisites.test.mjs
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { checkCommand, getNodeVersion } from "../../src/lib/prerequisites.mjs";
+
+describe("prerequisites", () => {
+  it("detects node as available", async () => {
+    const result = await checkCommand("node", ["--version"]);
+    assert.equal(result.available, true);
+    assert.ok(result.version);
+  });
+
+  it("detects nonexistent command as unavailable", async () => {
+    const result = await checkCommand("nonexistent-command-xyz", ["--version"]);
+    assert.equal(result.available, false);
+  });
+
+  it("gets node version as a number", () => {
+    const version = getNodeVersion();
+    assert.equal(typeof version, "number");
+    assert.ok(version >= 18);
+  });
+});

--- a/apps/worker/test/cli/tokens.test.mjs
+++ b/apps/worker/test/cli/tokens.test.mjs
@@ -1,0 +1,16 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateToken } from "../../src/lib/tokens.mjs";
+
+describe("tokens", () => {
+  it("generates a valid UUID v4 token", () => {
+    const token = generateToken();
+    assert.match(token, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it("generates unique tokens each call", () => {
+    const a = generateToken();
+    const b = generateToken();
+    assert.notEqual(a, b);
+  });
+});

--- a/apps/worker/test/cli/wrangler.test.mjs
+++ b/apps/worker/test/cli/wrangler.test.mjs
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildWranglerToml } from "../../src/lib/wrangler.mjs";
+
+describe("buildWranglerToml", () => {
+  const baseToml = `name = "unifi-mcp-relay"
+main = "src/index.ts"
+compatibility_date = "2025-03-14"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+TOOL_REGISTRATION_MODE = "lazy"
+
+[durable_objects]
+bindings = [{ name = "RELAY", class_name = "RelayObject" }]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RelayObject"]`;
+
+  it("returns original TOML when observability is false", () => {
+    const result = buildWranglerToml(baseToml, { observability: false });
+    assert.equal(result, baseToml);
+  });
+
+  it("returns original TOML when observability is undefined", () => {
+    const result = buildWranglerToml(baseToml, {});
+    assert.equal(result, baseToml);
+  });
+
+  it("appends observability block when enabled", () => {
+    const result = buildWranglerToml(baseToml, { observability: true });
+    assert.ok(result.includes("[observability]"));
+    assert.ok(result.includes("[observability.logs]"));
+    assert.ok(result.includes("enabled = true"));
+    assert.ok(result.includes("invocation_logs = true"));
+  });
+
+  it("appends both custom domain and observability", () => {
+    const result = buildWranglerToml(baseToml, {
+      customDomain: "mcp.example.com",
+      observability: true,
+    });
+    assert.ok(result.includes("[[routes]]"));
+    assert.ok(result.includes("mcp.example.com"));
+    assert.ok(result.includes("[observability]"));
+  });
+
+  it("does not duplicate observability block if already present", () => {
+    const tomlWithObs = baseToml + `\n\n[observability]\n[observability.logs]\nenabled = true\ninvocation_logs = true\n`;
+    const result = buildWranglerToml(tomlWithObs, { observability: true });
+    const matches = result.match(/\[observability\]/g);
+    assert.equal(matches.length, 1);
+  });
+});

--- a/apps/worker/worker/package-lock.json
+++ b/apps/worker/worker/package-lock.json
@@ -1,0 +1,3174 @@
+{
+  "name": "unifi-mcp-worker-source",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unifi-mcp-worker-source",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250313.0",
+        "@types/node": "^22.19.19",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
+      "integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
+      "integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
+      "integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
+      "integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
+      "integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260317.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260317.1.tgz",
+      "integrity": "sha512-+G4eVwyCpm8Au1ex8vQBCuA9wnwqetz4tPNRoB/53qvktERWBRMQnrtvC1k584yRE3emMThtuY0gWshvSJ++PQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
+      "integrity": "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.1.tgz",
+      "integrity": "sha512-XOjPId0qwSDKHaIsdzHJtKCxX0+nH8MhBwvrNsT7tVyKmdTx1jJ4XzN5RZXCdTzMpufLb+B8llTC0D8uCrLhcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.1.tgz",
+      "integrity": "sha512-vQuRd28p0gQpPrS6kppd8IrWmFo42U8Pz1XLRjSZXq5zCqyMDYFABT7/sywL11mO1EL10Qhh7MVPEwkG8GiBeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.1.tgz",
+      "integrity": "sha512-x6VG6U29+Ivlnajrg1IHdzXeAwSoEHBFVO+CtC9Brugx6de712CUJobRUxsIA0KYrQvCmzNrMPFTT1A4CCqNTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.1.tgz",
+      "integrity": "sha512-Sgi0Uo6t1YCHJMNO3Y8+bm+SvOanUGkoZKn/VJPwYUe2kp31X5KnXmzKd/NjW8iA3gFcfNZ64zh14uOGrIllCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.1.tgz",
+      "integrity": "sha512-AM4xnwEZwukdhk7laMWfzWu9JGSVnJd+Fowt6Fd7QW1nrf3h0Hp7Qx5881M4aqrUlKBCybOxz0jofvIIfl7C5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.1.tgz",
+      "integrity": "sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.1.tgz",
+      "integrity": "sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.1.tgz",
+      "integrity": "sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.1.tgz",
+      "integrity": "sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.1.tgz",
+      "integrity": "sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.1.tgz",
+      "integrity": "sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.1.tgz",
+      "integrity": "sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.1.tgz",
+      "integrity": "sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.1.tgz",
+      "integrity": "sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.1.tgz",
+      "integrity": "sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.1.tgz",
+      "integrity": "sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.1.tgz",
+      "integrity": "sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.1.tgz",
+      "integrity": "sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.1.tgz",
+      "integrity": "sha512-ARoKfflk0SiiYm3r1fmF73K/yB+PThmOwfWCk1sr7x/k9dc3uGLWuEE9if+Pw21el8MSpp3TMnG5vLNsJ/MMGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.1.tgz",
+      "integrity": "sha512-oOST61G6VM45Mz2vdzWMr1s2slI7y9LqxEV5fCoWi2MDONmMvgsJVHSXxce/I2xOSZPTZ47nDPOl1tkwKWSHcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.1.tgz",
+      "integrity": "sha512-x5WgLi5dWpRz7WclKBGEF15LcWTh0ewrHM6Cq4A+WUbkysUMZNeqt05bwPonOQ3ihPS/WMhAZV5zB1DfnI4Sxg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.1.tgz",
+      "integrity": "sha512-wS+zHAJRVP5zOL0e+a3V3E/NTEwM2HEvvNKoDy5Xcfs0o8lljxn+EAFPkUsxihBdmDq1JWzXmmB9cbssCPdxxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.1.tgz",
+      "integrity": "sha512-rhHyrMeLpErT/C7BxcEsU4COHQUzHyrPYW5tOZUeUhziNtRuYxmDWvqQqzpuUt8xpOgmbKa1btGXfnA/ANVO+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260317.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.1.tgz",
+      "integrity": "sha512-A3csI1HXEIfqe3oscgpoRMHdYlkReQKPH/g5JE53vFSjoM6YIAOGAzyDNeYffwd9oQkPWDj9xER8+vpxei8klA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260317.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
+      "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.1",
+        "@rollup/rollup-android-arm64": "4.59.1",
+        "@rollup/rollup-darwin-arm64": "4.59.1",
+        "@rollup/rollup-darwin-x64": "4.59.1",
+        "@rollup/rollup-freebsd-arm64": "4.59.1",
+        "@rollup/rollup-freebsd-x64": "4.59.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.1",
+        "@rollup/rollup-linux-arm64-musl": "4.59.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.1",
+        "@rollup/rollup-linux-loong64-musl": "4.59.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-gnu": "4.59.1",
+        "@rollup/rollup-linux-x64-musl": "4.59.1",
+        "@rollup/rollup-openbsd-x64": "4.59.1",
+        "@rollup/rollup-openharmony-arm64": "4.59.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.1",
+        "@rollup/rollup-win32-x64-gnu": "4.59.1",
+        "@rollup/rollup-win32-x64-msvc": "4.59.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260317.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
+      "integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260317.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260317.1",
+        "@cloudflare/workerd-linux-64": "1.20260317.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260317.1",
+        "@cloudflare/workerd-windows-64": "1.20260317.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.76.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.76.0.tgz",
+      "integrity": "sha512-Wan+CU5a0tu4HIxGOrzjNbkmxCT27HUmzrMj6kc7aoAnjSLv50Ggcn2Ant7wNQrD6xW3g31phKupZJgTZ8wZfQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260317.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260317.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260317.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/apps/worker/worker/package.json
+++ b/apps/worker/worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "unifi-mcp-worker-source",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250313.0",
+    "@types/node": "^22.19.19",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/apps/worker/worker/src/auth.ts
+++ b/apps/worker/worker/src/auth.ts
@@ -1,0 +1,83 @@
+// src/auth.ts
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Pads both strings to the max length, XORs all bytes, no early exit.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const maxLen = Math.max(a.length, b.length);
+  let result = 0;
+
+  for (let i = 0; i < maxLen; i++) {
+    const charA = i < a.length ? a.charCodeAt(i) : 0;
+    const charB = i < b.length ? b.charCodeAt(i) : 0;
+    result |= charA ^ charB;
+  }
+
+  // Also fold in length difference to catch length mismatches
+  result |= a.length ^ b.length;
+
+  return result === 0;
+}
+
+/**
+ * Validates a Bearer token from the Authorization header.
+ * Extracts the token and compares it to the expected token using
+ * constant-time comparison.
+ */
+export function validateBearerToken(request: Request, expectedToken: string): boolean {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return false;
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer") {
+    return false;
+  }
+
+  const token = parts[1];
+  return timingSafeEqual(token, expectedToken);
+}
+
+/**
+ * Extracts a Bearer token from the Authorization header.
+ * Returns the token string, or null if the header is missing or malformed.
+ */
+export function extractBearerToken(request: Request): string | null {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return null;
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer") {
+    return null;
+  }
+
+  return parts[1] || null;
+}
+
+/**
+ * Computes a SHA-256 hash of the given token using the Web Crypto API.
+ * Returns the hash as a lowercase hex string (64 characters).
+ */
+export async function hashToken(token: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(token);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Generates a cryptographically random token of 32 bytes,
+ * encoded as URL-safe base64 (no +, /, or = characters).
+ */
+export function generateToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const base64 = btoa(String.fromCharCode(...bytes));
+  // Convert to URL-safe base64 and strip padding
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}

--- a/apps/worker/worker/src/index.ts
+++ b/apps/worker/worker/src/index.ts
@@ -1,0 +1,93 @@
+// src/index.ts
+import type { Env, JsonRpcRequest } from "./types";
+import { validateBearerToken } from "./auth";
+
+// Re-export the Durable Object class (required by wrangler)
+export { RelayObject } from "./relay-object";
+
+function corsHeaders(origin?: string | null): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin || "",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+function jsonResponse(data: unknown, request: Request, status = 200): Response {
+  const origin = request.headers.get("Origin") || "";
+  return Response.json(data, { status, headers: corsHeaders(origin) });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const origin = request.headers.get("Origin") || "";
+
+    // CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders(origin) });
+    }
+
+    // Health check (no auth)
+    if (url.pathname === "/health") {
+      return jsonResponse({ status: "ok" }, request);
+    }
+
+    // MCP endpoint (cloud agents — authenticated with AGENT_TOKEN)
+    if (url.pathname === "/mcp" && request.method === "POST") {
+      if (!validateBearerToken(request, env.AGENT_TOKEN)) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      let body: JsonRpcRequest;
+      try {
+        body = (await request.json()) as JsonRpcRequest;
+      } catch {
+        return jsonResponse(
+          { jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } },
+          request,
+          400,
+        );
+      }
+
+      // Get DO singleton and forward
+      const doId = env.RELAY.idFromName("singleton");
+      const doStub = env.RELAY.get(doId);
+      const doResponse = await doStub.fetch(
+        new Request("https://relay-do/mcp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+      );
+
+      const result = await doResponse.json();
+      return jsonResponse(result, request);
+    }
+
+    // WebSocket upgrade (relay clients — token validated inside DO)
+    if (url.pathname === "/ws" && request.headers.get("Upgrade") === "websocket") {
+      const doId = env.RELAY.idFromName("singleton");
+      const doStub = env.RELAY.get(doId);
+      return doStub.fetch(request);
+    }
+
+    // Admin API (authenticated with ADMIN_TOKEN)
+    if (url.pathname.startsWith("/api/")) {
+      if (!validateBearerToken(request, env.ADMIN_TOKEN)) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      const doId = env.RELAY.idFromName("singleton");
+      const doStub = env.RELAY.get(doId);
+      const doResponse = await doStub.fetch(request);
+      // Add CORS headers to DO response
+      const responseBody = await doResponse.text();
+      return new Response(responseBody, {
+        status: doResponse.status,
+        headers: { ...Object.fromEntries(doResponse.headers), ...corsHeaders(origin) },
+      });
+    }
+
+    return new Response("Not Found", { status: 404, headers: corsHeaders(origin) });
+  },
+};

--- a/apps/worker/worker/src/mcp-handler.ts
+++ b/apps/worker/worker/src/mcp-handler.ts
@@ -1,0 +1,72 @@
+// src/mcp-handler.ts
+import type { JsonRpcRequest, JsonRpcResponse, ToolInfo, AggregatedResponse } from "./types";
+import { PROJECT_WEBSITE_URL, RELAY_SERVER_ICONS } from "./types";
+
+/** Interface that the Durable Object will implement */
+export interface RelayStub {
+  getToolList(mode: string): Promise<ToolInfo[]>;
+  handleToolCall(toolName: string, args: Record<string, unknown>): Promise<Record<string, unknown> | AggregatedResponse>;
+  isMultiLocation(): Promise<boolean>;
+}
+
+function jsonRpcError(id: string | number, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function jsonRpcResult(id: string | number, result: unknown): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+export async function handleMcpRequest(
+  body: JsonRpcRequest,
+  stub: RelayStub,
+  mode: string,
+): Promise<JsonRpcResponse> {
+  const { method, params, id } = body;
+
+  if (method === "initialize") {
+    return jsonRpcResult(id, {
+      protocolVersion: "2025-03-26",
+      serverInfo: {
+        name: "unifi-mcp-relay",
+        version: "1.0.0",
+        websiteUrl: PROJECT_WEBSITE_URL,
+        icons: RELAY_SERVER_ICONS,
+      },
+      capabilities: { tools: {} },
+    });
+  }
+
+  if (method === "notifications/initialized") {
+    // Notification, no response needed — but we return a result for simplicity
+    return jsonRpcResult(id, {});
+  }
+
+  if (method === "tools/list") {
+    const multiLocation = await stub.isMultiLocation();
+    const effectiveMode = multiLocation ? "lazy" : mode;
+    const tools = await stub.getToolList(effectiveMode);
+    return jsonRpcResult(id, { tools });
+  }
+
+  if (method === "tools/call") {
+    const toolName = (params as Record<string, unknown>)?.name as string;
+    const args = ((params as Record<string, unknown>)?.arguments ?? {}) as Record<string, unknown>;
+
+    if (!toolName) {
+      return jsonRpcError(id, -32602, "Missing tool name");
+    }
+
+    try {
+      const result = await stub.handleToolCall(toolName, args);
+      return jsonRpcResult(id, {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      return jsonRpcError(id, -32000, msg);
+    }
+  }
+
+  return jsonRpcError(id, -32601, `Method not found: ${method}`);
+}

--- a/apps/worker/worker/src/relay-object.ts
+++ b/apps/worker/worker/src/relay-object.ts
@@ -1,0 +1,1257 @@
+// src/relay-object.ts
+import { DurableObject } from "cloudflare:workers";
+import type { RelayStub } from "./mcp-handler";
+import { handleMcpRequest } from "./mcp-handler";
+import { hashToken, generateToken, extractBearerToken } from "./auth";
+import { toolInputSchema, toolServerOrigin } from "./tool-info";
+import type {
+  Env,
+  ToolInfo,
+  ToolAnnotations,
+  RegisterMessage,
+  ToolCallResponse,
+  CatalogUpdateMessage,
+  InboundMessage,
+  RegisteredMessage,
+  ToolCallRequest,
+  HeartbeatAckMessage,
+  ErrorMessage,
+  PendingRequest,
+  FanOutResult,
+  AggregatedResponse,
+} from "./types";
+import { PROTOCOL_VERSION, TOOL_CALL_TIMEOUT_MS } from "./types";
+
+// ---------------------------------------------------------------------------
+// Meta-tool definitions (virtual tools served by the relay itself)
+// ---------------------------------------------------------------------------
+
+const MAX_LOCATION_NAME_LENGTH = 128;
+
+const META_TOOL_INDEX: ToolInfo = {
+  name: "unifi_tool_index",
+  title: "UniFi Tool Index",
+  description:
+    "Discover available UniFi tools. Returns names and descriptions by default. " +
+    "Use 'category' to filter by area (e.g. clients, firewall, devices), " +
+    "'search' for keyword matching, or 'include_schemas' for full parameter schemas. " +
+    "Use this to discover tools before calling unifi_execute.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      category: {
+        type: "string",
+        description: "Optional category filter (e.g., 'clients', 'devices', 'firewall')",
+      },
+      search: {
+        type: "string",
+        description: "Optional search term to filter tools by name or description",
+      },
+      include_schemas: {
+        type: "boolean",
+        description:
+          "Include full input schemas per tool. Defaults to false. " +
+          "Set true with a category or search filter to get parameter details for specific tools.",
+        default: false,
+      },
+    },
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};
+
+const META_TOOL_EXECUTE: ToolInfo = {
+  name: "unifi_execute",
+  title: "UniFi Execute",
+  description:
+    "Execute a UniFi tool by name. Use unifi_tool_index to discover available tools first. " +
+    "Pass the tool name and its arguments.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      tool: { type: "string", description: "Name of the tool to execute" },
+      arguments: {
+        type: "object",
+        description: "Arguments to pass to the tool",
+        additionalProperties: true,
+      },
+      __location: {
+        type: "string",
+        description: "Target location ID (required for multi-location write operations)",
+      },
+    },
+    required: ["tool"],
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
+};
+
+const META_TOOL_BATCH: ToolInfo = {
+  name: "unifi_batch",
+  title: "UniFi Batch",
+  description:
+    "Execute multiple UniFi tools in a single request. Each call is an object with " +
+    "'tool' and 'arguments'. Results are returned in order.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      calls: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            tool: { type: "string" },
+            arguments: { type: "object", additionalProperties: true },
+            __location: { type: "string" },
+          },
+          required: ["tool"],
+        },
+        description: "Array of tool calls to execute",
+      },
+    },
+    required: ["calls"],
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: false,
+  },
+};
+
+const META_TOOL_LOCATION_TIMELINE: ToolInfo = {
+  name: "unifi_location_timeline",
+  title: "UniFi Location Timeline",
+  description:
+    "Query events across all connected UniFi products (Network, Protect, Access) " +
+    "and return a unified, time-sorted timeline. Correlates network events, camera " +
+    "motion, and door access in a single view.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      start_time: { type: "string", description: "Start of time window (ISO 8601)" },
+      end_time: { type: "string", description: "End of time window (ISO 8601)" },
+      location_id: {
+        type: "string",
+        description: "Filter to a specific location (omit to query all connected locations)",
+      },
+      products: {
+        type: "array",
+        items: { type: "string" },
+        description: "Filter to specific products: ['network', 'protect', 'access']",
+      },
+      area_hint: {
+        type: "string",
+        description: "Filter by area name (e.g., 'front door' matches AP, camera, and door names)",
+      },
+      event_types: {
+        type: "array",
+        items: { type: "string" },
+        description: "Filter by event type (e.g., 'motion', 'client_connect', 'badge_scan')",
+      },
+    },
+    required: ["start_time", "end_time"],
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};
+
+const META_TOOLS: ToolInfo[] = [META_TOOL_INDEX, META_TOOL_EXECUTE, META_TOOL_BATCH, META_TOOL_LOCATION_TIMELINE];
+
+// ---------------------------------------------------------------------------
+// Relay Durable Object
+// ---------------------------------------------------------------------------
+
+export class RelayObject extends DurableObject<Env> implements RelayStub {
+  /** location_id -> list of tools registered by that location */
+  private locationTools = new Map<string, ToolInfo[]>();
+  /** tool_name -> list of location_ids that provide it */
+  private toolToLocations = new Map<string, string[]>();
+  /** location_id -> active WebSocket for O(1) lookup */
+  private locationWebSockets = new Map<string, WebSocket>();
+  /** call_id -> pending promise waiting for a tool_result */
+  private pending = new Map<string, PendingRequest>();
+  /** Whether in-memory state has been rebuilt from SQLite since last wake */
+  private stateRebuilt = false;
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.ctx.blockConcurrencyWhile(() => this.ensureTables());
+  }
+
+  // -------------------------------------------------------------------------
+  // SQLite schema
+  // -------------------------------------------------------------------------
+
+  private async ensureTables(): Promise<void> {
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS locations (
+        location_id TEXT PRIMARY KEY,
+        location_name TEXT NOT NULL UNIQUE,
+        relay_token_hash TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_seen INTEGER NOT NULL
+      );
+    `);
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS location_tools (
+        location_id TEXT NOT NULL,
+        tool_name TEXT NOT NULL,
+        title TEXT,
+        description TEXT NOT NULL DEFAULT '',
+        input_schema TEXT,
+        annotations TEXT,
+        server_origin TEXT,
+        PRIMARY KEY (location_id, tool_name),
+        FOREIGN KEY (location_id) REFERENCES locations(location_id)
+      );
+    `);
+    this.ensureLocationToolsTitleColumn();
+  }
+
+  private ensureLocationToolsTitleColumn(): void {
+    const columns = this.ctx.storage.sql.exec(`PRAGMA table_info(location_tools)`).toArray();
+    const hasTitle = columns.some((column) => column.name === "title");
+    if (!hasTitle) {
+      this.ctx.storage.sql.exec(`ALTER TABLE location_tools ADD COLUMN title TEXT`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // In-memory state rebuild from SQLite
+  // -------------------------------------------------------------------------
+
+  private rebuildInMemoryState(): void {
+    this.locationTools.clear();
+    this.toolToLocations.clear();
+
+    // Rebuild WebSocket map from hibernation-managed sockets
+    this.locationWebSockets.clear();
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        const attachment = ws.deserializeAttachment() as { locationId?: string } | null;
+        if (attachment?.locationId) {
+          this.locationWebSockets.set(attachment.locationId, ws);
+        }
+      } catch {
+        // skip websockets without valid attachment
+      }
+    }
+
+    // Load all tools grouped by location
+    const rows = this.ctx.storage.sql.exec(
+      `SELECT lt.location_id, lt.tool_name, lt.title, lt.description, lt.input_schema, lt.annotations, lt.server_origin
+       FROM location_tools lt
+       JOIN locations l ON lt.location_id = l.location_id`,
+    ).toArray();
+
+    for (const row of rows) {
+      const locationId = row.location_id as string;
+      const tool: ToolInfo = {
+        name: row.tool_name as string,
+        description: (row.description as string) || "",
+      };
+
+      if (row.title) {
+        tool.title = row.title as string;
+      }
+      if (row.input_schema) {
+        try {
+          tool.inputSchema = JSON.parse(row.input_schema as string);
+        } catch {
+          // skip invalid schema
+        }
+      }
+      if (row.annotations) {
+        try {
+          tool.annotations = JSON.parse(row.annotations as string) as ToolAnnotations;
+        } catch {
+          // skip invalid annotations
+        }
+      }
+      if (row.server_origin) {
+        tool.serverOrigin = row.server_origin as string;
+      }
+
+      // Add to locationTools
+      if (!this.locationTools.has(locationId)) {
+        this.locationTools.set(locationId, []);
+      }
+      this.locationTools.get(locationId)!.push(tool);
+
+      // Add to toolToLocations
+      if (!this.toolToLocations.has(tool.name)) {
+        this.toolToLocations.set(tool.name, []);
+      }
+      const locs = this.toolToLocations.get(tool.name)!;
+      if (!locs.includes(locationId)) {
+        locs.push(locationId);
+      }
+    }
+
+    this.stateRebuilt = true;
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP fetch handler
+  // -------------------------------------------------------------------------
+
+  async fetch(request: Request): Promise<Response> {
+    if (!this.stateRebuilt) {
+      this.rebuildInMemoryState();
+    }
+
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    if (path === "/ws") {
+      return this.handleWebSocketUpgrade(request);
+    }
+    if (path === "/mcp" && request.method === "POST") {
+      return this.handleMcp(request);
+    }
+    if (path === "/api/locations" && request.method === "GET") {
+      return this.handleGetLocations();
+    }
+    if (path === "/api/locations/token" && request.method === "POST") {
+      return this.handleGenerateToken(request);
+    }
+    if (path === "/tools" && request.method === "GET") {
+      return this.handleGetTools();
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket upgrade
+  // -------------------------------------------------------------------------
+
+  private async handleWebSocketUpgrade(request: Request): Promise<Response> {
+    const upgradeHeader = request.headers.get("Upgrade");
+    if (!upgradeHeader || upgradeHeader.toLowerCase() !== "websocket") {
+      return new Response("Expected WebSocket upgrade", { status: 426 });
+    }
+
+    // Pre-authenticate: require a valid Bearer token that matches a registered location
+    const token = extractBearerToken(request);
+    if (!token) {
+      return new Response("Unauthorized: missing Bearer token", { status: 401 });
+    }
+
+    const tokenHash = await hashToken(token);
+    const rows = this.ctx.storage.sql.exec(
+      `SELECT location_id FROM locations WHERE relay_token_hash = ?`,
+      tokenHash,
+    ).toArray();
+
+    if (rows.length === 0) {
+      return new Response("Unauthorized: invalid relay token", { status: 401 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = [pair[0], pair[1]];
+
+    // Accept with hibernation API
+    this.ctx.acceptWebSocket(server);
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // MCP handler
+  // -------------------------------------------------------------------------
+
+  private async handleMcp(request: Request): Promise<Response> {
+    try {
+      const body = (await request.json()) as import("./types").JsonRpcRequest;
+      const mode = this.env.TOOL_REGISTRATION_MODE || "lazy";
+      const result = await handleMcpRequest(body, this, mode);
+      return new Response(JSON.stringify(result), {
+        headers: { "Content-Type": "application/json" },
+      });
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid request" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Admin: GET /api/locations
+  // -------------------------------------------------------------------------
+
+  private handleGetLocations(): Response {
+    const rows = this.ctx.storage.sql.exec(
+      `SELECT location_id, location_name, created_at, last_seen FROM locations ORDER BY location_name`,
+    ).toArray();
+
+    // Determine which locations are currently connected via WebSocket
+    const connectedLocationIds = new Set<string>();
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        const attachment = ws.deserializeAttachment() as { locationId?: string } | null;
+        if (attachment?.locationId) {
+          connectedLocationIds.add(attachment.locationId);
+        }
+      } catch {
+        // skip websockets without valid attachment
+      }
+    }
+
+    const locations = rows.map((row) => ({
+      location_id: row.location_id as string,
+      location_name: row.location_name as string,
+      created_at: row.created_at as number,
+      last_seen: row.last_seen as number,
+      connected: connectedLocationIds.has(row.location_id as string),
+    }));
+
+    return new Response(JSON.stringify({ locations }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Admin: POST /api/locations/token
+  // -------------------------------------------------------------------------
+
+  private async handleGenerateToken(request: Request): Promise<Response> {
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const locationName = body.location_name as string | undefined;
+    if (!locationName || typeof locationName !== "string") {
+      return new Response(JSON.stringify({ error: "Missing location_name" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (locationName.length > MAX_LOCATION_NAME_LENGTH) {
+      return new Response(
+        JSON.stringify({ error: `location_name exceeds maximum length of ${MAX_LOCATION_NAME_LENGTH} characters` }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const token = generateToken();
+    const tokenHash = await hashToken(token);
+    const locationId = crypto.randomUUID();
+    const now = Date.now();
+
+    this.ctx.storage.sql.exec(
+      `INSERT INTO locations (location_id, location_name, relay_token_hash, created_at, last_seen)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(location_name) DO UPDATE SET
+         relay_token_hash = excluded.relay_token_hash,
+         last_seen = excluded.last_seen`,
+      locationId,
+      locationName,
+      tokenHash,
+      now,
+      now,
+    );
+
+    // When the conflict fires, the original location_id is preserved.
+    // Query back the actual ID so the response is correct.
+    const rows = this.ctx.storage.sql.exec(
+      `SELECT location_id FROM locations WHERE location_name = ?`,
+      locationName,
+    ).toArray();
+    const actualLocationId = (rows[0]?.location_id as string) || locationId;
+
+    return new Response(
+      JSON.stringify({
+        location_id: actualLocationId,
+        location_name: locationName,
+        token,
+      }),
+      {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: GET /tools
+  // -------------------------------------------------------------------------
+
+  private handleGetTools(): Response {
+    const tools = this.getAggregatedTools();
+    return new Response(JSON.stringify({ tools }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket Hibernation API handlers
+  // -------------------------------------------------------------------------
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const raw = typeof message === "string" ? message : new TextDecoder().decode(message);
+
+    let parsed: InboundMessage;
+    try {
+      parsed = JSON.parse(raw) as InboundMessage;
+    } catch {
+      this.sendWs(ws, { type: "error", message: "Invalid JSON", code: "PARSE_ERROR" });
+      return;
+    }
+
+    switch (parsed.type) {
+      case "register":
+        await this.handleRegister(ws, parsed as RegisterMessage);
+        break;
+      case "tool_result":
+        this.handleToolResult(ws, parsed as ToolCallResponse);
+        break;
+      case "catalog_update":
+        this.handleCatalogUpdate(ws, parsed as CatalogUpdateMessage);
+        break;
+      case "heartbeat":
+        this.sendWs(ws, { type: "heartbeat_ack" });
+        break;
+      default:
+        this.sendWs(ws, {
+          type: "error",
+          message: `Unknown message type: ${(parsed as Record<string, unknown>).type}`,
+          code: "UNKNOWN_TYPE",
+        });
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): Promise<void> {
+    this.cleanupWebSocket(ws);
+  }
+
+  async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+    this.cleanupWebSocket(ws);
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket message handlers
+  // -------------------------------------------------------------------------
+
+  private async handleRegister(ws: WebSocket, msg: RegisterMessage): Promise<void> {
+    // Validate protocol version
+    if (msg.protocol_version !== PROTOCOL_VERSION) {
+      this.sendWs(ws, {
+        type: "error",
+        message: `Unsupported protocol version: ${msg.protocol_version}, expected ${PROTOCOL_VERSION}`,
+        code: "PROTOCOL_MISMATCH",
+      });
+      return;
+    }
+
+    // Validate location name
+    if (msg.location_name && msg.location_name.length > MAX_LOCATION_NAME_LENGTH) {
+      this.sendWs(ws, {
+        type: "error",
+        message: `location_name exceeds maximum length of ${MAX_LOCATION_NAME_LENGTH} characters`,
+        code: "INVALID_INPUT",
+      });
+      return;
+    }
+
+    // Hash the incoming token and look up matching location
+    const incomingHash = await hashToken(msg.token);
+
+    const rows = this.ctx.storage.sql.exec(
+      `SELECT location_id, location_name, relay_token_hash FROM locations WHERE relay_token_hash = ?`,
+      incomingHash,
+    ).toArray();
+
+    if (rows.length === 0) {
+      this.sendWs(ws, {
+        type: "error",
+        message: "Invalid relay token",
+        code: "AUTH_FAILED",
+      });
+      return;
+    }
+
+    const locationId = rows[0].location_id as string;
+    const locationName = rows[0].location_name as string;
+    const now = Date.now();
+
+    // Update last_seen and location_name (relay client may update its name)
+    this.ctx.storage.sql.exec(
+      `UPDATE locations SET last_seen = ?, location_name = ? WHERE location_id = ?`,
+      now,
+      msg.location_name || locationName,
+      locationId,
+    );
+
+    // Replace tools for this location
+    this.ctx.storage.sql.exec(`DELETE FROM location_tools WHERE location_id = ?`, locationId);
+
+    for (const tool of msg.tools) {
+      this.ctx.storage.sql.exec(
+        `INSERT INTO location_tools (location_id, tool_name, title, description, input_schema, annotations, server_origin)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        locationId,
+        tool.name,
+        tool.title || null,
+        tool.description || "",
+        toolInputSchema(tool) ? JSON.stringify(toolInputSchema(tool)) : null,
+        tool.annotations ? JSON.stringify(tool.annotations) : null,
+        toolServerOrigin(tool) || null,
+      );
+    }
+
+    // Rebuild in-memory state
+    this.rebuildInMemoryState();
+
+    // Attach location_id to the WebSocket for later identification
+    ws.serializeAttachment({ locationId, locationName: msg.location_name || locationName });
+
+    // Cache the WebSocket for O(1) lookup
+    this.locationWebSockets.set(locationId, ws);
+
+    // Send confirmation
+    const response: RegisteredMessage = {
+      type: "registered",
+      location_id: locationId,
+      location_name: msg.location_name || locationName,
+    };
+    this.sendWs(ws, response);
+  }
+
+  private handleToolResult(ws: WebSocket, msg: ToolCallResponse): void {
+    const pending = this.pending.get(msg.call_id);
+    if (!pending) {
+      // Stale or duplicate result, ignore
+      return;
+    }
+
+    // Verify the sender is the location that received the original tool_call
+    try {
+      const attachment = ws.deserializeAttachment() as { locationId?: string } | null;
+      if (attachment?.locationId && attachment.locationId !== pending.locationId) {
+        // Result from a different location than expected — reject it
+        return;
+      }
+    } catch {
+      // No attachment — unregistered WebSocket, ignore
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(msg.call_id);
+
+    if (msg.error) {
+      pending.reject(new Error(msg.error));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private handleCatalogUpdate(ws: WebSocket, msg: CatalogUpdateMessage): void {
+    const attachment = ws.deserializeAttachment() as { locationId?: string } | null;
+    if (!attachment?.locationId) {
+      this.sendWs(ws, {
+        type: "error",
+        message: "Must register before sending catalog updates",
+        code: "NOT_REGISTERED",
+      });
+      return;
+    }
+
+    const locationId = attachment.locationId;
+
+    // Replace tools for this location
+    this.ctx.storage.sql.exec(`DELETE FROM location_tools WHERE location_id = ?`, locationId);
+
+    for (const tool of msg.tools) {
+      this.ctx.storage.sql.exec(
+        `INSERT INTO location_tools (location_id, tool_name, title, description, input_schema, annotations, server_origin)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        locationId,
+        tool.name,
+        tool.title || null,
+        tool.description || "",
+        toolInputSchema(tool) ? JSON.stringify(toolInputSchema(tool)) : null,
+        tool.annotations ? JSON.stringify(tool.annotations) : null,
+        toolServerOrigin(tool) || null,
+      );
+    }
+
+    // Rebuild in-memory state
+    this.rebuildInMemoryState();
+
+    // Update last_seen
+    this.ctx.storage.sql.exec(
+      `UPDATE locations SET last_seen = ? WHERE location_id = ?`,
+      Date.now(),
+      locationId,
+    );
+  }
+
+  private cleanupWebSocket(ws: WebSocket): void {
+    try {
+      const attachment = ws.deserializeAttachment() as { locationId?: string } | null;
+      if (attachment?.locationId) {
+        // Remove from WebSocket cache -- location is no longer routable.
+        // In-memory tool state stays (tools are still in SQLite) so the
+        // location will become routable again when it reconnects.
+        this.locationWebSockets.delete(attachment.locationId);
+      }
+    } catch {
+      // No attachment, nothing to clean up
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // RelayStub interface implementation
+  // -------------------------------------------------------------------------
+
+  async getToolList(mode: string): Promise<ToolInfo[]> {
+    if (mode === "lazy" || mode === "meta_only") {
+      return META_TOOLS;
+    }
+
+    // eager mode: return all deduplicated tools from all locations
+    return this.getAggregatedTools();
+  }
+
+  async handleToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | AggregatedResponse> {
+    // Handle meta-tools
+    if (toolName === "unifi_tool_index") {
+      return this.handleToolIndex(args);
+    }
+    if (toolName === "unifi_execute") {
+      return this.handleExecute(args);
+    }
+    if (toolName === "unifi_batch") {
+      return this.handleBatch(args);
+    }
+    if (toolName === "unifi_location_timeline") {
+      return this.handleLocationTimeline(args);
+    }
+
+    // Direct tool call (eager mode)
+    return this.routeToolCall(toolName, args);
+  }
+
+  async isMultiLocation(): Promise<boolean> {
+    return this.locationTools.size > 1;
+  }
+
+  // -------------------------------------------------------------------------
+  // Meta-tool handlers
+  // -------------------------------------------------------------------------
+
+  private handleToolIndex(args: Record<string, unknown>): Record<string, unknown> {
+    const category = args.category as string | undefined;
+    const search = args.search as string | undefined;
+    const includeSchemas = Boolean(args.include_schemas);
+
+    // Build tool list with location metadata
+    const toolEntries: Array<{
+      name: string;
+      title?: string;
+      description: string;
+      locations: string[];
+      annotations?: ToolAnnotations;
+      inputSchema?: Record<string, unknown>;
+    }> = [];
+
+    const seen = new Set<string>();
+    for (const [locationId, tools] of this.locationTools) {
+      for (const tool of tools) {
+        if (!seen.has(tool.name)) {
+          seen.add(tool.name);
+          const entry: (typeof toolEntries)[number] = {
+            name: tool.name,
+            description: tool.description,
+            locations: this.toolToLocations.get(tool.name) || [locationId],
+            annotations: tool.annotations,
+          };
+          if (tool.title) {
+            entry.title = tool.title;
+          }
+          if (includeSchemas && tool.inputSchema) {
+            entry.inputSchema = tool.inputSchema;
+          }
+          toolEntries.push(entry);
+        }
+      }
+    }
+
+    let filtered = toolEntries;
+
+    // Filter by category (matches tools whose name or description contains the category)
+    if (category) {
+      const cat = category.toLowerCase();
+      filtered = filtered.filter(
+        (t) => t.name.toLowerCase().includes(cat) || t.description.toLowerCase().includes(cat),
+      );
+    }
+
+    // Filter by search term
+    if (search) {
+      const term = search.toLowerCase();
+      filtered = filtered.filter(
+        (t) => t.name.toLowerCase().includes(term) || t.description.toLowerCase().includes(term),
+      );
+    }
+
+    return {
+      success: true,
+      data: {
+        tools: filtered,
+        total: filtered.length,
+        multi_location: this.locationTools.size > 1,
+      },
+    };
+  }
+
+  private async handleExecute(args: Record<string, unknown>): Promise<Record<string, unknown> | AggregatedResponse> {
+    const toolName = args.tool as string;
+    if (!toolName) {
+      return { success: false, error: "Missing required argument: tool" };
+    }
+
+    const toolArgs = (args.arguments as Record<string, unknown>) || {};
+    const location = args.__location as string | undefined;
+    if (location) {
+      toolArgs.__location = location;
+    }
+
+    return this.routeToolCall(toolName, toolArgs);
+  }
+
+  private async handleBatch(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const calls = args.calls as Array<{ tool: string; arguments?: Record<string, unknown>; __location?: string }>;
+    if (!calls || !Array.isArray(calls)) {
+      return { success: false, error: "Missing required argument: calls (array)" };
+    }
+
+    const settled = await Promise.allSettled(
+      calls.map((call) => {
+        const callArgs = { ...(call.arguments || {}) };
+        if (call.__location) {
+          callArgs.__location = call.__location;
+        }
+        return this.routeToolCall(call.tool, callArgs);
+      }),
+    );
+
+    const results: Array<{ tool: string; result?: unknown; error?: string }> = settled.map((outcome, i) => {
+      if (outcome.status === "fulfilled") {
+        return { tool: calls[i].tool, result: outcome.value };
+      }
+      const msg = outcome.reason instanceof Error ? outcome.reason.message : "Unknown error";
+      return { tool: calls[i].tool, error: msg };
+    });
+
+    return { success: true, data: { results, total: results.length } };
+  }
+
+  private async handleLocationTimeline(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const startTime = args.start_time as string | undefined;
+    const endTime = args.end_time as string | undefined;
+
+    if (!startTime || !endTime) {
+      return { success: false, error: "start_time and end_time are required" };
+    }
+
+    // Validate ISO 8601
+    if (isNaN(Date.parse(startTime)) || isNaN(Date.parse(endTime))) {
+      return { success: false, error: "start_time and end_time must be valid ISO 8601 timestamps" };
+    }
+    if (new Date(endTime) <= new Date(startTime)) {
+      return { success: false, error: "end_time must be after start_time" };
+    }
+
+    const locationId = args.location_id as string | undefined;
+    const products = args.products as string[] | undefined;
+    const areaHint = args.area_hint as string | undefined;
+    const eventTypes = args.event_types as string[] | undefined;
+
+    // Event-listing tool names per product
+    const eventToolMap: Record<string, string> = {
+      network: "unifi_list_events",
+      protect: "unifi_protect_list_events",
+      access: "unifi_access_list_events",
+    };
+
+    // Convert time range to within_hours for Network events (which use a lookback window)
+    const startDate = new Date(startTime);
+    const endDate = new Date(endTime);
+    const withinHours = Math.max(1, Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60)));
+    // Hours from now to the start of the window (for Network's "within" param)
+    const hoursAgo = Math.max(1, Math.ceil((Date.now() - startDate.getTime()) / (1000 * 60 * 60)));
+
+    const targetProducts = products || Object.keys(eventToolMap);
+    const allEvents: Array<Record<string, unknown>> = [];
+
+    // Fan out event queries to each product's event tool
+    for (const product of targetProducts) {
+      const toolName = eventToolMap[product];
+      if (!toolName) continue;
+
+      // Check if any location has this tool
+      const locations = this.toolToLocations.get(toolName);
+      if (!locations || locations.length === 0) continue;
+
+      // Filter to specific location if requested
+      const targetLocations = locationId ? locations.filter((l) => l === locationId) : locations;
+      if (targetLocations.length === 0) continue;
+
+      // Build product-specific arguments
+      // Network uses within_hours lookback; Protect/Access may use start_time/end_time
+      const toolArgs: Record<string, unknown> = product === "network"
+        ? { within_hours: hoursAgo, limit: 3000 }
+        : { start_time: startTime, end_time: endTime };
+
+      try {
+        const result = await this.routeToolCall(toolName, toolArgs);
+
+        // Extract events from the result (handles both single and fan-out responses)
+        const events = this.extractEvents(result, product);
+        allEvents.push(...events);
+      } catch (err) {
+        // Log but continue — partial results are better than failure
+      }
+    }
+
+    // Sort by timestamp
+    allEvents.sort((a, b) => {
+      const tsA = String(a.timestamp || a.datetime || a.time || "");
+      const tsB = String(b.timestamp || b.datetime || b.time || "");
+      return tsA.localeCompare(tsB);
+    });
+
+    // Apply area_hint filter (case-insensitive substring match on area names)
+    let filtered = allEvents;
+    if (areaHint) {
+      const hint = areaHint.toLowerCase();
+      filtered = allEvents.filter((e) => {
+        const areaFields = [e.ap_name, e.camera_name, e.door_name, e.device_name, e.name].filter(Boolean);
+        return areaFields.some((f) => String(f).toLowerCase().includes(hint));
+      });
+    }
+
+    // Apply event_types filter
+    if (eventTypes && eventTypes.length > 0) {
+      const types = new Set(eventTypes);
+      filtered = filtered.filter((e) => types.has(String(e.type || e.event_type || "")));
+    }
+
+    // Build summary
+    const byProduct: Record<string, number> = {};
+    const byType: Record<string, number> = {};
+    const byLocation: Record<string, number> = {};
+    for (const e of filtered) {
+      const p = String(e._product || "unknown");
+      byProduct[p] = (byProduct[p] || 0) + 1;
+      const t = String(e.type || e.event_type || "unknown");
+      byType[t] = (byType[t] || 0) + 1;
+      if (e._location_id) {
+        const l = String(e._location_id);
+        byLocation[l] = (byLocation[l] || 0) + 1;
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        timeline: filtered,
+        summary: {
+          total_events: filtered.length,
+          by_product: byProduct,
+          by_type: byType,
+          by_location: byLocation,
+          time_range: { start: startTime, end: endTime },
+        },
+      },
+    };
+  }
+
+  /** Extract events from a tool call result, tagging each with product and location metadata. */
+  private extractEvents(
+    result: Record<string, unknown> | AggregatedResponse,
+    product: string,
+  ): Array<Record<string, unknown>> {
+    // Fan-out response (multi-location)
+    if ("results" in result && Array.isArray((result as AggregatedResponse).results)) {
+      const agg = result as AggregatedResponse;
+      const events: Array<Record<string, unknown>> = [];
+      for (const locResult of agg.results) {
+        if (locResult.error) continue;
+        const locEvents = this.extractEventsFromData(locResult.data);
+        for (const e of locEvents) {
+          e._product = product;
+          e._location_id = locResult.location_id;
+          e._location_name = locResult.location_name;
+        }
+        events.push(...locEvents);
+      }
+      return events;
+    }
+
+    // Single-location response
+    const data = (result as Record<string, unknown>).data ?? result;
+    const events = this.extractEventsFromData(data);
+    for (const e of events) {
+      e._product = product;
+    }
+    return events;
+  }
+
+  /** Pull the events array out of a tool result's data payload. */
+  private extractEventsFromData(data: unknown): Array<Record<string, unknown>> {
+    if (!data || typeof data !== "object") return [];
+
+    // Handle {success: true, data: {events: [...]}} pattern
+    const d = data as Record<string, unknown>;
+    if (d.success && d.data && typeof d.data === "object") {
+      const inner = d.data as Record<string, unknown>;
+      if (Array.isArray(inner.events)) return inner.events as Array<Record<string, unknown>>;
+    }
+
+    // Handle {events: [...]} directly
+    if (Array.isArray(d.events)) return d.events as Array<Record<string, unknown>>;
+
+    // Handle raw array
+    if (Array.isArray(data)) return data as Array<Record<string, unknown>>;
+
+    return [];
+  }
+
+  // -------------------------------------------------------------------------
+  // Tool call routing
+  // -------------------------------------------------------------------------
+
+  private async routeToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | AggregatedResponse> {
+    const locations = this.toolToLocations.get(toolName);
+    if (!locations || locations.length === 0) {
+      return { success: false, error: `Tool not found: ${toolName}` };
+    }
+
+    // Single location: always route directly
+    if (this.locationTools.size === 1) {
+      const locationId = locations[0];
+      return this.sendToolCall(locationId, toolName, args);
+    }
+
+    // Multi-location: check if the tool is read-only
+    const toolInfo = this.findToolInfo(toolName);
+    const isReadOnly = toolInfo?.annotations?.readOnlyHint === true;
+
+    if (isReadOnly) {
+      // Fan out to all locations that have this tool
+      return this.fanOutToolCall(toolName, args, locations);
+    }
+
+    // Write tool: requires explicit __location
+    const targetLocation = args.__location as string | undefined;
+    if (!targetLocation) {
+      // Build a helpful error with available locations
+      const locationNames = locations.map((locId) => {
+        const nameRow = this.ctx.storage.sql.exec(
+          `SELECT location_name FROM locations WHERE location_id = ?`,
+          locId,
+        ).toArray();
+        return { id: locId, name: (nameRow[0]?.location_name as string) || locId };
+      });
+      return {
+        success: false,
+        error: `Multi-location write operation requires __location argument. Available locations: ${JSON.stringify(locationNames)}`,
+      };
+    }
+
+    // Remove __location from args before sending
+    const { __location, ...cleanArgs } = args;
+    return this.sendToolCall(targetLocation, toolName, cleanArgs);
+  }
+
+  private async sendToolCall(
+    locationId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const ws = this.findWebSocketForLocation(locationId);
+    if (!ws) {
+      return { success: false, error: `Location ${locationId} is not connected` };
+    }
+
+    const callId = crypto.randomUUID();
+
+    const result = await new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(callId);
+        reject(new Error(`Tool call timed out after ${TOOL_CALL_TIMEOUT_MS}ms`));
+      }, TOOL_CALL_TIMEOUT_MS);
+
+      this.pending.set(callId, { resolve, reject, timeout, locationId });
+
+      const request: ToolCallRequest = {
+        type: "tool_call",
+        call_id: callId,
+        tool_name: toolName,
+        arguments: args,
+        timeout_ms: TOOL_CALL_TIMEOUT_MS,
+      };
+
+      this.sendWs(ws, request);
+    });
+
+    // If the result is already a structured response, return it
+    if (result && typeof result === "object" && "success" in (result as Record<string, unknown>)) {
+      return result as Record<string, unknown>;
+    }
+
+    return { success: true, data: result };
+  }
+
+  private async fanOutToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+    locationIds: string[],
+  ): Promise<AggregatedResponse> {
+    // Remove __location from args if present (not needed for fan-out)
+    const { __location, ...cleanArgs } = args;
+
+    const promises = locationIds.map(async (locationId): Promise<FanOutResult> => {
+      const ws = this.findWebSocketForLocation(locationId);
+      const locationName = this.getLocationName(locationId);
+
+      if (!ws) {
+        return { location_id: locationId, location_name: locationName, error: "Not connected" };
+      }
+
+      const callId = `${crypto.randomUUID()}-${locationId}`;
+
+      try {
+        const result = await new Promise<unknown>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            this.pending.delete(callId);
+            reject(new Error(`Timed out after ${TOOL_CALL_TIMEOUT_MS}ms`));
+          }, TOOL_CALL_TIMEOUT_MS);
+
+          this.pending.set(callId, { resolve, reject, timeout, locationId });
+
+          const request: ToolCallRequest = {
+            type: "tool_call",
+            call_id: callId,
+            tool_name: toolName,
+            arguments: cleanArgs,
+            timeout_ms: TOOL_CALL_TIMEOUT_MS,
+          };
+
+          this.sendWs(ws, request);
+        });
+
+        return { location_id: locationId, location_name: locationName, data: result };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        return { location_id: locationId, location_name: locationName, error: msg };
+      }
+    });
+
+    const results = await Promise.allSettled(promises);
+    const fanOutResults: FanOutResult[] = results.map((r) => {
+      if (r.status === "fulfilled") return r.value;
+      return {
+        location_id: "unknown",
+        location_name: "unknown",
+        error: r.reason instanceof Error ? r.reason.message : "Unknown error",
+      };
+    });
+
+    const responded = fanOutResults.filter((r) => !r.error).length;
+
+    return {
+      success: responded > 0,
+      results: fanOutResults,
+      partial: responded > 0 && responded < locationIds.length,
+      locations_total: locationIds.length,
+      locations_responded: responded,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Helper methods
+  // -------------------------------------------------------------------------
+
+  /** Get deduplicated tools across all locations (for eager mode) */
+  getAggregatedTools(): ToolInfo[] {
+    const seen = new Set<string>();
+    const tools: ToolInfo[] = [];
+
+    for (const locationToolList of this.locationTools.values()) {
+      for (const tool of locationToolList) {
+        if (!seen.has(tool.name)) {
+          seen.add(tool.name);
+          tools.push(tool);
+        }
+      }
+    }
+
+    return tools;
+  }
+
+  private findToolInfo(toolName: string): ToolInfo | undefined {
+    for (const tools of this.locationTools.values()) {
+      const found = tools.find((t) => t.name === toolName);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  private findWebSocketForLocation(locationId: string): WebSocket | null {
+    return this.locationWebSockets.get(locationId) ?? null;
+  }
+
+  private getLocationName(locationId: string): string {
+    const rows = this.ctx.storage.sql.exec(
+      `SELECT location_name FROM locations WHERE location_id = ?`,
+      locationId,
+    ).toArray();
+    return (rows[0]?.location_name as string) || locationId;
+  }
+
+  private sendWs(
+    ws: WebSocket,
+    msg: RegisteredMessage | ToolCallRequest | HeartbeatAckMessage | ErrorMessage,
+  ): void {
+    try {
+      ws.send(JSON.stringify(msg));
+    } catch {
+      // WebSocket may already be closed
+    }
+  }
+}

--- a/apps/worker/worker/src/tool-info.ts
+++ b/apps/worker/worker/src/tool-info.ts
@@ -1,0 +1,9 @@
+import type { ToolInfo } from "./types";
+
+export function toolInputSchema(tool: ToolInfo): Record<string, unknown> | undefined {
+  return tool.inputSchema ?? tool.input_schema;
+}
+
+export function toolServerOrigin(tool: ToolInfo): string | undefined {
+  return tool.serverOrigin ?? tool.server_origin;
+}

--- a/apps/worker/worker/src/types.ts
+++ b/apps/worker/worker/src/types.ts
@@ -1,0 +1,187 @@
+// src/types.ts
+// All TypeScript interfaces and constants for the UniFi MCP relay worker.
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PROTOCOL_VERSION = 1;
+export const TOOL_CALL_TIMEOUT_MS = 30_000;
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+export const HEARTBEAT_ACK_TIMEOUT_MS = 10_000;
+export const PROJECT_WEBSITE_URL = "https://github.com/sirkirby/unifi-mcp";
+
+export interface IconInfo {
+  src: string;
+  mimeType?: string;
+  sizes?: string[];
+}
+
+const RELAY_ICON_SRC =
+  "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20192%20192%22%3E%3Crect%20width%3D%22192%22%20height%3D%22192%22%20rx%3D%2238%22%20fill%3D%22%23111827%22%2F%3E%3Cpath%20d%3D%22M54%2096h84M96%2054v84%22%20stroke%3D%22%2338bdf8%22%20stroke-width%3D%2214%22%20stroke-linecap%3D%22round%22%2F%3E%3Ccircle%20cx%3D%2254%22%20cy%3D%2296%22%20r%3D%2218%22%20fill%3D%22%2322c55e%22%2F%3E%3Ccircle%20cx%3D%22138%22%20cy%3D%2296%22%20r%3D%2218%22%20fill%3D%22%2322c55e%22%2F%3E%3Ccircle%20cx%3D%2296%22%20cy%3D%2254%22%20r%3D%2218%22%20fill%3D%22%2322c55e%22%2F%3E%3Ccircle%20cx%3D%2296%22%20cy%3D%22138%22%20r%3D%2218%22%20fill%3D%22%2322c55e%22%2F%3E%3C%2Fsvg%3E";
+
+export const RELAY_SERVER_ICONS: IconInfo[] = [
+  {
+    src: RELAY_ICON_SRC,
+    mimeType: "image/svg+xml",
+    sizes: ["192x192"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Environment (Cloudflare bindings)
+// ---------------------------------------------------------------------------
+
+export interface Env {
+  RELAY: DurableObjectNamespace;
+  AGENT_TOKEN: string;
+  ADMIN_TOKEN: string;
+  TOOL_REGISTRATION_MODE: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tool metadata
+// ---------------------------------------------------------------------------
+
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export interface ToolInfo {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: Record<string, unknown>;
+  input_schema?: Record<string, unknown>;
+  annotations?: ToolAnnotations;
+  serverOrigin?: string;
+  server_origin?: string;
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket messages — relay client → worker (inbound)
+// ---------------------------------------------------------------------------
+
+export interface RegisterMessage {
+  type: "register";
+  protocol_version: number;
+  token: string;
+  location_name: string;
+  tools: ToolInfo[];
+  capabilities: string[];
+}
+
+export interface ToolCallResponse {
+  type: "tool_result";
+  call_id: string;
+  result?: unknown;
+  error?: string;
+}
+
+export interface CatalogUpdateMessage {
+  type: "catalog_update";
+  tools: ToolInfo[];
+  capabilities: string[];
+}
+
+export interface HeartbeatMessage {
+  type: "heartbeat";
+}
+
+export type InboundMessage =
+  | RegisterMessage
+  | ToolCallResponse
+  | CatalogUpdateMessage
+  | HeartbeatMessage;
+
+// ---------------------------------------------------------------------------
+// WebSocket messages — worker → relay client (outbound)
+// ---------------------------------------------------------------------------
+
+export interface RegisteredMessage {
+  type: "registered";
+  location_id: string;
+  location_name: string;
+}
+
+export interface ToolCallRequest {
+  type: "tool_call";
+  call_id: string;
+  tool_name: string;
+  arguments: Record<string, unknown>;
+  timeout_ms: number;
+}
+
+export interface HeartbeatAckMessage {
+  type: "heartbeat_ack";
+}
+
+export interface ErrorMessage {
+  type: "error";
+  message: string;
+  code?: string;
+}
+
+export type OutboundMessage =
+  | RegisteredMessage
+  | ToolCallRequest
+  | HeartbeatAckMessage
+  | ErrorMessage;
+
+// ---------------------------------------------------------------------------
+// MCP JSON-RPC
+// ---------------------------------------------------------------------------
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Durable Object internal state
+// ---------------------------------------------------------------------------
+
+export interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  timeout: ReturnType<typeof setTimeout>;
+  locationId: string;
+}
+
+export interface LocationInfo {
+  locationId: string;
+  locationName: string;
+  relayTokenHash: string;
+  lastSeen: number;
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out / aggregated responses
+// ---------------------------------------------------------------------------
+
+export interface FanOutResult {
+  location_id: string;
+  location_name: string;
+  data?: unknown;
+  error?: string;
+}
+
+export interface AggregatedResponse {
+  success: boolean;
+  results: FanOutResult[];
+  partial: boolean;
+  locations_total: number;
+  locations_responded: number;
+}

--- a/apps/worker/worker/test/auth.test.ts
+++ b/apps/worker/worker/test/auth.test.ts
@@ -1,0 +1,154 @@
+// test/auth.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  timingSafeEqual,
+  validateBearerToken,
+  extractBearerToken,
+  hashToken,
+  generateToken,
+} from "../src/auth";
+
+// ---------------------------------------------------------------------------
+// timingSafeEqual
+// ---------------------------------------------------------------------------
+describe("timingSafeEqual", () => {
+  it("returns true for equal strings", () => {
+    expect(timingSafeEqual("hello", "hello")).toBe(true);
+  });
+
+  it("returns false for different strings of the same length", () => {
+    expect(timingSafeEqual("hello", "world")).toBe(false);
+  });
+
+  it("returns false for strings of different lengths", () => {
+    expect(timingSafeEqual("short", "longer-string")).toBe(false);
+    expect(timingSafeEqual("longer-string", "short")).toBe(false);
+  });
+
+  it("returns true for two empty strings", () => {
+    expect(timingSafeEqual("", "")).toBe(true);
+  });
+
+  it("returns false when one string is empty and the other is not", () => {
+    expect(timingSafeEqual("", "nonempty")).toBe(false);
+    expect(timingSafeEqual("nonempty", "")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateBearerToken
+// ---------------------------------------------------------------------------
+describe("validateBearerToken", () => {
+  function makeRequest(headers: Record<string, string>): Request {
+    return new Request("https://example.com", { headers });
+  }
+
+  it("returns true when the Bearer token matches", () => {
+    const req = makeRequest({ Authorization: "Bearer mysecrettoken" });
+    expect(validateBearerToken(req, "mysecrettoken")).toBe(true);
+  });
+
+  it("returns false when the Bearer token does not match", () => {
+    const req = makeRequest({ Authorization: "Bearer wrongtoken" });
+    expect(validateBearerToken(req, "mysecrettoken")).toBe(false);
+  });
+
+  it("returns false when the Authorization header is missing", () => {
+    const req = makeRequest({});
+    expect(validateBearerToken(req, "mysecrettoken")).toBe(false);
+  });
+
+  it("returns false for a non-Bearer scheme (e.g., Basic)", () => {
+    const req = makeRequest({ Authorization: "Basic dXNlcjpwYXNz" });
+    expect(validateBearerToken(req, "dXNlcjpwYXNz")).toBe(false);
+  });
+
+  it("returns false for a malformed Authorization header (no space)", () => {
+    const req = makeRequest({ Authorization: "BearerNoSpace" });
+    expect(validateBearerToken(req, "BearerNoSpace")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractBearerToken
+// ---------------------------------------------------------------------------
+describe("extractBearerToken", () => {
+  function makeRequest(headers: Record<string, string>): Request {
+    return new Request("https://example.com", { headers });
+  }
+
+  it("extracts the Bearer token from the Authorization header", () => {
+    const req = makeRequest({ Authorization: "Bearer my-relay-token-abc" });
+    expect(extractBearerToken(req)).toBe("my-relay-token-abc");
+  });
+
+  it("returns null when the Authorization header is missing", () => {
+    const req = makeRequest({});
+    expect(extractBearerToken(req)).toBeNull();
+  });
+
+  it("returns null for a non-Bearer scheme", () => {
+    const req = makeRequest({ Authorization: "Basic dXNlcjpwYXNz" });
+    expect(extractBearerToken(req)).toBeNull();
+  });
+
+  it("returns null for a malformed header (no space)", () => {
+    const req = makeRequest({ Authorization: "BearerNoSpace" });
+    expect(extractBearerToken(req)).toBeNull();
+  });
+
+  it("is case-insensitive for the Bearer scheme", () => {
+    const req = makeRequest({ Authorization: "bearer my-token" });
+    expect(extractBearerToken(req)).toBe("my-token");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashToken
+// ---------------------------------------------------------------------------
+describe("hashToken", () => {
+  it("returns a 64-character lowercase hex string", async () => {
+    const hash = await hashToken("test-token");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces the same hash for the same input (deterministic)", async () => {
+    const hash1 = await hashToken("consistent-input");
+    const hash2 = await hashToken("consistent-input");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("produces different hashes for different inputs", async () => {
+    const hash1 = await hashToken("token-a");
+    const hash2 = await hashToken("token-b");
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateToken
+// ---------------------------------------------------------------------------
+describe("generateToken", () => {
+  it("produces a URL-safe base64 string (no +, /, or = characters)", () => {
+    const token = generateToken();
+    expect(token).not.toMatch(/[+/=]/);
+  });
+
+  it("uses only URL-safe base64 characters", () => {
+    const token = generateToken();
+    expect(token).toMatch(/^[A-Za-z0-9\-_]+$/);
+  });
+
+  it("generates unique tokens on successive calls", () => {
+    const token1 = generateToken();
+    const token2 = generateToken();
+    expect(token1).not.toBe(token2);
+  });
+
+  it("generates a token of the expected length (43 chars for 32 bytes URL-safe base64)", () => {
+    const token = generateToken();
+    // 32 bytes -> 44 base64 chars -> 43 after stripping one padding '='
+    expect(token.length).toBe(43);
+  });
+});

--- a/apps/worker/worker/test/mcp-handler.test.ts
+++ b/apps/worker/worker/test/mcp-handler.test.ts
@@ -1,0 +1,220 @@
+// test/mcp-handler.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { handleMcpRequest, type RelayStub } from "../src/mcp-handler";
+import type { JsonRpcRequest, ToolInfo } from "../src/types";
+
+function mockStub(overrides: Partial<RelayStub> = {}): RelayStub {
+  return {
+    getToolList: vi.fn().mockResolvedValue([]),
+    handleToolCall: vi.fn().mockResolvedValue({ success: true }),
+    isMultiLocation: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
+}
+
+function req(method: string, params?: Record<string, unknown>): JsonRpcRequest {
+  return { jsonrpc: "2.0", id: 1, method, params };
+}
+
+// ---------------------------------------------------------------------------
+// initialize
+// ---------------------------------------------------------------------------
+describe("initialize", () => {
+  it("returns server info with protocol version", async () => {
+    const stub = mockStub();
+    const response = await handleMcpRequest(req("initialize"), stub, "lazy");
+
+    expect(response.jsonrpc).toBe("2.0");
+    expect(response.id).toBe(1);
+    expect(response.error).toBeUndefined();
+
+    const result = response.result as Record<string, unknown>;
+    expect(result.protocolVersion).toBe("2025-03-26");
+    const serverInfo = result.serverInfo as Record<string, unknown>;
+    expect(serverInfo.name).toBe("unifi-mcp-relay");
+    expect(serverInfo.version).toBe("1.0.0");
+    expect(serverInfo.websiteUrl).toBe("https://github.com/sirkirby/unifi-mcp");
+    expect(serverInfo.icons).toEqual([
+      expect.objectContaining({
+        src: expect.stringMatching(/^data:image\/svg\+xml,/),
+        mimeType: "image/svg+xml",
+        sizes: ["192x192"],
+      }),
+    ]);
+    expect(result.capabilities).toEqual({ tools: {} });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// notifications/initialized
+// ---------------------------------------------------------------------------
+describe("notifications/initialized", () => {
+  it("returns empty result without calling stub", async () => {
+    const stub = mockStub();
+    const response = await handleMcpRequest(req("notifications/initialized"), stub, "lazy");
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({});
+    expect(stub.getToolList).not.toHaveBeenCalled();
+    expect(stub.handleToolCall).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tools/list
+// ---------------------------------------------------------------------------
+describe("tools/list", () => {
+  it("calls stub.getToolList with the provided mode when single-location", async () => {
+    const tools: ToolInfo[] = [
+      { name: "list_clients", title: "List Clients", description: "List all clients" },
+    ];
+    const stub = mockStub({
+      getToolList: vi.fn().mockResolvedValue(tools),
+      isMultiLocation: vi.fn().mockResolvedValue(false),
+    });
+
+    const response = await handleMcpRequest(req("tools/list"), stub, "eager");
+
+    expect(stub.isMultiLocation).toHaveBeenCalled();
+    expect(stub.getToolList).toHaveBeenCalledWith("eager");
+
+    const result = response.result as Record<string, unknown>;
+    expect(result.tools).toEqual(tools);
+    expect(response.error).toBeUndefined();
+  });
+
+  it("forces lazy mode when multi-location regardless of mode param", async () => {
+    const stub = mockStub({
+      getToolList: vi.fn().mockResolvedValue([]),
+      isMultiLocation: vi.fn().mockResolvedValue(true),
+    });
+
+    await handleMcpRequest(req("tools/list"), stub, "eager");
+
+    expect(stub.getToolList).toHaveBeenCalledWith("lazy");
+  });
+
+  it("uses lazy mode when mode param is already lazy (single-location)", async () => {
+    const stub = mockStub({
+      isMultiLocation: vi.fn().mockResolvedValue(false),
+    });
+
+    await handleMcpRequest(req("tools/list"), stub, "lazy");
+
+    expect(stub.getToolList).toHaveBeenCalledWith("lazy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tools/call
+// ---------------------------------------------------------------------------
+describe("tools/call", () => {
+  it("forwards tool call to stub and wraps result in MCP content format", async () => {
+    const toolResult = { success: true, data: { count: 42 } };
+    const stub = mockStub({
+      handleToolCall: vi.fn().mockResolvedValue(toolResult),
+    });
+
+    const response = await handleMcpRequest(
+      req("tools/call", { name: "list_clients", arguments: { site: "default" } }),
+      stub,
+      "lazy",
+    );
+
+    expect(stub.handleToolCall).toHaveBeenCalledWith("list_clients", { site: "default" });
+    expect(response.error).toBeUndefined();
+
+    const result = response.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+    expect(JSON.parse(content[0].text as string)).toEqual(toolResult);
+  });
+
+  it("defaults arguments to empty object when not provided", async () => {
+    const stub = mockStub();
+
+    await handleMcpRequest(
+      req("tools/call", { name: "list_clients" }),
+      stub,
+      "lazy",
+    );
+
+    expect(stub.handleToolCall).toHaveBeenCalledWith("list_clients", {});
+  });
+
+  it("returns -32000 error when stub throws", async () => {
+    const stub = mockStub({
+      handleToolCall: vi.fn().mockRejectedValue(new Error("Controller unreachable")),
+    });
+
+    const response = await handleMcpRequest(
+      req("tools/call", { name: "list_clients", arguments: {} }),
+      stub,
+      "lazy",
+    );
+
+    expect(response.result).toBeUndefined();
+    const error = response.error as Record<string, unknown>;
+    expect(error.code).toBe(-32000);
+    expect(error.message).toBe("Controller unreachable");
+  });
+
+  it("returns 'Unknown error' when stub throws a non-Error value", async () => {
+    const stub = mockStub({
+      handleToolCall: vi.fn().mockRejectedValue("raw string error"),
+    });
+
+    const response = await handleMcpRequest(
+      req("tools/call", { name: "list_clients", arguments: {} }),
+      stub,
+      "lazy",
+    );
+
+    const error = response.error as Record<string, unknown>;
+    expect(error.code).toBe(-32000);
+    expect(error.message).toBe("Unknown error");
+  });
+
+  it("returns -32602 error when tool name is missing", async () => {
+    const stub = mockStub();
+
+    const response = await handleMcpRequest(
+      req("tools/call", { arguments: { foo: "bar" } }),
+      stub,
+      "lazy",
+    );
+
+    expect(response.result).toBeUndefined();
+    const error = response.error as Record<string, unknown>;
+    expect(error.code).toBe(-32602);
+    expect(error.message).toBe("Missing tool name");
+    expect(stub.handleToolCall).not.toHaveBeenCalled();
+  });
+
+  it("returns -32602 error when params is undefined", async () => {
+    const stub = mockStub();
+
+    const response = await handleMcpRequest(req("tools/call"), stub, "lazy");
+
+    const error = response.error as Record<string, unknown>;
+    expect(error.code).toBe(-32602);
+    expect(error.message).toBe("Missing tool name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown method
+// ---------------------------------------------------------------------------
+describe("unknown method", () => {
+  it("returns -32601 error for an unrecognized method", async () => {
+    const stub = mockStub();
+
+    const response = await handleMcpRequest(req("resources/list"), stub, "lazy");
+
+    expect(response.result).toBeUndefined();
+    const error = response.error as Record<string, unknown>;
+    expect(error.code).toBe(-32601);
+    expect((error.message as string)).toContain("resources/list");
+  });
+});

--- a/apps/worker/worker/test/relay-object.test.ts
+++ b/apps/worker/worker/test/relay-object.test.ts
@@ -1,0 +1,549 @@
+// test/relay-object.test.ts
+//
+// Unit tests for RelayObject pure-logic methods and the RelayStub interface.
+// We cannot instantiate a real Durable Object or use SQLite/WebSockets in
+// vitest (that requires miniflare), so we test the exported pure functions
+// and validate the meta-tool definitions and routing logic indirectly.
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { ToolInfo, AggregatedResponse } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Since RelayObject depends on Cloudflare Durable Object runtime, we extract
+// and test the logic that can be exercised without the DO context.
+// We import the class type for interface verification and test the RelayStub
+// contract through the MCP handler integration.
+// ---------------------------------------------------------------------------
+
+import { handleMcpRequest, type RelayStub } from "../src/mcp-handler";
+import { toolInputSchema, toolServerOrigin } from "../src/tool-info";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal RelayStub mock backed by an in-memory tool map */
+function createMockRelay(
+  locationToolsMap: Map<string, ToolInfo[]> = new Map(),
+): RelayStub & {
+  locationTools: Map<string, ToolInfo[]>;
+  getAggregatedTools: () => ToolInfo[];
+} {
+  const locationTools = locationToolsMap;
+
+  // Build toolToLocations from locationTools
+  const toolToLocations = new Map<string, string[]>();
+  for (const [locId, tools] of locationTools) {
+    for (const tool of tools) {
+      if (!toolToLocations.has(tool.name)) {
+        toolToLocations.set(tool.name, []);
+      }
+      const locs = toolToLocations.get(tool.name)!;
+      if (!locs.includes(locId)) {
+        locs.push(locId);
+      }
+    }
+  }
+
+  function getAggregatedTools(): ToolInfo[] {
+    const seen = new Set<string>();
+    const tools: ToolInfo[] = [];
+    for (const locationToolList of locationTools.values()) {
+      for (const tool of locationToolList) {
+        if (!seen.has(tool.name)) {
+          seen.add(tool.name);
+          tools.push(tool);
+        }
+      }
+    }
+    return tools;
+  }
+
+  const stub: RelayStub & {
+    locationTools: Map<string, ToolInfo[]>;
+    getAggregatedTools: () => ToolInfo[];
+  } = {
+    locationTools,
+    getAggregatedTools,
+
+    async getToolList(mode: string): Promise<ToolInfo[]> {
+      if (mode === "lazy" || mode === "meta_only") {
+        // Return meta-tools
+        return [
+          {
+            name: "unifi_tool_index",
+            title: "UniFi Tool Index",
+            description: "List all available UniFi tools",
+            annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
+          },
+          {
+            name: "unifi_execute",
+            title: "UniFi Execute",
+            description: "Execute a UniFi tool by name",
+            annotations: { readOnlyHint: false, openWorldHint: false },
+          },
+          {
+            name: "unifi_batch",
+            title: "UniFi Batch",
+            description: "Execute multiple UniFi tools in a single request",
+            annotations: { readOnlyHint: false, openWorldHint: false },
+          },
+        ];
+      }
+      return getAggregatedTools();
+    },
+
+    async handleToolCall(
+      toolName: string,
+      args: Record<string, unknown>,
+    ): Promise<Record<string, unknown> | AggregatedResponse> {
+      if (toolName === "unifi_tool_index") {
+        const allTools = getAggregatedTools();
+        const includeSchemas = Boolean(args.include_schemas);
+        let filtered = allTools.map((t) => {
+          const entry: Record<string, unknown> = {
+            name: t.name,
+            description: t.description,
+            locations: toolToLocations.get(t.name) || [],
+            annotations: t.annotations,
+          };
+          if (t.title) {
+            entry.title = t.title;
+          }
+          if (includeSchemas && t.inputSchema) {
+            entry.inputSchema = t.inputSchema;
+          }
+          return entry;
+        });
+        const category = args.category as string | undefined;
+        const search = args.search as string | undefined;
+        if (category) {
+          const cat = category.toLowerCase();
+          filtered = filtered.filter(
+            (t) =>
+              (t.name as string).toLowerCase().includes(cat) ||
+              (t.description as string).toLowerCase().includes(cat),
+          );
+        }
+        if (search) {
+          const term = search.toLowerCase();
+          filtered = filtered.filter(
+            (t) =>
+              (t.name as string).toLowerCase().includes(term) ||
+              (t.description as string).toLowerCase().includes(term),
+          );
+        }
+        return { success: true, data: { tools: filtered, total: filtered.length, multi_location: locationTools.size > 1 } };
+      }
+      return { success: false, error: `Tool not found: ${toolName}` };
+    },
+
+    async isMultiLocation(): Promise<boolean> {
+      return locationTools.size > 1;
+    },
+  };
+
+  return stub;
+}
+
+function sampleTools(): ToolInfo[] {
+  return [
+    {
+      name: "list_clients",
+      title: "List Clients",
+      description: "List all connected clients",
+      inputSchema: { type: "object", properties: { site: { type: "string" } } },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    },
+    {
+      name: "list_devices",
+      title: "List Devices",
+      description: "List all network devices",
+      inputSchema: { type: "object", properties: { type: { type: "string" } } },
+      annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
+    },
+    {
+      name: "restart_device",
+      title: "Restart Device",
+      description: "Restart a network device",
+      inputSchema: { type: "object", properties: { mac: { type: "string" } } },
+      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
+    },
+  ];
+}
+
+function relayRegisterFixture(): Record<string, unknown> {
+  const fixturePath = fileURLToPath(
+    String(new URL("../../../../tests/fixtures/relay_register_with_metadata.json", import.meta.url)),
+  );
+  return JSON.parse(
+    readFileSync(fixturePath, "utf8"),
+  ) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// getAggregatedTools
+// ---------------------------------------------------------------------------
+describe("getAggregatedTools", () => {
+  it("returns empty array when no locations are registered", () => {
+    const relay = createMockRelay(new Map());
+    expect(relay.getAggregatedTools()).toEqual([]);
+  });
+
+  it("returns all tools from a single location", () => {
+    const tools = sampleTools();
+    const relay = createMockRelay(new Map([["loc-1", tools]]));
+    const result = relay.getAggregatedTools();
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.name)).toEqual(["list_clients", "list_devices", "restart_device"]);
+    expect(result.map((t) => t.title)).toEqual(["List Clients", "List Devices", "Restart Device"]);
+  });
+
+  it("deduplicates tools that appear in multiple locations", () => {
+    const tools1: ToolInfo[] = [
+      { name: "list_clients", description: "List all connected clients" },
+      { name: "list_devices", description: "List all network devices" },
+    ];
+    const tools2: ToolInfo[] = [
+      { name: "list_clients", description: "List all connected clients" },
+      { name: "get_system_info", description: "Get system information" },
+    ];
+
+    const relay = createMockRelay(
+      new Map([
+        ["loc-1", tools1],
+        ["loc-2", tools2],
+      ]),
+    );
+
+    const result = relay.getAggregatedTools();
+    expect(result).toHaveLength(3);
+    const names = result.map((t) => t.name);
+    expect(names).toContain("list_clients");
+    expect(names).toContain("list_devices");
+    expect(names).toContain("get_system_info");
+  });
+
+  it("keeps the first occurrence when tools are duplicated across locations", () => {
+    const tools1: ToolInfo[] = [{ name: "list_clients", description: "From location 1" }];
+    const tools2: ToolInfo[] = [{ name: "list_clients", description: "From location 2" }];
+
+    const relay = createMockRelay(
+      new Map([
+        ["loc-1", tools1],
+        ["loc-2", tools2],
+      ]),
+    );
+
+    const result = relay.getAggregatedTools();
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe("From location 1");
+  });
+
+  it("keeps title metadata when tools are aggregated", () => {
+    const relay = createMockRelay(
+      new Map([["loc-1", [{ name: "list_clients", title: "List Clients", description: "List clients" }]]]),
+    );
+
+    expect(relay.getAggregatedTools()[0].title).toBe("List Clients");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Python relay wire contract
+// ---------------------------------------------------------------------------
+describe("Python relay wire contract", () => {
+  it("accepts relay register tool metadata fields serialized as snake_case", () => {
+    const fixture = relayRegisterFixture();
+    const tools = fixture.tools as ToolInfo[];
+    const tool = tools[0];
+
+    expect(tool.title).toBe("List Devices");
+    expect(toolInputSchema(tool)).toEqual({ type: "object", properties: { site: { type: "string" } } });
+    expect(toolServerOrigin(tool)).toBe("unifi-network-mcp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getToolList
+// ---------------------------------------------------------------------------
+describe("getToolList", () => {
+  it("returns meta-tools in lazy mode", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+    const tools = await relay.getToolList("lazy");
+
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("unifi_tool_index");
+    expect(names).toContain("unifi_execute");
+    expect(names).toContain("unifi_batch");
+    expect(tools.find((tool) => tool.name === "unifi_tool_index")?.title).toBe("UniFi Tool Index");
+  });
+
+  it("returns meta-tools in meta_only mode", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+    const tools = await relay.getToolList("meta_only");
+
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("unifi_tool_index");
+    expect(names).toContain("unifi_execute");
+    expect(names).toContain("unifi_batch");
+  });
+
+  it("returns all aggregated tools in eager mode", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+    const tools = await relay.getToolList("eager");
+
+    expect(tools).toHaveLength(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("list_clients");
+    expect(names).toContain("list_devices");
+    expect(names).toContain("restart_device");
+  });
+
+  it("returns deduplicated tools in eager mode for multi-location", async () => {
+    const tools1: ToolInfo[] = [{ name: "list_clients", description: "List clients" }];
+    const tools2: ToolInfo[] = [
+      { name: "list_clients", description: "List clients" },
+      { name: "list_devices", description: "List devices" },
+    ];
+
+    const relay = createMockRelay(
+      new Map([
+        ["loc-1", tools1],
+        ["loc-2", tools2],
+      ]),
+    );
+
+    const tools = await relay.getToolList("eager");
+    expect(tools).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMultiLocation
+// ---------------------------------------------------------------------------
+describe("isMultiLocation", () => {
+  it("returns false when no locations are registered", async () => {
+    const relay = createMockRelay(new Map());
+    expect(await relay.isMultiLocation()).toBe(false);
+  });
+
+  it("returns false for a single location", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+    expect(await relay.isMultiLocation()).toBe(false);
+  });
+
+  it("returns true for multiple locations", async () => {
+    const relay = createMockRelay(
+      new Map([
+        ["loc-1", [{ name: "list_clients", description: "List clients" }]],
+        ["loc-2", [{ name: "list_devices", description: "List devices" }]],
+      ]),
+    );
+    expect(await relay.isMultiLocation()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP handler integration with RelayStub
+// ---------------------------------------------------------------------------
+describe("MCP handler with relay stub", () => {
+  it("tools/list forces lazy mode for multi-location", async () => {
+    const relay = createMockRelay(
+      new Map([
+        ["loc-1", sampleTools()],
+        ["loc-2", sampleTools()],
+      ]),
+    );
+
+    const spyGetToolList = vi.spyOn(relay, "getToolList");
+
+    const response = await handleMcpRequest(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      relay,
+      "eager",
+    );
+
+    // Multi-location should force lazy mode regardless of the mode param
+    expect(spyGetToolList).toHaveBeenCalledWith("lazy");
+    expect(response.error).toBeUndefined();
+
+    const result = response.result as Record<string, unknown>;
+    const tools = result.tools as ToolInfo[];
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.name)).toContain("unifi_tool_index");
+  });
+
+  it("tools/list uses the configured mode for single location", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+    const spyGetToolList = vi.spyOn(relay, "getToolList");
+
+    await handleMcpRequest(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      relay,
+      "eager",
+    );
+
+    expect(spyGetToolList).toHaveBeenCalledWith("eager");
+  });
+
+  it("tools/call dispatches unifi_tool_index and returns tool catalog", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+
+    const response = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "unifi_tool_index", arguments: {} },
+      },
+      relay,
+      "lazy",
+    );
+
+    expect(response.error).toBeUndefined();
+    const result = response.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(1);
+
+    const parsed = JSON.parse(content[0].text as string);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.tools).toHaveLength(3);
+    expect(parsed.data.tools[0].title).toBe("List Clients");
+    expect(parsed.data.multi_location).toBe(false);
+  });
+
+  it("unifi_tool_index omits schemas by default", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+
+    const response = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "unifi_tool_index", arguments: {} },
+      },
+      relay,
+      "lazy",
+    );
+
+    const result = response.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    const parsed = JSON.parse(content[0].text as string);
+    const tools = parsed.data.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(3);
+    for (const tool of tools) {
+      expect(tool.inputSchema).toBeUndefined();
+    }
+  });
+
+  it("unifi_tool_index includes schemas when include_schemas=true", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+
+    const response = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "unifi_tool_index", arguments: { include_schemas: true } },
+      },
+      relay,
+      "lazy",
+    );
+
+    const result = response.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    const parsed = JSON.parse(content[0].text as string);
+    const tools = parsed.data.tools as Array<Record<string, unknown>>;
+    expect(tools).toHaveLength(3);
+    for (const tool of tools) {
+      expect(tool.inputSchema).toBeDefined();
+    }
+  });
+
+  it("unifi_tool_index category filter narrows results", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+
+    const response = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "unifi_tool_index", arguments: { search: "client" } },
+      },
+      relay,
+      "lazy",
+    );
+
+    const result = response.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    const parsed = JSON.parse(content[0].text as string);
+    expect(parsed.data.tools).toHaveLength(1);
+    expect(parsed.data.tools[0].name).toBe("list_clients");
+  });
+
+  it("tools/call returns error for unknown tool", async () => {
+    const relay = createMockRelay(new Map([["loc-1", sampleTools()]]));
+
+    const response = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "nonexistent_tool", arguments: {} },
+      },
+      relay,
+      "lazy",
+    );
+
+    expect(response.error).toBeUndefined();
+    const result = response.result as Record<string, unknown>;
+    const content = result.content as Array<Record<string, unknown>>;
+    const parsed = JSON.parse(content[0].text as string);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain("not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Meta-tool definitions validation
+// ---------------------------------------------------------------------------
+describe("meta-tool definitions", () => {
+  it("all three meta-tools have valid annotations", async () => {
+    const relay = createMockRelay(new Map());
+    const tools = await relay.getToolList("lazy");
+
+    for (const tool of tools) {
+      expect(tool.annotations).toBeDefined();
+      expect(typeof tool.annotations!.readOnlyHint).toBe("boolean");
+    }
+  });
+
+  it("unifi_tool_index is read-only", async () => {
+    const relay = createMockRelay(new Map());
+    const tools = await relay.getToolList("lazy");
+    const index = tools.find((t) => t.name === "unifi_tool_index");
+
+    expect(index).toBeDefined();
+    expect(index!.annotations?.readOnlyHint).toBe(true);
+    expect(index!.annotations?.idempotentHint).toBe(true);
+  });
+
+  it("unifi_execute and unifi_batch are not read-only", async () => {
+    const relay = createMockRelay(new Map());
+    const tools = await relay.getToolList("lazy");
+
+    const execute = tools.find((t) => t.name === "unifi_execute");
+    const batch = tools.find((t) => t.name === "unifi_batch");
+
+    expect(execute).toBeDefined();
+    expect(execute!.annotations?.readOnlyHint).toBe(false);
+
+    expect(batch).toBeDefined();
+    expect(batch!.annotations?.readOnlyHint).toBe(false);
+  });
+});

--- a/apps/worker/worker/test/types.test.ts
+++ b/apps/worker/worker/test/types.test.ts
@@ -1,0 +1,51 @@
+// test/types.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  PROTOCOL_VERSION,
+  TOOL_CALL_TIMEOUT_MS,
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_ACK_TIMEOUT_MS,
+  PROJECT_WEBSITE_URL,
+  RELAY_SERVER_ICONS,
+} from "../src/types";
+
+describe("types constants", () => {
+  it("PROTOCOL_VERSION is 1", () => {
+    expect(PROTOCOL_VERSION).toBe(1);
+  });
+
+  it("TOOL_CALL_TIMEOUT_MS is 30_000", () => {
+    expect(TOOL_CALL_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it("HEARTBEAT_INTERVAL_MS is 30_000", () => {
+    expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
+  });
+
+  it("HEARTBEAT_ACK_TIMEOUT_MS is 10_000", () => {
+    expect(HEARTBEAT_ACK_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("constants are positive integers", () => {
+    for (const c of [
+      PROTOCOL_VERSION,
+      TOOL_CALL_TIMEOUT_MS,
+      HEARTBEAT_INTERVAL_MS,
+      HEARTBEAT_ACK_TIMEOUT_MS,
+    ]) {
+      expect(c).toBeGreaterThan(0);
+      expect(Number.isInteger(c)).toBe(true);
+    }
+  });
+
+  it("relay MCP metadata constants are stable and self-contained", () => {
+    expect(PROJECT_WEBSITE_URL).toBe("https://github.com/sirkirby/unifi-mcp");
+    expect(RELAY_SERVER_ICONS).toEqual([
+      expect.objectContaining({
+        src: expect.stringMatching(/^data:image\/svg\+xml,/),
+        mimeType: "image/svg+xml",
+        sizes: ["192x192"],
+      }),
+    ]);
+  });
+});

--- a/apps/worker/worker/tsconfig.json
+++ b/apps/worker/worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/apps/worker/worker/vitest.config.ts
+++ b/apps/worker/worker/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/apps/worker/worker/wrangler.toml
+++ b/apps/worker/worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "unifi-mcp-relay"
+main = "src/index.ts"
+compatibility_date = "2025-03-14"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+TOOL_REGISTRATION_MODE = "lazy"
+
+[durable_objects]
+bindings = [{ name = "RELAY", class_name = "RelayObject" }]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RelayObject"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,6 +9,7 @@ unifi-mcp/
     protect/              # UniFi Protect MCP server
     access/               # UniFi Access MCP server
     api/                  # REST + GraphQL API server
+    worker/               # Cloudflare Worker gateway + npm CLI
   packages/
     unifi-core/           # Shared UniFi controller connectivity
     unifi-mcp-shared/     # Shared MCP server patterns
@@ -17,7 +18,7 @@ unifi-mcp/
   docker/                 # Docker compose for servers and relay
 ```
 
-The workspace is managed by [uv](https://docs.astral.sh/uv/) with `pyproject.toml` at the root defining workspace members. Each app and package is an independent Python package with its own `pyproject.toml`.
+The Python workspace is managed by [uv](https://docs.astral.sh/uv/) with `pyproject.toml` at the root defining workspace members. Each Python app and package is independent with its own `pyproject.toml`. `apps/worker/` is excluded from the uv workspace and keeps its own Node/npm dependency graph.
 
 ## Package Responsibilities
 
@@ -115,6 +116,21 @@ A standalone sidecar that bridges local MCP servers to a Cloudflare Worker relay
 - `Dockerfile` -- container build
 
 The relay has **no dependency** on the MCP server packages (`unifi-core`, `unifi-mcp-shared`, or any `apps/*`). It is a pure MCP client that discovers tools via the standard MCP protocol.
+
+### apps/worker
+
+The Cloudflare Worker gateway and npm CLI used by cloud agents. The TypeScript Worker receives MCP JSON-RPC over HTTPS, routes tool calls through a Durable Object, and forwards them to connected local relay sidecars over WebSocket. The plain ESM CLI deploys and manages the Worker with Wrangler.
+
+- `bin/cli.mjs` -- npm CLI entry point
+- `src/commands/` -- install, upgrade, token rotation, location management, status, and destroy commands
+- `src/lib/` -- CLI support code for config, Wrangler, API calls, token generation, and display
+- `worker/src/` -- Cloudflare Worker and Durable Object TypeScript code
+- `worker/test/` -- Vitest tests for Worker protocol/auth behavior
+- `test/cli/` -- Node test runner coverage for CLI utilities
+- `package.json` and `package-lock.json` -- npm package for the published CLI
+- `worker/package.json` and `worker/package-lock.json` -- isolated Worker build/test dependencies
+
+The Worker intentionally remains a self-contained Node/TypeScript app. It lives in the monorepo so relay protocol changes, MCP metadata changes, and worker contract tests land in the same PR.
 
 ## Layering
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Used by: `apps/network`, `apps/protect`, `apps/access`.
 
 ### apps/network
 
-The UniFi Network MCP server. 91 tools across 16 categories covering firewall, clients, devices, networks, VPNs, routing, stats, and more.
+The UniFi Network MCP server. 169 tools across 21 categories covering firewall, clients, devices, networks, VPNs, routing, stats, and more.
 
 - `src/unifi_network_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch
@@ -69,7 +69,7 @@ The UniFi Network MCP server. 91 tools across 16 categories covering firewall, c
 
 ### apps/protect
 
-The UniFi Protect MCP server. 38 tools across 7 categories covering cameras, events, recordings, devices (lights/sensors/chimes), liveviews, system status, and the Alarm Manager. Connects via `uiprotect` (pyunifiprotect) for websocket-based real-time event streaming.
+The UniFi Protect MCP server. 43 tools across 8 categories covering cameras, events, recordings, devices (lights/sensors/chimes), liveviews, system status, and the Alarm Manager. Connects via `uiprotect` (pyunifiprotect) for websocket-based real-time event streaming.
 
 - `src/unifi_protect_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Complete documentation for the UniFi Network MCP Server v0.2.0.
+Complete documentation for the UniFi MCP ecosystem.
 
 ---
 
@@ -8,13 +8,16 @@ Complete documentation for the UniFi Network MCP Server v0.2.0.
 
 - **[Main README](../README.md)** - Project overview and installation
 - **[Quick Start](../QUICKSTART.md)** - Get started in 5 minutes
+- **[Architecture](ARCHITECTURE.md)** - Monorepo layout and package responsibilities
+- **[Worker Gateway](../apps/worker/)** - Cloudflare Worker gateway and npm CLI
+- **[Relay Sidecar](../packages/unifi-mcp-relay/)** - Local sidecar for cloud relay mode
 - **[Sponsor UniFi MCP](sponsor/)** - Support maintenance, AI costs, compatibility testing, and releases
 
 ---
 
-## Lazy Tool Loading ⭐ NEW!
+## Lazy Tool Loading
 
-**96% token savings with seamless UX**
+Lazy mode is the default for MCP servers and keeps initial tool context small.
 
 The server now supports three tool registration modes:
 
@@ -85,7 +88,7 @@ Complete guide to the permission system:
 ### Environment Variables
 
 ```bash
-# Tool registration mode (v0.2.0+)
+# Tool registration mode
 UNIFI_TOOL_REGISTRATION_MODE=lazy  # lazy (default), eager, meta_only
 
 # UniFi controller connection
@@ -103,7 +106,16 @@ UNIFI_MCP_HTTP_ENABLED=false
 UNIFI_MCP_DIAGNOSTICS=false
 ```
 
-Full configuration details in [config.yaml](../src/config/config.yaml).
+Full Network server defaults are in [config.yaml](../apps/network/src/unifi_network_mcp/config/config.yaml). Protect and Access keep their own defaults under `apps/protect/` and `apps/access/`.
+
+### Worker and Relay
+
+The cloud relay path has two packages:
+
+- `apps/worker/`: the TypeScript Cloudflare Worker gateway and published `unifi-mcp-worker` npm CLI
+- `packages/unifi-mcp-relay/`: the Python sidecar that connects local MCP servers to the Worker over WebSocket
+
+Use `make sync` in a source checkout to install both the Python workspace and worker npm dependencies.
 
 ---
 
@@ -152,4 +164,4 @@ See [CLAUDE.md](../CLAUDE.md) for project development guidelines.
 - **MCP Specification:** https://spec.modelcontextprotocol.io/
 - **FastMCP Documentation:** https://gofastmcp.com/
 - **UniFi Controller API:** https://ubntwiki.com/products/software/unifi-controller/api
-- **GitHub Repository:** https://github.com/sirkirby/unifi-network-mcp
+- **GitHub Repository:** https://github.com/sirkirby/unifi-mcp

--- a/docs/index.html
+++ b/docs/index.html
@@ -372,7 +372,7 @@
         </ul>
         <div style="margin-top: 24px; display: flex; gap: 12px; flex-wrap: wrap;">
           <a href="https://github.com/sirkirby/unifi-mcp/tree/main/packages/unifi-mcp-relay" class="btn btn-ghost">Relay sidecar <span class="ver-chip" data-pkg-version="unifi-mcp-relay" style="margin:0 2px 0 4px;"></span> →</a>
-          <a href="https://github.com/sirkirby/unifi-mcp-worker" class="btn btn-ghost">Worker gateway <span class="ver-chip" data-npm-version="unifi-mcp-worker" style="margin:0 2px 0 4px;"></span> →</a>
+          <a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/worker" class="btn btn-ghost">Worker gateway <span class="ver-chip" data-npm-version="unifi-mcp-worker" style="margin:0 2px 0 4px;"></span> →</a>
         </div>
       </div>
 

--- a/packages/unifi-mcp-relay/README.md
+++ b/packages/unifi-mcp-relay/README.md
@@ -1,6 +1,6 @@
 # UniFi MCP Relay
 
-A sidecar process that bridges locally-hosted MCP servers to a [Cloudflare Worker relay gateway](https://github.com/sirkirby/unifi-mcp-worker), enabling cloud agents (Claude, ChatGPT connectors, n8n, etc.) to access your UniFi MCP tools without exposing local ports.
+A sidecar process that bridges locally-hosted MCP servers to the [Cloudflare Worker relay gateway](https://github.com/sirkirby/unifi-mcp/tree/main/apps/worker), enabling cloud agents (Claude, ChatGPT connectors, n8n, etc.) to access your UniFi MCP tools without exposing local ports.
 
 ## How It Works
 

--- a/packages/unifi-mcp-relay/tests/test_protocol.py
+++ b/packages/unifi-mcp-relay/tests/test_protocol.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from unifi_mcp_relay.protocol import (
     PROTOCOL_VERSION,
@@ -10,6 +11,8 @@ from unifi_mcp_relay.protocol import (
     ToolResultMessage,
     parse_message,
 )
+
+FIXTURES_DIR = Path(__file__).resolve().parents[3] / "tests" / "fixtures"
 
 
 def test_register_message_serialization():
@@ -29,6 +32,22 @@ def test_register_message_serialization():
     assert len(data["tools"]) == 1
     assert data["tools"][0]["name"] == "list_devices"
     assert data["tools"][0]["title"] == "List Devices"
+
+
+def test_register_message_matches_worker_contract_fixture():
+    tool = ToolInfo(
+        name="list_devices",
+        title="List Devices",
+        description="List devices",
+        input_schema={"type": "object", "properties": {"site": {"type": "string"}}},
+        annotations={"readOnlyHint": True, "openWorldHint": False},
+        server_origin="unifi-network-mcp",
+    )
+    msg = RegisterMessage(token="test-token", location_name="Home Lab", tools=[tool], capabilities=["fan_out_v1"])
+
+    fixture = json.loads((FIXTURES_DIR / "relay_register_with_metadata.json").read_text())
+
+    assert json.loads(msg.to_json()) == fixture
 
 
 def test_parse_registered_message():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ members = [
     "apps/*",
     "packages/*",
 ]
+exclude = [
+    "apps/worker",
+]
 
 [tool.ruff]
 line-length = 120

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -45,6 +45,7 @@ class PackageConfig:
     install_command: str
     path_groups: tuple[PathGroup, ...]
     legacy_plain_v_tags: bool = False
+    badge_markdown: str | None = None
 
 
 @dataclass(frozen=True)
@@ -183,11 +184,29 @@ APP_CONFIGS = {
             ),
         ),
     ),
+    "worker": PackageConfig(
+        key="worker",
+        display_name="UniFi MCP Worker",
+        pypi_package="unifi-mcp-worker",
+        install_command="npm install -g unifi-mcp-worker@{version}",
+        path_groups=(
+            PathGroup("Worker", ("apps/worker/",)),
+            PathGroup(
+                "Release Infrastructure",
+                (
+                    ".github/workflows/release-worker.yml",
+                    ".github/workflows/test-worker.yml",
+                ),
+            ),
+        ),
+        badge_markdown="[![npm](https://img.shields.io/npm/v/unifi-mcp-worker)]"
+        "(https://www.npmjs.com/package/unifi-mcp-worker/v/{version})",
+    ),
 }
 
 PRIMARY_PATTERNS_BY_PACKAGE = {config.key: config.path_groups[0].patterns for config in APP_CONFIGS.values()}
 PACKAGE_KEYWORDS = tuple(APP_CONFIGS)
-PRODUCT_KEYS = ("network", "protect", "access", "relay")
+PRODUCT_KEYS = ("network", "protect", "access", "relay", "worker")
 
 
 def run_git(args: list[str]) -> str:
@@ -199,7 +218,10 @@ def run_git(args: list[str]) -> str:
 def parse_release_tag(tag: str) -> ReleaseTag:
     """Parse a package release tag such as ``network/v0.14.12``."""
 
-    match = re.match(r"^(?P<key>network|protect|access|core|shared|relay)/v(?P<version>\d+(?:\.\d+)*(?:\S*)?)$", tag)
+    match = re.match(
+        r"^(?P<key>network|protect|access|core|shared|relay|worker)/v(?P<version>\d+(?:\.\d+)*(?:\S*)?)$",
+        tag,
+    )
     if match:
         return ReleaseTag(tag=tag, package_key=match.group("key"), version=match.group("version"))
 
@@ -334,7 +356,9 @@ def render_release_notes(
         config.install_command.format(version=release_tag.version),
         "```",
         "",
-        f"[![PyPI](https://img.shields.io/pypi/v/{config.pypi_package})]"
+        config.badge_markdown.format(version=release_tag.version)
+        if config.badge_markdown
+        else f"[![PyPI](https://img.shields.io/pypi/v/{config.pypi_package})]"
         f"(https://pypi.org/project/{config.pypi_package}/{release_tag.version}/)",
         "",
         "## What's Changed",

--- a/tests/fixtures/relay_register_with_metadata.json
+++ b/tests/fixtures/relay_register_with_metadata.json
@@ -1,0 +1,29 @@
+{
+  "type": "register",
+  "protocol_version": 1,
+  "token": "test-token",
+  "location_name": "Home Lab",
+  "tools": [
+    {
+      "name": "list_devices",
+      "title": "List Devices",
+      "description": "List devices",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "site": {
+            "type": "string"
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false
+      },
+      "server_origin": "unifi-network-mcp"
+    }
+  ],
+  "capabilities": [
+    "fan_out_v1"
+  ]
+}

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -33,6 +33,12 @@ class TestParseReleaseTag:
         assert tag.package_key == "relay"
         assert tag.version == "0.1.3"
 
+    def test_worker_tag(self):
+        tag = parse_release_tag("worker/v1.3.1")
+
+        assert tag.package_key == "worker"
+        assert tag.version == "1.3.1"
+
     def test_legacy_plain_tag_maps_to_network(self):
         tag = parse_release_tag("v0.7.0")
 
@@ -108,6 +114,27 @@ class TestClassifyCommit:
 
         assert classify_commit(commit, APP_CONFIGS["network"]) is None
 
+    def test_worker_commit_matches_worker_group(self):
+        commit = CommitInfo(
+            sha="abc123",
+            subject="fix(worker): preserve tool titles",
+            files=("apps/worker/worker/src/relay-object.ts",),
+        )
+
+        classified = classify_commit(commit, APP_CONFIGS["worker"])
+
+        assert classified is not None
+        assert classified.group_title == "Worker"
+
+    def test_worker_commit_does_not_match_relay(self):
+        commit = CommitInfo(
+            sha="abc123",
+            subject="fix(worker): preserve tool titles",
+            files=("apps/worker/worker/src/relay-object.ts",),
+        )
+
+        assert classify_commit(commit, APP_CONFIGS["relay"]) is None
+
 
 class TestClassifyCommits:
     def test_splits_relevant_and_omitted(self):
@@ -173,3 +200,13 @@ class TestRendering:
 
         assert "No package-scoped code changes were detected" in notes
         assert "commits/core/v0.1.0" in notes
+
+    def test_render_worker_uses_npm_install_and_badge(self):
+        config = APP_CONFIGS["worker"]
+        release_tag = ReleaseTag(tag="worker/v1.3.1", package_key="worker", version="1.3.1")
+
+        notes = render_release_notes(release_tag, config, None, [], [])
+
+        assert "npm install -g unifi-mcp-worker@1.3.1" in notes
+        assert "https://img.shields.io/npm/v/unifi-mcp-worker" in notes
+        assert "https://www.npmjs.com/package/unifi-mcp-worker/v/1.3.1" in notes


### PR DESCRIPTION
## Summary
- import the self-contained TypeScript Worker CLI and Cloudflare Worker under `apps/worker`
- add root worker make targets, uv workspace exclusion, git ignores, and worker test/release workflows
- wire worker releases into the monorepo tag model with `worker/v*` tags, npm publish, and release-note generation
- add a shared relay/worker metadata fixture and teach the worker to preserve relay snake_case metadata fields
- update repo docs, architecture notes, contribution guidance, and release guidance for the worker app

## Verification
- `uv sync --all-packages --dry-run`
- `uv run ruff format . && uv run ruff check .`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'`\n- `uv run pytest tests/test_generate_release_notes.py packages/unifi-mcp-relay/tests/test_protocol.py -q`\n- `make worker-check`\n- `npm pack --dry-run` from `apps/worker`\n- `make check-generated`\n- `uv lock --check`\n- `make ci`\n\n## Notes\n- `npm ci` reports the existing Worker dependency audit surface: 1 moderate and 2 high vulnerabilities. I left that out of scope for this migration.\n- The old `/Users/chris/Repos/unifi-mcp-worker` checkout still has unrelated local `.myco`/`AGENTS.md` changes; this PR does not depend on or modify those local changes.