### PR TITLE
chore: add community standards

### DIFF
--- a/.agents/skills/claude-plugin-config-transport/SKILL.md
+++ b/.agents/skills/claude-plugin-config-transport/SKILL.md
@@ -8,11 +8,12 @@ description: >-
   asyncio.wait(FIRST_COMPLETED) must not be reintroduced; local development
   with claude --plugin-dir and its marketplace-cache blind spot; running
   check-prereqs.sh before plugin setup; writing Bash 3.2-compatible shell
-  scripts for plugins/; multi-target plugin support for Claude and Codex
-  targets; and issuing no-op patch releases when only plugin config or scripts
-  change. Apply even if the user doesn't explicitly mention transport races —
-  activate whenever plugin behavior, MCP tool availability, or
-  plugin-scoped shell scripts are being modified.
+  scripts for plugins/; multi-target plugin support for Claude, Codex, and
+  OpenClaw targets; atomic version sync across plugin manifests; and issuing
+  no-op patch releases when only plugin config or scripts change. Apply even
+  if the user doesn't explicitly mention transport races — activate whenever
+  plugin behavior, MCP tool availability, or plugin-scoped shell scripts are
+  being modified.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -30,8 +31,9 @@ This skill covers the full lifecycle of Claude MCP plugin integration in unifi-m
 - `plugins/unifi-protect/scripts/set-env.sh`, `plugins/unifi-protect/scripts/check-prereqs.sh`
 - `plugins/unifi-access/scripts/set-env.sh`, `plugins/unifi-access/scripts/check-prereqs.sh`
 - `packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py`
-- `.agents/plugins/marketplace.json` (multi-target plugin registry)
+- `.agents/plugins/marketplace.json` (multi-target plugin registry: Claude, Codex, OpenClaw)
 - `.codex-plugin/` (Codex-specific manifest directory, PR #246)
+- `.agents/plugins/openclaw/` (OpenClaw-specific manifest directory, PR #248)
 
 ## Prerequisites
 
@@ -40,7 +42,7 @@ Before modifying any plugin configuration or transport code:
 1. **Understand the uvx launch context.** When Claude launches a plugin via `uvx`, the plugin process is not PID 1. This distinction controls which transport path activates inside `transport.py` and whether HTTP transport will be enabled. The PID check is in `resolve_http_config()` in `transport.py`.
 2. **Know all three app directories.** Transport and HTTP config changes almost always need to be reflected in `apps/network/`, `apps/protect/`, and `apps/access/` in parallel. Partial application leaves inconsistent behavior.
 3. **Know all three plugin directories.** Script and setup changes apply to `plugins/unifi-network/`, `plugins/unifi-protect/`, and `plugins/unifi-access/`. Applying to only one or two creates inconsistent behavior that is nearly impossible for users to diagnose.
-4. **Know the multi-target plugin registry.** As of PR #246, unifi-mcp supports both Claude and Codex targets. Plugin configuration, version sync, and release procedures must account for target-specific manifests.
+4. **Know the multi-target plugin registry and all three runtimes.** As of PR #246 (Codex) and PR #248 (OpenClaw), unifi-mcp supports three plugin targets: Claude, Codex, and OpenClaw. Plugin configuration, version sync, and release procedures must account for target-specific manifests and initialization paths.
 5. **Hold the current MCP shared package version.** Plugin versions are slaved to MCP package tags; know the current tag before planning a release (see Procedure F).
 6. **Run `check-prereqs.sh` first** (see Procedure D) before activating any plugin setup change in a live environment.
 
@@ -87,7 +89,7 @@ This was the root cause of Issue #200, fixed in PR #202. The fix required change
 
 ### The current safe pattern in `transport.py`
 
-The current implementation in `packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py` uses stdio as the **primary control flow** — it runs to completion. HTTP runs as a **cancellable background task**. An HTTP failure must never cancel stdio. This pattern extends to **all transport targets** including Codex (PR #246).
+The current implementation in `packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py` uses stdio as the **primary control flow** — it runs to completion. HTTP runs as a **cancellable background task**. An HTTP failure must never cancel stdio. This pattern extends to **all transport targets** including Codex (PR #246) and OpenClaw (PR #248).
 
 ```python
 # SAFE — current implementation (run_transports function)
@@ -105,7 +107,7 @@ finally:
             pass
 ```
 
-`run_http()` catches its own `SystemExit` internally (port-bind failures from uvicorn), so a failed HTTP transport returns normally rather than propagating. Stdio lifecycle is unaffected. This design assumes the transport target (Claude, Codex) uses stdio as the primary transport and HTTP as optional.
+`run_http()` catches its own `SystemExit` internally (port-bind failures from uvicorn), so a failed HTTP transport returns normally rather than propagating. Stdio lifecycle is unaffected. This design assumes the transport target (Claude, Codex, OpenClaw) uses stdio as the primary transport and HTTP as optional.
 
 ### What NOT to do — the pre-fix anti-pattern
 
@@ -179,7 +181,7 @@ ls plugins/unifi-network/scripts/
 
 ### What it does
 
-`plugins/unifi-*/scripts/check-prereqs.sh` validates required environment variables and system state before plugin activation. It catches missing credentials and misconfigured endpoints before they produce cryptic user-facing failures. The scripts explicitly state Bash 3.2 compatibility.
+`plugins/unifi-*/scripts/check-prereqs.sh` validates required environment variables and system state before plugin activation. It catches missing credentials and misconfigured endpoints before they produce cryptic user-facing failures. The scripts explicitly state Bash 3.2 compatibility. OpenClaw plugins have identical prerequisites to Claude and Codex — the check-prereqs.sh scripts are target-agnostic.
 
 ### When to run it
 
@@ -274,9 +276,9 @@ If CI runs on Linux, add a macOS job or test locally — Linux bash is almost al
 
 Plugin versions are **strictly slaved** to MCP package release tags. The version referenced in plugin config must match a tagged MCP package version published to PyPI. There is no independent plugin version number.
 
-### Multi-target plugin registry (PR #246)
+### Multi-target plugin registry (PR #246, PR #248)
 
-As of PR #246, unifi-mcp supports **both Claude and Codex** as plugin targets. The multi-target registry lives in `.agents/plugins/marketplace.json`:
+As of PR #246 (Codex) and PR #248 (OpenClaw), unifi-mcp supports **three plugin targets: Claude, Codex, and OpenClaw**. The multi-target registry lives in `.agents/plugins/marketplace.json`:
 
 ```json
 {
@@ -293,11 +295,18 @@ As of PR #246, unifi-mcp supports **both Claude and Codex** as plugin targets. T
       {"name": "unifi-protect", "version": "1.2.3"},
       {"name": "unifi-access", "version": "1.2.3"}
     ]
+  },
+  "openclaw": {
+    "plugins": [
+      {"name": "unifi-network", "version": "1.2.3"},
+      {"name": "unifi-protect", "version": "1.2.3"},
+      {"name": "unifi-access", "version": "1.2.3"}
+    ]
   }
 }
 ```
 
-When a version bump is released, all target registries must be updated in the same commit. Codex-specific manifests are in `.codex-plugin/` and must be synchronized with the main app configs.
+When a version bump is released, **all target registries** in `.agents/plugins/marketplace.json` must be updated in the same commit. Codex-specific manifests are in `.codex-plugin/` and OpenClaw-specific manifests are in `.agents/plugins/openclaw/` — these must be synchronized with the main app configs and the root marketplace.json entry.
 
 ### When only plugin config or scripts change
 
@@ -310,13 +319,16 @@ If a PR modifies only plugin manifests or scripts (no Python code changes in `sh
    git push origin v1.2.4
    ```
 3. Wait for the release pipeline to publish the wheel to PyPI. The Python wheel is functionally identical to the prior version — the bump exists solely to create a version anchor the plugin can reference.
-4. Update the version field in **all target registries** in `.agents/plugins/marketplace.json` (both Claude and Codex).
-5. Update the version field in **all three apps'** config to `"1.2.4"`:
-   - `apps/network/src/unifi_network_mcp/config/config.yaml`
-   - `apps/protect/src/unifi_protect_mcp/config/config.yaml`
-   - `apps/access/src/unifi_access_mcp/config/config.yaml`
-6. Update Codex-specific manifests in `.codex-plugin/plugin.json` if transport-level changes were made.
-7. Do **not** update the plugin version before the PyPI step completes (PyPI ordering gate — see `monorepo-release-pipeline` skill).
+4. **Atomically update version fields** in all target registries and manifests:
+   - `.agents/plugins/marketplace.json` — all three target sections (claude, codex, openclaw) for all three plugins (network, protect, access)
+   - `.codex-plugin/plugin.json` — version field in the Codex-specific manifest
+   - `.agents/plugins/openclaw/plugin.json` — version field in the OpenClaw-specific manifest
+   - `apps/network/src/unifi_network_mcp/config/config.yaml` — version string
+   - `apps/protect/src/unifi_protect_mcp/config/config.yaml` — version string
+   - `apps/access/src/unifi_access_mcp/config/config.yaml` — version string
+
+5. **Workflow automation:** The `bump-plugin-versions.yml` CI workflow should atomically cover all three locations (marketplace.json root, .codex-plugin/plugin.json, .agents/plugins/openclaw/plugin.json) in a single workflow commit — do not bump them separately. Version skew between registry entries causes marketplace distribution inconsistencies.
+6. Do **not** update the plugin version before the PyPI step completes (PyPI ordering gate — see `monorepo-release-pipeline` skill).
 
 **Never skip the release for plugin-only changes.** Without a new tag, the plugin version field cannot advance, the config change has no anchored release identity, and existing users stay pinned to the cached old config until a tagged release forces cache invalidation.
 
@@ -329,6 +341,7 @@ If a PR modifies only plugin manifests or scripts (no Python code changes in `sh
 | `check-prereqs.sh` or `set-env.sh` change | Yes | No-op patch |
 | Plugin skill SKILL.md change | Yes | No-op patch |
 | Codex manifest or `.codex-plugin/` change | Yes | No-op patch |
+| OpenClaw manifest or `.agents/plugins/openclaw/` change | Yes | No-op patch |
 | Multi-target registry (.agents/plugins/marketplace.json) change | Yes | No-op patch |
 | README / docs only | No | — |
 
@@ -356,10 +369,14 @@ Config changes to HTTP transport behavior must be applied to all three apps (`ne
 
 A passing local test with `--plugin-dir` does not guarantee the marketplace-installed version behaves the same way. Always do a final marketplace-path test before shipping, especially after config or script changes.
 
-### OpenClaw bundle pattern — Codex-specific gotcha
+### Three-runtime transport pattern — Claude, Codex, and OpenClaw
 
-The Codex plugin uses the OpenClaw bundle pattern (decision-e7099071) where transport initialization is bundled with Codex-specific config loading. Changes to transport.py may require parallel changes to `.codex-plugin/` initialization code. Test both Claude and Codex transport paths after any transport change.
+The three plugin targets (Claude, Codex, and OpenClaw) have identical transport initialization patterns. Changes to `transport.py` apply to all three; transport-specific gotchas that were previously labeled as Codex-only (PR #246) now apply equally to OpenClaw (PR #248). When debugging transport issues, test against all three runtime targets if possible — a transport bug may surface in one target before appearing in others due to timing or initialization order differences.
+
+### Version sync atomicity — Marketplace registry must stay consistent
+
+The `.agents/plugins/marketplace.json` root registry, `.codex-plugin/plugin.json`, and `.agents/plugins/openclaw/plugin.json` must have matching version strings. If a release bumps only `.agents/plugins/marketplace.json` but forgets the target-specific manifests, the Codex and OpenClaw plugins will keep referencing the old version while the marketplace registry has advanced. This creates version skew that manifests as "tool unavailability for OpenClaw users while Codex works fine" — a confusing symptom that points to version mismatch, not transport issues. Always update all three registry locations atomically.
 
 ### Skill-dir naming collision — Manifest registration gotcha
 
-The `.agents/skills/*/` directory structure can collide with plugin name patterns if not carefully scoped. Plugin skill manifests registered in `.agents/plugins/*/skills/*/` must use fully qualified names (e.g., `unifi-mcp:skill-name`) to avoid colliding with agent-owned skills. Always verify that a new plugin skill manifest's fully qualified name does not collide with existing agent or plugin skill names (gotcha-b2b7f4d9).
+The `.agents/skills/*/` directory structure can collide with plugin name patterns if not carefully scoped. Plugin skill manifests registered in `.agents/plugins/*/skills/*/` must use fully qualified names (e.g., `unifi-mcp:skill-name`) to avoid colliding with agent-owned skills. Always verify that a new plugin skill manifest's fully qualified name does not collide with existing agent or plugin skill names. Test on all three targets (Claude, Codex, OpenClaw) — skill resolution may differ by target.

--- a/.agents/skills/community-pr-review/SKILL.md
+++ b/.agents/skills/community-pr-review/SKILL.md
@@ -6,9 +6,10 @@ description: >-
   checklist (f-string logger ban, Ruff lint enforcement, validator registry registration, doc site update ordering),
   the fork-edit model for trusted contributors, org-fork push limitations, the dual-subagent
   review pattern, PR body standards, technical API validation (live smoke tests, mutating
-  cycles), DISPATCH_ARG_TRANSLATORS registration for action tools, and the close-and-redirect 
-  pattern for unsalvageable PRs. Apply this skill before approving any externally-authored PR, 
-  before running the merge command, and when auditing recently merged PRs for compliance.
+  cycles), DISPATCH_ARG_TRANSLATORS registration for action tools, the unresponsive-first-time-contributor 
+  fork-edit exception for trivial fixes, and the close-and-redirect pattern for unsalvageable PRs. 
+  Apply this skill before approving any externally-authored PR, before running the merge command, 
+  and when auditing recently merged PRs for compliance.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -19,14 +20,16 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 Community PRs go through a fixed quality checklist before merge. For trusted contributors
 (level99 has 7+ merged PRs), the maintainer commits fixes directly to the contributor's fork
 branch rather than requesting round-trip revisions — this preserves attribution while eliminating
-latency. This skill documents the full workflow from first look to merge commit, including
-technical validation for PRs that touch UniFi API tool implementations.
+latency. An exception exists for first-time contributors who are historically unresponsive: when the fix is
+trivial (ruff format, simple doc change), apply fork-edit rather than request changes. This skill documents 
+the full workflow from first look to merge commit, including technical validation for PRs that touch UniFi API tool implementations.
 
 ## Prerequisites
 
 - PR is open and CI workflow state is understood (see Step 0b for first-time contributor gotcha)
 - You have push access to the contributor's fork (needed for the fork-edit model)
 - `AGENTS.md` is current — it is the canonical source for hard bans
+- For first-time contributors: check prior PR history to assess responsiveness (72+ hour silence threshold for fork-edit exception eligibility)
 - For PRs touching tool implementations or API handlers: a **live UniFi controller** must be reachable to run smoke tests
 
 ---
@@ -144,7 +147,7 @@ review comment (first-time contributors).
 Scan for f-string logger calls:
 
 ```bash
-grep -rn 'logger\.\\(debug\\|info\\|warning\\|error\\|critical\\)(f"' $(git diff --name-only origin/main...HEAD)
+grep -rn 'logger\\.\\\\(debug\\\\|info\\\\|warning\\\\|error\\\\|critical\\\\)(f\"' $(git diff --name-only origin/main...HEAD)
 ```
 
 Replace any hits with `%s`-style lazy formatting:
@@ -163,7 +166,7 @@ keep appearing. In PR #119, level99's tool layer used `%s` correctly but introdu
 calls in `device_manager.py` (14), `network_manager.py` (7), and `tools/network.py` (2). Always
 check manager files explicitly.
 
-**Implicit concatenation is invisible to grep:** Adjacent string literals (`"foo" "bar"`) cannot
+**Implicit concatenation is invisible to grep:** Adjacent string literals (`\"foo\" \"bar\"`) cannot
 be reliably caught by automated scripts. This survived a 481-call automated migration in PR #122
 and was only caught by manual review. Scan manually for this pattern when logger calls span lines.
 
@@ -228,7 +231,7 @@ class FirewallPolicyBase(BaseModel):
     schedule: dict = {"mode": "ALWAYS"}  # silently overwrites on update
 ```
 
-With this model, `update_firewall_policy({"name": "new"})` would silently inject unwanted field
+With this model, `update_firewall_policy({\"name\": \"new\"})` would silently inject unwanted field
 values — overwriting whatever the controller currently has, regardless of what the caller specified.
 
 **The rule:** Non-`None` defaults belong only in create-specific subclasses or create-specific
@@ -347,7 +350,7 @@ When you find merge blockers in Step 1, submit your GitHub review as **`request-
 as `comment`. This matters for two reasons:
 
 1. **Prevents accidental merge** — GitHub blocks merging a PR that has an unresolved
-   "request changes" review, even if CI is green.
+   \"request changes\" review, even if CI is green.
 2. **Signals mandatory work clearly** — the contributor sees their PR requires action, not just
    feedback.
 
@@ -370,7 +373,7 @@ Use the `comment` review type only when you have zero hard blockers and are leav
 ## Step 2 — Apply Fixes (Fork-Edit Model)
 
 If you found gaps in Step 1, don't request changes — fix them directly on the contributor's
-fork branch. This is the established model for trusted contributors.
+fork branch. This is the established model for trusted contributors and for unresponsive first-time contributors with trivial fixes.
 
 ```bash
 # Add the contributor's fork as a remote (one-time setup)
@@ -381,11 +384,11 @@ git fetch <contributor>
 git checkout -b review/<pr-branch> <contributor>/<pr-branch>
 
 # Make your fixes, then commit with attribution context
-git commit -m "fix: address review gaps from PR #NNN
+git commit -m \"fix: address review gaps from PR #NNN
 
 - Replace f-string loggers in device_manager.py (14 instances)
 - Register new validator in registry
-Co-authored-by: Contributor Name <email>"
+Co-authored-by: Contributor Name <email>\"
 
 # Push back to their fork
 git push <contributor> HEAD:<pr-branch>
@@ -400,11 +403,23 @@ the gap is mechanical and the fix is unambiguous.
 **Trusted contributor definition:** Level99 qualifies (7+ merged PRs). For first-time or
 low-history contributors, prefer review comments so they learn the patterns.
 
+### Unresponsive First-Time Contributor — Fork-Edit Exception
+
+When a first-time or low-history contributor is **historically unresponsive** (no response to prior comments within 72+ hours) AND the current PR fix is **trivial and mechanical** (e.g., ruff format, logger replacement, simple doc fix), apply the fork-edit model instead of requesting changes:
+
+1. **Check prior PR history** — Confirm the contributor has ignored feedback in a prior PR without a valid reason (timezone delay, notification failure, etc.)
+2. **Assess fix triviality** — Confirm the gap is mechanical and unambiguous; not a design decision or architectural choice
+3. **Apply fork-edit** — Use the fork-edit workflow above to commit fixes and push back to their branch
+
+**Trade-off:** The fork-edit approach unblocks the pipeline when a contributor is unresponsive, but it does not give the contributor an opportunity to learn the patterns. Use this exception when community momentum is more valuable than teaching opportunity.
+
+**Reference:** PR #288 established this heuristic — a first-time contributor did not respond for 72+ hours despite a ruff format request, but their fix was mechanically correct and unambiguous. Fork-edit unblocked the PR rather than leaving it stalled.
+
 ### Org Forks — Push Limitation
 
 **The fork-edit model only works for personal forks.** Org forks (e.g., `vigrai/unifi-mcp`
 from contributor fgallese in PR #133) block `git push` back to the contributor's branch even
-when "Allow edits from maintainers" is checked on the PR. That checkbox is scoped to personal
+when \"Allow edits from maintainers\" is checked on the PR. That checkbox is scoped to personal
 accounts — GitHub does not honor it for org-owned forks.
 
 Decision matrix:
@@ -444,7 +459,7 @@ For PRs that modify tools or API handlers, the PR description must include:
 ```
 
 **2. Embedded live test output** — Paste the raw terminal output (not a prose summary). Reviewers
-need actual values and shapes, not "tests passed."
+need actual values and shapes, not \"tests passed.\"
 
 ```markdown
 <details>
@@ -457,7 +472,7 @@ need actual values and shapes, not "tests passed."
 </details>
 ```
 
-Reviewers have been burned by "all tests passed" summaries that omit the one tool that returned a
+Reviewers have been burned by \"all tests passed\" summaries that omit the one tool that returned a
 malformed response. Embed the raw output and let the reviewer decide what matters.
 
 **3. Issue references** — Tag every issue using `#N` format. GitHub autolinks and auto-closes on merge:

--- a/.agents/skills/live-smoke-testing/SKILL.md
+++ b/.agents/skills/live-smoke-testing/SKILL.md
@@ -9,7 +9,8 @@ description: |
   and recognizing known API contract failure patterns that mock-based CI cannot catch. Apply
   this skill even if the user doesn't explicitly ask about the harness — activate whenever a
   PR requires live smoke evidence, a new tool category needs coverage, or an API contract
-  mismatch is suspected.
+  mismatch is suspected. CRITICAL: Treat live smoke as a PRE-MERGE BLOCKING GATE when code
+  changes API response parsing (new fields, filtering logic, payload normalization).
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -56,6 +57,51 @@ Before any live run, ensure:
 
 4. **Branch context** — the harness lives in `scripts/live_smoke.py` on the main branch.
    When branching or bisecting, confirm you have the current harness code before running.
+
+## Procedure 0: PRE-MERGE BLOCKING GATE — API Response Parsing Changes
+
+**Trigger Criteria — Live Smoke is Mandatory Before Merge:**
+
+Code changes in any of these categories require a pre-merge live smoke run that must PASS
+before the PR can be merged:
+
+- **Manager response normalization logic** — changes to how API response payloads are converted
+  to domain models (e.g., field mapping, null handling, type coercion in manager classes)
+- **New API response fields** — adding handling for fields that are new to the UniFi API or
+  new to a particular controller firmware version
+- **Filtering or field selection logic** — changes to which fields are extracted from responses,
+  or conditional inclusion/exclusion of fields based on hardware or firmware state
+- **Payload shape transformation** — restructuring nested payloads, flattening, or re-nesting
+  fields for compatibility with domain models
+- **Version-dependent API contracts** — changes that assume an API endpoint behaves differently
+  across firmware versions
+
+**Why this is a blocking gate:** Mock-based CI uses golden fixtures (static JSON files) that
+cannot evolve with real hardware firmware updates. Changes to response parsing are invisible
+to unit tests — they pass against the fixed fixture forever, but fail against real hardware
+running a different API version. The 2026-05-17 Access proxy incident (#283) exemplifies
+this: unit tests passed; live hardware returned auth-wrapped-in-200 errors invisible to mocks.
+
+**Execution:**
+
+```bash
+# For the affected domain(s) (e.g., network, protect, access):
+python scripts/live_smoke.py --server <domain> --phase readonly
+python scripts/live_smoke.py --server <domain> --phase safe
+# Both must exit status 0 with no failed/exception records in artifacts
+```
+
+**Sign-off:** Include in the PR description:
+```
+**Live Smoke Evidence:**
+- ✓ network readonly: 45 tools, 0 failures
+- ✓ network safe: 12 lifecycle ops, 0 failures
+- Artifacts: [link to live-smoke-results/{server}-{timestamp}.json]
+```
+
+The PR reviewer must confirm both phases passed and inspect the artifact for correct
+payloads before approving merge. This is equivalent to a code review checkpoint — it
+verifies API contract assumptions against reality before the code lands on main.
 
 ## Procedure A: Understand Tool Classification Tiers
 

--- a/.agents/skills/monorepo-release-pipeline/SKILL.md
+++ b/.agents/skills/monorepo-release-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: myco:monorepo-release-pipeline
 description: >-
-  Covers the full release pipeline for the unifi-mcp monorepo: determining release scope by analyzing changed packages, scoping hatch-vcs version tag globs per Python package to prevent sibling-tag contamination, pushing tags in strict dependency order (unifi-core → unifi-mcp-shared → app servers → relay → worker when needed), configuring scripts/generate_release_notes.py path scoping per package, wiring per-package publish workflows for OIDC trusted publishing, coordinating cross-package version bumps in pyproject.toml, understanding app vs. library versioning and writeback behavior, and validating releases post-tag. Apply this skill when cutting any release, adding a new package, bumping unifi-core, or debugging a versioning or publish-workflow failure — even if the user does not explicitly ask about tag ordering or release notes.
+  Covers the full release pipeline for the unifi-mcp monorepo: determining release scope by analyzing changed packages, scoping hatch-vcs version tag globs per Python package to prevent sibling-tag contamination, pushing tags in strict dependency order (unifi-core → unifi-mcp-shared → app servers → relay → worker when needed), configuring scripts/generate_release_notes.py path scoping per package, wiring per-package publish workflows for OIDC trusted publishing, coordinating cross-package version bumps in pyproject.toml, understanding app vs. library versioning and writeback behavior, and validating releases post-tag. Apply this skill when cutting any release, adding a new package, bumping unifi-core, or debugging a versioning or publish-workflow failure — even if the user does not explicitly ask about tag ordering or release notes. CRITICAL: All PRs require pin-alignment CI gate before merge (automated, cannot be skipped).
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -21,6 +21,9 @@ that bleed across package boundaries.
 ## Prerequisites
 
 - All feature PRs for the release are merged to `main`.
+- **All PRs targeting main must pass the pin-alignment CI gate (automated blocker).** This gate
+  runs on every PR and blocks stale transitive dependency pins that would cause fresh
+  installs to fail. See Procedure D, Step 0 for details.
 - Working tree is clean: `git status` shows nothing staged or modified.
 - Remote is current: `git fetch origin && git log origin/main..HEAD` shows nothing.
 - PyPI credentials are **not** stored locally — publishing is handled entirely by
@@ -70,6 +73,43 @@ git log --oneline network/v$(git tag -l 'network/v*' | sort -V | tail -1)..HEAD 
 | Plugin-only changes (manifest/config updates) | Patch release for cache invalidation (e.g., `network/v0.14.13` → `network/v0.14.14`) |
 | Worker (`apps/worker/`) | `worker/v*` |
 
+### Tagging Selectivity Framework
+
+Depending on the scope and confidence of the release, choose one of three tagging strategies:
+
+**Minimal (lowest risk, most conservative):**
+- Tag ONLY packages with code changes in their own directory.
+- Do not auto-tag downstream packages unless they explicitly changed.
+- Use case: Security patch in a transitive dependency (e.g., Pillow) that affects only one app.
+- Risk: Manual tag selection can miss packages. Confidence: high only if you've audited the
+  dependency chain and know exactly which app uses the patched library.
+- Example: `git tag protect/v0.3.5` (Access unchanged, Network unchanged — only Protect uses
+  the patched Pillow version)
+
+**Standard (recommended, balanced):**
+- Tag all packages with code changes PLUS all downstream dependents (even if they didn't
+  change code) to ensure they pick up shared library bumps.
+- Use case: Any bump to `unifi-core` or `unifi-mcp-shared`; new resource in any app.
+- Risk: Creates spurious patch releases for apps that only changed transitively. Builds
+  redundancy into the release (some wheel metadata will be stale). Confidence: high.
+- Example: Shared gains new validators → tag `shared/v*`, then `network/v*`, `protect/v*`,
+  `access/v*`, `relay/v*` (even if Network, Protect, Access, Relay only changed their
+  dependency bounds, not their code).
+
+**Full (maximum redundancy, CI safeguard):**
+- Tag all seven packages every release.
+- Use case: Scheduled releases, coordinated team releases, recovering from a prior broken
+  release sequence.
+- Risk: Creates unnecessary artifact churn; every package publishes even if unchanged.
+- Benefit: Rebuilds all wheels, catches stale pinning across the board, guaranteed CI runs
+  all workflows.
+- Example: `for p in core shared network protect access api relay; do git tag $p/v<version>; done`
+
+**Decision rule:** Start with Standard (accounts for the shared library rule and downstream
+dependency bumps). Use Minimal only if you've verified the transitive dependency chain and
+are confident of your scope. Use Full when recovering from a release failure or for
+scheduled releases.
+
 ### Plugin-only Release and Cache Invalidation
 
 When only the plugin manifest (e.g., `plugins/*/plugin.json`) changes with no code changes, a patch release must still be cut — not as code update, but to invalidate the marketplace cache and force existing users to pick up the new manifest.
@@ -115,7 +155,7 @@ Understanding the difference between library and app package versioning is essen
 
 ### Library packages (unifi-core, unifi-mcp-shared, relay)
 
-These packages use `dynamic = ["version"]` in `pyproject.toml` with hatch-vcs. Version is derived from the git tag **at build time** — no `_version.py` is ever committed to the repo. When a library tag is pushed:
+These packages use `dynamic = [\"version\"]` in `pyproject.toml` with hatch-vcs. Version is derived from the git tag **at build time** — no `_version.py` is ever committed to the repo. When a library tag is pushed:
 
 - The publish workflow builds and publishes the tagged commit as-is
 - `bump-plugin-versions.yml` runs and outputs: `No version changes to commit`
@@ -183,7 +223,33 @@ raw-options.fallback_version = "0.0.0"
 Each package's `--match` pattern must be scoped to its own tag prefix from the
 Package Map. Never share or widen the `--match` pattern across packages.
 
-## Procedure D: Align Cross-Package Dependency Bounds Before Tagging
+## Procedure D: Pin-Alignment CI Gate + Align Cross-Package Dependency Bounds Before Tagging
+
+### Step 0: Pin-Alignment CI Gate (Automated Blocker)
+
+**Critical:** The pin-alignment CI gate (PR #286) runs on every PR targeting `main` and
+**cannot be skipped**. This gate prevents the stale-pin incident (#283, 2026-05-17) from
+recurring. It automatically validates that every downstream package's dependency bounds
+in `pyproject.toml` permit the versions of upstream packages (`unifi-core`,
+`unifi-mcp-shared`) that exist on main.
+
+**How it works:**
+- On every PR, the gate builds all wheels and extracts their `Requires-Dist` metadata.
+- For each declared upstream dependency (e.g., `unifi-mcp-shared>=0.4.5,<0.5`), the gate
+  validates that the bound permits the actual version currently in use by the workspace.
+- If bounds are too narrow (e.g., `<0.5` when shared is actually 0.5.0 on main), the gate
+  **fails the PR** and you must fix the pins before merge.
+
+**Your action:** The gate blocks PRs automatically. If your PR fails the pin-alignment gate:
+1. Look at the CI job output for the specific package and bound that failed.
+2. Update the offending bounds in `pyproject.toml` (e.g., change `<0.5` to `<0.6`).
+3. Commit and push the fix.
+4. The gate re-runs automatically on push and must pass before merge is allowed.
+
+This is **not optional** and there is no override. The gate exists to prevent broken
+releases from landing on main.
+
+### Align Cross-Package Dependency Bounds Before Tagging
 
 Before creating release tags, inspect every downstream `pyproject.toml` dependency
 range for packages being released together. Tag order only solves publication timing;
@@ -251,7 +317,7 @@ for app in apps/network apps/protect apps/access packages/unifi-mcp-relay; do
   uv build --wheel "$app" --out-dir /tmp/wheelcheck/$(basename $app) 2>&1 | tail -2
   whl=$(ls /tmp/wheelcheck/$(basename $app)/*.whl | tail -1)
   python -m zipfile -e "$whl" /tmp/wheelcheck/extracted/$(basename $app)/
-  grep -h 'Requires-Dist.*\(unifi-mcp-shared\|unifi-core\)' \
+  grep -h 'Requires-Dist.*\\(unifi-mcp-shared\\|unifi-core\\)' \\
     /tmp/wheelcheck/extracted/$(basename $app)/*.dist-info/METADATA
 done
 ```
@@ -265,8 +331,8 @@ A fast supplementary grep that catches the most common shape:
 ```bash
 # Confirm no downstream pyproject still pins below the new upstream major.minor.
 # Example: releasing shared 0.5.0 — every match below should be empty.
-grep -n "unifi-mcp-shared" apps/*/pyproject.toml packages/*/pyproject.toml \
-  | grep -v 'workspace = true' \
+grep -n "unifi-mcp-shared" apps/*/pyproject.toml packages/*/pyproject.toml \\
+  | grep -v 'workspace = true' \\
   | grep -v '>=0.5'
 ```
 
@@ -343,7 +409,7 @@ in non-updated marketplaces.
 
 **Verification:** After a release workflow completes and the bumper runs, check the
 manifest commit in GitHub. All `plugin.json` and `.mcp.json` files should have updated
-version strings (e.g., `"version": "0.14.14"`), NOT corrupted field names. Spot-check
+version strings (e.g., `\"version\": \"0.14.14\"`), NOT corrupted field names. Spot-check
 that Claude plugin, OpenAI agents, and standalone MCP manifests are all in sync.
 
 ## Procedure F: Dependency-Ordered Tag Pushing
@@ -497,6 +563,25 @@ After pushing a tag, verify it resolved correctly before closing the work.
    python -c "import unifi_mcp_<app>; print(unifi_mcp_<app>.__version__)"
    ```
 
+5. **Post-Release Live Smoke Verification (Full Release Validation):**
+
+   After all tags are pushed and all PyPI packages are live, run a full post-release
+   smoke test to verify API contracts work end-to-end with the released wheel versions:
+
+   ```bash
+   # Set .env credentials (real hardware or staging controller)
+   # Then run the full three-domain smoke sequence:
+   python scripts/live_smoke.py --server network --phase safe
+   python scripts/live_smoke.py --server protect --phase safe
+   python scripts/live_smoke.py --server access --phase safe
+   ```
+
+   All three phases must exit with status 0 and have zero failed/exception records in
+   the artifacts. This confirms the released wheels work against real UniFi hardware
+   and that API contracts hold. This is the final release validation gate — if any phase
+   fails, the release is broken and requires either an immediate patch release or a
+   rollback announcement.
+
 ## Cross-Cutting Gotchas
 
 **Sibling tag contamination.** If `git_describe_command` `--match` is too broad
@@ -507,7 +592,7 @@ prints `0.3.5` from `importlib.metadata`. Fix: tighten the `--match` pattern in
 
 **PR merge is NOT the release trigger — the tag push is.** `hatch-vcs` reads git tags at build time to generate `_version.py`. Merging a PR does NOT trigger a release. If the tag is never pushed, PyPI stays on the old version with no error — the build succeeds but installs the previous release. The tag push IS the release trigger. (Session 3: `core/v0.1.2` was never tagged; PyPI stayed at 0.1.1 until the tag was pushed manually.) Always run Procedure H after tagging.
 
-**Silent version freeze.** If a tag is missing, `hatch-vcs` falls back to `fallback_version = "0.0.0"` or the last matching tag. There is no error at merge time. The failure surfaces only when a user installs and notices the wrong version. Always run Procedure H after tagging.
+**Silent version freeze.** If a tag is missing, `hatch-vcs` falls back to `fallback_version = \"0.0.0\"` or the last matching tag. There is no error at merge time. The failure surfaces only when a user installs and notices the wrong version. Always run Procedure H after tagging.
 
 **Missing tag causes broken downstream install.** If `unifi-core` code is merged but
 `core/vX.Y.Z` is never pushed, downstream packages requesting `unifi-core>=X.Y.Z`
@@ -515,6 +600,21 @@ will fail to install — pip resolver error, not a code error. Check PyPI before
 debugging code. The fix is to push the missing tag and wait for the publish workflow.
 
 **Main-only merges are invisible to existing users.** Cache invalidation for plugin manifests requires a tagged release. A main-only merge updates the repo but does not trigger a publish workflow or invalidate any user caches. Existing users stay on their cached version indefinitely until the next tagged release. If a manifest or policy change is urgent, cut a patch release immediately (see Procedure A: Plugin-only Release).
+
+**Malformed git tag — missing 'v' prefix.** During local tag creation, you may accidentally
+create a tag like `protect/0.4.2` (no 'v') instead of `protect/v0.4.2`. This tag exists
+locally but is syntactically wrong and will be ignored by hatch-vcs and CI workflows.
+The malformed tag remains in your local tag list indefinitely, cluttering the namespace
+and potentially confusing future releases. **Prevention:** Before pushing any tags, list
+and validate them:
+```bash
+git tag -l | grep -E 'network|protect|access|relay|core|shared|api' | sort -V
+# Validate every line contains '/v' prefix (e.g., "network/v0.14.13")
+# If you see a malformed tag like "protect/0.4.2", delete it:
+git tag -d protect/0.4.2
+# Then create the correct one:
+git tag protect/v0.4.2
+```
 
 **PyPI pin masked by workspace source — failure mode the entire CI matrix cannot detect.**
 Workspace `[tool.uv.sources]` overrides the version range in `[project.dependencies]`

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,108 @@
+name: Bug report
+description: Report something that is broken or behaving unexpectedly.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please do not include UniFi credentials, API keys, tokens, or private controller details.
+
+        If this is a security vulnerability, do not open a public issue. Use GitHub Security Advisories instead: https://github.com/sirkirby/unifi-mcp/security/advisories
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I am using the latest released version, or I confirmed the issue still exists on `main`.
+          required: true
+        - label: I have removed credentials, tokens, API keys, IP addresses, and other private data from the report.
+          required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - Network MCP server
+        - Protect MCP server
+        - Access MCP server
+        - Relay sidecar
+        - Cloudflare Worker / CLI
+        - API server
+        - Claude/Codex plugin packaging
+        - Documentation
+        - Unsure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Package version, git SHA, Docker image tag, or plugin version.
+      placeholder: "unifi-network-mcp 0.0.0, main@abcdef0, or ghcr.io/..."
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Python/Node versions, MCP client, install method, and UniFi application/controller versions.
+      placeholder: |
+        OS:
+        Python:
+        Node:
+        MCP client:
+        Install method:
+        UniFi application/controller:
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable reproduction you can.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste sanitized logs, tracebacks, tool responses, or command output.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, suspected cause, or anything else useful.
+    validations:
+      required: false
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sirkirby/unifi-mcp/security/advisories
+    about: Please report suspected vulnerabilities privately through GitHub Security Advisories.
+  - name: Questions and troubleshooting
+    url: https://github.com/sirkirby/unifi-mcp/discussions
+    about: Use GitHub Discussions for setup help, configuration questions, and general troubleshooting.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,42 @@
+name: Documentation issue
+description: Report missing, confusing, or incorrect documentation.
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link or path to the affected README, docs page, plugin file, or comment.
+      placeholder: "README.md, apps/network/docs/configuration.md, ..."
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong or missing?
+      description: Describe the confusing, outdated, incomplete, or incorrect content.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: If you know the fix, describe or paste the replacement text.
+    validations:
+      required: false
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: Feature request
+description: Suggest a new capability, integration, or improvement.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for product ideas and enhancements. For implementation questions or troubleshooting help, a GitHub Discussion is usually a better fit.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and discussions for similar requests.
+          required: true
+        - label: This request fits the project scope described in the README and CONTRIBUTING.md.
+          required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Network MCP server
+        - Protect MCP server
+        - Access MCP server
+        - Relay sidecar
+        - Cloudflare Worker / CLI
+        - API server
+        - Claude/Codex plugin packaging
+        - Documentation
+        - Cross-project / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and why is the current behavior insufficient?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior, API shape, tool, workflow, or documentation change you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds or other designs have you considered?
+    validations:
+      required: false
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation notes
+      description: If you know where this should live, include files, managers, tools, APIs, or docs that may be affected.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to help implement or test this change.
+          required: false
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- Describe what changed and why. -->
+
+## Type of change
+
+- [ ] `fix:` bug fix
+- [ ] `feat:` new feature
+- [ ] `docs:` documentation only
+- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
+- [ ] `test:` adding or updating tests
+- [ ] `chore:` maintenance, dependencies, CI, or configuration
+
+## Scope
+
+- [ ] Network MCP server
+- [ ] Protect MCP server
+- [ ] Access MCP server
+- [ ] Relay sidecar
+- [ ] Cloudflare Worker / CLI
+- [ ] API server
+- [ ] Shared packages
+- [ ] Plugin packaging
+- [ ] Documentation
+
+## Checklist
+
+- [ ] I read `CONTRIBUTING.md`.
+- [ ] I ran the focused tests or checks for the files I changed.
+- [ ] I ran `make pre-commit`, or I explained below why it was not run.
+- [ ] I updated generated manifests with `make manifest` when changing MCP tools.
+- [ ] I added or updated tests for behavior changes.
+- [ ] I updated documentation for user-visible changes.
+- [ ] I did not commit credentials, tokens, controller addresses, or other private data.
+
+## Testing
+
+<!-- List commands run and relevant results. If not run, explain why. -->
+
+## Notes for reviewers
+
+<!-- Call out risky areas, migration notes, screenshots, follow-up work, or anything that deserves extra attention. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the repository maintainer using the contact information
+listed on the maintainer's GitHub profile:
+https://github.com/sirkirby
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,24 @@
 # Contributing
 
+Thanks for helping improve UniFi MCP. Please follow the
+[Code of Conduct](CODE_OF_CONDUCT.md) in all project spaces.
+
+## Before You Start
+
+- Search existing issues and discussions before opening a new one.
+- For substantial features, behavior changes, or new tool categories, open an
+  issue first so maintainers can confirm the direction before you invest time.
+- Use [GitHub Discussions](https://github.com/sirkirby/unifi-mcp/discussions)
+  for setup help, configuration questions, and general troubleshooting.
+- Do not include UniFi credentials, API keys, tokens, controller addresses, or
+  other private deployment details in public issues, discussions, pull requests,
+  screenshots, or logs.
+- Report suspected vulnerabilities privately through
+  [GitHub Security Advisories](https://github.com/sirkirby/unifi-mcp/security/advisories),
+  not public issues.
+
+For more support routing details, see [SUPPORT.md](SUPPORT.md).
+
 ## Prerequisites
 
 - Python 3.13+

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,41 @@
+# Support
+
+UniFi MCP is maintained as an open source project. Support is best effort and
+community-driven.
+
+## Where to Get Help
+
+Use the channel that matches what you need:
+
+| Need | Where to go |
+|------|-------------|
+| Setup help, configuration questions, or troubleshooting | [GitHub Discussions](https://github.com/sirkirby/unifi-mcp/discussions) |
+| Reproducible bugs | [Open a bug report](https://github.com/sirkirby/unifi-mcp/issues/new/choose) |
+| Feature requests or design discussion | [Open a feature request](https://github.com/sirkirby/unifi-mcp/issues/new/choose) or start a discussion |
+| Security vulnerabilities | [Report privately through GitHub Security Advisories](https://github.com/sirkirby/unifi-mcp/security/advisories) |
+
+Please do not post UniFi credentials, API keys, tokens, controller addresses, or
+other private deployment details in public issues or discussions.
+
+## Before Asking
+
+Please check these resources first:
+
+- [README.md](README.md) for installation and quick-start guidance
+- [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow and test commands
+- [SECURITY.md](SECURITY.md) for the security model and vulnerability reporting
+- Existing [issues](https://github.com/sirkirby/unifi-mcp/issues) and
+  [discussions](https://github.com/sirkirby/unifi-mcp/discussions)
+
+When asking for help, include the component you are using, package version or git
+SHA, install method, MCP client, operating system, and sanitized logs or command
+output.
+
+## Scope
+
+This project maintains the UniFi MCP servers, shared packages, relay sidecar,
+Cloudflare Worker gateway, API server, and plugin packaging in this repository.
+
+Problems in UniFi controller firmware or upstream client libraries should be
+reported to their maintainers. See [SECURITY.md](SECURITY.md) for the current
+in-scope and out-of-scope security boundaries.


### PR DESCRIPTION
## Summary

Adds the missing community-health files GitHub was flagging and tightens contributor-facing guidance for a larger open source audience.

## What changed

- Added a Contributor Covenant `CODE_OF_CONDUCT.md`.
- Added GitHub issue forms for bug reports, feature requests, and documentation issues.
- Added issue-template routing for security reports and support questions.
- Added a pull request template aligned with the existing contributing workflow.
- Added `SUPPORT.md` with support, security, and discussion routing.
- Updated `CONTRIBUTING.md` to link the Code of Conduct, support guidance, and security advisory flow.

## Validation

- Parsed all `.github/ISSUE_TEMPLATE/*.yml` files with Ruby YAML.
- Ran `git diff --cached --check` before committing.

Full `make pre-commit` was not run because this is a docs/community-template-only change.