### PR TITLE
fix: load lazy tools before relay forwarding

### DIFF
--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
@@ -44,6 +44,7 @@ class ServerInfo:
     url: str
     session_id: str | None = None
     protocol_version: str | None = None
+    lazy_load_tool_name: str | None = None
     tools: list[ToolInfo] = field(default_factory=list)
 
 
@@ -314,9 +315,14 @@ async def discover_tools(server_url: str) -> ServerInfo | None:
 
         # Step 3: Look for a *_tool_index meta-tool (suffix match)
         tool_index_name = None
+        lazy_load_tool_name = None
         for tool in listed_tools:
-            if tool.get("name", "").endswith("_tool_index"):
-                tool_index_name = tool["name"]
+            tool_name = tool.get("name", "")
+            if tool_name.endswith("_tool_index"):
+                tool_index_name = tool_name
+            elif tool_name.endswith("_load_tools"):
+                lazy_load_tool_name = tool_name
+            if tool_index_name and lazy_load_tool_name:
                 break
 
         if tool_index_name:
@@ -344,6 +350,7 @@ async def discover_tools(server_url: str) -> ServerInfo | None:
             url=server_url,
             session_id=client.session_id,
             protocol_version=client.protocol_version,
+            lazy_load_tool_name=lazy_load_tool_name if tool_index_name else None,
             tools=tools,
         )
         logger.info("[discovery] Discovered %d tools from %s (%s)", len(tools), server_name, server_url)

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
@@ -11,6 +11,13 @@ from unifi_mcp_relay.discovery import McpHttpClient, ServerInfo
 logger = logging.getLogger("unifi-mcp-relay")
 
 
+_META_TOOL_SUFFIXES = ("_tool_index", "_load_tools", "_execute", "_batch", "_batch_status")
+
+
+def _is_meta_tool(tool_name: str) -> bool:
+    return tool_name.endswith(_META_TOOL_SUFFIXES)
+
+
 class ToolForwarder:
     """Routes tool calls to the correct local MCP server.
 
@@ -21,9 +28,18 @@ class ToolForwarder:
     def __init__(self, server_infos: list[ServerInfo]) -> None:
         self._tool_to_url: dict[str, str] = {}
         self._clients: dict[str, McpHttpClient] = {}
+        self._lazy_load_tool_by_url: dict[str, str] = {}
+        self._lazy_advertised_tools_by_url: dict[str, set[str]] = {}
+        self._loaded_lazy_tools_by_url: dict[str, set[str]] = {}
         for info in server_infos:
             for tool in info.tools:
                 self._tool_to_url[tool.name] = info.url
+            if info.lazy_load_tool_name:
+                self._lazy_load_tool_by_url[info.url] = info.lazy_load_tool_name
+                self._lazy_advertised_tools_by_url[info.url] = {
+                    tool.name for tool in info.tools if not _is_meta_tool(tool.name)
+                }
+                self._loaded_lazy_tools_by_url.setdefault(info.url, set())
             if info.url not in self._clients:
                 self._clients[info.url] = McpHttpClient(
                     info.url,
@@ -66,6 +82,10 @@ class ToolForwarder:
         if not client:
             raise RuntimeError(f"No client for {server_url}")
         result = await client.request("tools/call", {"name": tool_name, "arguments": arguments})
+        return self._parse_tool_result(result, tool_name)
+
+    def _parse_tool_result(self, result: dict, tool_name: str) -> Any:
+        """Parse a tools/call result from current or legacy MCP response shapes."""
         structured = result.get("structuredContent")
         if isinstance(structured, dict):
             return structured
@@ -78,6 +98,24 @@ class ToolForwarder:
                 logger.warning("[forwarder] Failed to parse tool response for %s: %s", tool_name, exc)
                 return result
         return result
+
+    async def _ensure_lazy_tool_loaded(self, server_url: str, tool_name: str) -> None:
+        """Load a lazy-advertised tool on the backing server before forwarding."""
+        load_tool_name = self._lazy_load_tool_by_url.get(server_url)
+        if not load_tool_name:
+            return
+        if tool_name not in self._lazy_advertised_tools_by_url.get(server_url, set()):
+            return
+        loaded_tools = self._loaded_lazy_tools_by_url.setdefault(server_url, set())
+        if tool_name in loaded_tools:
+            return
+
+        result = await self._call(server_url, load_tool_name, {"tools": [tool_name]})
+        if isinstance(result, dict) and tool_name in result.get("loaded", []):
+            loaded_tools.add(tool_name)
+            return
+
+        raise RuntimeError(f"Failed to load lazy tool {tool_name} via {load_tool_name}: {result}")
 
     async def forward(self, tool_name: str, arguments: dict) -> Any | None:
         """Forward a tool call to the correct server.
@@ -96,6 +134,7 @@ class ToolForwarder:
         if not url:
             logger.warning("[forwarder] Unknown tool: %s", tool_name)
             return None
+        await self._ensure_lazy_tool_loaded(url, tool_name)
         return await self._call(url, tool_name, arguments)
 
     async def forward_with_error(self, tool_name: str, arguments: dict) -> Any | str:
@@ -115,6 +154,7 @@ class ToolForwarder:
         if not url:
             return f"Unknown tool: {tool_name}"
         try:
+            await self._ensure_lazy_tool_loaded(url, tool_name)
             return await self._call(url, tool_name, arguments)
         except Exception as e:
             logger.exception("[forwarder] Failed to forward %s to %s", tool_name, url)

--- a/packages/unifi-mcp-relay/tests/test_discovery.py
+++ b/packages/unifi-mcp-relay/tests/test_discovery.py
@@ -190,6 +190,11 @@ async def test_discover_tools_lazy_mode(mock_mcp_client):
                         "description": "Execute a tool by name",
                         "inputSchema": {"type": "object", "properties": {"tool_name": {"type": "string"}}},
                     },
+                    {
+                        "name": "unifi_load_tools",
+                        "description": "Load lazy tools",
+                        "inputSchema": {"type": "object", "properties": {"tools": {"type": "array"}}},
+                    },
                 ]
             }
         elif method == "tools/call":
@@ -212,6 +217,7 @@ async def test_discover_tools_lazy_mode(mock_mcp_client):
     assert result.url == "http://localhost:3000"
     assert result.session_id == "session-abc-123"
     assert result.protocol_version == LEGACY_MCP_PROTOCOL_REVISION
+    assert result.lazy_load_tool_name == "unifi_load_tools"
     assert len(result.tools) == 2
 
     # Verify tools are properly converted to ToolInfo with server_origin
@@ -265,6 +271,11 @@ async def test_discover_tools_identifies_tool_index_by_suffix(mock_mcp_client):
                         "description": "Execute a tool",
                         "inputSchema": {"type": "object", "properties": {}},
                     },
+                    {
+                        "name": "protect_load_tools",
+                        "description": "Load lazy tools",
+                        "inputSchema": {"type": "object", "properties": {"tools": {"type": "array"}}},
+                    },
                 ]
             }
         elif method == "tools/call":
@@ -284,6 +295,7 @@ async def test_discover_tools_identifies_tool_index_by_suffix(mock_mcp_client):
 
     assert result is not None
     assert result.name == "unifi-protect-mcp"
+    assert result.lazy_load_tool_name == "protect_load_tools"
     assert len(result.tools) == 1
     assert result.tools[0].name == "protect_list_cameras"
     assert result.tools[0].server_origin == "unifi-protect-mcp"

--- a/packages/unifi-mcp-relay/tests/test_forwarder.py
+++ b/packages/unifi-mcp-relay/tests/test_forwarder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -63,6 +64,28 @@ def test_forwarder_pre_sets_negotiated_protocol_versions(server_infos):
     assert fwd._clients["http://localhost:3001"]._protocol_version == LEGACY_MCP_PROTOCOL_REVISION
 
 
+def test_forwarder_tracks_lazy_loaders():
+    fwd = ToolForwarder(
+        [
+            ServerInfo(
+                name="unifi-network-mcp",
+                url="http://localhost:3000",
+                session_id="session-abc",
+                protocol_version="2025-11-25",
+                lazy_load_tool_name="unifi_load_tools",
+                tools=[
+                    ToolInfo(name="unifi_tool_index", description="Index", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_load_tools", description="Load", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_list_clients", description="List clients", server_origin="unifi-network-mcp"),
+                ],
+            )
+        ]
+    )
+
+    assert fwd._lazy_load_tool_by_url["http://localhost:3000"] == "unifi_load_tools"
+    assert fwd._lazy_advertised_tools_by_url["http://localhost:3000"] == {"unifi_list_clients"}
+
+
 async def test_forwarder_forwards_tool_call(server_infos):
     fwd = ToolForwarder(server_infos)
     with patch.object(fwd, "_call", new_callable=AsyncMock) as mock_call:
@@ -116,6 +139,172 @@ async def test_forwarder_call_uses_client_request(server_infos):
     mock_client.request.assert_called_once_with(
         "tools/call", {"name": "unifi_list_devices", "arguments": {"compact": False}}
     )
+
+
+async def test_forwarder_loads_lazy_tool_before_first_direct_call():
+    fwd = ToolForwarder(
+        [
+            ServerInfo(
+                name="unifi-network-mcp",
+                url="http://localhost:3000",
+                session_id="session-abc",
+                protocol_version="2025-11-25",
+                lazy_load_tool_name="unifi_load_tools",
+                tools=[
+                    ToolInfo(name="unifi_tool_index", description="Index", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_load_tools", description="Load", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_list_clients", description="List clients", server_origin="unifi-network-mcp"),
+                ],
+            )
+        ]
+    )
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        side_effect=[
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"loaded": ["unifi_list_clients"], "errors": None}),
+                    }
+                ]
+            },
+            {"content": [{"type": "text", "text": json.dumps({"success": True, "data": []})}]},
+        ]
+    )
+    fwd._clients["http://localhost:3000"] = mock_client
+
+    result = await fwd.forward("unifi_list_clients", {"compact": True})
+
+    assert result == {"success": True, "data": []}
+    assert mock_client.request.await_args_list[0].args == (
+        "tools/call",
+        {"name": "unifi_load_tools", "arguments": {"tools": ["unifi_list_clients"]}},
+    )
+    assert mock_client.request.await_args_list[1].args == (
+        "tools/call",
+        {"name": "unifi_list_clients", "arguments": {"compact": True}},
+    )
+
+
+async def test_forwarder_caches_successfully_loaded_lazy_tools():
+    fwd = ToolForwarder(
+        [
+            ServerInfo(
+                name="unifi-network-mcp",
+                url="http://localhost:3000",
+                lazy_load_tool_name="unifi_load_tools",
+                tools=[
+                    ToolInfo(name="unifi_load_tools", description="Load", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_list_clients", description="List clients", server_origin="unifi-network-mcp"),
+                ],
+            )
+        ]
+    )
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        side_effect=[
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"loaded": ["unifi_list_clients"], "errors": None}),
+                    }
+                ]
+            },
+            {"content": [{"type": "text", "text": json.dumps({"success": True, "data": [1]})}]},
+            {"content": [{"type": "text", "text": json.dumps({"success": True, "data": [2]})}]},
+        ]
+    )
+    fwd._clients["http://localhost:3000"] = mock_client
+
+    first = await fwd.forward("unifi_list_clients", {})
+    second = await fwd.forward("unifi_list_clients", {})
+
+    assert first == {"success": True, "data": [1]}
+    assert second == {"success": True, "data": [2]}
+    load_calls = [call for call in mock_client.request.await_args_list if call.args[1]["name"] == "unifi_load_tools"]
+    assert len(load_calls) == 1
+
+
+async def test_forwarder_does_not_load_eager_or_meta_tools():
+    fwd = ToolForwarder(
+        [
+            ServerInfo(
+                name="unifi-network-mcp",
+                url="http://localhost:3000",
+                lazy_load_tool_name="unifi_load_tools",
+                tools=[
+                    ToolInfo(name="unifi_tool_index", description="Index", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_load_tools", description="Load", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_list_clients", description="List clients", server_origin="unifi-network-mcp"),
+                ],
+            ),
+            ServerInfo(
+                name="unifi-protect-mcp",
+                url="http://localhost:3001",
+                tools=[
+                    ToolInfo(
+                        name="protect_list_cameras",
+                        description="List cameras",
+                        server_origin="unifi-protect-mcp",
+                    ),
+                ],
+            ),
+        ]
+    )
+    network_client = AsyncMock()
+    network_client.request = AsyncMock(return_value={"content": [{"type": "text", "text": json.dumps({"tools": []})}]})
+    protect_client = AsyncMock()
+    protect_client.request = AsyncMock(
+        return_value={"content": [{"type": "text", "text": json.dumps({"success": True, "data": []})}]}
+    )
+    fwd._clients["http://localhost:3000"] = network_client
+    fwd._clients["http://localhost:3001"] = protect_client
+
+    await fwd.forward("unifi_tool_index", {})
+    await fwd.forward("protect_list_cameras", {})
+
+    assert network_client.request.await_args.args[1]["name"] == "unifi_tool_index"
+    assert protect_client.request.await_args.args[1]["name"] == "protect_list_cameras"
+
+
+async def test_forwarder_reports_lazy_load_failure():
+    fwd = ToolForwarder(
+        [
+            ServerInfo(
+                name="unifi-network-mcp",
+                url="http://localhost:3000",
+                lazy_load_tool_name="unifi_load_tools",
+                tools=[
+                    ToolInfo(name="unifi_load_tools", description="Load", server_origin="unifi-network-mcp"),
+                    ToolInfo(name="unifi_list_clients", description="List clients", server_origin="unifi-network-mcp"),
+                ],
+            )
+        ]
+    )
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(
+        return_value={
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "loaded": [],
+                            "errors": [{"tool": "unifi_list_clients", "error": "Failed to load"}],
+                        }
+                    ),
+                }
+            ]
+        }
+    )
+    fwd._clients["http://localhost:3000"] = mock_client
+
+    error = await fwd.forward_with_error("unifi_list_clients", {})
+
+    assert "Failed to load lazy tool unifi_list_clients" in error
+    assert mock_client.request.await_count == 1
 
 
 async def test_forwarder_call_prefers_structured_content(server_infos):


### PR DESCRIPTION
## Summary

- closes #276
- captures each local server's `*_load_tools` meta-tool during relay discovery when the server is in lazy mode
- pre-loads lazy-advertised domain tools before the relay forwards the first direct call to the backing MCP server
- caches successful loads and skips load attempts for eager servers and meta-tools

## Verification

- `uv run --package unifi-mcp-relay pytest packages/unifi-mcp-relay/tests -q`
- `uv run --with ruff ruff check packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py packages/unifi-mcp-relay/tests/test_discovery.py packages/unifi-mcp-relay/tests/test_forwarder.py`
- `uv run --with ruff ruff format --check packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py packages/unifi-mcp-relay/tests/test_discovery.py packages/unifi-mcp-relay/tests/test_forwarder.py`
- `docker compose --env-file .env -f docker/docker-compose.yml --profile relay up -d --build unifi-mcp-relay`
- local relay forwarding smoke against compose MCP servers:
  - discovered lazy loaders: `unifi_load_tools`, `protect_load_tools`, `access_load_tools`
  - `unifi_list_clients` returned `success=True`
  - `protect_list_cameras` returned `success=True`
  - `access_list_doors` returned `success=True`

## Notes

Compose interpolation needs `--env-file .env` for `UNIFI_RELAY_URL` and `UNIFI_RELAY_TOKEN`; without it, the relay container's explicit environment block overrides the `env_file` values with blanks.
