### PR TITLE
test: add MCP protocol smoke gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help sync build check test lint format format-check format-fix manifest generate server-manifests skill-references \
-       check-skill-references check-generated pre-commit ci core-test shared-test \
+       check-skill-references check-generated pre-commit ci core-test shared-test protocol-smoke \
        relay-test worker-install worker-test worker-typecheck worker-build worker-check docker-relay \
        docker-build docker-up docker-down docker-logs
 
@@ -29,6 +29,7 @@ help:
 	@echo ""
 	@echo "  make core-test      Run unifi-core tests only"
 	@echo "  make shared-test    Run unifi-mcp-shared tests only"
+	@echo "  make protocol-smoke Run MCP protocol conformance smoke tests"
 	@echo "  make worker-build   Install worker deps + typecheck Worker app"
 	@echo "  make worker-check   Run worker CLI tests + TypeScript checks"
 
@@ -45,7 +46,7 @@ core-test:
 shared-test:
 	uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -v
 
-test: core-test shared-test relay-test worker-test
+test: core-test shared-test relay-test protocol-smoke worker-test
 	$(MAKE) -C apps/network test
 	$(MAKE) -C apps/protect test
 	$(MAKE) -C apps/access test
@@ -88,6 +89,9 @@ check-generated: check-skill-references
 
 relay-test:
 	uv run --package unifi-mcp-relay pytest packages/unifi-mcp-relay/tests -v
+
+protocol-smoke:
+	uv run --package unifi-network-mcp python scripts/smoke_mcp_metadata.py --server all --registration-mode all
 
 worker-install:
 	npm ci --prefix apps/worker

--- a/scripts/smoke_mcp_metadata.py
+++ b/scripts/smoke_mcp_metadata.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Smoke test MCP server metadata over the real stdio transport.
+"""Smoke test MCP standard surfaces over the real stdio transport.
 
 This validates the MCP protocol surface without invoking any UniFi tools:
-``initialize`` for server metadata and ``tools/list`` for tool titles.
+``initialize`` for server metadata and ``tools/list`` for tool metadata across
+the supported registration modes.
 """
 
 from __future__ import annotations
@@ -17,9 +18,11 @@ from typing import Any
 import anyio
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
 
 PROJECT_WEBSITE_URL = "https://github.com/sirkirby/unifi-mcp"
 REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRATION_MODES = ("lazy", "eager", "meta_only")
 
 
 class MetadataSmokeError(AssertionError):
@@ -31,8 +34,10 @@ class ServerSpec:
     package: str
     command: str
     expected_name: str
+    prefix: str
     index_tool: str
     expected_index_title: str
+    representative_tool: str
 
 
 SERVER_SPECS = {
@@ -40,22 +45,28 @@ SERVER_SPECS = {
         package="unifi-network-mcp",
         command="unifi-network-mcp",
         expected_name="unifi-network-mcp",
+        prefix="unifi",
         index_tool="unifi_tool_index",
         expected_index_title="UniFi Network Tool Index",
+        representative_tool="unifi_list_clients",
     ),
     "protect": ServerSpec(
         package="unifi-protect-mcp",
         command="unifi-protect-mcp",
         expected_name="unifi-protect-mcp",
+        prefix="protect",
         index_tool="protect_tool_index",
         expected_index_title="UniFi Protect Tool Index",
+        representative_tool="protect_list_cameras",
     ),
     "access": ServerSpec(
         package="unifi-access-mcp",
         command="unifi-access-mcp",
         expected_name="unifi-access-mcp",
+        prefix="access",
         index_tool="access_tool_index",
         expected_index_title="UniFi Access Tool Index",
+        representative_tool="access_list_doors",
     ),
 }
 
@@ -67,6 +78,10 @@ def _field(obj: Any, name: str) -> Any:
     if isinstance(obj, dict):
         return obj.get(name)
     return getattr(obj, name, None)
+
+
+def _tool_by_name(tools: list[Any]) -> dict[str, Any]:
+    return {_field(tool, "name"): tool for tool in tools}
 
 
 def validate_icons(icons: list[Any] | None, *, label: str) -> None:
@@ -94,6 +109,23 @@ def validate_icons(icons: list[Any] | None, *, label: str) -> None:
             raise MetadataSmokeError(f"{label}: icon src is not PNG data")
 
 
+def validate_initialize_result(spec: ServerSpec, init: Any) -> None:
+    """Validate initialize negotiation and server metadata."""
+    protocol_version = _field(init, "protocolVersion")
+    if protocol_version != DEFAULT_MCP_PROTOCOL_REVISION:
+        raise MetadataSmokeError(
+            f"{spec.expected_name}: expected protocolVersion {DEFAULT_MCP_PROTOCOL_REVISION!r}, "
+            f"got {protocol_version!r}"
+        )
+
+    capabilities = _field(init, "capabilities")
+    tools_capability = _field(capabilities, "tools")
+    if tools_capability is None:
+        raise MetadataSmokeError(f"{spec.expected_name}: initialize result did not advertise tools capability")
+
+    validate_server_metadata(spec, init.serverInfo)
+
+
 def validate_server_metadata(spec: ServerSpec, server_info: Any) -> None:
     """Validate initialize.serverInfo metadata."""
     name = _field(server_info, "name")
@@ -113,9 +145,22 @@ def validate_server_metadata(spec: ServerSpec, server_info: Any) -> None:
     validate_icons(_field(server_info, "icons"), label=spec.expected_name)
 
 
-def validate_tool_titles(spec: ServerSpec, tools: list[Any]) -> None:
-    """Validate tools/list includes the expected meta-tool title."""
-    by_name = {_field(tool, "name"): tool for tool in tools}
+def validate_tool_schema(tool: Any, *, label: str) -> None:
+    """Validate standard MCP Tool fields that must always be present."""
+    input_schema = _field(tool, "inputSchema")
+    if not isinstance(input_schema, dict):
+        raise MetadataSmokeError(f"{label}: missing inputSchema")
+    if input_schema.get("type") != "object":
+        raise MetadataSmokeError(f"{label}: expected object inputSchema, got {input_schema!r}")
+
+    description = _field(tool, "description")
+    if not description:
+        raise MetadataSmokeError(f"{label}: missing description")
+
+
+def validate_meta_tool_surface(spec: ServerSpec, tools: list[Any]) -> None:
+    """Validate tools/list includes the expected compatibility meta-tools."""
+    by_name = _tool_by_name(tools)
     tool = by_name.get(spec.index_tool)
     if tool is None:
         raise MetadataSmokeError(f"{spec.expected_name}: missing {spec.index_tool} in tools/list")
@@ -126,8 +171,79 @@ def validate_tool_titles(spec: ServerSpec, tools: list[Any]) -> None:
             f"{spec.expected_name}: {spec.index_tool} expected title {spec.expected_index_title!r}, got {title!r}"
         )
 
+    validate_tool_schema(tool, label=f"{spec.expected_name}:{spec.index_tool}")
+    annotations = _field(tool, "annotations")
+    if _field(annotations, "readOnlyHint") is not True or _field(annotations, "openWorldHint") is not False:
+        raise MetadataSmokeError(f"{spec.expected_name}: {spec.index_tool} missing read-only closed-world annotations")
 
-def smoke_env(*, use_current_env: bool = False) -> dict[str, str]:
+    required_meta_tools = {
+        spec.index_tool,
+        f"{spec.prefix}_execute",
+        f"{spec.prefix}_batch",
+        f"{spec.prefix}_batch_status",
+    }
+    missing = sorted(required_meta_tools - set(by_name))
+    if missing:
+        raise MetadataSmokeError(f"{spec.expected_name}: missing meta-tools in tools/list: {missing}")
+
+
+def validate_mode_tools(spec: ServerSpec, tools: list[Any], *, registration_mode: str) -> None:
+    """Validate registration-mode-specific standard tools/list behavior."""
+    by_name = _tool_by_name(tools)
+    load_tool_name = f"{spec.prefix}_load_tools"
+    representative = by_name.get(spec.representative_tool)
+    load_tool = by_name.get(load_tool_name)
+
+    if registration_mode == "lazy":
+        if load_tool is None:
+            raise MetadataSmokeError(f"{spec.expected_name}: lazy mode missing {load_tool_name}")
+        validate_tool_schema(load_tool, label=f"{spec.expected_name}:{load_tool_name}")
+        annotations = _field(load_tool, "annotations")
+        if _field(annotations, "idempotentHint") is not True or _field(annotations, "openWorldHint") is not False:
+            raise MetadataSmokeError(
+                f"{spec.expected_name}: {load_tool_name} missing idempotent closed-world annotations"
+            )
+        if "notifications/tools/list_changed" not in (_field(load_tool, "description") or ""):
+            raise MetadataSmokeError(f"{spec.expected_name}: {load_tool_name} does not document list_changed refresh")
+        if representative is not None:
+            raise MetadataSmokeError(
+                f"{spec.expected_name}: lazy mode should not expose {spec.representative_tool} before loading"
+            )
+        return
+
+    if registration_mode == "meta_only":
+        if load_tool is not None:
+            raise MetadataSmokeError(f"{spec.expected_name}: meta_only mode should not expose {load_tool_name}")
+        if representative is not None:
+            raise MetadataSmokeError(
+                f"{spec.expected_name}: meta_only mode should not expose {spec.representative_tool} directly"
+            )
+        return
+
+    if registration_mode == "eager":
+        if load_tool is not None:
+            raise MetadataSmokeError(f"{spec.expected_name}: eager mode should not expose {load_tool_name}")
+        if representative is None:
+            raise MetadataSmokeError(f"{spec.expected_name}: eager mode missing {spec.representative_tool}")
+        validate_tool_schema(representative, label=f"{spec.expected_name}:{spec.representative_tool}")
+        annotations = _field(representative, "annotations")
+        if _field(annotations, "openWorldHint") is not False:
+            raise MetadataSmokeError(
+                f"{spec.expected_name}: {spec.representative_tool} missing closed-world annotation"
+            )
+        output_schema = _field(representative, "outputSchema")
+        if not isinstance(output_schema, dict):
+            raise MetadataSmokeError(f"{spec.expected_name}: {spec.representative_tool} missing outputSchema")
+        if not {"success", "data", "error"}.issubset(output_schema.get("properties", {})):
+            raise MetadataSmokeError(
+                f"{spec.expected_name}: {spec.representative_tool} outputSchema does not describe UniFi response"
+            )
+        return
+
+    raise MetadataSmokeError(f"Unknown registration mode: {registration_mode}")
+
+
+def smoke_env(*, registration_mode: str, use_current_env: bool = False) -> dict[str, str]:
     """Build the environment used by the metadata smoke server subprocesses."""
     env = os.environ.copy()
     if not use_current_env:
@@ -152,6 +268,7 @@ def smoke_env(*, use_current_env: bool = False) -> dict[str, str]:
             }
         )
     env["UNIFI_MCP_HTTP_ENABLED"] = "false"
+    env["UNIFI_TOOL_REGISTRATION_MODE"] = registration_mode
     return env
 
 
@@ -170,9 +287,9 @@ def selected_server_names(*, server: str, use_current_env: bool) -> list[str]:
     return list(OFFLINE_SERVER_NAMES)
 
 
-async def smoke_server(spec: ServerSpec, *, use_current_env: bool = False) -> str:
+async def smoke_server(spec: ServerSpec, *, registration_mode: str, use_current_env: bool = False) -> str:
     """Run the stdio MCP smoke for one server and return a one-line summary."""
-    env = smoke_env(use_current_env=use_current_env)
+    env = smoke_env(registration_mode=registration_mode, use_current_env=use_current_env)
 
     params = StdioServerParameters(
         command="uv",
@@ -184,15 +301,18 @@ async def smoke_server(spec: ServerSpec, *, use_current_env: bool = False) -> st
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
             init = await session.initialize()
-            validate_server_metadata(spec, init.serverInfo)
+            validate_initialize_result(spec, init)
 
             tools_result = await session.list_tools()
-            validate_tool_titles(spec, tools_result.tools)
+            validate_meta_tool_surface(spec, tools_result.tools)
+            validate_mode_tools(spec, tools_result.tools, registration_mode=registration_mode)
 
             return (
                 f"{spec.expected_name} "
+                f"mode={registration_mode} "
                 f"{init.serverInfo.version} "
                 f"{spec.expected_index_title} "
+                f"tools={len(tools_result.tools)} "
                 f"icons={len(init.serverInfo.icons or [])}"
             )
 
@@ -213,14 +333,28 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Use the current controller environment instead of offline dummy credentials.",
     )
+    parser.add_argument(
+        "--registration-mode",
+        choices=[*REGISTRATION_MODES, "all"],
+        default="lazy",
+        help="Registration mode to smoke test. Use 'all' to cover lazy, eager, and meta_only.",
+    )
     return parser.parse_args()
 
 
 async def main_async() -> None:
     args = parse_args()
     server_names = selected_server_names(server=args.server, use_current_env=args.use_current_env)
+    registration_modes = list(REGISTRATION_MODES) if args.registration_mode == "all" else [args.registration_mode]
     for server_name in server_names:
-        print(await smoke_server(SERVER_SPECS[server_name], use_current_env=args.use_current_env))
+        for registration_mode in registration_modes:
+            print(
+                await smoke_server(
+                    SERVER_SPECS[server_name],
+                    registration_mode=registration_mode,
+                    use_current_env=args.use_current_env,
+                )
+            )
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- extend the stdio MCP smoke harness to validate `initialize` negotiation and `tools/list` metadata against the current MCP standard surfaces
- cover lazy, eager, and meta_only registration modes for Network and Protect in the offline smoke path
- add `make protocol-smoke` and wire it into the top-level `make test` gate

## Notes
- The smoke uses dummy offline controller credentials, so Network/Protect controller connection failures in stderr are expected. The asserted contract is that the MCP stdio server still initializes and exposes the expected standard tool metadata after startup.
- Access remains opt-in via `--server access --use-current-env` because its existing startup path requires real controller initialization.

## Validation
- `make pre-commit`
- `make protocol-smoke`

Closes #258