### PR TITLE
fix: negotiate relay MCP protocol version

### DIFF
--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
@@ -22,10 +22,14 @@ from importlib.metadata import PackageNotFoundError, version
 
 import aiohttp
 from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL, mcp_icons_for_server
+from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
 
 from unifi_mcp_relay.protocol import ToolInfo
 
 logger = logging.getLogger("unifi-mcp-relay")
+
+LEGACY_MCP_PROTOCOL_REVISION = "2025-03-26"
+SUPPORTED_MCP_PROTOCOL_REVISIONS = frozenset({DEFAULT_MCP_PROTOCOL_REVISION, LEGACY_MCP_PROTOCOL_REVISION})
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -39,6 +43,7 @@ class ServerInfo:
     name: str
     url: str
     session_id: str | None = None
+    protocol_version: str | None = None
     tools: list[ToolInfo] = field(default_factory=list)
 
 
@@ -54,20 +59,63 @@ class McpHttpClient:
     the MCP Streamable HTTP transport spec.
     """
 
-    def __init__(self, server_url: str, session_id: str | None = None) -> None:
+    def __init__(
+        self,
+        server_url: str,
+        session_id: str | None = None,
+        protocol_version: str | None = None,
+    ) -> None:
         self._base_url = server_url.rstrip("/") + "/mcp"
         self._session: aiohttp.ClientSession | None = None
         self._session_id: str | None = session_id
+        self._protocol_version: str | None = protocol_version
         self._request_id: int = 0
 
     @property
     def session_id(self) -> str | None:
         return self._session_id
 
+    @property
+    def protocol_version(self) -> str | None:
+        return self._protocol_version
+
+    def _set_negotiated_protocol_version(self, value: str | None) -> None:
+        if value is None:
+            self._protocol_version = LEGACY_MCP_PROTOCOL_REVISION
+            logger.info(
+                "[discovery] Server omitted protocolVersion during initialize; using compatibility fallback %s",
+                self._protocol_version,
+            )
+            return
+
+        if value not in SUPPORTED_MCP_PROTOCOL_REVISIONS:
+            raise RuntimeError(
+                f"Unsupported MCP protocol version negotiated by server: {value!r}. "
+                f"Supported versions: {sorted(SUPPORTED_MCP_PROTOCOL_REVISIONS)}"
+            )
+
+        self._protocol_version = value
+        if value != DEFAULT_MCP_PROTOCOL_REVISION:
+            logger.info(
+                "[discovery] Server negotiated older MCP protocol version %s; preserving compatibility",
+                value,
+            )
+
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
         return self._session
+
+    def _headers(self, *, include_protocol_version: bool) -> dict[str, str]:
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self._session_id:
+            headers["MCP-Session-Id"] = self._session_id
+        if include_protocol_version and self._protocol_version:
+            headers["MCP-Protocol-Version"] = self._protocol_version
+        return headers
 
     async def request(self, method: str, params: dict | None = None) -> dict:
         """Send a JSON-RPC request to the MCP server.
@@ -94,12 +142,7 @@ class McpHttpClient:
         if params is not None:
             payload["params"] = params
 
-        headers: dict[str, str] = {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-        }
-        if self._session_id:
-            headers["Mcp-Session-Id"] = self._session_id
+        headers = self._headers(include_protocol_version=method != "initialize")
 
         async with session.post(self._base_url, json=payload, headers=headers) as resp:
             # Capture session ID from response
@@ -128,7 +171,11 @@ class McpHttpClient:
         if "error" in data:
             raise RuntimeError(f"MCP error: {data['error']}")
 
-        return data.get("result", {})
+        result = data.get("result", {})
+        if method == "initialize":
+            self._set_negotiated_protocol_version(result.get("protocolVersion"))
+
+        return result
 
     async def notify(self, method: str, params: dict | None = None) -> None:
         """Send a JSON-RPC notification (no id, no response expected)."""
@@ -141,12 +188,7 @@ class McpHttpClient:
         if params is not None:
             payload["params"] = params
 
-        headers: dict[str, str] = {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-        }
-        if self._session_id:
-            headers["Mcp-Session-Id"] = self._session_id
+        headers = self._headers(include_protocol_version=True)
 
         async with session.post(self._base_url, json=payload, headers=headers) as resp:
             if "mcp-session-id" in resp.headers:
@@ -244,7 +286,7 @@ async def discover_tools(server_url: str) -> ServerInfo | None:
         init_result = await client.request(
             "initialize",
             {
-                "protocolVersion": "2025-03-26",
+                "protocolVersion": DEFAULT_MCP_PROTOCOL_REVISION,
                 "capabilities": {},
                 "clientInfo": {
                     "name": "unifi-mcp-relay",
@@ -301,6 +343,7 @@ async def discover_tools(server_url: str) -> ServerInfo | None:
             name=server_name,
             url=server_url,
             session_id=client.session_id,
+            protocol_version=client.protocol_version,
             tools=tools,
         )
         logger.info("[discovery] Discovered %d tools from %s (%s)", len(tools), server_name, server_url)

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
@@ -25,7 +25,11 @@ class ToolForwarder:
             for tool in info.tools:
                 self._tool_to_url[tool.name] = info.url
             if info.url not in self._clients:
-                self._clients[info.url] = McpHttpClient(info.url, session_id=info.session_id)
+                self._clients[info.url] = McpHttpClient(
+                    info.url,
+                    session_id=info.session_id,
+                    protocol_version=info.protocol_version,
+                )
 
     def get_server_url(self, tool_name: str) -> str | None:
         """Return the server URL responsible for the given tool, or None if unknown."""
@@ -51,7 +55,8 @@ class ToolForwarder:
             arguments: Tool arguments dict.
 
         Returns:
-            Parsed result: JSON-decoded text from content[0] if present, else raw result dict.
+        Parsed result: structuredContent when present, JSON-decoded text
+        from content[0] if present, else raw result dict.
 
         Raises:
             RuntimeError: If no client is registered for the given server URL.
@@ -61,6 +66,9 @@ class ToolForwarder:
         if not client:
             raise RuntimeError(f"No client for {server_url}")
         result = await client.request("tools/call", {"name": tool_name, "arguments": arguments})
+        structured = result.get("structuredContent")
+        if isinstance(structured, dict):
+            return structured
         content = result.get("content", [])
         if content and content[0].get("type") == "text":
             raw_text = content[0].get("text", "")

--- a/packages/unifi-mcp-relay/tests/test_discovery.py
+++ b/packages/unifi-mcp-relay/tests/test_discovery.py
@@ -7,6 +7,8 @@ from importlib.metadata import version
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from unifi_mcp_relay.discovery import LEGACY_MCP_PROTOCOL_REVISION, McpHttpClient
+from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
 
 
 @pytest.fixture
@@ -19,10 +21,118 @@ def mock_mcp_client():
         mock_instance.request = AsyncMock(side_effect=side_effect_fn)
         mock_instance.close = AsyncMock()
         mock_instance.session_id = "session-abc-123"
+        mock_instance.protocol_version = LEGACY_MCP_PROTOCOL_REVISION
         mock_cls.return_value = mock_instance
         return mock_cls, mock_instance
 
     return make_mock
+
+
+class FakeResponse:
+    def __init__(self, payload: dict | None = None, *, headers: dict | None = None, status: int = 200) -> None:
+        self._payload = payload or {}
+        self.headers = headers or {}
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise RuntimeError(f"HTTP {self.status}")
+
+    async def json(self) -> dict:
+        return self._payload
+
+
+class FakeSession:
+    closed = False
+
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses = list(responses)
+        self.posts: list[dict] = []
+
+    def post(self, url: str, *, json: dict, headers: dict):
+        self.posts.append({"url": url, "json": json, "headers": headers})
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_http_client_sends_negotiated_protocol_version_after_initialize():
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": DEFAULT_MCP_PROTOCOL_REVISION,
+                        "serverInfo": {"name": "server"},
+                    },
+                },
+                headers={"mcp-session-id": "session-123"},
+            ),
+            FakeResponse(status=202),
+            FakeResponse({"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}),
+        ]
+    )
+    client = McpHttpClient("http://localhost:3000")
+    client._session = session
+
+    await client.request("initialize", {"protocolVersion": DEFAULT_MCP_PROTOCOL_REVISION})
+    await client.notify("notifications/initialized")
+    await client.request("tools/list")
+
+    assert session.posts[0]["headers"].get("MCP-Protocol-Version") is None
+    assert session.posts[1]["headers"]["MCP-Protocol-Version"] == DEFAULT_MCP_PROTOCOL_REVISION
+    assert session.posts[1]["headers"]["MCP-Session-Id"] == "session-123"
+    assert session.posts[2]["headers"]["MCP-Protocol-Version"] == DEFAULT_MCP_PROTOCOL_REVISION
+    assert session.posts[2]["headers"]["MCP-Session-Id"] == "session-123"
+
+
+@pytest.mark.asyncio
+async def test_http_client_preserves_older_negotiated_protocol_version():
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"protocolVersion": LEGACY_MCP_PROTOCOL_REVISION},
+                }
+            ),
+            FakeResponse({"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}),
+        ]
+    )
+    client = McpHttpClient("http://localhost:3000")
+    client._session = session
+
+    await client.request("initialize", {"protocolVersion": DEFAULT_MCP_PROTOCOL_REVISION})
+    await client.request("tools/list")
+
+    assert client.protocol_version == LEGACY_MCP_PROTOCOL_REVISION
+    assert session.posts[1]["headers"]["MCP-Protocol-Version"] == LEGACY_MCP_PROTOCOL_REVISION
+
+
+@pytest.mark.asyncio
+async def test_http_client_falls_back_when_server_omits_protocol_version():
+    session = FakeSession(
+        [
+            FakeResponse({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "old-server"}}}),
+            FakeResponse({"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}),
+        ]
+    )
+    client = McpHttpClient("http://localhost:3000")
+    client._session = session
+
+    await client.request("initialize", {"protocolVersion": DEFAULT_MCP_PROTOCOL_REVISION})
+    await client.request("tools/list")
+
+    assert client.protocol_version == LEGACY_MCP_PROTOCOL_REVISION
+    assert session.posts[1]["headers"]["MCP-Protocol-Version"] == LEGACY_MCP_PROTOCOL_REVISION
 
 
 @pytest.mark.asyncio
@@ -52,6 +162,7 @@ async def test_discover_tools_lazy_mode(mock_mcp_client):
 
     def route_request(method, params=None):
         if method == "initialize":
+            assert params["protocolVersion"] == DEFAULT_MCP_PROTOCOL_REVISION
             assert params["clientInfo"]["name"] == "unifi-mcp-relay"
             assert params["clientInfo"]["title"] == "UniFi MCP Relay"
             assert params["clientInfo"]["version"] == version("unifi-mcp-relay")
@@ -100,6 +211,7 @@ async def test_discover_tools_lazy_mode(mock_mcp_client):
     assert result.name == "unifi-network-mcp"
     assert result.url == "http://localhost:3000"
     assert result.session_id == "session-abc-123"
+    assert result.protocol_version == LEGACY_MCP_PROTOCOL_REVISION
     assert len(result.tools) == 2
 
     # Verify tools are properly converted to ToolInfo with server_origin

--- a/packages/unifi-mcp-relay/tests/test_forwarder.py
+++ b/packages/unifi-mcp-relay/tests/test_forwarder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from unifi_mcp_relay.discovery import ServerInfo
+from unifi_mcp_relay.discovery import LEGACY_MCP_PROTOCOL_REVISION, ServerInfo
 from unifi_mcp_relay.forwarder import ToolForwarder
 from unifi_mcp_relay.protocol import ToolInfo
 
@@ -17,6 +17,7 @@ def server_infos():
             name="unifi-network-mcp",
             url="http://localhost:3000",
             session_id="session-abc",
+            protocol_version="2025-11-25",
             tools=[
                 ToolInfo(name="unifi_list_devices", description="List devices", server_origin="unifi-network-mcp"),
                 ToolInfo(name="unifi_reboot_device", description="Reboot", server_origin="unifi-network-mcp"),
@@ -26,6 +27,7 @@ def server_infos():
             name="unifi-protect-mcp",
             url="http://localhost:3001",
             session_id="session-xyz",
+            protocol_version=LEGACY_MCP_PROTOCOL_REVISION,
             tools=[
                 ToolInfo(name="protect_list_cameras", description="List cameras", server_origin="unifi-protect-mcp"),
             ],
@@ -53,6 +55,12 @@ def test_forwarder_pre_sets_session_ids(server_infos):
     fwd = ToolForwarder(server_infos)
     assert fwd._clients["http://localhost:3000"]._session_id == "session-abc"
     assert fwd._clients["http://localhost:3001"]._session_id == "session-xyz"
+
+
+def test_forwarder_pre_sets_negotiated_protocol_versions(server_infos):
+    fwd = ToolForwarder(server_infos)
+    assert fwd._clients["http://localhost:3000"]._protocol_version == "2025-11-25"
+    assert fwd._clients["http://localhost:3001"]._protocol_version == LEGACY_MCP_PROTOCOL_REVISION
 
 
 async def test_forwarder_forwards_tool_call(server_infos):
@@ -108,6 +116,25 @@ async def test_forwarder_call_uses_client_request(server_infos):
     mock_client.request.assert_called_once_with(
         "tools/call", {"name": "unifi_list_devices", "arguments": {"compact": False}}
     )
+
+
+async def test_forwarder_call_prefers_structured_content(server_infos):
+    """_call returns MCP structuredContent when current protocol servers provide it."""
+    fwd = ToolForwarder(server_infos)
+
+    payload = {"success": True, "data": [{"mac": "aa:bb:cc:dd:ee:ff"}]}
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={
+            "structuredContent": payload,
+            "content": [{"type": "text", "text": ""}],
+            "isError": False,
+        }
+    )
+    fwd._clients["http://localhost:3000"] = mock_client
+
+    result = await fwd._call("http://localhost:3000", "unifi_list_devices", {"compact": False})
+    assert result == payload
 
 
 async def test_forwarder_call_returns_raw_result_when_no_text_content(server_infos):


### PR DESCRIPTION
## Summary

- initialize relay discovery with the current MCP protocol revision (`2025-11-25`)
- store the server-negotiated protocol version and send `MCP-Protocol-Version` on subsequent Streamable HTTP requests
- preserve compatibility with older/missing protocol negotiation by falling back to `2025-03-26`
- carry the negotiated protocol version into `ToolForwarder` clients
- support current-protocol `structuredContent` tool results while preserving the older text-JSON fallback

Closes #253

## Verification

- `uv run --package unifi-mcp-relay pytest packages/unifi-mcp-relay/tests -v` (`103 passed`)
- `uv run --with ruff ruff check packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py packages/unifi-mcp-relay/tests/test_discovery.py packages/unifi-mcp-relay/tests/test_forwarder.py`
- `uv run --with ruff ruff format --check packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py packages/unifi-mcp-relay/tests/test_discovery.py packages/unifi-mcp-relay/tests/test_forwarder.py`
- Docker compose relay smoke from the branch:
  - relay waited through startup readiness race
  - discovered 3/3 local servers
  - negotiated `2025-11-25` for Network, Protect, and Access
  - discovered 256 lazy-mode tools
  - forwarded `*_tool_index` calls succeeded for all three products

## Follow-up Noted

During live Docker smoke, direct domain tool forwarding in lazy mode still returns `Unknown tool` unless the local server has loaded the module. That behavior predates this protocol-header change and should be handled separately from #253 because it changes relay lazy-execution routing semantics.
