### PR TITLE
chore: use uv for Python Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@
 
 version: 2
 updates:
-  # Python dependencies (pyproject.toml)
-  - package-ecosystem: "pip"
+  # Python dependencies (uv.lock + pyproject.toml workspace)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -78,6 +78,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Keep these majors explicit: they affect the compiler/test surface or
+      # must match the Node version used by CI and the worker release workflow.
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "vitest"
+        update-types:
+          - "version-update:semver-major"
 
   # Docker base images
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary
- switch Python Dependabot version updates from `pip` to the GitHub-supported `uv` ecosystem so updates operate against the uv workspace/lockfile
- keep Worker compiler/test major bumps explicit rather than automatic weekly Dependabot PRs

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot yaml ok"'`\n\n## Notes\n- GitHub documents `uv` as a supported Dependabot ecosystem. Astral also recommends `package-ecosystem: "uv"` for projects using `uv.lock`.\n- The already-open Worker runtime minor/patch PR was merged separately as #263.