### PR TITLE
feat: align MCP resource metadata and subscription notes

### DIFF
--- a/apps/access/src/unifi_access_mcp/resources/events.py
+++ b/apps/access/src/unifi_access_mcp/resources/events.py
@@ -13,20 +13,41 @@ from __future__ import annotations
 import json
 import logging
 
+from mcp.types import Annotations
+
 from unifi_access_mcp.runtime import event_manager, server
 
 logger = logging.getLogger(__name__)
+
+EVENT_RESOURCE_META = {
+    "io.unifi.resourceKind": "event-buffer",
+    "io.unifi.updateMode": "poll",
+    "io.unifi.pollIntervalMs": 1000,
+    "io.unifi.protocolSubscribe": False,
+    "io.unifi.relatedTools": ["access_recent_events", "access_subscribe_events"],
+}
+
+EVENT_SUMMARY_RESOURCE_META = {
+    "io.unifi.resourceKind": "event-summary",
+    "io.unifi.updateMode": "poll",
+    "io.unifi.pollIntervalMs": 1000,
+    "io.unifi.protocolSubscribe": False,
+    "io.unifi.relatedTools": ["access_recent_events", "access_subscribe_events"],
+}
 
 
 @server.resource(
     "access://events/stream",
     name="Access Event Stream",
+    title="Recent Access Events",
     description=(
         "Real-time UniFi Access events from the event buffer. "
         "Returns a JSON array of recent events (newest first). "
         "Poll this resource to monitor for door opens, denials, and other events."
     ),
     mime_type="application/json",
+    annotations=Annotations(audience=["user", "assistant"], priority=0.8),
+    meta=EVENT_RESOURCE_META,
 )
 async def event_stream() -> str:
     """Return recent events from the event ring buffer as JSON."""
@@ -41,11 +62,14 @@ async def event_stream() -> str:
 @server.resource(
     "access://events/stream/summary",
     name="Access Event Stream Summary",
+    title="Access Event Buffer Summary",
     description=(
         "Summary statistics for the event buffer: total count and breakdown by "
         "event type. Lightweight alternative to reading the full event stream."
     ),
     mime_type="application/json",
+    annotations=Annotations(audience=["assistant"], priority=0.5),
+    meta=EVENT_SUMMARY_RESOURCE_META,
 )
 async def event_stream_summary() -> str:
     """Return summary statistics of the event buffer."""

--- a/apps/access/tests/unit/test_event_resource.py
+++ b/apps/access/tests/unit/test_event_resource.py
@@ -1,0 +1,109 @@
+"""Tests for event stream MCP resources."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_event_manager():
+    """Patch event_manager in the resources module."""
+    mgr = MagicMock()
+    with patch("unifi_access_mcp.resources.events.event_manager", mgr):
+        yield mgr
+
+
+class TestAccessEventStreamResource:
+    @pytest.mark.asyncio
+    async def test_returns_json_array(self, mock_event_manager):
+        from unifi_access_mcp.resources.events import event_stream
+
+        mock_event_manager.get_recent_from_buffer.return_value = [
+            {"id": "evt-1", "type": "door_open", "door_id": "door-1"},
+            {"id": "evt-2", "type": "access_denied", "door_id": "door-2"},
+        ]
+
+        result = await event_stream()
+
+        data = json.loads(result)
+        assert isinstance(data, list)
+        assert data[0]["id"] == "evt-1"
+        assert data[1]["type"] == "access_denied"
+
+    @pytest.mark.asyncio
+    async def test_registered_with_mcp_resource_metadata(self):
+        import unifi_access_mcp.resources.events  # noqa: F401
+        from unifi_access_mcp.runtime import server
+
+        resources = await server.list_resources()
+        stream = next(r for r in resources if str(r.uri) == "access://events/stream")
+
+        assert stream.title == "Recent Access Events"
+        assert stream.annotations is not None
+        assert stream.annotations.audience == ["user", "assistant"]
+        assert stream.annotations.priority == 0.8
+        assert stream.meta == {
+            "io.unifi.resourceKind": "event-buffer",
+            "io.unifi.updateMode": "poll",
+            "io.unifi.pollIntervalMs": 1000,
+            "io.unifi.protocolSubscribe": False,
+            "io.unifi.relatedTools": ["access_recent_events", "access_subscribe_events"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_server_read_resource_returns_json_content(self, mock_event_manager):
+        import unifi_access_mcp.resources.events  # noqa: F401
+        from unifi_access_mcp.runtime import server
+
+        mock_event_manager.get_recent_from_buffer.return_value = [{"id": "evt-1", "type": "door_open"}]
+
+        contents = await server.read_resource("access://events/stream")
+
+        assert len(contents) == 1
+        assert contents[0].mime_type == "application/json"
+        assert json.loads(contents[0].content) == [{"id": "evt-1", "type": "door_open"}]
+        assert contents[0].meta["io.unifi.resourceKind"] == "event-buffer"
+
+
+class TestAccessEventStreamSummaryResource:
+    @pytest.mark.asyncio
+    async def test_summary_counts(self, mock_event_manager):
+        from unifi_access_mcp.resources.events import event_stream_summary
+
+        mock_event_manager.get_recent_from_buffer.return_value = [
+            {"type": "door_open", "door_id": "door-1"},
+            {"type": "door_open", "door_id": "door-1"},
+            {"type": "access_denied", "door_id": "door-2"},
+        ]
+        mock_event_manager.buffer_size = 3
+
+        result = await event_stream_summary()
+
+        data = json.loads(result)
+        assert data["total_events"] == 3
+        assert data["by_type"]["door_open"] == 2
+        assert data["by_door"]["door-1"] == 2
+        assert data["buffer_size"] == 3
+
+    @pytest.mark.asyncio
+    async def test_summary_registered_with_mcp_resource_metadata(self):
+        import unifi_access_mcp.resources.events  # noqa: F401
+        from unifi_access_mcp.runtime import server
+
+        resources = await server.list_resources()
+        summary = next(r for r in resources if str(r.uri) == "access://events/stream/summary")
+
+        assert summary.title == "Access Event Buffer Summary"
+        assert summary.annotations is not None
+        assert summary.annotations.audience == ["assistant"]
+        assert summary.annotations.priority == 0.5
+        assert summary.meta == {
+            "io.unifi.resourceKind": "event-summary",
+            "io.unifi.updateMode": "poll",
+            "io.unifi.pollIntervalMs": 1000,
+            "io.unifi.protocolSubscribe": False,
+            "io.unifi.relatedTools": ["access_recent_events", "access_subscribe_events"],
+        }

--- a/apps/protect/src/unifi_protect_mcp/resources/events.py
+++ b/apps/protect/src/unifi_protect_mcp/resources/events.py
@@ -22,20 +22,41 @@ from __future__ import annotations
 import json
 import logging
 
+from mcp.types import Annotations
+
 from unifi_protect_mcp.runtime import event_manager, server
 
 logger = logging.getLogger(__name__)
+
+EVENT_RESOURCE_META = {
+    "io.unifi.resourceKind": "event-buffer",
+    "io.unifi.updateMode": "poll",
+    "io.unifi.pollIntervalMs": 1000,
+    "io.unifi.protocolSubscribe": False,
+    "io.unifi.relatedTools": ["protect_recent_events", "protect_subscribe_events"],
+}
+
+EVENT_SUMMARY_RESOURCE_META = {
+    "io.unifi.resourceKind": "event-summary",
+    "io.unifi.updateMode": "poll",
+    "io.unifi.pollIntervalMs": 1000,
+    "io.unifi.protocolSubscribe": False,
+    "io.unifi.relatedTools": ["protect_recent_events", "protect_subscribe_events"],
+}
 
 
 @server.resource(
     "protect://events/stream",
     name="Protect Event Stream",
+    title="Recent Protect Events",
     description=(
         "Real-time UniFi Protect events from the websocket buffer. "
         "Returns a JSON array of recent events (newest first). "
         "Poll this resource to monitor for motion, smart detections, rings, and other events."
     ),
     mime_type="application/json",
+    annotations=Annotations(audience=["user", "assistant"], priority=0.8),
+    meta=EVENT_RESOURCE_META,
 )
 async def event_stream() -> str:
     """Return recent events from the websocket ring buffer as JSON."""
@@ -50,12 +71,15 @@ async def event_stream() -> str:
 @server.resource(
     "protect://events/stream/summary",
     name="Protect Event Stream Summary",
+    title="Protect Event Buffer Summary",
     description=(
         "Summary statistics for the event buffer: total count, breakdown by "
         "event type, and breakdown by camera. Lightweight alternative to "
         "reading the full event stream."
     ),
     mime_type="application/json",
+    annotations=Annotations(audience=["assistant"], priority=0.5),
+    meta=EVENT_SUMMARY_RESOURCE_META,
 )
 async def event_stream_summary() -> str:
     """Return summary statistics of the event buffer."""

--- a/apps/protect/src/unifi_protect_mcp/resources/snapshots.py
+++ b/apps/protect/src/unifi_protect_mcp/resources/snapshots.py
@@ -24,9 +24,26 @@ import json
 import logging
 from typing import Any, Dict, List
 
+from mcp.types import Annotations
+
 from unifi_protect_mcp.runtime import camera_manager, server
 
 logger = logging.getLogger(__name__)
+
+SNAPSHOT_RESOURCE_META = {
+    "io.unifi.resourceKind": "camera-snapshot",
+    "io.unifi.updateMode": "on-demand",
+    "io.unifi.protocolSubscribe": False,
+    "io.unifi.relatedTools": ["protect_get_snapshot", "protect_list_cameras"],
+}
+
+SNAPSHOT_INDEX_RESOURCE_META = {
+    "io.unifi.resourceKind": "snapshot-index",
+    "io.unifi.updateMode": "poll",
+    "io.unifi.pollIntervalMs": 10000,
+    "io.unifi.protocolSubscribe": False,
+    "io.unifi.relatedTools": ["protect_get_snapshot", "protect_list_cameras"],
+}
 
 
 # ---------------------------------------------------------------------------
@@ -37,6 +54,7 @@ logger = logging.getLogger(__name__)
 @server.resource(
     "protect://cameras/{camera_id}/snapshot",
     name="Camera Snapshot",
+    title="Live Camera Snapshot",
     description=(
         "Live JPEG snapshot from a UniFi Protect camera. "
         "Replace {camera_id} with the camera's ID (discover IDs via "
@@ -44,6 +62,8 @@ logger = logging.getLogger(__name__)
         "protect_list_cameras tool)."
     ),
     mime_type="image/jpeg",
+    annotations=Annotations(audience=["user", "assistant"], priority=0.7),
+    meta=SNAPSHOT_RESOURCE_META,
 )
 async def camera_snapshot(camera_id: str) -> bytes:
     """Fetch a JPEG snapshot for the given camera.
@@ -78,12 +98,15 @@ async def camera_snapshot(camera_id: str) -> bytes:
 @server.resource(
     "protect://cameras/snapshots",
     name="Camera Snapshot Index",
+    title="Camera Snapshot Index",
     description=(
         "JSON index of all cameras available for snapshot capture. "
         "Each entry includes the camera ID, name, connection state, "
         "and the resource URI to fetch its snapshot."
     ),
     mime_type="application/json",
+    annotations=Annotations(audience=["assistant"], priority=0.6),
+    meta=SNAPSHOT_INDEX_RESOURCE_META,
 )
 async def camera_snapshot_index() -> str:
     """Return a JSON array of cameras with their snapshot resource URIs."""

--- a/apps/protect/tests/unit/test_event_resource.py
+++ b/apps/protect/tests/unit/test_event_resource.py
@@ -60,6 +60,40 @@ class TestEventStreamResource:
         assert "error" in data
         assert "buffer broken" in data["error"]
 
+    @pytest.mark.asyncio
+    async def test_registered_with_mcp_resource_metadata(self):
+        import unifi_protect_mcp.resources.events  # noqa: F401
+        from unifi_protect_mcp.runtime import server
+
+        resources = await server.list_resources()
+        stream = next(r for r in resources if str(r.uri) == "protect://events/stream")
+
+        assert stream.title == "Recent Protect Events"
+        assert stream.annotations is not None
+        assert stream.annotations.audience == ["user", "assistant"]
+        assert stream.annotations.priority == 0.8
+        assert stream.meta == {
+            "io.unifi.resourceKind": "event-buffer",
+            "io.unifi.updateMode": "poll",
+            "io.unifi.pollIntervalMs": 1000,
+            "io.unifi.protocolSubscribe": False,
+            "io.unifi.relatedTools": ["protect_recent_events", "protect_subscribe_events"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_server_read_resource_returns_json_content(self, mock_event_manager):
+        import unifi_protect_mcp.resources.events  # noqa: F401
+        from unifi_protect_mcp.runtime import server
+
+        mock_event_manager.get_recent_from_buffer.return_value = [{"id": "evt-1", "type": "motion"}]
+
+        contents = await server.read_resource("protect://events/stream")
+
+        assert len(contents) == 1
+        assert contents[0].mime_type == "application/json"
+        assert json.loads(contents[0].content) == [{"id": "evt-1", "type": "motion"}]
+        assert contents[0].meta["io.unifi.resourceKind"] == "event-buffer"
+
 
 # ---------------------------------------------------------------------------
 # protect://events/stream/summary
@@ -122,3 +156,23 @@ class TestEventStreamSummaryResource:
         assert data["by_type"]["motion"] == 1
         assert data["by_type"]["unknown"] == 1
         assert data["by_camera"]["unknown"] == 2
+
+    @pytest.mark.asyncio
+    async def test_summary_registered_with_mcp_resource_metadata(self):
+        import unifi_protect_mcp.resources.events  # noqa: F401
+        from unifi_protect_mcp.runtime import server
+
+        resources = await server.list_resources()
+        summary = next(r for r in resources if str(r.uri) == "protect://events/stream/summary")
+
+        assert summary.title == "Protect Event Buffer Summary"
+        assert summary.annotations is not None
+        assert summary.annotations.audience == ["assistant"]
+        assert summary.annotations.priority == 0.5
+        assert summary.meta == {
+            "io.unifi.resourceKind": "event-summary",
+            "io.unifi.updateMode": "poll",
+            "io.unifi.pollIntervalMs": 1000,
+            "io.unifi.protocolSubscribe": False,
+            "io.unifi.relatedTools": ["protect_recent_events", "protect_subscribe_events"],
+        }

--- a/apps/protect/tests/unit/test_snapshot_resource.py
+++ b/apps/protect/tests/unit/test_snapshot_resource.py
@@ -225,6 +225,49 @@ class TestSnapshotResourceRegistration:
         assert len(index_resources) == 1
         assert index_resources[0].mime_type == "application/json"
 
+    def test_snapshot_template_has_mcp_metadata(self):
+        """The snapshot template should expose MCP title, annotations, and namespaced metadata."""
+        import unifi_protect_mcp.resources.snapshots  # noqa: F401
+        from unifi_protect_mcp.runtime import server
+
+        templates = server._resource_manager.list_templates()
+        snapshot_templates = [t for t in templates if t.uri_template == "protect://cameras/{camera_id}/snapshot"]
+        assert len(snapshot_templates) == 1
+        template = snapshot_templates[0]
+
+        assert template.title == "Live Camera Snapshot"
+        assert template.annotations is not None
+        assert template.annotations.audience == ["user", "assistant"]
+        assert template.annotations.priority == 0.7
+        assert template.meta == {
+            "io.unifi.resourceKind": "camera-snapshot",
+            "io.unifi.updateMode": "on-demand",
+            "io.unifi.protocolSubscribe": False,
+            "io.unifi.relatedTools": ["protect_get_snapshot", "protect_list_cameras"],
+        }
+
+    def test_snapshot_index_has_mcp_metadata(self):
+        """The snapshot index should expose MCP title, annotations, and namespaced metadata."""
+        import unifi_protect_mcp.resources.snapshots  # noqa: F401
+        from unifi_protect_mcp.runtime import server
+
+        resources = server._resource_manager.list_resources()
+        index_resources = [r for r in resources if str(r.uri) == "protect://cameras/snapshots"]
+        assert len(index_resources) == 1
+        index = index_resources[0]
+
+        assert index.title == "Camera Snapshot Index"
+        assert index.annotations is not None
+        assert index.annotations.audience == ["assistant"]
+        assert index.annotations.priority == 0.6
+        assert index.meta == {
+            "io.unifi.resourceKind": "snapshot-index",
+            "io.unifi.updateMode": "poll",
+            "io.unifi.pollIntervalMs": 10000,
+            "io.unifi.protocolSubscribe": False,
+            "io.unifi.relatedTools": ["protect_get_snapshot", "protect_list_cameras"],
+        }
+
 
 # ---------------------------------------------------------------------------
 # protect_get_snapshot tool (include_image=True mode)

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,12 @@ Design note for mapping UniFi compatibility jobs to experimental MCP Tasks:
 - Why batch execution is the safest first native Tasks workflow
 - What must be implemented before advertising task capabilities
 
+#### [MCP Resources and Subscriptions Alignment](mcp-resources-subscriptions.md)
+Design note for mapping UniFi event buffers and snapshot surfaces to MCP resources:
+- Current Protect and Access MCP resource inventory
+- Which surfaces fit `resources/read` and resource templates
+- Why protocol resource subscriptions are not advertised until update notifications can be delivered safely
+
 #### [Permissions](permissions.md) 🔐 **SECURITY**
 Complete guide to the permission system:
 - How permissions work

--- a/docs/mcp-resources-subscriptions.md
+++ b/docs/mcp-resources-subscriptions.md
@@ -1,0 +1,85 @@
+# MCP Resources and Subscriptions Alignment
+
+This note maps UniFi MCP event and snapshot surfaces to the MCP 2025-11-25
+resource model. It keeps the existing REST/API SSE endpoints in place for
+non-MCP API clients and treats MCP resources as an MCP-native context surface,
+not as a replacement transport.
+
+Reference: https://modelcontextprotocol.io/specification/2025-11-25/server/resources
+
+## Current Resource Inventory
+
+| Server | URI | Type | Contents | Update mode |
+| --- | --- | --- | --- | --- |
+| Protect | `protect://events/stream` | Resource | Recent websocket event buffer as JSON | Poll |
+| Protect | `protect://events/stream/summary` | Resource | Event count summary as JSON | Poll |
+| Protect | `protect://cameras/snapshots` | Resource | Camera snapshot URI index as JSON | Poll |
+| Protect | `protect://cameras/{camera_id}/snapshot` | Resource template | Live JPEG snapshot bytes | On demand |
+| Access | `access://events/stream` | Resource | Recent event buffer as JSON | Poll |
+| Access | `access://events/stream/summary` | Resource | Event count summary as JSON | Poll |
+
+These resources now expose MCP-native metadata:
+
+- `title` for UI display.
+- `annotations` for host-side prioritization.
+- Namespaced `_meta` keys describing UniFi-specific behavior:
+  - `io.unifi.resourceKind`
+  - `io.unifi.updateMode`
+  - `io.unifi.pollIntervalMs` where polling is expected
+  - `io.unifi.protocolSubscribe`
+  - `io.unifi.relatedTools`
+
+## Resource Candidates
+
+| Candidate | Recommendation | Rationale |
+| --- | --- | --- |
+| Recent events | Keep as resources | Event buffers are bounded, contextual snapshots that fit `resources/read`. |
+| Event buffer summaries | Keep as resources | Summaries are lightweight and useful for automatic context selection. |
+| Camera snapshot index | Keep as resource | It is a discoverable index of available snapshot resource URIs. |
+| Individual camera snapshots | Keep as resource template | The URI template maps directly to MCP resource templates and returns binary content. |
+| Door status snapshots | Add later as Access resource templates | `access://doors/{door_id}/status` would fit once we want a reference beyond events. |
+| Device status snapshots | Add later as Network or Access resource templates | Useful for status context, but should be scoped per product and tested separately. |
+
+## Subscriptions
+
+MCP defines `resources/subscribe` and
+`notifications/resources/updated` for resource update pushes. The current MCP
+SDK exposes low-level request handlers and `ServerSession.send_resource_updated`,
+but FastMCP does not expose a public broadcast API that can safely emit resource
+notifications from UniFi websocket callbacks running outside a request session.
+
+Because of that, UniFi MCP should not advertise protocol resource subscriptions
+yet. The resource `_meta` value `io.unifi.protocolSubscribe: false` is
+intentional. Clients should poll the resource URIs or use the existing
+`*_subscribe_events` tools for instructions until a safe notification path
+exists.
+
+Adoption gate before enabling `resources/subscribe`:
+
+1. FastMCP exposes a supported server/session notification broadcast API, or we
+   add a well-tested local session registry without patching SDK internals.
+2. Event managers can emit `notifications/resources/updated` for the exact URI
+   whose backing buffer changed.
+3. Tests cover subscribe, unsubscribe, update notification delivery, and
+   shutdown cleanup.
+4. Relay behavior is verified so remote clients receive the same update
+   semantics as local clients.
+
+## API SSE Separation
+
+The API server SSE endpoints under `apps/api/src/unifi_api/routes/streams/`
+remain separate and in scope for non-MCP API users. They should not be removed
+or redirected as part of MCP resource alignment. MCP resources are optimized for
+host-driven context selection; API SSE streams are optimized for application
+clients that need long-lived event streams.
+
+## Reference Implementation
+
+The current reference implementation is the Protect and Access event resource
+metadata pattern:
+
+- Existing URIs remain stable.
+- Resource reads continue returning the same JSON payloads.
+- MCP metadata tells clients how to display and refresh resources.
+- Protocol subscriptions are explicitly marked unavailable until update
+  notifications can be delivered correctly.


### PR DESCRIPTION
Closes #255

## Summary
- adds MCP-native titles, annotations, and namespaced metadata to Protect/Access event resources and Protect snapshot resources
- documents the resource/subscription alignment plan against the MCP 2025-11-25 resource model
- keeps API SSE streams separate and leaves protocol resource subscriptions disabled until FastMCP has a safe update-notification path

## Validation
- make pre-commit
- uv run --package unifi-protect-mcp pytest apps/protect/tests/unit/test_event_resource.py apps/protect/tests/unit/test_snapshot_resource.py apps/protect/tests/unit/test_event_tools.py -q
- uv run --package unifi-access-mcp pytest apps/access/tests/unit/test_event_resource.py apps/access/tests/unit/test_events.py -q
- uv run ruff check apps/protect/src/unifi_protect_mcp/resources/events.py apps/access/src/unifi_access_mcp/resources/events.py apps/protect/src/unifi_protect_mcp/resources/snapshots.py apps/protect/tests/unit/test_event_resource.py apps/access/tests/unit/test_event_resource.py apps/protect/tests/unit/test_snapshot_resource.py
- local in-process MCP resource smoke for Protect and Access list/read surfaces