### PR TITLE
feat: prototype MCP tasks mapping

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,12 @@ Documentation for standard MCP discovery and the UniFi meta-tool extension path:
 `*_tool_index` and `*_execute` when lazy loading or context limits make a compact
 manifest-backed catalog more practical.
 
+#### [MCP Tasks Alignment](mcp-tasks.md)
+Design note for mapping UniFi compatibility jobs to experimental MCP Tasks:
+- How `jobId` and batch status map to `taskId` and Task states
+- Why batch execution is the safest first native Tasks workflow
+- What must be implemented before advertising task capabilities
+
 #### [Permissions](permissions.md) 🔐 **SECURITY**
 Complete guide to the permission system:
 - How permissions work

--- a/docs/mcp-tasks.md
+++ b/docs/mcp-tasks.md
@@ -1,0 +1,114 @@
+# MCP Tasks Alignment
+
+MCP Tasks are an experimental capability in the `2025-11-25` protocol
+revision. UniFi MCP should align with the standard shape now, but avoid
+advertising first-class task capability until the server runtime path can handle
+task-augmented requests end to end.
+
+References:
+
+- [MCP Tasks specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)
+- [MCP schema reference](https://modelcontextprotocol.io/specification/2025-11-25/schema)
+- [2025-11-25 release announcement](https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/)
+
+## Standard Shape
+
+The spec defines Tasks as durable state machines for deferred work. A receiver
+returns a `CreateTaskResult` immediately when it accepts a task-augmented
+request, and the requestor later uses `tasks/get` and `tasks/result`.
+
+The SDK already exposes these protocol models:
+
+- `Task`
+- `CreateTaskResult`
+- `GetTaskResult`
+- `GetTaskPayloadResult`
+- `ListTasksResult`
+- `TaskStatusNotification`
+- task capability models for clients and servers
+
+## UniFi Mapping
+
+UniFi MCP already has compatibility jobs through `*_batch` and
+`*_batch_status`. Those remain stable and continue to return `jobId`.
+
+The standard MCP mapping is:
+
+| Current UniFi job field | MCP Task field | Notes |
+|-------------------------|----------------|-------|
+| `jobId` | `taskId` | Keep the same opaque ID when adapting compatibility jobs. |
+| `status=running` | `status=working` | Non-terminal task state. |
+| `status=done` | `status=completed` | Result is available from the existing job result today; future protocol handlers should return it from `tasks/result`. |
+| `status=error` | `status=failed` | Tool results with `isError=true` are also failed tasks under the spec. |
+| `status=unknown` | protocol error for native Tasks | Compatibility `*_batch_status` may still return `unknown`; native `tasks/get` should reject missing IDs with invalid params. |
+| `started` | `createdAt` | Convert Unix timestamp to ISO 8601 UTC. |
+| `completed` | `lastUpdatedAt` | Use `started` while still working. |
+| configured retention | `ttl` | Default prototype value is 10 minutes. |
+| configured polling hint | `pollInterval` | Default prototype value is 1 second. |
+
+## Prototype Scope
+
+This PR adds `unifi_mcp_shared.tasks` as a small adapter layer:
+
+- `task_from_job_status(job_id, job_status)` converts a compatibility job
+  status to the MCP SDK `Task` model.
+- `task_to_dict(task)` serializes protocol field names such as `taskId`,
+  `createdAt`, and `pollInterval`.
+- `create_task_result_from_job(...)` creates the standard `CreateTaskResult`
+  shape and can include the provisional
+  `io.modelcontextprotocol/model-immediate-response` metadata.
+- `related_task_meta(task_id)` returns
+  `io.modelcontextprotocol/related-task` metadata for task-associated messages.
+
+This deliberately does not replace `*_batch` or `*_batch_status`, and it does
+not yet advertise Tasks in server capabilities.
+
+## Candidate Workflow
+
+The best first native workflow is batch execution status, not RF scans, backups,
+upgrades, or clip export.
+
+Why batch first:
+
+- It already has an in-memory job store and status tool.
+- It is non-destructive when composed from read-only operations.
+- It exists across Network, Protect, and Access through shared meta-tools.
+- It lets us validate task state mapping without adding controller-specific
+  polling logic.
+
+Recommended implementation sequence:
+
+1. Keep `*_batch` returning `jobId` for compatibility.
+2. Add experimental task capability only when FastMCP exposes a stable handler
+   path for task-augmented `tools/call` requests.
+3. On task-augmented `*_batch` calls, return `CreateTaskResult` with the first
+   accepted batch job or a parent task representing the batch.
+4. Implement native `tasks/get` by reading the existing job store through the
+   adapter.
+5. Implement native `tasks/result` so terminal tasks return exactly the
+   underlying tool result or JSON-RPC error.
+6. Add `tasks/list` with cursor pagination before advertising list capability.
+7. Add `tasks/cancel` only after `JobStore` tracks the underlying
+   `asyncio.Task`, because the spec requires terminal `cancelled` state after a
+   valid cancellation request.
+
+## Adoption Gates
+
+Do not mark MCP Tasks as fully supported until all of these are true:
+
+- `initialize` advertises task capabilities only for implemented operations.
+- `tasks/get` rejects nonexistent IDs with JSON-RPC invalid params instead of
+  the compatibility `unknown` status.
+- `tasks/result` blocks for non-terminal tasks and returns the underlying
+  request result for terminal tasks.
+- `tasks/list` is paginated and scoped to retrievable tasks.
+- Task responses include `createdAt`, `lastUpdatedAt`, and actual `ttl`.
+- Optional `notifications/tasks/status` are treated as best-effort only; clients
+  must still be able to poll.
+- Cancellation is not advertised until cancellation semantics are real.
+
+## Compatibility Position
+
+`*_batch` and `*_batch_status` are still the correct compatibility surface for
+current clients. Native MCP Tasks should come alongside them, not replace them,
+because Tasks are still experimental and client support will vary.

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/__main__.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/__main__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
 import sys
@@ -9,7 +10,16 @@ import sys
 from dotenv import load_dotenv
 
 
-def main() -> None:
+def _build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        prog="unifi-mcp-relay",
+        description="Bridge local UniFi MCP servers to a configured UniFi MCP relay worker.",
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    _build_parser().parse_args(argv)
+
     load_dotenv()
     logging.basicConfig(
         level=logging.INFO,

--- a/packages/unifi-mcp-relay/tests/test_entrypoint.py
+++ b/packages/unifi-mcp-relay/tests/test_entrypoint.py
@@ -1,0 +1,22 @@
+import sys
+
+import pytest
+
+
+def test_help_prints_usage_without_loading_relay_config(monkeypatch, capsys):
+    from unifi_mcp_relay import __main__ as entrypoint
+
+    dotenv_calls = []
+    monkeypatch.setattr(sys, "argv", ["unifi-mcp-relay", "--help"])
+    monkeypatch.setattr(entrypoint, "load_dotenv", lambda: dotenv_calls.append(True))
+    for name in ("UNIFI_RELAY_URL", "UNIFI_RELAY_TOKEN", "UNIFI_RELAY_LOCATION_NAME"):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    captured = capsys.readouterr()
+    assert exc.value.code == 0
+    assert dotenv_calls == []
+    assert "usage: unifi-mcp-relay" in captured.out
+    assert "UNIFI_RELAY_URL" not in captured.err

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
@@ -20,18 +20,33 @@ from unifi_mcp_shared.lazy_tools import (
     setup_lazy_loading,
 )
 from unifi_mcp_shared.meta_tools import register_load_tools, register_meta_tools
+from unifi_mcp_shared.tasks import (
+    DEFAULT_TASK_POLL_INTERVAL_MS,
+    DEFAULT_TASK_TTL_MS,
+    MCP_MODEL_IMMEDIATE_RESPONSE_META,
+    MCP_RELATED_TASK_META,
+    create_task_result_from_job,
+    related_task_meta,
+    task_from_job_status,
+    task_to_dict,
+)
 from unifi_mcp_shared.tool_loader import auto_load_tools
 
 __all__ = [
     "JOBS",
     "JobStore",
     "LazyToolLoader",
+    "MCP_MODEL_IMMEDIATE_RESPONSE_META",
+    "MCP_RELATED_TASK_META",
     "PolicyGateChecker",
     "ResourceValidator",
+    "DEFAULT_TASK_POLL_INTERVAL_MS",
+    "DEFAULT_TASK_TTL_MS",
     "auto_load_tools",
     "build_tool_module_map",
     "create_preview",
     "create_response",
+    "create_task_result_from_job",
     "error_response",
     "get_tool_annotations",
     "get_job_status",
@@ -40,10 +55,13 @@ __all__ = [
     "preview_response",
     "register_load_tools",
     "register_meta_tools",
+    "related_task_meta",
     "setup_lazy_loading",
     "setup_logging",
     "start_async_tool",
     "success_response",
+    "task_from_job_status",
+    "task_to_dict",
     "toggle_preview",
     "update_preview",
 ]

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tasks.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tasks.py
@@ -1,0 +1,106 @@
+"""MCP Tasks adapters for UniFi compatibility job state.
+
+The existing UniFi batch meta-tools expose ``jobId`` values backed by
+``unifi_core.jobs.JobStore``. This module keeps that compatibility surface
+unchanged while providing a small, typed bridge to the experimental MCP Tasks
+shape introduced in protocol revision 2025-11-25.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from mcp.types import CreateTaskResult, Task
+
+MCP_RELATED_TASK_META = "io.modelcontextprotocol/related-task"
+MCP_MODEL_IMMEDIATE_RESPONSE_META = "io.modelcontextprotocol/model-immediate-response"
+
+DEFAULT_TASK_TTL_MS = 600_000
+DEFAULT_TASK_POLL_INTERVAL_MS = 1_000
+
+TaskStatus = Literal["working", "input_required", "completed", "failed", "cancelled"]
+
+_JOB_STATUS_TO_TASK_STATUS: dict[str, TaskStatus] = {
+    "running": "working",
+    "done": "completed",
+    "error": "failed",
+    "unknown": "failed",
+}
+
+
+def _timestamp_to_datetime(value: Any, *, fallback: datetime | None = None) -> datetime:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    if fallback is not None:
+        return fallback
+    return datetime.now(timezone.utc)
+
+
+def _status_message(job_status: dict[str, Any], task_status: TaskStatus) -> str:
+    if task_status == "working":
+        return "Operation is in progress."
+    if task_status == "completed":
+        return "Operation completed."
+    if task_status == "failed":
+        return str(job_status.get("error") or "Operation failed.")
+    if task_status == "cancelled":
+        return "Operation was cancelled."
+    return "Operation requires additional input."
+
+
+def task_from_job_status(
+    job_id: str,
+    job_status: dict[str, Any],
+    *,
+    ttl_ms: int | None = DEFAULT_TASK_TTL_MS,
+    poll_interval_ms: int | None = DEFAULT_TASK_POLL_INTERVAL_MS,
+) -> Task:
+    """Convert UniFi compatibility job status to an MCP ``Task`` model."""
+    task_status = _JOB_STATUS_TO_TASK_STATUS.get(str(job_status.get("status")), "failed")
+    created_at = _timestamp_to_datetime(job_status.get("started"))
+    last_updated_at = _timestamp_to_datetime(job_status.get("completed"), fallback=created_at)
+
+    return Task(
+        taskId=job_id,
+        status=task_status,
+        statusMessage=_status_message(job_status, task_status),
+        createdAt=created_at,
+        lastUpdatedAt=last_updated_at,
+        ttl=ttl_ms,
+        pollInterval=poll_interval_ms,
+    )
+
+
+def task_to_dict(task: Task) -> dict[str, Any]:
+    """Serialize an MCP task model using protocol field names."""
+    return task.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def create_task_result_from_job(
+    job_id: str,
+    job_status: dict[str, Any],
+    *,
+    ttl_ms: int | None = DEFAULT_TASK_TTL_MS,
+    poll_interval_ms: int | None = DEFAULT_TASK_POLL_INTERVAL_MS,
+    immediate_message: str | None = None,
+) -> dict[str, Any]:
+    """Build the ``CreateTaskResult`` shape for a task-backed job."""
+    task = task_from_job_status(
+        job_id,
+        job_status,
+        ttl_ms=ttl_ms,
+        poll_interval_ms=poll_interval_ms,
+    )
+    meta = None
+    if immediate_message is not None:
+        meta = {MCP_MODEL_IMMEDIATE_RESPONSE_META: immediate_message}
+    result = CreateTaskResult(task=task, _meta=meta)
+    return result.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def related_task_meta(task_id: str) -> dict[str, Any]:
+    """Return MCP related-task metadata for task-associated messages."""
+    return {MCP_RELATED_TASK_META: {"taskId": task_id}}

--- a/packages/unifi-mcp-shared/tests/test_tasks.py
+++ b/packages/unifi-mcp-shared/tests/test_tasks.py
@@ -1,0 +1,125 @@
+"""Tests for MCP Tasks adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from mcp.types import CreateTaskResult, Task
+from unifi_mcp_shared.tasks import (
+    DEFAULT_TASK_POLL_INTERVAL_MS,
+    DEFAULT_TASK_TTL_MS,
+    MCP_MODEL_IMMEDIATE_RESPONSE_META,
+    MCP_RELATED_TASK_META,
+    create_task_result_from_job,
+    related_task_meta,
+    task_from_job_status,
+    task_to_dict,
+)
+
+
+def test_task_from_running_job_status():
+    task = task_from_job_status(
+        "job-123",
+        {
+            "status": "running",
+            "started": 1_700_000_000,
+            "result": None,
+            "error": None,
+        },
+    )
+
+    assert isinstance(task, Task)
+    assert task.taskId == "job-123"
+    assert task.status == "working"
+    assert task.statusMessage == "Operation is in progress."
+    assert task.createdAt == datetime.fromtimestamp(1_700_000_000, tz=timezone.utc)
+    assert task.lastUpdatedAt == task.createdAt
+    assert task.ttl == DEFAULT_TASK_TTL_MS
+    assert task.pollInterval == DEFAULT_TASK_POLL_INTERVAL_MS
+
+
+def test_task_from_completed_job_status_uses_completion_timestamp():
+    task = task_from_job_status(
+        "job-123",
+        {
+            "status": "done",
+            "started": 1_700_000_000,
+            "completed": 1_700_000_030,
+            "result": {"success": True},
+            "error": None,
+        },
+        ttl_ms=None,
+        poll_interval_ms=None,
+    )
+
+    assert task.status == "completed"
+    assert task.statusMessage == "Operation completed."
+    assert task.createdAt == datetime.fromtimestamp(1_700_000_000, tz=timezone.utc)
+    assert task.lastUpdatedAt == datetime.fromtimestamp(1_700_000_030, tz=timezone.utc)
+    assert task.ttl is None
+    assert task.pollInterval is None
+
+
+def test_task_from_failed_job_status_uses_error_message():
+    task = task_from_job_status(
+        "job-123",
+        {
+            "status": "error",
+            "started": 1_700_000_000,
+            "completed": 1_700_000_005,
+            "result": None,
+            "error": "Controller rejected request",
+        },
+    )
+
+    assert task.status == "failed"
+    assert task.statusMessage == "Controller rejected request"
+
+
+def test_unknown_job_status_maps_to_failed_task():
+    task = task_from_job_status("missing", {"status": "unknown"})
+
+    assert task.status == "failed"
+    assert task.statusMessage == "Operation failed."
+
+
+def test_task_to_dict_uses_protocol_field_names():
+    task = task_from_job_status(
+        "job-123",
+        {
+            "status": "running",
+            "started": 1_700_000_000,
+        },
+    )
+
+    payload = task_to_dict(task)
+
+    assert payload == {
+        "taskId": "job-123",
+        "status": "working",
+        "statusMessage": "Operation is in progress.",
+        "createdAt": "2023-11-14T22:13:20Z",
+        "lastUpdatedAt": "2023-11-14T22:13:20Z",
+        "ttl": DEFAULT_TASK_TTL_MS,
+        "pollInterval": DEFAULT_TASK_POLL_INTERVAL_MS,
+    }
+
+
+def test_create_task_result_from_job_validates_against_sdk_model():
+    payload = create_task_result_from_job(
+        "job-123",
+        {
+            "status": "running",
+            "started": 1_700_000_000,
+        },
+        immediate_message="Started operation. Poll tasks/get for status.",
+    )
+
+    parsed = CreateTaskResult.model_validate(payload)
+    assert parsed.task.taskId == "job-123"
+    assert parsed.task.status == "working"
+    assert payload["_meta"] == {MCP_MODEL_IMMEDIATE_RESPONSE_META: "Started operation. Poll tasks/get for status."}
+
+
+def test_related_task_meta():
+    assert related_task_meta("job-123") == {MCP_RELATED_TASK_META: {"taskId": "job-123"}}


### PR DESCRIPTION
## Summary

- closes #254
- adds `docs/mcp-tasks.md` with the UniFi mapping for experimental MCP Tasks
- adds `unifi_mcp_shared.tasks`, a typed adapter from existing compatibility job state to SDK `Task` / `CreateTaskResult` shapes
- keeps `*_batch` and `*_batch_status` compatibility behavior unchanged

## Spec alignment

Grounded against the official `2025-11-25` Tasks spec:

- Tasks are experimental and should not be advertised until implemented end to end
- task-augmented `tools/call` returns `CreateTaskResult` first, then actual results via `tasks/result`
- `tasks/get`, `tasks/list`, `tasks/cancel`, task status notifications, `ttl`, `pollInterval`, and related-task metadata each have explicit behavior gates

## Proposed next implementation path

The design note recommends batch execution as the first native workflow because it is shared, already job-backed, and can be safely tested with read-only operations. RF scans, backups, upgrades, and clip exports remain later candidates once native task plumbing exists.

## Verification

- `uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests/test_tasks.py packages/unifi-mcp-shared/tests/test_jobs.py packages/unifi-mcp-shared/tests/test_meta_tools.py -q`
- `uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -q`
- `uv run --with ruff ruff check packages/unifi-mcp-shared/src/unifi_mcp_shared/tasks.py packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py packages/unifi-mcp-shared/tests/test_tasks.py`
- `uv run --with ruff ruff format --check packages/unifi-mcp-shared/src/unifi_mcp_shared/tasks.py packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py packages/unifi-mcp-shared/tests/test_tasks.py`
- `uv run --package unifi-network-mcp python -c "import unifi_network_mcp; print('network ok')"`
- `uv run --package unifi-protect-mcp python -c "import unifi_protect_mcp; print('protect ok')"`
- `uv run --package unifi-access-mcp python -c "import unifi_access_mcp; print('access ok')"`
- `make pre-commit`

Note: `make pre-commit` passed. During worker dependency install, npm reported the existing audit finding count, but it did not fail the gate.
