### PR TITLE
fix: bump unifi-mcp-shared pin to >=0.5.0,<0.6 across published packages

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Access MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.4.5,<0.5",
+    "unifi-mcp-shared>=0.5.0,<0.6",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -5,7 +5,7 @@ description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.4.5,<0.5",
+    "unifi-mcp-shared>=0.5.0,<0.6",
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Protect MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.4.5,<0.5",
+    "unifi-mcp-shared>=0.5.0,<0.6",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
     "unifi-core[protect]>=0.3.2,<0.4",

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "mcp[cli]>=1.26.0,<2",
     "aiohttp>=3.13.4",
     "python-dotenv>=1.2.2",
-    "unifi-mcp-shared>=0.4.5,<0.5",
+    "unifi-mcp-shared>=0.5.0,<0.6",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Hotfix for #283. The 0.18.0 / 0.4.0 / 0.3.0 / 0.2.0 coordinated release pinned `unifi-mcp-shared>=0.4.5,<0.5` across all four published packages, but the same release introduced `from unifi_mcp_shared.metadata import …` in:

- `apps/network/src/unifi_network_mcp/runtime.py`
- `apps/protect/src/unifi_protect_mcp/runtime.py`
- `apps/access/src/unifi_access_mcp/runtime.py`
- `packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py`

The `metadata` module only exists in `unifi-mcp-shared` 0.5.0. Result: fresh `uvx unifi-network-mcp@latest` (and the same for protect / access / relay) resolves shared 0.4.5 and crashes immediately with `ModuleNotFoundError: No module named 'unifi_mcp_shared.metadata'`.

This PR bumps the pin to `>=0.5.0,<0.6` in all four `pyproject.toml` files. `uv.lock` is unaffected — workspace sources override the version range for local dev, so the bug only manifests in built wheels' `requires_dist`.

## Follow-up

After merge, tag patch releases (shared 0.5.0 is already on PyPI, so no upstream wait):

- `network/v0.18.1`
- `protect/v0.4.1`
- `access/v0.3.1`
- `relay/v0.2.1`

Then yank `0.18.0` / `0.4.0` / `0.3.0` / `0.2.0` from PyPI so `@latest` resolves to the working version for everyone, including users who already hit the broken release.

## Test plan

- [ ] CI green
- [ ] After publish: `uvx --refresh unifi-network-mcp@0.18.1 --help` boots without `ModuleNotFoundError`
- [ ] Same smoke test for `unifi-protect-mcp@0.4.1`, `unifi-access-mcp@0.3.1`, `unifi-mcp-relay@0.2.1`

Fixes #283