### PR TITLE
fix(network/clients): preserve user-assigned client alias as distinct name field

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -257,6 +257,7 @@ type BackupPage {
 type BlockedClient {
   mac: ID
   hostname: String
+  name: String
   lastSeen: String
   blocked: Boolean!
 }
@@ -350,6 +351,7 @@ type Client {
   mac: ID
   ip: String
   hostname: String
+  name: String
   isWired: Boolean!
   isGuest: Boolean!
   status: String!
@@ -382,6 +384,7 @@ type ClientLookup {
   mac: ID
   ip: String
   hostname: String
+  name: String
   isOnline: Boolean!
   lastSeen: String
 }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -313,6 +313,17 @@
               }
             ],
             "title": "Mac"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
           }
         },
         "title": "BlockedClientModel",
@@ -644,6 +655,17 @@
               }
             ],
             "title": "Mac"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
           },
           "note": {
             "anyOf": [

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -246,6 +246,7 @@ type BackupPage {
 type BlockedClient {
   mac: ID
   hostname: String
+  name: String
   lastSeen: String
   blocked: Boolean!
 }
@@ -339,6 +340,7 @@ type Client {
   mac: ID
   ip: String
   hostname: String
+  name: String
   isWired: Boolean!
   isGuest: Boolean!
   status: String!
@@ -371,6 +373,7 @@ type ClientLookup {
   mac: ID
   ip: String
   hostname: String
+  name: String
   isOnline: Boolean!
   lastSeen: String
 }

--- a/apps/api/src/unifi_api/graphql/types/network/client.py
+++ b/apps/api/src/unifi_api/graphql/types/network/client.py
@@ -43,6 +43,7 @@ class Client:
     mac: strawberry.ID | None
     ip: str | None
     hostname: str | None
+    name: str | None
     is_wired: bool
     is_guest: bool
     status: str
@@ -73,7 +74,8 @@ class Client:
         return cls(
             mac=raw.get("mac"),
             ip=raw.get("last_ip") or raw.get("ip"),
-            hostname=raw.get("hostname") or raw.get("name"),
+            hostname=raw.get("hostname") or None,
+            name=raw.get("name") or None,
             is_wired=bool(raw.get("is_wired", False)),
             is_guest=bool(raw.get("is_guest", False)),
             status="online" if raw.get("is_online") else "offline",
@@ -120,6 +122,7 @@ class Client:
 class BlockedClient:
     mac: strawberry.ID | None
     hostname: str | None
+    name: str | None
     last_seen: str | None
     blocked: bool
 
@@ -136,7 +139,8 @@ class BlockedClient:
     def from_manager_output(cls, obj: Any) -> "BlockedClient":
         return cls(
             mac=_get(obj, "mac"),
-            hostname=_get(obj, "hostname") or _get(obj, "name"),
+            hostname=_get(obj, "hostname") or None,
+            name=_get(obj, "name") or None,
             last_seen=_iso(_get(obj, "last_seen")),
             blocked=bool(_get(obj, "blocked", True)),
         )
@@ -151,6 +155,7 @@ class ClientLookup:
     mac: strawberry.ID | None
     ip: str | None
     hostname: str | None
+    name: str | None
     is_online: bool
     last_seen: str | None
 
@@ -163,7 +168,8 @@ class ClientLookup:
         return cls(
             mac=_get(obj, "mac"),
             ip=_get(obj, "last_ip") or _get(obj, "ip"),
-            hostname=_get(obj, "hostname") or _get(obj, "name"),
+            hostname=_get(obj, "hostname") or None,
+            name=_get(obj, "name") or None,
             is_online=bool(_get(obj, "is_online", False)),
             last_seen=_iso(_get(obj, "last_seen")),
         )

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -96,6 +96,7 @@ async def test_action_endpoint_dispatches_and_audits(tmp_path, monkeypatch) -> N
             "mac": "aa:bb",
             "ip": None,
             "hostname": None,
+            "name": None,
             "is_wired": False,
             "is_guest": False,
             "status": "online",

--- a/packages/unifi-core/src/unifi_core/network/models/clients.py
+++ b/packages/unifi-core/src/unifi_core/network/models/clients.py
@@ -72,7 +72,12 @@ class Client(BaseModel):
     )
     hostname: Optional[str] = Field(
         default=None,
-        description="Hostname or display name",
+        description="DHCP-reported hostname from the device itself",
+        json_schema_extra={"mutable": False},
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="User-assigned alias set in the UniFi console (preferred for display)",
         json_schema_extra={"mutable": False},
     )
     is_wired: bool = Field(
@@ -128,7 +133,8 @@ def client_from_controller(obj: Any) -> Client:
     return Client(
         mac=raw.get("mac"),
         ip=raw.get("last_ip") or raw.get("ip"),
-        hostname=raw.get("hostname") or raw.get("name"),
+        hostname=raw.get("hostname") or None,
+        name=raw.get("name") or None,
         is_wired=bool(raw.get("is_wired", False)),
         is_guest=bool(raw.get("is_guest", False)),
         status="online" if raw.get("is_online") else "offline",
@@ -154,7 +160,12 @@ class BlockedClient(BaseModel):
     )
     hostname: Optional[str] = Field(
         default=None,
-        description="Hostname or display name",
+        description="DHCP-reported hostname from the device itself",
+        json_schema_extra={"mutable": False},
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="User-assigned alias set in the UniFi console (preferred for display)",
         json_schema_extra={"mutable": False},
     )
     last_seen: Optional[str] = Field(
@@ -177,7 +188,8 @@ def blocked_client_from_controller(obj: Any) -> BlockedClient:
     """Build a BlockedClient from a controller API response."""
     return BlockedClient(
         mac=_get(obj, "mac"),
-        hostname=_get(obj, "hostname") or _get(obj, "name"),
+        hostname=_get(obj, "hostname") or None,
+        name=_get(obj, "name") or None,
         last_seen=_stringify_dt(_get(obj, "last_seen")),
         blocked=bool(_get(obj, "blocked", True)),
     )
@@ -203,7 +215,12 @@ class ClientLookup(BaseModel):
     )
     hostname: Optional[str] = Field(
         default=None,
-        description="Hostname or display name",
+        description="DHCP-reported hostname from the device itself",
+        json_schema_extra={"mutable": False},
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="User-assigned alias set in the UniFi console (preferred for display)",
         json_schema_extra={"mutable": False},
     )
     is_online: bool = Field(
@@ -230,7 +247,8 @@ def client_lookup_from_controller(obj: Any) -> ClientLookup:
     return ClientLookup(
         mac=_get(obj, "mac"),
         ip=_get(obj, "last_ip") or _get(obj, "ip"),
-        hostname=_get(obj, "hostname") or _get(obj, "name"),
+        hostname=_get(obj, "hostname") or None,
+        name=_get(obj, "name") or None,
         is_online=bool(_get(obj, "is_online", False)),
         last_seen=_stringify_dt(_get(obj, "last_seen")),
     )

--- a/packages/unifi-core/tests/network/models/test_clients.py
+++ b/packages/unifi-core/tests/network/models/test_clients.py
@@ -1,0 +1,114 @@
+"""Unit tests for the Network Client / BlockedClient / ClientLookup models.
+
+Covers the four-cell matrix for the (hostname, name) pair so that the
+user-assigned alias is preserved alongside the DHCP-reported hostname.
+"""
+
+from __future__ import annotations
+
+from unifi_core.network.models.clients import (
+    BLOCKEDCLIENT_READ_ONLY_FIELDS,
+    CLIENT_MUTABLE_FIELDS,
+    CLIENT_READ_ONLY_FIELDS,
+    CLIENTLOOKUP_READ_ONLY_FIELDS,
+    Client,
+    blocked_client_from_controller,
+    client_from_controller,
+    client_lookup_from_controller,
+)
+
+
+class TestClientFieldSets:
+    def test_no_mutable_fields(self) -> None:
+        assert CLIENT_MUTABLE_FIELDS == frozenset()
+
+    def test_read_only_covers_all_fields(self) -> None:
+        all_fields = frozenset(Client.model_fields.keys())
+        assert CLIENT_READ_ONLY_FIELDS == all_fields
+
+    def test_name_field_is_part_of_schema(self) -> None:
+        assert "name" in Client.model_fields
+        assert "hostname" in Client.model_fields
+
+
+class TestClientFromController:
+    def test_both_set_distinct(self) -> None:
+        c = client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "hostname": "RingHpCam-c0", "name": "RingCam-Driveway"})
+        assert c.hostname == "RingHpCam-c0"
+        assert c.name == "RingCam-Driveway"
+
+    def test_both_set_equal(self) -> None:
+        c = client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "hostname": "same", "name": "same"})
+        assert c.hostname == "same"
+        assert c.name == "same"
+
+    def test_name_only(self) -> None:
+        c = client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "name": "Office Apple TV"})
+        assert c.hostname is None
+        assert c.name == "Office Apple TV"
+
+    def test_hostname_only(self) -> None:
+        c = client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "hostname": "Office-TV-3"})
+        assert c.hostname == "Office-TV-3"
+        assert c.name is None
+
+    def test_neither_set(self) -> None:
+        c = client_from_controller({"mac": "aa:bb:cc:dd:ee:ff"})
+        assert c.hostname is None
+        assert c.name is None
+
+    def test_empty_strings_normalize_to_none(self) -> None:
+        c = client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "hostname": "", "name": ""})
+        assert c.hostname is None
+        assert c.name is None
+
+
+class TestBlockedClientFromController:
+    def test_both_set_distinct(self) -> None:
+        c = blocked_client_from_controller(
+            {"mac": "aa:bb:cc:dd:ee:ff", "hostname": "HarmonyHub", "name": "Living Room Harmony"}
+        )
+        assert c.hostname == "HarmonyHub"
+        assert c.name == "Living Room Harmony"
+
+    def test_name_only(self) -> None:
+        c = blocked_client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "name": "Living Room Harmony"})
+        assert c.hostname is None
+        assert c.name == "Living Room Harmony"
+
+    def test_hostname_only(self) -> None:
+        c = blocked_client_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "hostname": "HarmonyHub"})
+        assert c.hostname == "HarmonyHub"
+        assert c.name is None
+
+    def test_read_only_covers_name(self) -> None:
+        assert "name" in BLOCKEDCLIENT_READ_ONLY_FIELDS
+
+
+class TestClientLookupFromController:
+    def test_both_set_distinct(self) -> None:
+        c = client_lookup_from_controller(
+            {
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "ip": "10.0.0.5",
+                "hostname": "Elgato Key Light 1C09",
+                "name": "Office Key Light Right",
+                "is_online": True,
+            }
+        )
+        assert c.hostname == "Elgato Key Light 1C09"
+        assert c.name == "Office Key Light Right"
+        assert c.is_online is True
+
+    def test_name_only(self) -> None:
+        c = client_lookup_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "name": "Office Key Light"})
+        assert c.hostname is None
+        assert c.name == "Office Key Light"
+
+    def test_hostname_only(self) -> None:
+        c = client_lookup_from_controller({"mac": "aa:bb:cc:dd:ee:ff", "hostname": "Elgato Key Light"})
+        assert c.hostname == "Elgato Key Light"
+        assert c.name is None
+
+    def test_read_only_covers_name(self) -> None:
+        assert "name" in CLIENTLOOKUP_READ_ONLY_FIELDS


### PR DESCRIPTION
## Summary

The Client / BlockedClient / ClientLookup factories were collapsing the UniFi controller's `name` field (the user-assigned alias from the console) into `hostname` via an `or` fallback. When both fields were populated, the alias was silently discarded — agents and API consumers saw the cryptic DHCP-reported hostname instead of the human-readable label the user set.

Fixes #298.

## Evidence

Live verification against a 445-client controller showed **121 records** where the alias was being lost. Examples currently being returned by the deployed MCP:

| User alias (raw `name`) | DHCP hostname (raw `hostname`) | What we returned |
|---|---|---|
| Living Room Harmony | HarmonyHub | HarmonyHub |
| Office Apple TV | Office-TV-3 | Office-TV-3 |
| Office Key Light Right | Elgato Key Light 1C09 | Elgato Key Light 1C09 |
| Dyson FR Fan | E2A-US-NGA1533A | E2A-US-NGA1533A |

After this fix, all 121 records expose `name` alongside `hostname`.

## Changes

**Pydantic (`packages/unifi-core/src/unifi_core/network/models/clients.py`)**
- Add `name: Optional[str]` field to `Client`, `BlockedClient`, `ClientLookup`
- Stop using `name` as an `or` fallback for `hostname` in all three factories

**Strawberry GraphQL (`apps/api/src/unifi_api/graphql/types/network/client.py`)**
- Add `name: str | None` field to all three types
- Stop using `name` as an `or` fallback for `hostname` in all three `from_manager_output` classmethods

**Tests**
- New `packages/unifi-core/tests/network/models/test_clients.py` — covers the four-cell (hostname, name) matrix for all three factories. Fills a pre-existing gap (these models had no model-level tests).
- Updated `apps/api/tests/test_action_endpoint.py` to include `name: None` in its hardcoded expected client dict.

**Regenerated drift artifacts**
- `apps/api/src/unifi_api/graphql/schema.graphql`
- `apps/api/openapi.json`
- `apps/api/docs/graphql-reference.md`

## Verification

- [x] `make pre-commit` — clean (lint, format, generate, test, worker-typecheck)
- [x] Cross-layer symmetry tests pass for all three classes
- [x] 17 new unit tests pass
- [x] All 796 `apps/api` tests pass; all 656 `apps/network` tests pass; all 566 `unifi-core/network` tests pass
- [x] Live probe against production controller: 121/121 affected records now preserve `name`
- [x] `scripts/live_smoke.py --server network --phase readonly --tool unifi_list_clients` — green
- [x] `scripts/check_pin_alignment.py` — green
- [x] No issue/PR references in code per project rules

## Release notes

`unifi-core` patch bump (additive field, no breaking changes). Downstream pin bumps to `>=0.3.6` deferred to a follow-up PR after `core/v0.3.6` is tagged and published, per the project's release pipeline rules.

## Out of scope

- Issue #297 (`/stat/sta` clients showing offline) is a separate code path with different symptoms — kept open pending environment details from the reporter.