### PR TITLE
fix(firewall): allow IP+OBJECT validation with ip_group_id (empty ips)

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -281,14 +281,18 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
             continue
         target = ep.get("matching_target")
         if target in ("IP", "NETWORK") and not ep.get("matching_target_type"):
-            expected = "SPECIFIC" if target == "IP" else "OBJECT"
-            return "%s.matching_target_type is required when matching_target is '%s'. Use '%s'." % (
+            expected = "'SPECIFIC' or 'OBJECT'" if target == "IP" else "'OBJECT'"
+            return "%s.matching_target_type is required when matching_target is '%s'. Use %s." % (
                 direction,
                 target,
                 expected,
             )
-        if target == "IP" and not ep.get("ips"):
-            return "%s.ips array is required when matching_target is 'IP'." % direction
+        if target == "IP":
+            target_type = ep.get("matching_target_type")
+            if target_type == "OBJECT" and not ep.get("ip_group_id"):
+                return "%s.ip_group_id is required when matching_target is 'IP' with matching_target_type 'OBJECT'." % direction
+            if target_type != "OBJECT" and not ep.get("ips"):
+                return "%s.ips array is required when matching_target is 'IP'." % direction
         if target == "NETWORK" and not ep.get("network_ids"):
             return "%s.network_ids array is required when matching_target is 'NETWORK'." % direction
     return None

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -290,7 +290,10 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
         if target == "IP":
             target_type = ep.get("matching_target_type")
             if target_type == "OBJECT" and not ep.get("ip_group_id"):
-                return "%s.ip_group_id is required when matching_target is 'IP' with matching_target_type 'OBJECT'." % direction
+                return (
+                    "%s.ip_group_id is required when matching_target is 'IP' with matching_target_type 'OBJECT'."
+                    % direction
+                )
             if target_type != "OBJECT" and not ep.get("ips"):
                 return "%s.ips array is required when matching_target is 'IP'." % direction
         if target == "NETWORK" and not ep.get("network_ids"):

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -319,6 +319,69 @@ class TestCreateZoneTargetingValidation:
         assert result["success"] is False
         assert "network_ids" in result["error"]
 
+    @pytest.mark.asyncio
+    async def test_ip_object_targeting_with_ip_group_id_passes_validation(self):
+        """IP targeting with matching_target_type=OBJECT and ip_group_id (ips empty) should pass.
+
+        UniFi V2 firewall policies that reference a reusable IP group object use this
+        pattern: source/destination has matching_target_type=OBJECT, ip_group_id set,
+        and ips=[]. The validator must allow this combination.
+        """
+        zone_data = {
+            "name": "Allow VLAN to internal host",
+            "action": "ALLOW",
+            "protocol": "all",
+            "source": {
+                "zone_id": "internal-zone",
+                "matching_target": "IP",
+                "matching_target_type": "OBJECT",
+                "ip_group_id": "group_internal_hosts",
+                "ips": [],
+            },
+            "destination": {
+                "zone_id": "trusted-zone",
+                "matching_target": "IP",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["192.168.1.100"],
+            },
+        }
+        created_raw = {**zone_data, "_id": "new_obj_001"}
+        mock_created = MagicMock()
+        mock_created.raw = created_raw
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_policy = AsyncMock(return_value=mock_created)
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is True
+        assert result["policy_id"] == "new_obj_001"
+
+    @pytest.mark.asyncio
+    async def test_ip_object_targeting_without_ip_group_id_fails(self):
+        """IP targeting with matching_target_type=OBJECT but no ip_group_id should fail."""
+        zone_data = {
+            "name": "Bad object policy",
+            "action": "ALLOW",
+            "source": {
+                "zone_id": "internal",
+                "matching_target": "IP",
+                "matching_target_type": "OBJECT",
+                "ips": [],
+                # missing ip_group_id
+            },
+            "destination": {"zone_id": "wan", "matching_target": "ANY"},
+        }
+
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is False
+        assert "ip_group_id" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # Legacy V1 field migration errors (#210)


### PR DESCRIPTION
## Summary

The `_validate_zone_targeting` validator unconditionally requires `ips` to be non-empty when `matching_target == "IP"`, but the V2 firewall API legitimately supports policies that reference a reusable IP group object via `ip_group_id` with an empty `ips` array:

```json
{
  "matching_target": "IP",
  "matching_target_type": "OBJECT",
  "ip_group_id": "<group-object-id>",
  "ips": []
}
```

This is the standard shape for any IP-group-based policy on modern firmware (UDM-SE 8.4.x+), but the validator rejected it at create-time, blocking `unifi_create_firewall_policy` for any rule that references an IP group object — even though equivalent policies exist on the controller already.

## Fix

Under `matching_target == "IP"`:
- If `matching_target_type == "OBJECT"`: require `ip_group_id` (allow empty `ips`)
- Otherwise: require non-empty `ips`

Also widened the missing-`matching_target_type` error hint to include "SPECIFIC" or "OBJECT".

## Tests

Two new cases in `apps/network/tests/unit/test_firewall_tools.py::TestCreateZoneTargetingValidation`:
- `test_ip_object_targeting_with_ip_group_id_passes_validation` — verifies the OBJECT + `ip_group_id` shape passes the validator and creates the policy
- `test_ip_object_targeting_without_ip_group_id_fails` — verifies the validator still rejects OBJECT without `ip_group_id`
