### PR TITLE
ci: add cross-package pin-alignment gate to prevent #283 class of bug

### DIFF
--- a/.github/workflows/check-pin-alignment.yml
+++ b/.github/workflows/check-pin-alignment.yml
@@ -1,0 +1,52 @@
+name: "Check: Cross-package pin alignment"
+
+# Verifies that each downstream wheel's declared pin permits an importable
+# upstream when resolved against PyPI. Catches the failure mode where
+# workspace [tool.uv.sources] masks a stale pin in [project.dependencies]
+# (incident #283). Uses no untrusted event inputs — only repo source.
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - "apps/*/pyproject.toml"
+      - "packages/*/pyproject.toml"
+      - "scripts/check_pin_alignment.py"
+      - ".github/workflows/check-pin-alignment.yml"
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches: [ main, develop ]
+    paths:
+      - "apps/*/pyproject.toml"
+      - "packages/*/pyproject.toml"
+      - "scripts/check_pin_alignment.py"
+      - ".github/workflows/check-pin-alignment.yml"
+
+env:
+  # hatch-vcs fallback for branches without an upstream-package tag in ancestry.
+  SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev0"
+
+permissions:
+  contents: read
+
+jobs:
+  pin-alignment:
+    name: "Pin alignment (PyPI install + smoke import)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # hatch-vcs needs full history to derive versions from tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Run pin-alignment check
+        run: python3 scripts/check_pin_alignment.py

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Verify that each downstream wheel's declared pin permits an importable upstream.
+
+The failure this catches
+------------------------
+
+Each downstream ``pyproject.toml`` declares a version range for shared upstream
+packages (``unifi-mcp-shared``, ``unifi-core``) in ``[project.dependencies]``.
+That range becomes the wheel's ``Requires-Dist`` metadata, which is what
+``pip``/``uv`` resolves against PyPI on a user's machine.
+
+In the workspace, ``[tool.uv.sources]`` overrides the version range and resolves
+to the local checkout. As a result, ``uv lock --check``, ``uv sync``, ``pytest``,
+and every CI job pass cleanly even when the declared range excludes the version
+of the upstream package that contains code the downstream imports. The bug only
+surfaces post-publish, on a fresh ``uvx <pkg>@latest`` install on a user's
+machine. Issue #283 was a real instance of this failure mode.
+
+How this script catches it
+---------------------------
+
+1. Build a workspace wheel for every upstream and downstream package.
+2. For each downstream wheel, create a clean venv with no workspace context.
+3. ``pip install`` the downstream wheel with ``--find-links`` pointing at the
+   workspace upstream wheels and ``--index-url`` set to PyPI. This is the exact
+   resolution path a user hits, except that workspace upstream wheels are
+   available as an additional source so coordinated upstream-downstream PRs do
+   not falsely fail.
+4. Attempt a smoke import of the downstream's runtime entrypoint. If the import
+   succeeds, the declared pin permits a working upstream version. If it fails
+   with ``ModuleNotFoundError`` (or pip itself fails with no matching version),
+   the pin is stale and a fresh PyPI install would crash.
+
+Exit code 0 on success, 1 on any failure. Diagnostic output is printed to
+stdout and is intended to be read directly from the CI log.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import venv
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+UPSTREAM_PACKAGES: dict[str, Path] = {
+    "unifi-mcp-shared": REPO / "packages/unifi-mcp-shared",
+    "unifi-core": REPO / "packages/unifi-core",
+}
+
+
+@dataclass(frozen=True)
+class Downstream:
+    src: Path
+    dist_name: str
+    smoke_import: str
+
+
+DOWNSTREAM_PACKAGES: list[Downstream] = [
+    Downstream(REPO / "apps/network", "unifi-network-mcp", "unifi_network_mcp.main"),
+    Downstream(REPO / "apps/protect", "unifi-protect-mcp", "unifi_protect_mcp.main"),
+    Downstream(REPO / "apps/access", "unifi-access-mcp", "unifi_access_mcp.main"),
+    Downstream(REPO / "apps/api", "unifi-api-server", "unifi_api"),
+    Downstream(
+        REPO / "packages/unifi-mcp-relay",
+        "unifi-mcp-relay",
+        "unifi_mcp_relay.discovery",
+    ),
+]
+
+
+def run_capture(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args, check=True, capture_output=True, text=True, **kwargs
+    )
+
+
+def build_wheel(src: Path, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_capture(["uv", "build", "--wheel", str(src), "--out-dir", str(out_dir)])
+    wheels = sorted(out_dir.glob("*.whl"), key=lambda p: p.stat().st_mtime)
+    if not wheels:
+        raise RuntimeError(f"uv build produced no wheel for {src}")
+    return wheels[-1]
+
+
+def check_downstream(
+    pkg: Downstream, downstream_wheel: Path, find_links: Path, venv_dir: Path
+) -> tuple[bool, str]:
+    venv.create(venv_dir, with_pip=True, clear=True, symlinks=True)
+    py = venv_dir / "bin" / "python"
+
+    try:
+        run_capture(
+            [
+                str(py),
+                "-m",
+                "pip",
+                "install",
+                "--quiet",
+                "--disable-pip-version-check",
+                "--find-links",
+                str(find_links),
+                "--index-url",
+                "https://pypi.org/simple",
+                str(downstream_wheel),
+            ]
+        )
+    except subprocess.CalledProcessError as exc:
+        return False, (
+            "pip install failed — the declared pin range cannot be satisfied by "
+            "PyPI plus workspace-built upstream wheels.\n\n"
+            f"{(exc.stderr or '').strip()[-2000:]}"
+        )
+
+    try:
+        run_capture([str(py), "-c", f"import {pkg.smoke_import}"])
+    except subprocess.CalledProcessError as exc:
+        return False, (
+            f"`import {pkg.smoke_import}` failed after install. The declared pin "
+            f"resolved to an upstream version that does not contain the imported "
+            f"code path.\n\n"
+            f"{(exc.stderr or '').strip()[-2000:]}"
+        )
+
+    return True, "OK"
+
+
+def main() -> int:
+    if shutil.which("uv") is None:
+        print("error: `uv` is not on PATH", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="pin-alignment-") as tmp:
+        tmp_path = Path(tmp)
+        find_links = tmp_path / "wheels"
+        find_links.mkdir()
+
+        print("Building upstream wheels (workspace) -> --find-links source")
+        for name, path in UPSTREAM_PACKAGES.items():
+            wheel = build_wheel(path, find_links)
+            print(f"  {name}: {wheel.name}")
+
+        print()
+        print("Checking each downstream wheel in a clean venv against PyPI")
+        failures: list[tuple[str, str]] = []
+        for pkg in DOWNSTREAM_PACKAGES:
+            wheel = build_wheel(pkg.src, tmp_path / "downstream" / pkg.dist_name)
+            venv_dir = tmp_path / "venvs" / pkg.dist_name
+            ok, msg = check_downstream(pkg, wheel, find_links, venv_dir)
+            status = "PASS" if ok else "FAIL"
+            print(f"  [{status}] {pkg.dist_name} ({wheel.name})")
+            if not ok:
+                failures.append((pkg.dist_name, msg))
+
+        if failures:
+            print()
+            print("=" * 70)
+            print("PIN ALIGNMENT CHECK FAILED")
+            print("=" * 70)
+            for name, msg in failures:
+                print()
+                print(f"--- {name} ---")
+                print(msg)
+            print()
+            print(
+                "Why this matters: workspace `[tool.uv.sources]` overrides the "
+                "version range in `[project.dependencies]`, so this failure is "
+                "invisible to `uv lock --check`, `uv sync`, and every "
+                "workspace-based test job. The pin only takes effect in the "
+                "wheel's `Requires-Dist` metadata — i.e., on a user's machine "
+                "running `uvx <pkg>@latest` or `pip install <pkg>`."
+            )
+            print()
+            print(
+                "Two failure shapes are common:\n"
+                "  • Stale pin: an existing pin's upper bound excludes the "
+                "upstream version that contains code the downstream now imports. "
+                "Fix by widening the upper bound in the failing downstream's "
+                "`pyproject.toml` (e.g., `unifi-mcp-shared>=0.5.0,<0.6`).\n"
+                "  • Premature pin bump: a downstream now requires an upstream "
+                "version that has not been published to PyPI yet. Split the "
+                "change: merge and release the upstream first, then open a "
+                "follow-up PR that bumps the downstream pin and adds the imports."
+            )
+            print()
+            print(
+                "See `.agents/skills/monorepo-release-pipeline/SKILL.md` "
+                "Procedure D for the manual wheel-metadata check this CI gate "
+                "automates."
+            )
+            return 1
+
+        print()
+        print("All downstream wheels install and import cleanly with their "
+              "declared pins.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -74,9 +74,7 @@ DOWNSTREAM_PACKAGES: list[Downstream] = [
 
 
 def run_capture(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        args, check=True, capture_output=True, text=True, **kwargs
-    )
+    return subprocess.run(args, check=True, capture_output=True, text=True, **kwargs)
 
 
 def build_wheel(src: Path, out_dir: Path) -> Path:
@@ -88,9 +86,7 @@ def build_wheel(src: Path, out_dir: Path) -> Path:
     return wheels[-1]
 
 
-def check_downstream(
-    pkg: Downstream, downstream_wheel: Path, find_links: Path, venv_dir: Path
-) -> tuple[bool, str]:
+def check_downstream(pkg: Downstream, downstream_wheel: Path, find_links: Path, venv_dir: Path) -> tuple[bool, str]:
     venv.create(venv_dir, with_pip=True, clear=True, symlinks=True)
     py = venv_dir / "bin" / "python"
 
@@ -196,8 +192,7 @@ def main() -> int:
             return 1
 
         print()
-        print("All downstream wheels install and import cleanly with their "
-              "declared pins.")
+        print("All downstream wheels install and import cleanly with their declared pins.")
         return 0
 
 


### PR DESCRIPTION
## Summary

Hard CI gate that catches the failure mode behind #283 automatically, instead of relying on the human running the release skill's Procedure D check before tagging.

**The bug class:** a downstream package's `[project.dependencies]` pin excludes the version of an upstream workspace package that contains code the downstream imports. The bug is invisible to every workspace-based check because `[tool.uv.sources]` overrides the version range during local resolution. `uv lock --check`, `uv sync`, the full test matrix, the lint matrix, and even the Dockerfiles (which use `uv sync --frozen` against the workspace lock) all pass cleanly. The pin only takes effect in the published wheel's `Requires-Dist`, i.e., on a user's machine resolving via `uvx <pkg>@latest`.

This is the third PR in the response to #283. #284 fixed the immediate breakage; #285 hardened the release skill's documentation; this PR adds the enforcement layer.

## How the gate works

`scripts/check_pin_alignment.py`:

1. Builds workspace wheels for shared, core, and every published downstream (`network`, `protect`, `access`, `api`, `relay`).
2. For each downstream wheel: creates a clean venv with no workspace context.
3. `pip install`s the downstream wheel with `--index-url=PyPI` plus `--find-links` pointing at the workspace upstream wheels. This is the *exact* resolution path a user hits, with workspace upstream available as a fallback so a coordinated upstream-downstream PR doesn't falsely fail just because the upstream version isn't published yet.
4. Runs a smoke `import` of the downstream's runtime entrypoint (e.g., `unifi_network_mcp.main`).
5. Fails with the full traceback if any install or import breaks.

`.github/workflows/check-pin-alignment.yml` runs the check on every PR and push that touches any `pyproject.toml` under `apps/` or `packages/`, the check script, or the workflow file.

## Verification

**Positive** (current main, post-#284, all four pins corrected): all five downstream wheels PASS.

```
Building upstream wheels (workspace) -> --find-links source
  unifi-mcp-shared: unifi_mcp_shared-0.5.1.dev5+g9907fbf-py3-none-any.whl
  unifi-core: unifi_core-0.3.4.dev5+g9907fbf-py3-none-any.whl

Checking each downstream wheel in a clean venv against PyPI
  [PASS] unifi-network-mcp
  [PASS] unifi-protect-mcp
  [PASS] unifi-access-mcp
  [PASS] unifi-api-server
  [PASS] unifi-mcp-relay

All downstream wheels install and import cleanly with their declared pins.
```

**Negative** (temporarily reverted `apps/network/pyproject.toml` to the broken `<0.5` pin from before #284): the gate produces the *exact* `ModuleNotFoundError` from #283:

```
  [FAIL] unifi-network-mcp
--- unifi-network-mcp ---
`import unifi_network_mcp.main` failed after install. The declared pin resolved
to an upstream version that does not contain the imported code path.

Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import unifi_network_mcp.main
  File ".../unifi_network_mcp/main.py", line 19, in <module>
    from unifi_network_mcp.runtime import (...)
  File ".../unifi_network_mcp/runtime.py", line 30, in <module>
    from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL, configure_mcp_server_metadata
ModuleNotFoundError: No module named 'unifi_mcp_shared.metadata'
```

Pin restored after negative test.

## False-positive surface

The gate will fail on a PR that bumps a downstream pin to require an upstream version that hasn't been published to PyPI yet (e.g., bumping `>=0.5.0` before `shared/v0.5.0` is tagged). The gate's failure message documents this case and instructs the author to split the change into upstream-first and downstream-second PRs — which is the established release-pipeline pattern (Procedure F in `.agents/skills/monorepo-release-pipeline/SKILL.md`).

This is a feature: the gate enforces the release-ordering discipline as a hard CI check rather than relying on procedural memory.

## Test plan

- [x] Local positive test on current main (all PASS)
- [x] Local negative test reproducing #283 (FAIL with original traceback)
- [x] CI green on this PR

Related: #283 (incident), #284 (hotfix), #285 (release-skill update)