### PR TITLE
Add firewall policy ordering tools

### DIFF
--- a/.agents/skills/add-integration-api-tool/SKILL.md
+++ b/.agents/skills/add-integration-api-tool/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: add-integration-api-tool
+description: >
+  Use this skill when adding any tool that talks to the UniFi public Integration API
+  (X-API-Key auth, /proxy/network/integration/...). The integration API uses a
+  different ID namespace and field schema from the V2 controller API, so these tools
+  form their own "families" with scoped IDs. Covers when to start a new family vs
+  join an existing one, how to scope IDs in tool descriptions, the narrow conditions
+  under which silent ID translation is allowed (rare), how to wire auth, and how to
+  bridge between ID spaces (explicit named bridging tools only). Applies whether
+  you are adding a read tool, a mutation tool, or a paired family of both.
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Adding a Tool That Uses the UniFi Integration API
+
+The UniFi controller exposes two API surfaces. They are not interchangeable.
+Skipping this distinction creates silent footguns where IDs from one API are
+accepted by tools backed by the other and silently fail — or worse, succeed
+against the wrong resource.
+
+## The two surfaces
+
+| | V2 controller API | Integration API |
+|---|---|---|
+| Auth | session cookie | `X-API-Key` header |
+| Path prefix | `/proxy/network/api/...`, `/proxy/network/v2/api/...` | `/proxy/network/integration/v1/...` |
+| IDs | Mongo ObjectIDs (`674f0...`) | UUIDs (`0998be5a-...`) |
+| Field naming | `snake_case` | `camelCase` |
+| Action shape | `"action": "ALLOW"` + flat fields | nested `{"action": {"type": "ALLOW", "allowReturnTraffic": true}}` |
+| `ip_version` | `"BOTH"` | `"ipProtocolScope": {"ipVersion": "IPV4_AND_IPV6"}` |
+| Coverage | everything the web UI uses | curated, expanding subset |
+| Membership | full controller state | filtered (system policies often excluded) |
+
+These differences are not cosmetic. The same logical resource appears in V2
+with a Mongo ID and in Integration with a UUID, with no native bridge field
+connecting them.
+
+## Step 1: Identify the family
+
+A *tool family* is a set of tools whose returned IDs and accepted IDs are
+interchangeable.
+
+- Reading + writing to the same API endpoint group? Same family.
+- Reading from V2 and writing to V2? Same family (the existing firewall
+  policy CRUD family).
+- Reading from Integration and writing to Integration? Same family.
+- Mixing? You're inventing a bridging tool — see Step 5.
+
+**Current families in this codebase:**
+
+| Family | API | IDs | Tools |
+|---|---|---|---|
+| Firewall policy CRUD | V2 | Mongo | `unifi_list_firewall_policies`, `unifi_get_firewall_policy_details`, create / update / delete / toggle |
+| Firewall policy ordering | Integration | UUID | `unifi_get_firewall_policy_ordering` + `unifi_reorder_firewall_policies` |
+
+If your new tool fits cleanly inside an existing family, join it. If not,
+start a new family — and document its boundary.
+
+## Step 2: Scope IDs in the tool description
+
+Any tool that returns IDs which could be confused with another family's IDs
+MUST include a scoping clause in its `description`. This applies to:
+
+- MCP tool descriptions (`@server.tool(description=...)`)
+- GraphQL type and query descriptions (`@strawberry.type(description=...)`, `@strawberry.field(description=...)`)
+- REST route descriptions (`@router.get(description=...)`)
+
+Standard formula:
+
+> *"These IDs are scoped to the &lt;family-name&gt; tool family — do not
+> pass them to other &lt;resource&gt; tools."*
+
+Canonical example from the ordering family:
+
+```python
+@server.tool(
+    name="unifi_get_firewall_policy_ordering",
+    description=(
+        "Get user-defined firewall policy ordering for a source/destination "
+        "firewall zone pair. Returns policy IDs from the UniFi public integration "
+        "API (UUIDs); these IDs are scoped to the ordering tool family — pass them "
+        "ONLY to unifi_reorder_firewall_policies. They do NOT correspond to the "
+        "policy IDs returned by unifi_list_firewall_policies or any other "
+        "controller-API firewall tool."
+    ),
+    ...
+)
+```
+
+The scoping clause is not optional for integration-API tools.
+
+## Step 3: Require the API key, with clear remediation
+
+Integration API endpoints reject session-cookie auth. Without the API key,
+the tool MUST fail with a remediation message. Put the check in the manager
+so every tool in the family inherits it:
+
+```python
+if self._auth is None or not self._auth.has_api_key:
+    raise RuntimeError(
+        "<feature> requires a UniFi API key. "
+        "Create a Network API token in UniFi Control Plane -> Integrations "
+        "and set UNIFI_API_KEY or UNIFI_NETWORK_API_KEY for the MCP."
+    )
+```
+
+See `firewall_manager.py:_request_integration_api` for the canonical
+implementation.
+
+## Step 4: Silent ID translation — when allowed, when banned
+
+**Banned by default.** Silently translating between V2 and Integration ID
+spaces inside a tool is forbidden because the underlying mapping is rarely
+1:1.
+
+**Grandfathered exception: zones.** PR #301 translates V2 zone IDs to
+Integration zone UUIDs internally via `_get_integration_firewall_zones`.
+This is allowed *only* because zones meet all three criteria:
+
+- **1:1**: every V2 zone has exactly one Integration zone and vice versa
+- **Stable**: changes via either API remain consistent
+- **Deterministic**: zone names are unique and stable bridge fields
+
+**Do not extend the silent-translation pattern** to a new resource without
+verifying these three criteria against live data. The data for policies
+fails all three (180 V2 vs 25 Integration; 8 duplicate names in V2; no
+bridge field in Integration's `metadata`).
+
+## Step 5: When you genuinely need to bridge ID namespaces
+
+Rare. But if a workflow requires it: write a named bridging tool. The
+bridge is visible in the API surface and its failure modes are
+documented:
+
+```python
+@server.tool(
+    name="unifi_resolve_policy_id_for_ordering",
+    description=(
+        "Look up the integration-API ordering UUID for a V2 firewall policy. "
+        "Returns None when the policy has no Integration-API representation "
+        "(e.g., predefined system policies, IP-group-referenced policies). "
+        "This is the only sanctioned bridge between the firewall policy CRUD "
+        "family and the firewall policy ordering family."
+    ),
+    ...
+)
+```
+
+Don't bury translation inside other tools. Make the bridge first-class.
+
+## Step 6: Tests
+
+Cover the family boundary explicitly:
+
+- **Auth requirement** — tool fails fast without an API key, with the
+  remediation message. Anchor: `test_firewall_manager.py::test_ordering_requires_api_key`.
+- **Scoped IDs** — for ordering-style tools, the response contains
+  integration UUIDs (not V2 IDs) and downstream tools in the family accept
+  them.
+- **Bridge failure modes** — if you wrote a bridging tool (Step 5), every
+  failure mode (missing-in-target, name collision, etc.) has a test.
+
+## Step 7: Doc surface
+
+In the skill docs for the resource category, group integration-API tools
+together. They share a contract; the doc should make that obvious. Don't
+interleave them with V2 tools in the listing.
+
+For the API server (REST + GraphQL), the same scoping rules apply to the
+operation/route descriptions. After editing those, regenerate the
+OpenAPI spec and reference docs via `make pre-commit`.
+
+## Reference implementation
+
+`apps/network/src/unifi_network_mcp/tools/firewall.py` — the ordering
+family.
+
+Read these elements before writing your own:
+
+- The two tool descriptions scoping the UUIDs
+- The shared API-key requirement at the manager layer
+  (`_request_integration_api`)
+- The zone-ID translation (`_get_integration_firewall_zones`) — the *only*
+  sanctioned silent translation
+- That the family is exactly two tools with no cross-family entry points
+
+## Enforcement note
+
+Family scoping is currently *guidance*, not runtime/type enforcement.
+Cross-family ID misuse fails at the controller (400 from the integration
+API) and surfaces as a tool error. The agent reads the scoping clause in
+the tool description and routes IDs accordingly.
+
+Stronger enforcement options (typed IDs via `NewType`, runtime regex
+validation, a `family` field in `tools_manifest.json`) are deliberately
+deferred until the integration-API surface grows beyond the current single
+family. If you find yourself adding a second integration-API family,
+reopen this question.
+
+## Related rules
+
+- AGENTS.md → `### API Surface Boundaries` (terse statement of the rule)
+- Myco decision spore `architecture-d44806fa` (full reasoning + live data)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,22 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 - No monkey-patches in production code
 - **Anchor:** `apps/network/src/unifi_network_mcp/config/config.yaml`
 
+### API Surface Boundaries
+
+UniFi exposes two API surfaces with disjoint ID namespaces: the V2 controller API (session cookie auth, Mongo ObjectIDs, `snake_case` fields) and the public Integration API (`X-API-Key` auth, UUIDs, `camelCase` fields). They are **not interchangeable**.
+
+- **Tool families share an ID space.** Tools whose returned IDs and accepted IDs are mutually portable form a *family*. Cross-family ID use is prohibited.
+- **Tool descriptions MUST scope IDs** when they could be confused with another family's IDs. Standard formula: *"These IDs are scoped to the <family> tool family — do not pass them to other <resource> tools."* This applies to MCP tool descriptions, GraphQL type/query descriptions, and REST route descriptions alike.
+- **Integration API tools MUST require an API key** and fail with a clear remediation message when it is missing. The auth check belongs in the manager so every tool in the family inherits it.
+- **Silent cross-API ID translation is banned** unless the mapping is 1:1, stable, and verified against live data. Zones are grandfathered (1:1 by name, stable, unique). Policies are not (membership diverges, no bridge field, V2 has duplicate names).
+- **Bridging tools must be explicit.** If you need to cross ID namespaces, write a named bridging tool (`unifi_resolve_<resource>_id_for_<family>`) with documented failure modes. Never bury the bridge inside another tool.
+
+**Enforcement:** family scoping is currently *guidance* — descriptions + this rule. There is no runtime or type-level check. Cross-family ID misuse fails at the controller (e.g., 400 from the integration API) and surfaces as a tool error. Stronger enforcement (typed IDs, runtime regex checks, manifest family field) is on the table if and when the integration-API surface grows beyond the current single family.
+
+**Reference family (Integration API):** `unifi_get_firewall_policy_ordering` + `unifi_reorder_firewall_policies` in `apps/network/src/unifi_network_mcp/tools/firewall.py`.
+
+**Skill:** `add-integration-api-tool` (full procedure for contributors).
+
 ## Permission System
 
 Two concepts:

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -670,6 +670,13 @@ type FirewallGroupPage {
   nextCursor: String
 }
 
+"""
+User-defined firewall policy ordering for a source/destination zone pair.
+"""
+type FirewallPolicyOrdering {
+  ordering: JSON!
+}
+
 """A firewall policy rule."""
 type FirewallRule {
   id: ID
@@ -985,6 +992,11 @@ type NetworkQuery {
 
   """List firewall zones (typically a small flat list — no pagination)."""
   firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
+
+  """
+  Get user-defined firewall policy ordering for a source/destination zone pair.
+  """
+  firewallPolicyOrdering(controller: ID!, sourceFirewallZoneId: String!, destinationFirewallZoneId: String!, site: String! = "default"): FirewallPolicyOrdering!
 
   """List QoS rules on the given controller/site (paginated)."""
   qosRules(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): QosRulePage!
@@ -1892,6 +1904,7 @@ Read-only access to UniFi Network resources.
 - `firewallGroups: FirewallGroupPage!`  — List firewall address/port groups (paginated).
 - `firewallPolicies: FirewallRulePage!`  — List firewall policies/rules on the given controller/site (paginated).
 - `firewallPolicy: FirewallRule`  — Look up a single firewall policy/rule by id.
+- `firewallPolicyOrdering: FirewallPolicyOrdering!`  — Get user-defined firewall policy ordering for a source/destination zone pair.
 - `firewallZones: [FirewallZone!]!`  — List firewall zones (typically a small flat list — no pagination).
 - `gatewayStats: [StatPoint!]!`  — Gateway stats timeseries.
 - `ipsEvents: EventLogPage!`  — List recent IPS/IDS events (paginated).

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -671,7 +671,7 @@ type FirewallGroupPage {
 }
 
 """
-User-defined firewall policy ordering for a source/destination zone pair.
+User-defined firewall policy ordering for a source/destination zone pair. Policy IDs in this object are UniFi integration-API UUIDs scoped to the ordering tool family — use them only with the matching reorder mutation. They do NOT correspond to the policy IDs returned by other controller-API firewall queries.
 """
 type FirewallPolicyOrdering {
   ordering: JSON!
@@ -994,7 +994,7 @@ type NetworkQuery {
   firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
 
   """
-  Get user-defined firewall policy ordering for a source/destination zone pair.
+  Get user-defined firewall policy ordering for a source/destination zone pair. Returns policy IDs from the UniFi integration API (UUIDs); these IDs are scoped to the ordering tool family and do NOT correspond to the policy IDs returned by firewallPolicies or other controller-API firewall queries. Requires a UniFi API key (UNIFI_API_KEY).
   """
   firewallPolicyOrdering(controller: ID!, sourceFirewallZoneId: String!, destinationFirewallZoneId: String!, site: String! = "default"): FirewallPolicyOrdering!
 
@@ -1904,7 +1904,7 @@ Read-only access to UniFi Network resources.
 - `firewallGroups: FirewallGroupPage!`  — List firewall address/port groups (paginated).
 - `firewallPolicies: FirewallRulePage!`  — List firewall policies/rules on the given controller/site (paginated).
 - `firewallPolicy: FirewallRule`  — Look up a single firewall policy/rule by id.
-- `firewallPolicyOrdering: FirewallPolicyOrdering!`  — Get user-defined firewall policy ordering for a source/destination zone pair.
+- `firewallPolicyOrdering: FirewallPolicyOrdering!`  — Get user-defined firewall policy ordering for a source/destination zone pair. Returns policy IDs from the UniFi integration API (UUIDs); these IDs are scoped to the ordering tool family and do NOT correspond to the policy IDs returned by firewallPolicies or other controller-API firewall queries. Requires a UniFi API key (UNIFI_API_KEY).
 - `firewallZones: [FirewallZone!]!`  — List firewall zones (typically a small flat list — no pagination).
 - `gatewayStats: [StatPoint!]!`  — Gateway stats timeseries.
 - `ipsEvents: EventLogPage!`  — List recent IPS/IDS events (paginated).

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -509,6 +509,19 @@ Fetch a user by listing then filtering — no native get_user method.
 
 **Returns:** `Detail_FirewallGroupModel_`
 
+### `GET /v1/sites/{site_id}/firewall/policy-ordering` — Get Firewall Policy Ordering
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `source_firewall_zone_id` (query) (required)
+- `destination_firewall_zone_id` (query) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_FirewallPolicyOrderingModel_`
+
 ### `GET /v1/sites/{site_id}/firewall/rules` — List Firewall Rules
 
 

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -509,7 +509,10 @@ Fetch a user by listing then filtering — no native get_user method.
 
 **Returns:** `Detail_FirewallGroupModel_`
 
-### `GET /v1/sites/{site_id}/firewall/policy-ordering` — Get Firewall Policy Ordering
+### `GET /v1/sites/{site_id}/firewall/policy-ordering` — Get firewall policy ordering for a zone pair (integration API)
+
+
+Returns the user-defined firewall policy ordering for a source/destination zone pair, sourced from the UniFi public integration API. Policy IDs in the response are integration-API UUIDs scoped to the ordering tool family — use them only with the matching reorder action; they do NOT correspond to the policy IDs returned by /firewall/rules or other controller-API endpoints. Requires a UniFi API key (UNIFI_API_KEY).
 
 
 **Parameters:**

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -11290,6 +11290,7 @@
     },
     "/v1/sites/{site_id}/firewall/policy-ordering": {
       "get": {
+        "description": "Returns the user-defined firewall policy ordering for a source/destination zone pair, sourced from the UniFi public integration API. Policy IDs in the response are integration-API UUIDs scoped to the ordering tool family \u2014 use them only with the matching reorder action; they do NOT correspond to the policy IDs returned by /firewall/rules or other controller-API endpoints. Requires a UniFi API key (UNIFI_API_KEY).",
         "operationId": "get_firewall_policy_ordering_v1_sites__site_id__firewall_policy_ordering_get",
         "parameters": [
           {
@@ -11360,7 +11361,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Get Firewall Policy Ordering",
+        "summary": "Get firewall policy ordering for a zone pair (integration API)",
         "tags": [
           "network/firewall"
         ]

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1358,6 +1358,31 @@
         "title": "Detail[FirewallGroupModel]",
         "type": "object"
       },
+      "Detail_FirewallPolicyOrderingModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/FirewallPolicyOrderingModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[FirewallPolicyOrderingModel]",
+        "type": "object"
+      },
       "Detail_FirewallRuleModel_": {
         "additionalProperties": true,
         "properties": {
@@ -2275,6 +2300,16 @@
           }
         },
         "title": "FirewallGroupModel",
+        "type": "object"
+      },
+      "FirewallPolicyOrderingModel": {
+        "additionalProperties": true,
+        "properties": {
+          "ordering": {
+            "title": "Ordering"
+          }
+        },
+        "title": "FirewallPolicyOrderingModel",
         "type": "object"
       },
       "FirewallRuleModel": {
@@ -11248,6 +11283,84 @@
           }
         },
         "summary": "Get Firewall Group Details",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/policy-ordering": {
+      "get": {
+        "operationId": "get_firewall_policy_ordering_v1_sites__site_id__firewall_policy_ordering_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_firewall_zone_id",
+            "required": true,
+            "schema": {
+              "title": "Source Firewall Zone Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "destination_firewall_zone_id",
+            "required": true,
+            "schema": {
+              "title": "Destination Firewall Zone Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_FirewallPolicyOrderingModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Firewall Policy Ordering",
         "tags": [
           "network/firewall"
         ]

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -49,6 +49,7 @@ from unifi_api.graphql.types.network.dpi import DpiApplication, DpiCategory
 from unifi_api.graphql.types.network.event import EventLog
 from unifi_api.graphql.types.network.firewall import (
     FirewallGroup,
+    FirewallPolicyOrdering,
     FirewallRule,
     FirewallZone,
 )
@@ -704,6 +705,42 @@ async def _fetch_firewall_zones(
             if cm.site != site:
                 await cm.set_site(site)
             return list(await mgr.get_firewall_zones())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_firewall_policy_ordering(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    source_firewall_zone_id: str,
+    destination_firewall_zone_id: str,
+) -> dict:
+    key = (
+        f"network/firewall-policy-ordering/{controller}/{site}/{source_firewall_zone_id}/{destination_firewall_zone_id}"
+    )
+
+    async def _do() -> dict:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "network",
+                "firewall_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return dict(
+                await mgr.get_firewall_policy_ordering(
+                    source_firewall_zone_id,
+                    destination_firewall_zone_id,
+                )
+            )
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -2806,6 +2843,28 @@ class NetworkQuery:
         ctx: GraphQLContext = info.context
         raw = await _fetch_firewall_zones(ctx, controller, site)
         return [FirewallZone.from_manager_output(z) for z in raw]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Get user-defined firewall policy ordering for a source/destination zone pair.",
+    )
+    async def firewall_policy_ordering(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        source_firewall_zone_id: str,
+        destination_firewall_zone_id: str,
+        site: str = "default",
+    ) -> FirewallPolicyOrdering:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_firewall_policy_ordering(
+            ctx,
+            controller,
+            site,
+            source_firewall_zone_id,
+            destination_firewall_zone_id,
+        )
+        return FirewallPolicyOrdering.from_manager_output(raw)
 
     # ---- QoS domain ------------------------------------------------------
 

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -2846,7 +2846,13 @@ class NetworkQuery:
 
     @strawberry.field(
         permission_classes=[IsRead],
-        description="Get user-defined firewall policy ordering for a source/destination zone pair.",
+        description=(
+            "Get user-defined firewall policy ordering for a source/destination zone pair. "
+            "Returns policy IDs from the UniFi integration API (UUIDs); these IDs are scoped "
+            "to the ordering tool family and do NOT correspond to the policy IDs returned by "
+            "firewallPolicies or other controller-API firewall queries. Requires a UniFi API "
+            "key (UNIFI_API_KEY)."
+        ),
     )
     async def firewall_policy_ordering(
         self,

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -659,6 +659,13 @@ type FirewallGroupPage {
   nextCursor: String
 }
 
+"""
+User-defined firewall policy ordering for a source/destination zone pair.
+"""
+type FirewallPolicyOrdering {
+  ordering: JSON!
+}
+
 """A firewall policy rule."""
 type FirewallRule {
   id: ID
@@ -974,6 +981,11 @@ type NetworkQuery {
 
   """List firewall zones (typically a small flat list — no pagination)."""
   firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
+
+  """
+  Get user-defined firewall policy ordering for a source/destination zone pair.
+  """
+  firewallPolicyOrdering(controller: ID!, sourceFirewallZoneId: String!, destinationFirewallZoneId: String!, site: String! = "default"): FirewallPolicyOrdering!
 
   """List QoS rules on the given controller/site (paginated)."""
   qosRules(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): QosRulePage!

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -660,7 +660,7 @@ type FirewallGroupPage {
 }
 
 """
-User-defined firewall policy ordering for a source/destination zone pair.
+User-defined firewall policy ordering for a source/destination zone pair. Policy IDs in this object are UniFi integration-API UUIDs scoped to the ordering tool family — use them only with the matching reorder mutation. They do NOT correspond to the policy IDs returned by other controller-API firewall queries.
 """
 type FirewallPolicyOrdering {
   ordering: JSON!
@@ -983,7 +983,7 @@ type NetworkQuery {
   firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
 
   """
-  Get user-defined firewall policy ordering for a source/destination zone pair.
+  Get user-defined firewall policy ordering for a source/destination zone pair. Returns policy IDs from the UniFi integration API (UUIDs); these IDs are scoped to the ordering tool family and do NOT correspond to the policy IDs returned by firewallPolicies or other controller-API firewall queries. Requires a UniFi API key (UNIFI_API_KEY).
   """
   firewallPolicyOrdering(controller: ID!, sourceFirewallZoneId: String!, destinationFirewallZoneId: String!, site: String! = "default"): FirewallPolicyOrdering!
 

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -112,9 +112,6 @@ from unifi_api.graphql.types.network.firewall import (
     FirewallGroup as NetworkFirewallGroupType,
 )
 from unifi_api.graphql.types.network.firewall import (
-    FirewallPolicyOrdering as NetworkFirewallPolicyOrderingType,
-)
-from unifi_api.graphql.types.network.firewall import (
     FirewallRule as NetworkFirewallRuleType,
 )
 from unifi_api.graphql.types.network.firewall import (
@@ -389,11 +386,6 @@ def build_type_registry() -> TypeRegistry:
         "unifi_list_firewall_zones",
         NetworkFirewallZoneType,
         "list",
-    )
-    reg.register_tool_type(
-        "unifi_get_firewall_policy_ordering",
-        NetworkFirewallPolicyOrderingType,
-        "detail",
     )
 
     # network/qos (tool-keyed only)

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -365,6 +365,7 @@ def build_type_registry() -> TypeRegistry:
     # network/firewall (rules + groups + zones)
     reg.register_type("network", "firewall/rules", NetworkFirewallRuleType)
     reg.register_type("network", "firewall/rules/{id}", NetworkFirewallRuleType)
+    reg.register_type("network", "firewall/policy-ordering", NetworkFirewallPolicyOrderingType)
     reg.register_tool_type(
         "unifi_list_firewall_policies",
         NetworkFirewallRuleType,

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -112,6 +112,9 @@ from unifi_api.graphql.types.network.firewall import (
     FirewallGroup as NetworkFirewallGroupType,
 )
 from unifi_api.graphql.types.network.firewall import (
+    FirewallPolicyOrdering as NetworkFirewallPolicyOrderingType,
+)
+from unifi_api.graphql.types.network.firewall import (
     FirewallRule as NetworkFirewallRuleType,
 )
 from unifi_api.graphql.types.network.firewall import (
@@ -386,6 +389,11 @@ def build_type_registry() -> TypeRegistry:
         "unifi_list_firewall_zones",
         NetworkFirewallZoneType,
         "list",
+    )
+    reg.register_tool_type(
+        "unifi_get_firewall_policy_ordering",
+        NetworkFirewallPolicyOrderingType,
+        "detail",
     )
 
     # network/qos (tool-keyed only)

--- a/apps/api/src/unifi_api/graphql/types/network/firewall.py
+++ b/apps/api/src/unifi_api/graphql/types/network/firewall.py
@@ -11,6 +11,8 @@ Phase 6 PR2 Task 22 migration target. Three read shapes that used to live in
                       re-exposed as ``members``)
 - ``FirewallZone``  — list_firewall_zones (V2 zone-matrix; the manager strips
                       the policy-count matrix before this layer sees it)
+- ``FirewallPolicyOrdering`` — get_firewall_policy_ordering
+                               (Integration API zone-pair ordering object)
 
 The mutation ack serializer (``FirewallMutationAckSerializer``) is preserved
 in the original module since it covers create/update/delete/toggle for both
@@ -155,6 +157,26 @@ class FirewallZone:
             networks=_get(obj, "networks") or _get(obj, "network_ids") or [],
             default_policy=_get(obj, "default_policy") or _get(obj, "default_action"),
         )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@strawberry.type(description="User-defined firewall policy ordering for a source/destination zone pair.")
+class FirewallPolicyOrdering:
+    ordering: strawberry.scalars.JSON  # type: ignore[name-defined]
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "display_columns": ["ordering"],
+        }
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "FirewallPolicyOrdering":
+        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
+        return cls(ordering=raw.get("orderedFirewallPolicyIds", raw))
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/apps/api/src/unifi_api/graphql/types/network/firewall.py
+++ b/apps/api/src/unifi_api/graphql/types/network/firewall.py
@@ -162,7 +162,14 @@ class FirewallZone:
         return asdict(self)
 
 
-@strawberry.type(description="User-defined firewall policy ordering for a source/destination zone pair.")
+@strawberry.type(
+    description=(
+        "User-defined firewall policy ordering for a source/destination zone pair. "
+        "Policy IDs in this object are UniFi integration-API UUIDs scoped to the ordering "
+        "tool family — use them only with the matching reorder mutation. They do NOT "
+        "correspond to the policy IDs returned by other controller-API firewall queries."
+    )
+)
 class FirewallPolicyOrdering:
     ordering: strawberry.scalars.JSON  # type: ignore[name-defined]
 

--- a/apps/api/src/unifi_api/graphql/types/network/firewall.py
+++ b/apps/api/src/unifi_api/graphql/types/network/firewall.py
@@ -11,8 +11,6 @@ Phase 6 PR2 Task 22 migration target. Three read shapes that used to live in
                       re-exposed as ``members``)
 - ``FirewallZone``  — list_firewall_zones (V2 zone-matrix; the manager strips
                       the policy-count matrix before this layer sees it)
-- ``FirewallPolicyOrdering`` — get_firewall_policy_ordering
-                               (Integration API zone-pair ordering object)
 
 The mutation ack serializer (``FirewallMutationAckSerializer``) is preserved
 in the original module since it covers create/update/delete/toggle for both
@@ -157,26 +155,6 @@ class FirewallZone:
             networks=_get(obj, "networks") or _get(obj, "network_ids") or [],
             default_policy=_get(obj, "default_policy") or _get(obj, "default_action"),
         )
-
-    def to_dict(self) -> dict:
-        return asdict(self)
-
-
-@strawberry.type(description="User-defined firewall policy ordering for a source/destination zone pair.")
-class FirewallPolicyOrdering:
-    ordering: strawberry.scalars.JSON  # type: ignore[name-defined]
-
-    @classmethod
-    def render_hint(cls, kind: str) -> dict:
-        return {
-            "kind": kind,
-            "display_columns": ["ordering"],
-        }
-
-    @classmethod
-    def from_manager_output(cls, obj: Any) -> "FirewallPolicyOrdering":
-        raw = getattr(obj, "raw", obj if isinstance(obj, dict) else {})
-        return cls(ordering=raw.get("orderedFirewallPolicyIds", raw))
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -135,6 +135,15 @@ async def get_firewall_rule(
     response_model=Detail[to_pydantic_model(FirewallPolicyOrdering)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/firewall"],
+    summary="Get firewall policy ordering for a zone pair (integration API)",
+    description=(
+        "Returns the user-defined firewall policy ordering for a source/destination "
+        "zone pair, sourced from the UniFi public integration API. Policy IDs in the "
+        "response are integration-API UUIDs scoped to the ordering tool family — use "
+        "them only with the matching reorder action; they do NOT correspond to the "
+        "policy IDs returned by /firewall/rules or other controller-API endpoints. "
+        "Requires a UniFi API key (UNIFI_API_KEY)."
+    ),
 )
 async def get_firewall_policy_ordering(
     request: Request,

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -8,7 +8,7 @@ from unifi_core.exceptions import UniFiNotFoundError
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.graphql.pydantic_export import to_pydantic_model
-from unifi_api.graphql.types.network.firewall import FirewallRule
+from unifi_api.graphql.types.network.firewall import FirewallPolicyOrdering, FirewallRule
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
@@ -123,6 +123,47 @@ async def get_firewall_rule(
 
     type_class = request.app.state.type_registry.lookup("network", "firewall/rules/{id}")
     data = type_class.from_manager_output(rule).to_dict()
+    hint = type_class.render_hint("detail")
+    return {
+        "data": data,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/firewall/policy-ordering",
+    response_model=Detail[to_pydantic_model(FirewallPolicyOrdering)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
+)
+async def get_firewall_policy_ordering(
+    request: Request,
+    site_id: str,
+    source_firewall_zone_id: str = Query(...),
+    destination_firewall_zone_id: str = Query(...),
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "network",
+            "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        ordering = await mgr.get_firewall_policy_ordering(
+            source_firewall_zone_id,
+            destination_firewall_zone_id,
+        )
+
+    tool_type = request.app.state.type_registry.lookup_tool("unifi_get_firewall_policy_ordering")
+    type_class = tool_type[0] if tool_type else FirewallPolicyOrdering
+    data = type_class.from_manager_output(ordering).to_dict()
     hint = type_class.render_hint("detail")
     return {
         "data": data,

--- a/apps/api/src/unifi_api/serializers/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/serializers/network/firewall_rules.py
@@ -27,7 +27,6 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
         "unifi_update_firewall_policy": {"kind": RenderKind.DETAIL},
         "unifi_delete_firewall_policy": {"kind": RenderKind.DETAIL},
         "unifi_toggle_firewall_policy": {"kind": RenderKind.DETAIL},
-        "unifi_reorder_firewall_policies": {"kind": RenderKind.DETAIL},
         "unifi_create_firewall_group": {"kind": RenderKind.DETAIL},
         "unifi_update_firewall_group": {"kind": RenderKind.DETAIL},
         "unifi_delete_firewall_group": {"kind": RenderKind.DETAIL},

--- a/apps/api/src/unifi_api/serializers/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/serializers/network/firewall_rules.py
@@ -27,6 +27,7 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
         "unifi_update_firewall_policy": {"kind": RenderKind.DETAIL},
         "unifi_delete_firewall_policy": {"kind": RenderKind.DETAIL},
         "unifi_toggle_firewall_policy": {"kind": RenderKind.DETAIL},
+        "unifi_reorder_firewall_policies": {"kind": RenderKind.DETAIL},
         "unifi_create_firewall_group": {"kind": RenderKind.DETAIL},
         "unifi_update_firewall_group": {"kind": RenderKind.DETAIL},
         "unifi_delete_firewall_group": {"kind": RenderKind.DETAIL},

--- a/apps/api/src/unifi_api/services/actions.py
+++ b/apps/api/src/unifi_api/services/actions.py
@@ -44,6 +44,7 @@ from typing import Any, Iterable
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from unifi_api.services.dispatch_overrides import (
+    CONFIRM_REQUIRED_TOOLS,
     DISPATCH_ARG_TRANSLATORS,
     DISPATCH_OVERRIDES,
 )
@@ -281,6 +282,8 @@ async def dispatch_action(
         raise DispatchEntryMissing(
             f"no dispatch entry for tool '{tool_name}' (no manager.method() call discovered in tool body)"
         )
+    if tool_name in CONFIRM_REQUIRED_TOOLS and not confirm:
+        raise ValueError(f"tool '{tool_name}' requires confirm=true")
 
     manager = await factory.get_domain_manager(
         session=session,

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -72,6 +72,7 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     # Firewall: tool layer pre-fetches list to find policy by id.
     "unifi_toggle_firewall_policy": ("firewall_manager", "toggle_firewall_policy"),
     "unifi_update_firewall_policy": ("firewall_manager", "update_firewall_policy"),
+    "unifi_reorder_firewall_policies": ("firewall_manager", "reorder_firewall_policies"),
     # Toggle tools: tool body needs current enabled flag to compute new state.
     "unifi_toggle_port_forward": ("firewall_manager", "toggle_port_forward"),
     "unifi_toggle_qos_rule_enabled": ("qos_manager", "update_qos_rule"),

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -72,7 +72,6 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     # Firewall: tool layer pre-fetches list to find policy by id.
     "unifi_toggle_firewall_policy": ("firewall_manager", "toggle_firewall_policy"),
     "unifi_update_firewall_policy": ("firewall_manager", "update_firewall_policy"),
-    "unifi_reorder_firewall_policies": ("firewall_manager", "reorder_firewall_policies"),
     # Toggle tools: tool body needs current enabled flag to compute new state.
     "unifi_toggle_port_forward": ("firewall_manager", "toggle_port_forward"),
     "unifi_toggle_qos_rule_enabled": ("qos_manager", "update_qos_rule"),

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -115,6 +115,16 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
 }
 
 
+CONFIRM_REQUIRED_TOOLS: frozenset[str] = frozenset(
+    {
+        # The manager now enforces the ordering invariants, but this action is
+        # still a live reorder operation. Keep the API action path aligned with
+        # the MCP tool's explicit confirmation contract.
+        "unifi_reorder_firewall_policies",
+    }
+)
+
+
 # Format: tool_name -> callable(args_dict) -> (positional_args, keyword_args)
 #
 # The default dispatcher invokes ``manager.method(**args)``. Tools registered

--- a/apps/api/tests/graphql/fixtures/network/test_firewall.py
+++ b/apps/api/tests/graphql/fixtures/network/test_firewall.py
@@ -5,6 +5,7 @@
 # tool: unifi_list_firewall_groups
 # tool: unifi_get_firewall_group_details
 # tool: unifi_list_firewall_zones
+# tool: unifi_get_firewall_policy_ordering
 """
 
 from __future__ import annotations
@@ -151,3 +152,36 @@ async def test_firewall_zones_list(tmp_path, monkeypatch):
     assert len(zones) == 2
     names = {z["name"] for z in zones}
     assert names == {"LAN", "WAN"}
+
+
+@pytest.mark.asyncio
+async def test_firewall_policy_ordering_detail(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "firewall_manager", "get_firewall_policy_ordering"): {
+                "orderedFirewallPolicyIds": {
+                    "beforeSystemDefined": ["allow-1"],
+                    "afterSystemDefined": ["block-1"],
+                }
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ firewallPolicyOrdering(
+            controller: "{cid}",
+            sourceFirewallZoneId: "zone-src",
+            destinationFirewallZoneId: "zone-dst"
+        ) {{
+            ordering
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    ordering = body["data"]["network"]["firewallPolicyOrdering"]["ordering"]
+    assert ordering["beforeSystemDefined"] == ["allow-1"]

--- a/apps/api/tests/routes/resources/test_network_filtering.py
+++ b/apps/api/tests/routes/resources/test_network_filtering.py
@@ -209,6 +209,40 @@ async def test_list_firewall_zones_happy_path(tmp_path, monkeypatch) -> None:
     assert names == {"internal", "external"}
 
 
+@pytest.mark.asyncio
+async def test_get_firewall_policy_ordering_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, source_zone, destination_zone):
+        assert source_zone == "zone-src"
+        assert destination_zone == "zone-dst"
+        return {
+            "orderedFirewallPolicyIds": {
+                "beforeSystemDefined": ["allow-1"],
+                "afterSystemDefined": ["block-1"],
+            }
+        }
+
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+
+    monkeypatch.setattr(FirewallManager, "get_firewall_policy_ordering", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            (
+                f"/v1/sites/default/firewall/policy-ordering?controller={cid}"
+                "&source_firewall_zone_id=zone-src&destination_firewall_zone_id=zone-dst"
+            ),
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["ordering"]["beforeSystemDefined"] == ["allow-1"]
+
+
 # ---------- QoS rules ----------
 
 

--- a/apps/api/tests/serializers/test_network_filtering.py
+++ b/apps/api/tests/serializers/test_network_filtering.py
@@ -73,21 +73,6 @@ def test_firewall_zone_list_serializer_shape() -> None:
     assert FirewallZone.render_hint("list")["kind"] == "list"
 
 
-def test_firewall_policy_ordering_detail_shape() -> None:
-    from unifi_api.graphql.types.network.firewall import FirewallPolicyOrdering
-
-    sample = {
-        "orderedFirewallPolicyIds": {
-            "beforeSystemDefined": ["policy-a"],
-            "afterSystemDefined": ["policy-b"],
-        },
-    }
-    out = FirewallPolicyOrdering.from_manager_output(sample).to_dict()
-    assert out["ordering"]["beforeSystemDefined"] == ["policy-a"]
-    assert out["ordering"]["afterSystemDefined"] == ["policy-b"]
-    assert FirewallPolicyOrdering.render_hint("detail")["kind"] == "detail"
-
-
 # ---- Firewall mutation acks ----
 
 
@@ -98,7 +83,6 @@ def test_firewall_mutation_ack_dispatches_for_all_mutations() -> None:
         "unifi_update_firewall_policy",
         "unifi_delete_firewall_policy",
         "unifi_toggle_firewall_policy",
-        "unifi_reorder_firewall_policies",
         "unifi_create_firewall_group",
         "unifi_update_firewall_group",
         "unifi_delete_firewall_group",

--- a/apps/api/tests/serializers/test_network_filtering.py
+++ b/apps/api/tests/serializers/test_network_filtering.py
@@ -73,6 +73,21 @@ def test_firewall_zone_list_serializer_shape() -> None:
     assert FirewallZone.render_hint("list")["kind"] == "list"
 
 
+def test_firewall_policy_ordering_detail_shape() -> None:
+    from unifi_api.graphql.types.network.firewall import FirewallPolicyOrdering
+
+    sample = {
+        "orderedFirewallPolicyIds": {
+            "beforeSystemDefined": ["policy-a"],
+            "afterSystemDefined": ["policy-b"],
+        },
+    }
+    out = FirewallPolicyOrdering.from_manager_output(sample).to_dict()
+    assert out["ordering"]["beforeSystemDefined"] == ["policy-a"]
+    assert out["ordering"]["afterSystemDefined"] == ["policy-b"]
+    assert FirewallPolicyOrdering.render_hint("detail")["kind"] == "detail"
+
+
 # ---- Firewall mutation acks ----
 
 
@@ -83,6 +98,7 @@ def test_firewall_mutation_ack_dispatches_for_all_mutations() -> None:
         "unifi_update_firewall_policy",
         "unifi_delete_firewall_policy",
         "unifi_toggle_firewall_policy",
+        "unifi_reorder_firewall_policies",
         "unifi_create_firewall_group",
         "unifi_update_firewall_group",
         "unifi_delete_firewall_group",

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -268,6 +268,47 @@ def test_dispatch_overrides_specific_targets() -> None:
     assert table["access_update_policy"].method == "apply_update_policy"
 
 
+@pytest.mark.asyncio
+async def test_dispatch_reorder_firewall_policies_requires_confirm() -> None:
+    entry = ToolEntry(
+        name="unifi_reorder_firewall_policies",
+        product="network",
+        category="firewall",
+        manager="",
+        method="",
+    )
+    registry = _registry_with(entry)
+    factory = MagicMock()
+
+    with pytest.raises(ValueError, match="requires confirm=true"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_reorder_firewall_policies",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={
+                "source_firewall_zone_id": "zone-src",
+                "destination_firewall_zone_id": "zone-dst",
+                "ordered_firewall_policy_ids": {
+                    "beforeSystemDefined": ["allow-1"],
+                    "afterSystemDefined": ["block-1"],
+                },
+            },
+            confirm=False,
+            dispatch_table={
+                "unifi_reorder_firewall_policies": DispatchEntry(
+                    manager_attr="firewall_manager",
+                    method="reorder_firewall_policies",
+                ),
+            },
+        )
+
+    factory.get_domain_manager.assert_not_called()
+
+
 # -----------------------------------------------------------------------------
 # Argument translators — bridge tool flat kwargs → manager-shaped positional args
 # -----------------------------------------------------------------------------

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -248,6 +248,7 @@ def test_dispatch_overrides_specific_targets() -> None:
     assert table["unifi_toggle_wlan"].method == "toggle_wlan"
     # Toggle that needs current state
     assert table["unifi_toggle_firewall_policy"].method == "toggle_firewall_policy"
+    assert table["unifi_reorder_firewall_policies"].method == "reorder_firewall_policies"
     # Stats: list-returning method (was AST-captured as get_X_details, a dict)
     assert table["unifi_get_device_stats"].manager_attr == "stats_manager"
     assert table["unifi_get_device_stats"].method == "get_device_stats"

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -248,7 +248,6 @@ def test_dispatch_overrides_specific_targets() -> None:
     assert table["unifi_toggle_wlan"].method == "toggle_wlan"
     # Toggle that needs current state
     assert table["unifi_toggle_firewall_policy"].method == "toggle_firewall_policy"
-    assert table["unifi_reorder_firewall_policies"].method == "reorder_firewall_policies"
     # Stats: list-returning method (was AST-captured as get_X_details, a dict)
     assert table["unifi_get_device_stats"].manager_attr == "stats_manager"
     assert table["unifi_get_device_stats"].method == "get_device_stats"

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -238,7 +238,7 @@ def get_system_manager() -> SystemManager:
 
 @lru_cache
 def get_firewall_manager() -> FirewallManager:
-    return FirewallManager(get_connection_manager())
+    return FirewallManager(get_connection_manager(), get_auth())
 
 
 @lru_cache

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -4,6 +4,7 @@ Firewall policy tools for Unifi Network MCP server.
 
 import json
 import logging
+from collections import Counter
 from typing import Annotated, Any, Dict
 
 from mcp.types import ToolAnnotations
@@ -710,6 +711,9 @@ async def reorder_firewall_policies(
         if not source_firewall_zone_id or not destination_firewall_zone_id:
             return {"success": False, "error": "source_firewall_zone_id and destination_firewall_zone_id are required"}
 
+        if not isinstance(ordered_firewall_policy_ids, dict):
+            return {"success": False, "error": "ordered_firewall_policy_ids must be an object"}
+
         before = ordered_firewall_policy_ids.get("beforeSystemDefined")
         after = ordered_firewall_policy_ids.get("afterSystemDefined")
         if not isinstance(before, list) or not isinstance(after, list):
@@ -717,25 +721,43 @@ async def reorder_firewall_policies(
                 "success": False,
                 "error": "ordered_firewall_policy_ids must include beforeSystemDefined and afterSystemDefined arrays",
             }
+        requested_order = before + after
+        if not all(isinstance(policy_id, str) and policy_id for policy_id in requested_order):
+            return {
+                "success": False,
+                "error": "ordered_firewall_policy_ids arrays must contain only non-empty policy ID strings",
+            }
+        duplicate_ids = sorted(policy_id for policy_id, count in Counter(requested_order).items() if count > 1)
+        if duplicate_ids:
+            return {
+                "success": False,
+                "error": "Reorder payload contains duplicate policy IDs: %s" % ", ".join(duplicate_ids),
+            }
 
         current = await firewall_manager.get_firewall_policy_ordering(
             source_firewall_zone_id,
             destination_firewall_zone_id,
         )
         current_ordering = current.get("orderedFirewallPolicyIds", current)
-        requested_ids = set(before) | set(after)
-        current_ids = set(current_ordering.get("beforeSystemDefined", [])) | set(
-            current_ordering.get("afterSystemDefined", [])
-        )
-        if requested_ids != current_ids:
+        if not isinstance(current_ordering, dict):
+            return {
+                "success": False,
+                "error": "Current firewall policy ordering response did not include an ordering object",
+            }
+        current_order = current_ordering.get("beforeSystemDefined", []) + current_ordering.get("afterSystemDefined", [])
+        requested_counts = Counter(requested_order)
+        current_counts = Counter(current_order)
+        if requested_counts != current_counts:
+            missing_ids = sorted((current_counts - requested_counts).elements())
+            unexpected_ids = sorted((requested_counts - current_counts).elements())
             return {
                 "success": False,
                 "error": (
                     "Reorder payload must preserve the exact current policy ID set. "
                     "Missing: %s; unexpected: %s"
                     % (
-                        ", ".join(sorted(current_ids - requested_ids)) or "none",
-                        ", ".join(sorted(requested_ids - current_ids)) or "none",
+                        ", ".join(missing_ids) or "none",
+                        ", ".join(unexpected_ids) or "none",
                     )
                 ),
                 "current_ordering": current_ordering,

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -638,7 +638,10 @@ async def update_firewall_policy(
     name="unifi_get_firewall_policy_ordering",
     description=(
         "Get user-defined firewall policy ordering for a source/destination firewall zone pair. "
-        "Use this instead of reading policy index when planning rule order; UniFi assigns index values."
+        "Returns policy IDs from the UniFi public integration API (UUIDs); these IDs are scoped "
+        "to the ordering tool family — pass them ONLY to unifi_reorder_firewall_policies. They "
+        "do NOT correspond to the policy IDs returned by unifi_list_firewall_policies or any "
+        "other controller-API firewall tool. Requires a UniFi API key (UNIFI_API_KEY)."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -676,8 +679,11 @@ async def get_firewall_policy_ordering(
     name="unifi_reorder_firewall_policies",
     description=(
         "Reorder user-defined firewall policies for a source/destination firewall zone pair. "
-        "Pass the complete orderedFirewallPolicyIds object with beforeSystemDefined and "
-        "afterSystemDefined arrays. Requires confirmation."
+        "Pass the complete orderedFirewallPolicyIds object obtained from "
+        "unifi_get_firewall_policy_ordering (beforeSystemDefined + afterSystemDefined arrays). "
+        "These IDs are integration-API UUIDs scoped to the ordering tool family — they are NOT "
+        "the policy IDs returned by unifi_list_firewall_policies. Requires confirmation and a "
+        "UniFi API key (UNIFI_API_KEY)."
     ),
     permission_category="firewall_policies",
     permission_action="update",

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -623,6 +623,139 @@ async def update_firewall_policy(
 
 
 @server.tool(
+    name="unifi_get_firewall_policy_ordering",
+    description=(
+        "Get user-defined firewall policy ordering for a source/destination firewall zone pair. "
+        "Use this instead of reading policy index when planning rule order; UniFi assigns index values."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_firewall_policy_ordering(
+    source_firewall_zone_id: Annotated[
+        str,
+        Field(description="Source firewall zone ID from unifi_list_firewall_zones"),
+    ],
+    destination_firewall_zone_id: Annotated[
+        str,
+        Field(description="Destination firewall zone ID from unifi_list_firewall_zones"),
+    ],
+) -> Dict[str, Any]:
+    """Get user-defined firewall policy ordering for a zone pair."""
+    try:
+        if not source_firewall_zone_id or not destination_firewall_zone_id:
+            return {"success": False, "error": "source_firewall_zone_id and destination_firewall_zone_id are required"}
+
+        ordering = await firewall_manager.get_firewall_policy_ordering(
+            source_firewall_zone_id,
+            destination_firewall_zone_id,
+        )
+        return {
+            "success": True,
+            "source_firewall_zone_id": source_firewall_zone_id,
+            "destination_firewall_zone_id": destination_firewall_zone_id,
+            "ordering": ordering.get("orderedFirewallPolicyIds", ordering),
+        }
+    except Exception as e:
+        logger.error("Error getting firewall policy ordering: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to get firewall policy ordering: {e}"}
+
+
+@server.tool(
+    name="unifi_reorder_firewall_policies",
+    description=(
+        "Reorder user-defined firewall policies for a source/destination firewall zone pair. "
+        "Pass the complete orderedFirewallPolicyIds object with beforeSystemDefined and "
+        "afterSystemDefined arrays. Requires confirmation."
+    ),
+    permission_category="firewall_policies",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def reorder_firewall_policies(
+    source_firewall_zone_id: Annotated[
+        str,
+        Field(description="Source firewall zone ID from unifi_list_firewall_zones"),
+    ],
+    destination_firewall_zone_id: Annotated[
+        str,
+        Field(description="Destination firewall zone ID from unifi_list_firewall_zones"),
+    ],
+    ordered_firewall_policy_ids: Annotated[
+        Dict[str, list[str]],
+        Field(
+            description=(
+                "Complete ordering object: {'beforeSystemDefined': [...], 'afterSystemDefined': [...]}. "
+                "Preserve all existing policy IDs unless intentionally moving them."
+            )
+        ),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, applies the reorder. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Reorder user-defined firewall policies for a zone pair."""
+    try:
+        if not source_firewall_zone_id or not destination_firewall_zone_id:
+            return {"success": False, "error": "source_firewall_zone_id and destination_firewall_zone_id are required"}
+
+        before = ordered_firewall_policy_ids.get("beforeSystemDefined")
+        after = ordered_firewall_policy_ids.get("afterSystemDefined")
+        if not isinstance(before, list) or not isinstance(after, list):
+            return {
+                "success": False,
+                "error": "ordered_firewall_policy_ids must include beforeSystemDefined and afterSystemDefined arrays",
+            }
+
+        current = await firewall_manager.get_firewall_policy_ordering(
+            source_firewall_zone_id,
+            destination_firewall_zone_id,
+        )
+        current_ordering = current.get("orderedFirewallPolicyIds", current)
+        requested_ids = set(before) | set(after)
+        current_ids = set(current_ordering.get("beforeSystemDefined", [])) | set(
+            current_ordering.get("afterSystemDefined", [])
+        )
+        if requested_ids != current_ids:
+            return {
+                "success": False,
+                "error": (
+                    "Reorder payload must preserve the exact current policy ID set. "
+                    "Missing: %s; unexpected: %s"
+                    % (
+                        ", ".join(sorted(current_ids - requested_ids)) or "none",
+                        ", ".join(sorted(requested_ids - current_ids)) or "none",
+                    )
+                ),
+                "current_ordering": current_ordering,
+            }
+
+        if not confirm:
+            return update_preview(
+                resource_type="firewall_policy_ordering",
+                resource_id=f"{source_firewall_zone_id}->{destination_firewall_zone_id}",
+                resource_name="Firewall policy ordering",
+                current_state=current_ordering,
+                updates={"orderedFirewallPolicyIds": ordered_firewall_policy_ids},
+            )
+
+        result = await firewall_manager.reorder_firewall_policies(
+            source_firewall_zone_id,
+            destination_firewall_zone_id,
+            ordered_firewall_policy_ids,
+        )
+        return {
+            "success": True,
+            "source_firewall_zone_id": source_firewall_zone_id,
+            "destination_firewall_zone_id": destination_firewall_zone_id,
+            "ordering": result.get("orderedFirewallPolicyIds", result),
+        }
+    except Exception as e:
+        logger.error("Error reordering firewall policies: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to reorder firewall policies: {e}"}
+
+
+@server.tool(
     name="unifi_list_firewall_zones",
     description="List controller firewall zones (V2 API).",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -392,15 +392,19 @@ async def create_firewall_policy(
         logger.warning("Invalid firewall policy data: %s", err)
         return {"success": False, "error": "Validation Error: %s" % err}
 
-    # Apply the same defaults the legacy schema validator provided.
+    # Apply controller-required V2 defaults for create only. Do not move these
+    # into shared update validation; omitted update fields must remain untouched.
     validated_data: Dict[str, Any] = {
         "enabled": True,
         "protocol": "all",
         "ip_version": "BOTH",
         "logging": False,
         "connection_state_type": "ALL",
+        "schedule": {"mode": "ALWAYS"},
         **policy_data,
     }
+    if validated_data.get("schedule") is None:
+        validated_data["schedule"] = {"mode": "ALWAYS"}
 
     # Validate zone targeting requirements (matching_target_type, ips, network_ids)
     targeting_error = _validate_zone_targeting(validated_data)
@@ -411,6 +415,13 @@ async def create_firewall_policy(
     if not isinstance(action, str) or action.upper() not in ("ALLOW", "BLOCK", "REJECT"):
         return {"success": False, "error": "Invalid action '%s'. Must be ALLOW, BLOCK, or REJECT." % action}
     validated_data["action"] = action.upper()
+    if validated_data["action"] in ("BLOCK", "REJECT"):
+        if validated_data.get("create_allow_respond") is True:
+            return {
+                "success": False,
+                "error": "create_allow_respond must be false for BLOCK/REJECT firewall policies.",
+            }
+        validated_data.setdefault("create_allow_respond", False)
 
     policy_name = validated_data.get("name", "Unnamed Policy")
 

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -746,7 +746,7 @@ async def reorder_firewall_policies(
                 resource_type="firewall_policy_ordering",
                 resource_id=f"{source_firewall_zone_id}->{destination_firewall_zone_id}",
                 resource_name="Firewall policy ordering",
-                current_state=current_ordering,
+                current_state={"orderedFirewallPolicyIds": current_ordering},
                 updates={"orderedFirewallPolicyIds": ordered_firewall_policy_ids},
             )
 

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -6315,7 +6315,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get user-defined firewall policy ordering for a source/destination firewall zone pair. Use this instead of reading policy index when planning rule order; UniFi assigns index values.",
+      "description": "Get user-defined firewall policy ordering for a source/destination firewall zone pair. Returns policy IDs from the UniFi public integration API (UUIDs); these IDs are scoped to the ordering tool family \u2014 pass them ONLY to unifi_reorder_firewall_policies. They do NOT correspond to the policy IDs returned by unifi_list_firewall_policies or any other controller-API firewall tool. Requires a UniFi API key (UNIFI_API_KEY).",
       "name": "unifi_get_firewall_policy_ordering",
       "schema": {
         "input": {
@@ -12506,7 +12506,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Reorder user-defined firewall policies for a source/destination firewall zone pair. Pass the complete orderedFirewallPolicyIds object with beforeSystemDefined and afterSystemDefined arrays. Requires confirmation.",
+      "description": "Reorder user-defined firewall policies for a source/destination firewall zone pair. Pass the complete orderedFirewallPolicyIds object obtained from unifi_get_firewall_policy_ordering (beforeSystemDefined + afterSystemDefined arrays). These IDs are integration-API UUIDs scoped to the ordering tool family \u2014 they are NOT the policy IDs returned by unifi_list_firewall_policies. Requires confirmation and a UniFi API key (UNIFI_API_KEY).",
       "name": "unifi_reorder_firewall_policies",
       "permission_action": "update",
       "permission_category": "firewall_policies",

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 174,
+  "count": 176,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -62,6 +62,7 @@
     "unifi_get_event_types": "unifi_network_mcp.tools.events",
     "unifi_get_firewall_group_details": "unifi_network_mcp.tools.firewall",
     "unifi_get_firewall_policy_details": "unifi_network_mcp.tools.firewall",
+    "unifi_get_firewall_policy_ordering": "unifi_network_mcp.tools.firewall",
     "unifi_get_gateway_stats": "unifi_network_mcp.tools.stats",
     "unifi_get_ips_events": "unifi_network_mcp.tools.stats",
     "unifi_get_lldp_neighbors": "unifi_network_mcp.tools.switch",
@@ -129,6 +130,7 @@
     "unifi_recent_events": "unifi_network_mcp.tools.events",
     "unifi_rename_client": "unifi_network_mcp.tools.clients",
     "unifi_rename_device": "unifi_network_mcp.tools.devices",
+    "unifi_reorder_firewall_policies": "unifi_network_mcp.tools.firewall",
     "unifi_revoke_voucher": "unifi_network_mcp.tools.hotspot",
     "unifi_set_client_ip_settings": "unifi_network_mcp.tools.clients",
     "unifi_set_device_led": "unifi_network_mcp.tools.devices",
@@ -6313,6 +6315,103 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
+      "description": "Get user-defined firewall policy ordering for a source/destination firewall zone pair. Use this instead of reading policy index when planning rule order; UniFi assigns index values.",
+      "name": "unifi_get_firewall_policy_ordering",
+      "schema": {
+        "input": {
+          "properties": {
+            "destination_firewall_zone_id": {
+              "description": "Destination firewall zone ID from unifi_list_firewall_zones",
+              "type": "string"
+            },
+            "source_firewall_zone_id": {
+              "description": "Source firewall zone ID from unifi_list_firewall_zones",
+              "type": "string"
+            }
+          },
+          "required": [
+            "source_firewall_zone_id",
+            "destination_firewall_zone_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Get Firewall Policy Ordering"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
       "description": "Get gateway WAN/LAN performance history including bandwidth, CPU, and memory utilization.",
       "name": "unifi_get_gateway_stats",
       "schema": {
@@ -12399,6 +12498,116 @@
         }
       },
       "title": "Rename Device"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Reorder user-defined firewall policies for a source/destination firewall zone pair. Pass the complete orderedFirewallPolicyIds object with beforeSystemDefined and afterSystemDefined arrays. Requires confirmation.",
+      "name": "unifi_reorder_firewall_policies",
+      "permission_action": "update",
+      "permission_category": "firewall_policies",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, applies the reorder. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "destination_firewall_zone_id": {
+              "description": "Destination firewall zone ID from unifi_list_firewall_zones",
+              "type": "string"
+            },
+            "ordered_firewall_policy_ids": {
+              "description": "Complete ordering object: {'beforeSystemDefined': [...], 'afterSystemDefined': [...]}. Preserve all existing policy IDs unless intentionally moving them.",
+              "type": "object"
+            },
+            "source_firewall_zone_id": {
+              "description": "Source firewall zone ID from unifi_list_firewall_zones",
+              "type": "string"
+            }
+          },
+          "required": [
+            "source_firewall_zone_id",
+            "destination_firewall_zone_id",
+            "ordered_firewall_policy_ids"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Reorder Firewall Policies"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -405,6 +405,39 @@ class TestFirewallPolicyOrdering:
         )
 
     @pytest.mark.asyncio
+    async def test_reorder_policy_ordering_ignores_cached_ordering_for_validation(self, firewall_manager):
+        stale_ordering = {
+            "orderedFirewallPolicyIds": {
+                "beforeSystemDefined": ["stale-allow"],
+                "afterSystemDefined": ["stale-block"],
+            }
+        }
+
+        def fake_get_cached(key):
+            if key == "firewall_policy_ordering_zone-src_zone-dst_default":
+                return stale_ordering
+            return None
+
+        firewall_manager._connection.get_cached.side_effect = fake_get_cached
+        firewall_manager._request_integration_api = AsyncMock(
+            side_effect=[
+                {"data": [{"id": "site-uuid", "name": "default"}]},
+                {"data": [{"id": "zone-src", "name": "Internal"}, {"id": "zone-dst", "name": "External"}]},
+                {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
+                {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
+            ]
+        )
+        ordering = {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}
+
+        result = await firewall_manager.reorder_firewall_policies("zone-src", "zone-dst", ordering)
+
+        assert result["orderedFirewallPolicyIds"] == ordering
+        calls = firewall_manager._request_integration_api.call_args_list
+        assert calls[2].args[0] == "get"
+        assert calls[2].args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
+        assert calls[3].args[0] == "put"
+
+    @pytest.mark.asyncio
     async def test_reorder_rejects_duplicate_policy_ids_before_api_call(self, firewall_manager):
         firewall_manager._request_integration_api = AsyncMock()
         ordering = {"beforeSystemDefined": ["allow", "allow"], "afterSystemDefined": ["block"]}

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -275,6 +275,11 @@ class TestFirewallPolicyOrdering:
     """Ordering is managed through the official integration API, not index PUTs."""
 
     @pytest.mark.asyncio
+    async def test_ordering_requires_api_key(self, firewall_manager):
+        with pytest.raises(RuntimeError, match="requires a UniFi API key"):
+            await firewall_manager._request_integration_api("get", "/v1/sites")
+
+    @pytest.mark.asyncio
     async def test_get_policy_ordering_uses_integration_endpoint(self, firewall_manager):
         firewall_manager._request_integration_api = AsyncMock(
             side_effect=[

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -284,6 +284,7 @@ class TestFirewallPolicyOrdering:
         firewall_manager._request_integration_api = AsyncMock(
             side_effect=[
                 {"data": [{"id": "site-uuid", "name": "default"}]},
+                {"data": [{"id": "zone-src", "name": "Internal"}, {"id": "zone-dst", "name": "External"}]},
                 {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
             ]
         )
@@ -292,6 +293,8 @@ class TestFirewallPolicyOrdering:
 
         assert result["orderedFirewallPolicyIds"]["beforeSystemDefined"] == ["allow"]
         call = firewall_manager._request_integration_api.call_args_list[1]
+        assert call.args[1] == "/v1/sites/site-uuid/firewall/zones"
+        call = firewall_manager._request_integration_api.call_args_list[2]
         assert call.args[0] == "get"
         assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
         assert call.kwargs["params"] == {
@@ -304,6 +307,7 @@ class TestFirewallPolicyOrdering:
         firewall_manager._request_integration_api = AsyncMock(
             side_effect=[
                 {"data": [{"id": "site-uuid", "name": "default"}]},
+                {"data": [{"id": "zone-src", "name": "Internal"}, {"id": "zone-dst", "name": "External"}]},
                 {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
             ]
         )
@@ -313,9 +317,44 @@ class TestFirewallPolicyOrdering:
 
         assert result["orderedFirewallPolicyIds"] == ordering
         call = firewall_manager._request_integration_api.call_args_list[1]
+        assert call.args[1] == "/v1/sites/site-uuid/firewall/zones"
+        call = firewall_manager._request_integration_api.call_args_list[2]
         assert call.args[0] == "put"
         assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
         assert call.kwargs["data"] == {"orderedFirewallPolicyIds": ordering}
+
+    @pytest.mark.asyncio
+    async def test_policy_ordering_translates_v2_zone_ids_to_integration_ids(self, firewall_manager):
+        firewall_manager._request_integration_api = AsyncMock(
+            side_effect=[
+                {"data": [{"id": "site-uuid", "name": "default"}]},
+                {
+                    "data": [
+                        {"id": "integration-internal", "name": "Internal"},
+                        {"id": "integration-external", "name": "External"},
+                    ]
+                },
+                {"orderedFirewallPolicyIds": {"beforeSystemDefined": [], "afterSystemDefined": []}},
+            ]
+        )
+
+        with patch.object(
+            firewall_manager,
+            "get_firewall_zones",
+            new_callable=AsyncMock,
+            return_value=[
+                {"_id": "v2-internal", "name": "Internal", "zone_key": "internal"},
+                {"_id": "v2-external", "name": "External", "zone_key": "external"},
+            ],
+        ):
+            await firewall_manager.get_firewall_policy_ordering("v2-internal", "v2-external")
+
+        call = firewall_manager._request_integration_api.call_args_list[2]
+        assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
+        assert call.kwargs["params"] == {
+            "sourceFirewallZoneId": "integration-internal",
+            "destinationFirewallZoneId": "integration-external",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -43,6 +43,8 @@ def _make_mock_connection(routes: list | None = None):
     conn = MagicMock()
     conn.ensure_connected = AsyncMock(return_value=True)
     conn.request = AsyncMock(return_value={})
+    conn.host = "127.0.0.1"
+    conn.port = 443
     conn.site = "default"
     conn.get_cached = MagicMock(return_value=None)
     conn._update_cache = MagicMock()
@@ -274,10 +276,82 @@ class TestToggleFirewallPolicyPayload:
 class TestFirewallPolicyOrdering:
     """Ordering is managed through the official integration API, not index PUTs."""
 
+    class _ResponseContext:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _Response:
+        def __init__(self, status=200, json_body=None, json_error=None, text_body=""):
+            self.status = status
+            self._json_body = json_body
+            self._json_error = json_error
+            self._text_body = text_body
+
+        async def json(self, content_type=None):
+            if self._json_error is not None:
+                raise self._json_error
+            return self._json_body
+
+        async def text(self):
+            return self._text_body
+
+    class _Session:
+        def __init__(self, response):
+            self.response = response
+            self.closed = False
+
+        def request(self, *args, **kwargs):
+            return TestFirewallPolicyOrdering._ResponseContext(self.response)
+
+        async def close(self):
+            self.closed = True
+
+    @staticmethod
+    def _manager_with_integration_response(mock_connection, response):
+        from unifi_core.network.managers.firewall_manager import FirewallManager
+
+        session = TestFirewallPolicyOrdering._Session(response)
+        auth = MagicMock()
+        auth.has_api_key = True
+        auth.get_api_key_session = AsyncMock(return_value=session)
+        return FirewallManager(mock_connection, auth), session
+
     @pytest.mark.asyncio
     async def test_ordering_requires_api_key(self, firewall_manager):
         with pytest.raises(RuntimeError, match="requires a UniFi API key"):
             await firewall_manager._request_integration_api("get", "/v1/sites")
+
+    @pytest.mark.asyncio
+    async def test_integration_api_reports_non_json_error_body(self, mock_connection):
+        response = self._Response(status=502, json_error=ValueError("not json"), text_body="<html>bad gateway</html>")
+        manager, session = self._manager_with_integration_response(mock_connection, response)
+
+        with pytest.raises(RuntimeError, match="Integration API returned 502.*bad gateway"):
+            await manager._request_integration_api("get", "/v1/sites")
+
+        assert session.closed is True
+
+    @pytest.mark.asyncio
+    async def test_integration_api_reports_empty_error_body(self, mock_connection):
+        response = self._Response(status=500, json_error=ValueError("not json"), text_body="")
+        manager, _session = self._manager_with_integration_response(mock_connection, response)
+
+        with pytest.raises(RuntimeError, match="Integration API returned 500.*<empty body>"):
+            await manager._request_integration_api("get", "/v1/sites")
+
+    @pytest.mark.asyncio
+    async def test_integration_api_reports_non_json_success_body(self, mock_connection):
+        response = self._Response(status=200, json_error=ValueError("not json"), text_body="OK")
+        manager, _session = self._manager_with_integration_response(mock_connection, response)
+
+        with pytest.raises(RuntimeError, match="Integration API returned non-JSON response.*OK"):
+            await manager._request_integration_api("get", "/v1/sites")
 
     @pytest.mark.asyncio
     async def test_get_policy_ordering_uses_integration_endpoint(self, firewall_manager):

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -267,6 +267,53 @@ class TestToggleFirewallPolicyPayload:
 
 
 # ---------------------------------------------------------------------------
+# firewall policy ordering — official integration API support
+# ---------------------------------------------------------------------------
+
+
+class TestFirewallPolicyOrdering:
+    """Ordering is managed through the official integration API, not index PUTs."""
+
+    @pytest.mark.asyncio
+    async def test_get_policy_ordering_uses_integration_endpoint(self, firewall_manager):
+        firewall_manager._request_integration_api = AsyncMock(
+            side_effect=[
+                {"data": [{"id": "site-uuid", "name": "default"}]},
+                {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
+            ]
+        )
+
+        result = await firewall_manager.get_firewall_policy_ordering("zone-src", "zone-dst")
+
+        assert result["orderedFirewallPolicyIds"]["beforeSystemDefined"] == ["allow"]
+        call = firewall_manager._request_integration_api.call_args_list[1]
+        assert call.args[0] == "get"
+        assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
+        assert call.kwargs["params"] == {
+            "sourceFirewallZoneId": "zone-src",
+            "destinationFirewallZoneId": "zone-dst",
+        }
+
+    @pytest.mark.asyncio
+    async def test_reorder_policy_ordering_sends_complete_payload(self, firewall_manager):
+        firewall_manager._request_integration_api = AsyncMock(
+            side_effect=[
+                {"data": [{"id": "site-uuid", "name": "default"}]},
+                {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
+            ]
+        )
+        ordering = {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}
+
+        result = await firewall_manager.reorder_firewall_policies("zone-src", "zone-dst", ordering)
+
+        assert result["orderedFirewallPolicyIds"] == ordering
+        call = firewall_manager._request_integration_api.call_args_list[1]
+        assert call.args[0] == "put"
+        assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
+        assert call.kwargs["data"] == {"orderedFirewallPolicyIds": ordering}
+
+
+# ---------------------------------------------------------------------------
 # ID-lookup iteration robustness — issue #151
 #
 # `next((x for x in items if x.id == target), None)` over aiounifi item

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -383,6 +383,7 @@ class TestFirewallPolicyOrdering:
                 {"data": [{"id": "site-uuid", "name": "default"}]},
                 {"data": [{"id": "zone-src", "name": "Internal"}, {"id": "zone-dst", "name": "External"}]},
                 {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
+                {"orderedFirewallPolicyIds": {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}},
             ]
         )
         ordering = {"beforeSystemDefined": ["allow"], "afterSystemDefined": ["block"]}
@@ -393,12 +394,57 @@ class TestFirewallPolicyOrdering:
         call = firewall_manager._request_integration_api.call_args_list[1]
         assert call.args[1] == "/v1/sites/site-uuid/firewall/zones"
         call = firewall_manager._request_integration_api.call_args_list[2]
+        assert call.args[0] == "get"
+        assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
+        call = firewall_manager._request_integration_api.call_args_list[3]
         assert call.args[0] == "put"
         assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
         assert call.kwargs["data"] == {"orderedFirewallPolicyIds": ordering}
         firewall_manager._connection._invalidate_cache.assert_any_call(
             "firewall_policy_ordering_zone-src_zone-dst_default"
         )
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_duplicate_policy_ids_before_api_call(self, firewall_manager):
+        firewall_manager._request_integration_api = AsyncMock()
+        ordering = {"beforeSystemDefined": ["allow", "allow"], "afterSystemDefined": ["block"]}
+
+        with pytest.raises(ValueError, match="duplicate policy IDs: allow"):
+            await firewall_manager.reorder_firewall_policies("zone-src", "zone-dst", ordering)
+
+        firewall_manager._request_integration_api.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_non_string_policy_ids_before_api_call(self, firewall_manager):
+        firewall_manager._request_integration_api = AsyncMock()
+        ordering = {"beforeSystemDefined": ["allow", None], "afterSystemDefined": ["block"]}
+
+        with pytest.raises(ValueError, match="non-empty policy ID strings"):
+            await firewall_manager.reorder_firewall_policies("zone-src", "zone-dst", ordering)
+
+        firewall_manager._request_integration_api.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_payload_that_drops_current_policy(self, firewall_manager):
+        firewall_manager._request_integration_api = AsyncMock(
+            side_effect=[
+                {"data": [{"id": "site-uuid", "name": "default"}]},
+                {"data": [{"id": "zone-src", "name": "Internal"}, {"id": "zone-dst", "name": "External"}]},
+                {
+                    "orderedFirewallPolicyIds": {
+                        "beforeSystemDefined": ["allow-1", "allow-2"],
+                        "afterSystemDefined": ["block-1"],
+                    }
+                },
+            ]
+        )
+        ordering = {"beforeSystemDefined": ["allow-1"], "afterSystemDefined": ["block-1"]}
+
+        with pytest.raises(ValueError, match="Missing: allow-2; unexpected: none"):
+            await firewall_manager.reorder_firewall_policies("zone-src", "zone-dst", ordering)
+
+        assert firewall_manager._request_integration_api.call_count == 3
+        assert firewall_manager._request_integration_api.call_args_list[-1].args[0] == "get"
 
     @pytest.mark.asyncio
     async def test_policy_ordering_translates_v2_zone_ids_to_integration_ids(self, firewall_manager):

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -396,6 +396,9 @@ class TestFirewallPolicyOrdering:
         assert call.args[0] == "put"
         assert call.args[1] == "/v1/sites/site-uuid/firewall/policies/ordering"
         assert call.kwargs["data"] == {"orderedFirewallPolicyIds": ordering}
+        firewall_manager._connection._invalidate_cache.assert_any_call(
+            "firewall_policy_ordering_zone-src_zone-dst_default"
+        )
 
     @pytest.mark.asyncio
     async def test_policy_ordering_translates_v2_zone_ids_to_integration_ids(self, firewall_manager):

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -718,6 +718,102 @@ class TestUpdateFirewallPolicyV2Fields:
 
 
 # ---------------------------------------------------------------------------
+# firewall policy ordering
+# ---------------------------------------------------------------------------
+
+
+class TestFirewallPolicyOrderingTools:
+    """Tools for the dedicated UniFi policy ordering endpoint."""
+
+    ORDERING = {
+        "beforeSystemDefined": ["allow-1", "allow-2"],
+        "afterSystemDefined": ["block-1"],
+    }
+
+    @pytest.mark.asyncio
+    async def test_get_policy_ordering_success(self):
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policy_ordering = AsyncMock(
+                return_value={"orderedFirewallPolicyIds": copy.deepcopy(self.ORDERING)}
+            )
+
+            from unifi_network_mcp.tools.firewall import get_firewall_policy_ordering
+
+            result = await get_firewall_policy_ordering("zone-src", "zone-dst")
+
+        assert result["success"] is True
+        assert result["ordering"] == self.ORDERING
+        mock_fm.get_firewall_policy_ordering.assert_called_once_with("zone-src", "zone-dst")
+
+    @pytest.mark.asyncio
+    async def test_reorder_preview_preserves_current_id_set(self):
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policy_ordering = AsyncMock(
+                return_value={"orderedFirewallPolicyIds": copy.deepcopy(self.ORDERING)}
+            )
+
+            from unifi_network_mcp.tools.firewall import reorder_firewall_policies
+
+            result = await reorder_firewall_policies(
+                source_firewall_zone_id="zone-src",
+                destination_firewall_zone_id="zone-dst",
+                ordered_firewall_policy_ids={
+                    "beforeSystemDefined": ["allow-2", "allow-1"],
+                    "afterSystemDefined": ["block-1"],
+                },
+                confirm=False,
+            )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_missing_policy_id(self):
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policy_ordering = AsyncMock(
+                return_value={"orderedFirewallPolicyIds": copy.deepcopy(self.ORDERING)}
+            )
+
+            from unifi_network_mcp.tools.firewall import reorder_firewall_policies
+
+            result = await reorder_firewall_policies(
+                source_firewall_zone_id="zone-src",
+                destination_firewall_zone_id="zone-dst",
+                ordered_firewall_policy_ids={
+                    "beforeSystemDefined": ["allow-1"],
+                    "afterSystemDefined": ["block-1"],
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "Missing: allow-2" in result["error"]
+        mock_fm.reorder_firewall_policies.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reorder_confirm_calls_manager(self):
+        requested = {"beforeSystemDefined": ["allow-2", "allow-1"], "afterSystemDefined": ["block-1"]}
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policy_ordering = AsyncMock(
+                return_value={"orderedFirewallPolicyIds": copy.deepcopy(self.ORDERING)}
+            )
+            mock_fm.reorder_firewall_policies = AsyncMock(return_value={"orderedFirewallPolicyIds": requested})
+
+            from unifi_network_mcp.tools.firewall import reorder_firewall_policies
+
+            result = await reorder_firewall_policies(
+                source_firewall_zone_id="zone-src",
+                destination_firewall_zone_id="zone-dst",
+                ordered_firewall_policy_ids=requested,
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        assert result["ordering"] == requested
+        mock_fm.reorder_firewall_policies.assert_called_once_with("zone-src", "zone-dst", requested)
+
+
+# ---------------------------------------------------------------------------
 # delete_firewall_policy
 # ---------------------------------------------------------------------------
 

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -838,6 +838,11 @@ class TestFirewallPolicyOrderingTools:
 
         assert result["success"] is True
         assert result.get("requires_confirmation") is True
+        assert result["preview"]["current"]["orderedFirewallPolicyIds"] == self.ORDERING
+        assert result["preview"]["proposed"]["orderedFirewallPolicyIds"] == {
+            "beforeSystemDefined": ["allow-2", "allow-1"],
+            "afterSystemDefined": ["block-1"],
+        }
 
     @pytest.mark.asyncio
     async def test_reorder_rejects_missing_policy_id(self):

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -221,6 +221,33 @@ class TestCreateFirewallPolicyV2Validation:
         assert captured["create_allow_respond"] is False
 
     @pytest.mark.asyncio
+    async def test_create_adds_reject_create_allow_respond_false(self):
+        """REJECT creates must also send create_allow_respond=false."""
+        zone_data = {
+            "name": "Reject from External",
+            "action": "REJECT",
+            "source": {"zone_id": "external", "matching_target": "ANY"},
+            "destination": {"zone_id": "internal", "matching_target": "ANY"},
+        }
+        captured = {}
+
+        async def capture_create(data):
+            captured.update(data)
+            mock = MagicMock()
+            mock.raw = {**data, "_id": "new_reject"}
+            return mock
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_policy = AsyncMock(side_effect=capture_create)
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is True
+        assert captured["create_allow_respond"] is False
+
+    @pytest.mark.asyncio
     async def test_create_rejects_block_create_allow_respond_true(self):
         """A BLOCK policy cannot ask UniFi to create an allow-respond rule."""
         zone_data = {
@@ -816,6 +843,25 @@ class TestFirewallPolicyOrderingTools:
         assert result["success"] is True
         assert result["ordering"] == self.ORDERING
         mock_fm.get_firewall_policy_ordering.assert_called_once_with("zone-src", "zone-dst")
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_payload_missing_after_key(self):
+        """A payload that omits afterSystemDefined entirely must be rejected."""
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            from unifi_network_mcp.tools.firewall import reorder_firewall_policies
+
+            result = await reorder_firewall_policies(
+                source_firewall_zone_id="zone-src",
+                destination_firewall_zone_id="zone-dst",
+                ordered_firewall_policy_ids={"beforeSystemDefined": ["allow-1"]},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "beforeSystemDefined" in result["error"]
+        assert "afterSystemDefined" in result["error"]
+        mock_fm.get_firewall_policy_ordering.assert_not_called()
+        mock_fm.reorder_firewall_policies.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reorder_preview_preserves_current_id_set(self):

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -167,6 +167,78 @@ class TestCreateFirewallPolicyV2Validation:
         assert result["policy_id"] == "new_002"
 
     @pytest.mark.asyncio
+    async def test_create_adds_required_schedule_default(self):
+        """UniFi requires a schedule object on create even when callers omit it."""
+        zone_data = {
+            "name": "Allow HA to Hue",
+            "action": "ALLOW",
+            "source": {"zone_id": "internal", "matching_target": "ANY"},
+            "destination": {"zone_id": "internal", "matching_target": "ANY"},
+        }
+        captured = {}
+
+        async def capture_create(data):
+            captured.update(data)
+            mock = MagicMock()
+            mock.raw = {**data, "_id": "new_schedule"}
+            return mock
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_policy = AsyncMock(side_effect=capture_create)
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is True
+        assert captured["schedule"] == {"mode": "ALWAYS"}
+
+    @pytest.mark.asyncio
+    async def test_create_adds_block_create_allow_respond_false(self):
+        """BLOCK/REJECT creates must send create_allow_respond=false."""
+        zone_data = {
+            "name": "Block Clients to Management",
+            "action": "BLOCK",
+            "source": {"zone_id": "internal", "matching_target": "ANY"},
+            "destination": {"zone_id": "internal", "matching_target": "ANY"},
+        }
+        captured = {}
+
+        async def capture_create(data):
+            captured.update(data)
+            mock = MagicMock()
+            mock.raw = {**data, "_id": "new_block"}
+            return mock
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_policy = AsyncMock(side_effect=capture_create)
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is True
+        assert captured["create_allow_respond"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_block_create_allow_respond_true(self):
+        """A BLOCK policy cannot ask UniFi to create an allow-respond rule."""
+        zone_data = {
+            "name": "Bad Block",
+            "action": "BLOCK",
+            "create_allow_respond": True,
+            "source": {"zone_id": "internal", "matching_target": "ANY"},
+            "destination": {"zone_id": "internal", "matching_target": "ANY"},
+        }
+
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is False
+        assert "create_allow_respond" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_v2_policy_with_uppercase_action(self):
         """Uppercase ALLOW/BLOCK/REJECT action validates against the V2 schema."""
         zone_data = {

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -868,6 +868,46 @@ class TestFirewallPolicyOrderingTools:
         mock_fm.reorder_firewall_policies.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_reorder_rejects_duplicate_policy_id(self):
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            from unifi_network_mcp.tools.firewall import reorder_firewall_policies
+
+            result = await reorder_firewall_policies(
+                source_firewall_zone_id="zone-src",
+                destination_firewall_zone_id="zone-dst",
+                ordered_firewall_policy_ids={
+                    "beforeSystemDefined": ["allow-1", "allow-1"],
+                    "afterSystemDefined": ["block-1"],
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "duplicate policy IDs: allow-1" in result["error"]
+        mock_fm.get_firewall_policy_ordering.assert_not_called()
+        mock_fm.reorder_firewall_policies.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reorder_rejects_non_string_policy_id(self):
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            from unifi_network_mcp.tools.firewall import reorder_firewall_policies
+
+            result = await reorder_firewall_policies(
+                source_firewall_zone_id="zone-src",
+                destination_firewall_zone_id="zone-dst",
+                ordered_firewall_policy_ids={
+                    "beforeSystemDefined": ["allow-1", None],
+                    "afterSystemDefined": ["block-1"],
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "non-empty policy ID strings" in result["error"]
+        mock_fm.get_firewall_policy_ordering.assert_not_called()
+        mock_fm.reorder_firewall_policies.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_reorder_confirm_calls_manager(self):
         requested = {"beforeSystemDefined": ["allow-2", "allow-1"], "afterSystemDefined": ["block-1"]}
         with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -180,11 +180,7 @@ class FirewallManager:
         except Exception:
             local_zones = []
         local = next(
-            (
-                z
-                for z in local_zones
-                if isinstance(z, dict) and wanted in self._zone_match_values(z)
-            ),
+            (z for z in local_zones if isinstance(z, dict) and wanted in self._zone_match_values(z)),
             None,
         )
         if not local:
@@ -192,11 +188,7 @@ class FirewallManager:
 
         local_values = self._zone_match_values(local)
         translated = next(
-            (
-                z
-                for z in integration_zones
-                if local_values & self._zone_match_values(z) and z.get("id")
-            ),
+            (z for z in integration_zones if local_values & self._zone_match_values(z) and z.get("id")),
             None,
         )
         return str(translated["id"]) if translated and translated.get("id") else candidate
@@ -409,7 +401,8 @@ class FirewallManager:
                 data=payload,
             )
             self._connection._invalidate_cache(
-                f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_{source_integration_zone_id}_{destination_integration_zone_id}"
+                f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_"
+                f"{source_integration_zone_id}_{destination_integration_zone_id}_{self._connection.site}"
             )
             self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_True_{self._connection.site}")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_False_{self._connection.site}")

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+from collections import Counter
 from typing import Any, Dict, List, Optional
 
 import aiohttp
@@ -36,6 +37,60 @@ class FirewallManager:
         """
         self._connection = connection_manager
         self._auth = auth
+
+    @staticmethod
+    def _requested_firewall_policy_ids(ordered_firewall_policy_ids: Any) -> list[str]:
+        if not isinstance(ordered_firewall_policy_ids, dict):
+            raise ValueError("ordered_firewall_policy_ids must be an object")
+
+        before = ordered_firewall_policy_ids.get("beforeSystemDefined")
+        after = ordered_firewall_policy_ids.get("afterSystemDefined")
+        if not isinstance(before, list) or not isinstance(after, list):
+            raise ValueError(
+                "ordered_firewall_policy_ids must include beforeSystemDefined and afterSystemDefined arrays"
+            )
+
+        requested_order = before + after
+        if not all(isinstance(policy_id, str) and policy_id for policy_id in requested_order):
+            raise ValueError("ordered_firewall_policy_ids arrays must contain only non-empty policy ID strings")
+
+        duplicate_ids = sorted(policy_id for policy_id, count in Counter(requested_order).items() if count > 1)
+        if duplicate_ids:
+            raise ValueError("Reorder payload contains duplicate policy IDs: %s" % ", ".join(duplicate_ids))
+
+        return requested_order
+
+    @staticmethod
+    def _validate_firewall_policy_ordering_matches_current(
+        ordered_firewall_policy_ids: Any,
+        current_ordering_response: Any,
+    ) -> None:
+        requested_order = FirewallManager._requested_firewall_policy_ids(ordered_firewall_policy_ids)
+
+        if not isinstance(current_ordering_response, dict):
+            raise RuntimeError("Current firewall policy ordering response did not include an ordering object")
+        current_ordering = current_ordering_response.get("orderedFirewallPolicyIds", current_ordering_response)
+        if not isinstance(current_ordering, dict):
+            raise RuntimeError("Current firewall policy ordering response did not include an ordering object")
+
+        before = current_ordering.get("beforeSystemDefined", [])
+        after = current_ordering.get("afterSystemDefined", [])
+        if not isinstance(before, list) or not isinstance(after, list):
+            raise RuntimeError("Current firewall policy ordering response did not include ordering arrays")
+
+        current_order = before + after
+        requested_counts = Counter(requested_order)
+        current_counts = Counter(current_order)
+        if requested_counts != current_counts:
+            missing_ids = sorted((current_counts - requested_counts).elements())
+            unexpected_ids = sorted((requested_counts - current_counts).elements())
+            raise ValueError(
+                "Reorder payload must preserve the exact current policy ID set. Missing: %s; unexpected: %s"
+                % (
+                    ", ".join(missing_ids) or "none",
+                    ", ".join(unexpected_ids) or "none",
+                )
+            )
 
     async def _request_integration_api(
         self,
@@ -374,6 +429,8 @@ class FirewallManager:
         ordered_firewall_policy_ids: Dict[str, List[str]],
     ) -> Dict[str, Any]:
         """Reorder user-defined firewall policies for a zone pair."""
+        self._requested_firewall_policy_ids(ordered_firewall_policy_ids)
+
         if not await self._connection.ensure_connected():
             raise ConnectionError("Not connected to controller")
 
@@ -392,18 +449,32 @@ class FirewallManager:
             "destinationFirewallZoneId": destination_integration_zone_id,
         }
         payload = {"orderedFirewallPolicyIds": ordered_firewall_policy_ids}
+        cache_key = (
+            f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_"
+            f"{source_integration_zone_id}_{destination_integration_zone_id}_{self._connection.site}"
+        )
 
         try:
+            current_ordering = self._connection.get_cached(cache_key)
+            if current_ordering is None:
+                current_ordering = await self._request_integration_api(
+                    "get",
+                    f"/v1/sites/{site_id}/firewall/policies/ordering",
+                    params=params,
+                )
+                self._connection._update_cache(cache_key, current_ordering)
+            self._validate_firewall_policy_ordering_matches_current(
+                ordered_firewall_policy_ids,
+                current_ordering,
+            )
+
             response = await self._request_integration_api(
                 "put",
                 f"/v1/sites/{site_id}/firewall/policies/ordering",
                 params=params,
                 data=payload,
             )
-            self._connection._invalidate_cache(
-                f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_"
-                f"{source_integration_zone_id}_{destination_integration_zone_id}_{self._connection.site}"
-            )
+            self._connection._invalidate_cache(cache_key)
             self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_True_{self._connection.site}")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_False_{self._connection.site}")
             return response if isinstance(response, dict) else {}

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -3,11 +3,13 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
+import aiohttp
 from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.firewall_policy import FirewallPolicy
 from aiounifi.models.port_forward import PortForward
 from aiounifi.models.traffic_route import TrafficRoute
 
+from unifi_core.auth import UniFiAuth
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.merge import deep_merge
 from unifi_core.network.managers.connection_manager import ConnectionManager
@@ -15,6 +17,7 @@ from unifi_core.network.managers.connection_manager import ConnectionManager
 logger = logging.getLogger("unifi-network-mcp")
 
 CACHE_PREFIX_FIREWALL_POLICIES = "firewall_policies"
+CACHE_PREFIX_FIREWALL_POLICY_ORDERING = "firewall_policy_ordering"
 CACHE_PREFIX_TRAFFIC_ROUTES = "traffic_routes"
 CACHE_PREFIX_PORT_FORWARDS = "port_forwards"
 CACHE_PREFIX_FIREWALL_ZONES = "firewall_zones"
@@ -24,13 +27,93 @@ CACHE_PREFIX_FIREWALL_GROUPS = "firewall_groups"
 class FirewallManager:
     """Manages Firewall Policies, Traffic Routes, and Port Forwards on the Unifi Controller."""
 
-    def __init__(self, connection_manager: ConnectionManager):
+    def __init__(self, connection_manager: ConnectionManager, auth: UniFiAuth | None = None):
         """Initialize the Firewall Manager.
 
         Args:
             connection_manager: The shared ConnectionManager instance.
         """
         self._connection = connection_manager
+        self._auth = auth
+
+    async def _request_integration_api(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, str]] = None,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Call the official UniFi Network integration API.
+
+        Prefer API-key auth when configured. Otherwise reuse the logged-in
+        local controller session, which works for local UniFi OS controllers.
+        """
+        base_url = f"https://{self._connection.host}:{self._connection.port}"
+        url = f"{base_url}/proxy/network/integration{path}"
+        timeout = aiohttp.ClientTimeout(total=10)
+
+        if self._auth is not None and self._auth.has_api_key:
+            session = await self._auth.get_api_key_session()
+            close_session = True
+        else:
+            if not await self._connection.ensure_connected():
+                raise ConnectionError("Not connected to controller")
+            if self._connection._aiohttp_session is None or self._connection._aiohttp_session.closed:
+                raise ConnectionError("Controller session is not available")
+            session = self._connection._aiohttp_session
+            close_session = False
+
+        try:
+            async with session.request(
+                method.upper(),
+                url,
+                params=params,
+                json=data,
+                ssl=False,
+                timeout=timeout,
+            ) as resp:
+                body = await resp.json(content_type=None)
+                if resp.status < 200 or resp.status >= 300:
+                    raise RuntimeError(f"Integration API returned {resp.status} for {path}: {body}")
+                return body if isinstance(body, dict) else {}
+        finally:
+            if close_session:
+                await session.close()
+
+    async def _get_integration_site_id(self) -> str:
+        """Resolve the configured site name/key to the integration API site ID."""
+        cache_key = f"integrations_site_id_{self._connection.site}"
+        cached = self._connection.get_cached(cache_key)
+        if isinstance(cached, str) and cached:
+            return cached
+
+        result = await self._request_integration_api("get", "/v1/sites")
+        sites = result.get("data", []) if isinstance(result, dict) else []
+        if not isinstance(sites, list) or not sites:
+            return self._connection.site
+
+        configured = self._connection.site
+        match = next(
+            (
+                s
+                for s in sites
+                if isinstance(s, dict)
+                and configured
+                in {
+                    str(s.get("id", "")),
+                    str(s.get("name", "")),
+                    str(s.get("key", "")),
+                    str(s.get("siteId", "")),
+                }
+            ),
+            None,
+        )
+        if match is None and len(sites) == 1 and isinstance(sites[0], dict):
+            match = sites[0]
+
+        site_id = str((match or {}).get("id") or configured)
+        self._connection._update_cache(cache_key, site_id)
+        return site_id
 
     async def get_firewall_policies(self, include_predefined: bool = False) -> List[FirewallPolicy]:
         """Get firewall policies.
@@ -157,6 +240,78 @@ class FirewallManager:
             return True
         except Exception as e:
             logger.error("Error updating firewall policy %s: %s", policy_id, e, exc_info=True)
+            raise
+
+    async def get_firewall_policy_ordering(
+        self,
+        source_firewall_zone_id: str,
+        destination_firewall_zone_id: str,
+    ) -> Dict[str, Any]:
+        """Return user-defined firewall policy ordering for a zone pair.
+
+        UniFi's V2 policy ``index`` is controller-assigned. Reordering is a
+        separate official API surface scoped to a source/destination zone pair.
+        """
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+
+        params = {
+            "sourceFirewallZoneId": source_firewall_zone_id,
+            "destinationFirewallZoneId": destination_firewall_zone_id,
+        }
+        cache_key = (
+            f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_"
+            f"{source_firewall_zone_id}_{destination_firewall_zone_id}_{self._connection.site}"
+        )
+        cached_data: Optional[Dict[str, Any]] = self._connection.get_cached(cache_key)
+        if cached_data is not None:
+            return cached_data
+
+        try:
+            site_id = await self._get_integration_site_id()
+            result = await self._request_integration_api(
+                "get",
+                f"/v1/sites/{site_id}/firewall/policies/ordering",
+                params=params,
+            )
+            self._connection._update_cache(cache_key, result)
+            return result
+        except Exception as e:
+            logger.error("Error getting firewall policy ordering: %s", e, exc_info=True)
+            raise
+
+    async def reorder_firewall_policies(
+        self,
+        source_firewall_zone_id: str,
+        destination_firewall_zone_id: str,
+        ordered_firewall_policy_ids: Dict[str, List[str]],
+    ) -> Dict[str, Any]:
+        """Reorder user-defined firewall policies for a zone pair."""
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+
+        params = {
+            "sourceFirewallZoneId": source_firewall_zone_id,
+            "destinationFirewallZoneId": destination_firewall_zone_id,
+        }
+        payload = {"orderedFirewallPolicyIds": ordered_firewall_policy_ids}
+
+        try:
+            site_id = await self._get_integration_site_id()
+            response = await self._request_integration_api(
+                "put",
+                f"/v1/sites/{site_id}/firewall/policies/ordering",
+                params=params,
+                data=payload,
+            )
+            self._connection._invalidate_cache(
+                f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_{source_firewall_zone_id}_{destination_firewall_zone_id}"
+            )
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_True_{self._connection.site}")
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_False_{self._connection.site}")
+            return response if isinstance(response, dict) else {}
+        except Exception as e:
+            logger.error("Error reordering firewall policies: %s", e, exc_info=True)
             raise
 
     async def get_traffic_routes(self) -> List[TrafficRoute]:

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -45,23 +45,23 @@ class FirewallManager:
     ) -> Dict[str, Any]:
         """Call the official UniFi Network integration API.
 
-        Prefer API-key auth when configured. Otherwise reuse the logged-in
-        local controller session, which works for local UniFi OS controllers.
+        The integration API rejects local controller cookies for these
+        endpoints, so an API key is required.
         """
+        if self._auth is None or not self._auth.has_api_key:
+            raise RuntimeError(
+                "Firewall policy ordering requires a UniFi API key. "
+                "Create a Network API token in UniFi Control Plane -> Integrations "
+                "and set UNIFI_API_KEY or UNIFI_NETWORK_API_KEY for the MCP."
+            )
+
         base_url = f"https://{self._connection.host}:{self._connection.port}"
         url = f"{base_url}/proxy/network/integration{path}"
         timeout = aiohttp.ClientTimeout(total=10)
 
-        if self._auth is not None and self._auth.has_api_key:
-            session = await self._auth.get_api_key_session()
-            close_session = True
-        else:
-            if not await self._connection.ensure_connected():
-                raise ConnectionError("Not connected to controller")
-            if self._connection._aiohttp_session is None or self._connection._aiohttp_session.closed:
-                raise ConnectionError("Controller session is not available")
-            session = self._connection._aiohttp_session
-            close_session = False
+        # get_api_key_session() supplies the required X-API-Key header. The
+        # integration endpoints reject the local controller cookie session.
+        session = await self._auth.get_api_key_session()
 
         try:
             async with session.request(
@@ -77,8 +77,7 @@ class FirewallManager:
                     raise RuntimeError(f"Integration API returned {resp.status} for {path}: {body}")
                 return body if isinstance(body, dict) else {}
         finally:
-            if close_session:
-                await session.close()
+            await session.close()
 
     async def _get_integration_site_id(self) -> str:
         """Resolve the configured site name/key to the integration API site ID."""

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -73,7 +73,21 @@ class FirewallManager:
                 ssl=False,
                 timeout=timeout,
             ) as resp:
-                body = await resp.json(content_type=None)
+                try:
+                    body = await resp.json(content_type=None)
+                except Exception:
+                    try:
+                        body_text = (await resp.text()).strip()
+                    except Exception as text_error:
+                        body_text = f"<failed to read response body: {text_error}>"
+                    if len(body_text) > 500:
+                        body_text = f"{body_text[:500]}..."
+                    if resp.status < 200 or resp.status >= 300:
+                        detail = body_text or "<empty body>"
+                        raise RuntimeError(f"Integration API returned {resp.status} for {path}: {detail}")
+                    detail = body_text or "<empty body>"
+                    raise RuntimeError(f"Integration API returned non-JSON response for {path}: {detail}")
+
                 if resp.status < 200 or resp.status >= 300:
                     raise RuntimeError(f"Integration API returned {resp.status} for {path}: {body}")
                 return body if isinstance(body, dict) else {}

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -455,14 +455,14 @@ class FirewallManager:
         )
 
         try:
-            current_ordering = self._connection.get_cached(cache_key)
-            if current_ordering is None:
-                current_ordering = await self._request_integration_api(
-                    "get",
-                    f"/v1/sites/{site_id}/firewall/policies/ordering",
-                    params=params,
-                )
-                self._connection._update_cache(cache_key, current_ordering)
+            # Reorder is a live mutation; validate against fresh controller
+            # state instead of a cached read to avoid TOCTOU policy drops.
+            current_ordering = await self._request_integration_api(
+                "get",
+                f"/v1/sites/{site_id}/firewall/policies/ordering",
+                params=params,
+            )
+            self._connection._update_cache(cache_key, current_ordering)
             self._validate_firewall_policy_ordering_matches_current(
                 ordered_firewall_policy_ids,
                 current_ordering,

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("unifi-network-mcp")
 
 CACHE_PREFIX_FIREWALL_POLICIES = "firewall_policies"
 CACHE_PREFIX_FIREWALL_POLICY_ORDERING = "firewall_policy_ordering"
+CACHE_PREFIX_INTEGRATION_FIREWALL_ZONES = "integration_firewall_zones"
 CACHE_PREFIX_TRAFFIC_ROUTES = "traffic_routes"
 CACHE_PREFIX_PORT_FORWARDS = "port_forwards"
 CACHE_PREFIX_FIREWALL_ZONES = "firewall_zones"
@@ -113,6 +114,78 @@ class FirewallManager:
         site_id = str((match or {}).get("id") or configured)
         self._connection._update_cache(cache_key, site_id)
         return site_id
+
+    async def _get_integration_firewall_zones(self, site_id: str | None = None) -> List[Dict[str, Any]]:
+        """Return firewall zones from the official integration API."""
+        if site_id is None:
+            site_id = await self._get_integration_site_id()
+        cache_key = f"{CACHE_PREFIX_INTEGRATION_FIREWALL_ZONES}_{site_id}"
+        cached = self._connection.get_cached(cache_key)
+        if isinstance(cached, list):
+            return cached
+
+        result = await self._request_integration_api(
+            "get",
+            f"/v1/sites/{site_id}/firewall/zones",
+        )
+        zones = result.get("data", []) if isinstance(result, dict) else []
+        if not isinstance(zones, list):
+            zones = []
+        zones = [zone for zone in zones if isinstance(zone, dict)]
+        self._connection._update_cache(cache_key, zones)
+        return zones
+
+    @staticmethod
+    def _zone_match_values(zone: Dict[str, Any]) -> set[str]:
+        values: set[str] = set()
+        for key in ("id", "_id", "name", "key", "zoneKey", "zone_key"):
+            value = zone.get(key)
+            if value is not None:
+                values.add(str(value).strip().lower())
+        return values
+
+    async def _resolve_integration_firewall_zone_id(
+        self,
+        zone_id: str,
+        integration_zones: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """Translate local V2 firewall zone IDs to integration API zone IDs."""
+        candidate = str(zone_id).strip()
+        if not candidate:
+            return candidate
+
+        if integration_zones is None:
+            integration_zones = await self._get_integration_firewall_zones()
+        wanted = candidate.lower()
+        direct = next((z for z in integration_zones if wanted in self._zone_match_values(z)), None)
+        if direct and direct.get("id"):
+            return str(direct["id"])
+
+        try:
+            local_zones = await self.get_firewall_zones()
+        except Exception:
+            local_zones = []
+        local = next(
+            (
+                z
+                for z in local_zones
+                if isinstance(z, dict) and wanted in self._zone_match_values(z)
+            ),
+            None,
+        )
+        if not local:
+            return candidate
+
+        local_values = self._zone_match_values(local)
+        translated = next(
+            (
+                z
+                for z in integration_zones
+                if local_values & self._zone_match_values(z) and z.get("id")
+            ),
+            None,
+        )
+        return str(translated["id"]) if translated and translated.get("id") else candidate
 
     async def get_firewall_policies(self, include_predefined: bool = False) -> List[FirewallPolicy]:
         """Get firewall policies.
@@ -254,20 +327,29 @@ class FirewallManager:
         if not await self._connection.ensure_connected():
             raise ConnectionError("Not connected to controller")
 
+        site_id = await self._get_integration_site_id()
+        integration_zones = await self._get_integration_firewall_zones(site_id)
+        source_integration_zone_id = await self._resolve_integration_firewall_zone_id(
+            source_firewall_zone_id,
+            integration_zones,
+        )
+        destination_integration_zone_id = await self._resolve_integration_firewall_zone_id(
+            destination_firewall_zone_id,
+            integration_zones,
+        )
         params = {
-            "sourceFirewallZoneId": source_firewall_zone_id,
-            "destinationFirewallZoneId": destination_firewall_zone_id,
+            "sourceFirewallZoneId": source_integration_zone_id,
+            "destinationFirewallZoneId": destination_integration_zone_id,
         }
         cache_key = (
             f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_"
-            f"{source_firewall_zone_id}_{destination_firewall_zone_id}_{self._connection.site}"
+            f"{source_integration_zone_id}_{destination_integration_zone_id}_{self._connection.site}"
         )
         cached_data: Optional[Dict[str, Any]] = self._connection.get_cached(cache_key)
         if cached_data is not None:
             return cached_data
 
         try:
-            site_id = await self._get_integration_site_id()
             result = await self._request_integration_api(
                 "get",
                 f"/v1/sites/{site_id}/firewall/policies/ordering",
@@ -289,14 +371,23 @@ class FirewallManager:
         if not await self._connection.ensure_connected():
             raise ConnectionError("Not connected to controller")
 
+        site_id = await self._get_integration_site_id()
+        integration_zones = await self._get_integration_firewall_zones(site_id)
+        source_integration_zone_id = await self._resolve_integration_firewall_zone_id(
+            source_firewall_zone_id,
+            integration_zones,
+        )
+        destination_integration_zone_id = await self._resolve_integration_firewall_zone_id(
+            destination_firewall_zone_id,
+            integration_zones,
+        )
         params = {
-            "sourceFirewallZoneId": source_firewall_zone_id,
-            "destinationFirewallZoneId": destination_firewall_zone_id,
+            "sourceFirewallZoneId": source_integration_zone_id,
+            "destinationFirewallZoneId": destination_integration_zone_id,
         }
         payload = {"orderedFirewallPolicyIds": ordered_firewall_policy_ids}
 
         try:
-            site_id = await self._get_integration_site_id()
             response = await self._request_integration_api(
                 "put",
                 f"/v1/sites/{site_id}/firewall/policies/ordering",
@@ -304,7 +395,7 @@ class FirewallManager:
                 data=payload,
             )
             self._connection._invalidate_cache(
-                f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_{source_firewall_zone_id}_{destination_firewall_zone_id}"
+                f"{CACHE_PREFIX_FIREWALL_POLICY_ORDERING}_{source_integration_zone_id}_{destination_integration_zone_id}"
             )
             self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_True_{self._connection.site}")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_FIREWALL_POLICIES}_False_{self._connection.site}")

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -180,7 +180,11 @@ class FirewallManager:
         except Exception:
             local_zones = []
         local = next(
-            (z for z in local_zones if isinstance(z, dict) and wanted in self._zone_match_values(z)),
+            (
+                z
+                for z in local_zones
+                if isinstance(z, dict) and wanted in self._zone_match_values(z)
+            ),
             None,
         )
         if not local:
@@ -188,7 +192,11 @@ class FirewallManager:
 
         local_values = self._zone_match_values(local)
         translated = next(
-            (z for z in integration_zones if local_values & self._zone_match_values(z) and z.get("id")),
+            (
+                z
+                for z in integration_zones
+                if local_values & self._zone_match_values(z) and z.get("id")
+            ),
             None,
         )
         return str(translated["id"]) if translated and translated.get("id") else candidate

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -180,11 +180,7 @@ class FirewallManager:
         except Exception:
             local_zones = []
         local = next(
-            (
-                z
-                for z in local_zones
-                if isinstance(z, dict) and wanted in self._zone_match_values(z)
-            ),
+            (z for z in local_zones if isinstance(z, dict) and wanted in self._zone_match_values(z)),
             None,
         )
         if not local:
@@ -192,11 +188,7 @@ class FirewallManager:
 
         local_values = self._zone_match_values(local)
         translated = next(
-            (
-                z
-                for z in integration_zones
-                if local_values & self._zone_match_values(z) and z.get("id")
-            ),
+            (z for z in integration_zones if local_values & self._zone_match_values(z) and z.get("id")),
             None,
         )
         return str(translated["id"]) if translated and translated.get("id") else candidate

--- a/plugins/unifi-network/skills/firewall-manager/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-manager/SKILL.md
@@ -103,6 +103,8 @@ For app-aware rules (TikTok, YouTube, Steam, BitTorrent, etc.), consult `referen
 - `unifi_get_firewall_policy_ordering` — read the user-defined policy ordering for a source/destination zone pair. Use this when rule placement matters; do not infer editable order from `index`.
 - `unifi_reorder_firewall_policies` — reorder user-defined policies for a source/destination zone pair. Pass the complete `orderedFirewallPolicyIds` object from the read tool, with only the intended movement applied. Preview first, then confirm.
 
+Policy ordering uses UniFi's official integration API and requires an API key (`UNIFI_API_KEY` or `UNIFI_NETWORK_API_KEY`). Local username/password controller sessions can read policies and zones, but they cannot call the ordering endpoint.
+
 ---
 
 ## 5. Verify after every mutation

--- a/plugins/unifi-network/skills/firewall-manager/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-manager/SKILL.md
@@ -100,6 +100,8 @@ For app-aware rules (TikTok, YouTube, Steam, BitTorrent, etc.), consult `referen
 - `unifi_create_firewall_policy` — V2 zone-based create. Wraps the payload in `policy_data`. Pre-resolve zone IDs (`unifi_list_firewall_zones`) and network IDs (`unifi_list_networks`) before constructing it.
 - `unifi_update_firewall_policy` — partial update via fetch-merge-put. Pass only the fields you want to change in `update_data` (e.g., `{"enabled": true}`). This is the canonical way to enable/disable a policy because it preserves all other fields.
 - `unifi_toggle_firewall_policy` — convenience wrapper for flipping `enabled`. Prefer `unifi_update_firewall_policy` with `update_data={"enabled": …}` — it's the canonical fetch-merge-put path and produces the same result with no special casing.
+- `unifi_get_firewall_policy_ordering` — read the user-defined policy ordering for a source/destination zone pair. Use this when rule placement matters; do not infer editable order from `index`.
+- `unifi_reorder_firewall_policies` — reorder user-defined policies for a source/destination zone pair. Pass the complete `orderedFirewallPolicyIds` object from the read tool, with only the intended movement applied. Preview first, then confirm.
 
 ---
 
@@ -214,6 +216,7 @@ The "manual procedure" sections of older versions of this skill assumed a separa
 ## 9. Tips
 
 - `unifi_create_firewall_policy` is the canonical create tool. Pre-resolve zone IDs and network IDs before constructing the V2 payload.
+- `index` is controller-assigned on zone-based policies. Do not try to move policies by updating `index`; use the dedicated ordering tools.
 - Users say "block" loosely — clarify whether they want `REJECT` (sends RST/ICMP unreachable, faster client failure) or `BLOCK` (silent discard, less informative to the client). `REJECT` is usually right for internal traffic, `BLOCK` for external-facing rules. The action comparison table is in `references/firewall-schema.md`.
 - DPI rules are bypassable by VPNs. When blocking social media or gaming, also consider blocking the VPN/Proxy DPI category. See `references/dpi-categories.md`.
 - Rule order matters for `camera-isolation` and other multi-rule templates. Confirm ordering with `unifi_list_firewall_policies` after creation.

--- a/plugins/unifi-network/skills/firewall-manager/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-manager/SKILL.md
@@ -104,6 +104,7 @@ For app-aware rules (TikTok, YouTube, Steam, BitTorrent, etc.), consult `referen
 - `unifi_reorder_firewall_policies` — reorder user-defined policies for a source/destination zone pair. Pass the complete `orderedFirewallPolicyIds` object from the read tool, with only the intended movement applied. Preview first, then confirm.
 
 Policy ordering uses UniFi's official integration API and requires an API key (`UNIFI_API_KEY` or `UNIFI_NETWORK_API_KEY`). Local username/password controller sessions can read policies and zones, but they cannot call the ordering endpoint.
+The ordering endpoint uses integration API zone UUIDs internally. The local MCP manager accepts the normal `unifi_list_firewall_zones` IDs and translates them by zone name before calling the ordering endpoint.
 
 ---
 

--- a/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
+++ b/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
@@ -183,6 +183,33 @@ Time ranges that span midnight are supported.
 
 ---
 
+## Policy Ordering
+
+Zone-based firewall policy ordering is not changed by updating `index`.
+Use the dedicated ordering API through the MCP tools:
+
+```text
+unifi_get_firewall_policy_ordering
+unifi_reorder_firewall_policies
+```
+
+Ordering is scoped to a source/destination firewall zone pair and has this
+shape:
+
+```json
+{
+  "orderedFirewallPolicyIds": {
+    "beforeSystemDefined": ["<policy-id>"],
+    "afterSystemDefined": ["<policy-id>"]
+  }
+}
+```
+
+For reorder operations, preserve the complete current policy ID set and only
+move IDs between or within `beforeSystemDefined` and `afterSystemDefined`.
+
+---
+
 ## Full Worked Example — Block IoT zone to Internal zone
 
 ```json

--- a/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
+++ b/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
@@ -208,6 +208,10 @@ shape:
 For reorder operations, preserve the complete current policy ID set and only
 move IDs between or within `beforeSystemDefined` and `afterSystemDefined`.
 
+These tools require a UniFi Network integration API key (`UNIFI_API_KEY` or
+`UNIFI_NETWORK_API_KEY`). Local username/password controller cookies are not
+accepted by `/proxy/network/integration/v1/sites/.../firewall/policies/ordering`.
+
 ---
 
 ## Full Worked Example — Block IoT zone to Internal zone

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (174 tools)
+# Network Server Tool Reference (176 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -105,12 +105,13 @@ Always available, regardless of registration mode.
 ## Firewall
 
 <!-- AUTO:tools:firewall -->
-12 tools.
+14 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_firewall_group_details` | Read | Get detailed configuration for a specific firewall group by ID. |
 | `unifi_get_firewall_policy_details` | Read | Get detailed configuration for a specific firewall policy by ID. |
+| `unifi_get_firewall_policy_ordering` | Read | Get user-defined firewall policy ordering for a source/destination firewall zone pair. |
 | `unifi_list_firewall_groups` | Read | List firewall groups (address and port groups) used as reusable objects in firewall policies. |
 | `unifi_list_firewall_policies` | Read | List firewall policies configured on the Unifi Network controller. |
 | `unifi_list_firewall_zones` | Read | List controller firewall zones (V2 API). |
@@ -118,6 +119,7 @@ Always available, regardless of registration mode.
 | `unifi_create_firewall_policy` | Mutate | Create a V2 zone-based firewall policy with schema validation. |
 | `unifi_delete_firewall_group` | Mutate | Delete a firewall group. |
 | `unifi_delete_firewall_policy` | Mutate | Delete a firewall policy by ID. |
+| `unifi_reorder_firewall_policies` | Mutate | Reorder user-defined firewall policies for a source/destination firewall zone pair. |
 | `unifi_toggle_firewall_policy` | Mutate | Enable or disable a specific firewall policy by ID. |
 | `unifi_update_firewall_group` | Mutate | Update an existing firewall group. |
 | `unifi_update_firewall_policy` | Mutate | Update specific fields of an existing V2 zone-based firewall policy by ID. |

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (176 tools)
+# Network Server Tool Reference (174 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -105,13 +105,12 @@ Always available, regardless of registration mode.
 ## Firewall
 
 <!-- AUTO:tools:firewall -->
-14 tools.
+12 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_firewall_group_details` | Read | Get detailed configuration for a specific firewall group by ID. |
 | `unifi_get_firewall_policy_details` | Read | Get detailed configuration for a specific firewall policy by ID. |
-| `unifi_get_firewall_policy_ordering` | Read | Get user-defined firewall policy ordering for a source/destination firewall zone pair. |
 | `unifi_list_firewall_groups` | Read | List firewall groups (address and port groups) used as reusable objects in firewall policies. |
 | `unifi_list_firewall_policies` | Read | List firewall policies configured on the Unifi Network controller. |
 | `unifi_list_firewall_zones` | Read | List controller firewall zones (V2 API). |
@@ -119,7 +118,6 @@ Always available, regardless of registration mode.
 | `unifi_create_firewall_policy` | Mutate | Create a V2 zone-based firewall policy with schema validation. |
 | `unifi_delete_firewall_group` | Mutate | Delete a firewall group. |
 | `unifi_delete_firewall_policy` | Mutate | Delete a firewall policy by ID. |
-| `unifi_reorder_firewall_policies` | Mutate | Reorder user-defined firewall policies for a source/destination firewall zone pair. |
 | `unifi_toggle_firewall_policy` | Mutate | Enable or disable a specific firewall policy by ID. |
 | `unifi_update_firewall_group` | Mutate | Update an existing firewall group. |
 | `unifi_update_firewall_policy` | Mutate | Update specific fields of an existing V2 zone-based firewall policy by ID. |


### PR DESCRIPTION
## Summary

Add explicit firewall policy ordering support for UniFi zone-based firewall rules and wire the ordering read surface into the API.

### Changes

- Add `unifi_get_firewall_policy_ordering`
- Add `unifi_reorder_firewall_policies`
- Use the UniFi Network integration API endpoint:
  - `GET /v1/sites/{siteId}/firewall/policies/ordering`
  - `PUT /v1/sites/{siteId}/firewall/policies/ordering`
- Require API-key auth for ordering calls via `X-API-Key`
- Translate normal V2 firewall zone IDs from `unifi_list_firewall_zones` to integration API zone UUIDs
- Add REST and GraphQL API read surfaces for firewall policy ordering
- Require explicit confirm for API action dispatch of firewall reorder
- Harden reorder payload validation:
  - require `beforeSystemDefined` and `afterSystemDefined` arrays
  - reject non-string or empty policy IDs
  - reject duplicate policy IDs
  - reject payloads that add/drop policy IDs instead of only moving existing IDs
- Validate reorder payloads against a fresh current controller ordering before PUT, not cached ordering
- Invalidate firewall ordering and policy caches after reorder
- Harden integration API error reporting for non-JSON or empty error bodies
- Fix V2 firewall create defaults required by the controller:
  - default `schedule` to `{"mode":"ALWAYS"}`
  - default `create_allow_respond=false` for BLOCK/REJECT
- Document the new ordering behavior in the firewall skill reference

## Why

Zone-based firewall rule order is user-defined per source/destination zone pair. The controller may expose an `index` on policies, but actual reorder operations use the dedicated ordering endpoint and the `orderedFirewallPolicyIds` payload.

This avoids brittle `index` writes and matches the official UniFi Network API surface. The confirmed reorder path now re-fetches current ordering immediately before mutation so a stale cache cannot accidentally validate a payload that would drop or add policy IDs.

## Testing

- `ruff check .`
- `pytest apps/network/tests -q`
- `pytest packages/unifi-core/tests -q`
- `pytest apps/api/tests/test_actions_dispatcher.py -q`
- WSL: `make pre-commit`

Additional live smoke against a UniFi controller before the API-surface follow-up:

- discovered `unifi_get_firewall_policy_ordering`
- listed firewall zones
- read ordering for `Internal -> Internal`
- verified reorder preview shows both current and proposed ordering without executing a mutation

Notes:

- WSL `make pre-commit` passed.
- Offline MCP metadata smoke checks log expected local connection failures against dummy controller credentials; they completed successfully.
- Existing Worker `npm audit` warning remains: 6 vulnerabilities in Worker dev tooling. Not touched by this firewall PR.