### PR TITLE
feat(network): add search/limit/field & section selection to read-only tools to reduce response sizes

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -32,6 +32,28 @@ from unifi_network_mcp.runtime import client_manager, server
 
 logger = logging.getLogger(__name__)
 
+_ACTIVE_CONNECTION_KEYS: tuple[str, ...] = (
+    "_uptime_by_uap",
+    "_uptime_by_usw",
+    "_uptime_by_ugw",
+    "uptime",
+)
+
+
+def _is_online(raw: dict) -> bool:
+    """Mirror of unifi_core.network.models.clients._is_online — derives
+    online status from a controller record, falling back to
+    active-connection indicators when ``is_online`` is omitted by the
+    controller firmware.
+    """
+    if raw.get("is_online") is True:
+        return True
+    for key in _ACTIVE_CONNECTION_KEYS:
+        v = raw.get(key)
+        if isinstance(v, (int, float)) and v > 0:
+            return True
+    return False
+
 
 @server.tool(
     name="unifi_lookup_by_ip",
@@ -71,7 +93,8 @@ async def lookup_by_ip(
         "Returns connected clients with mac, name, hostname, ip, status (online/offline), "
         "connection type (wired/wireless), and for wireless clients: ssid, signal_dbm, "
         "channel, radio. Filter by filter_type (all/wired/wireless), set "
-        "include_offline=true for historical clients. For a single client's full raw "
+        "include_offline=true for historical clients. Use search to filter by "
+        "name/hostname/IP/MAC (case-insensitive). For a single client's full raw "
         "object, use unifi_get_client_details. For IP-to-client lookup, use "
         "unifi_lookup_by_ip."
     ),
@@ -85,7 +108,22 @@ async def list_clients(
         bool,
         Field(description="When true, includes offline/disconnected clients from controller history. Default false"),
     ] = False,
+    search: Annotated[
+        Optional[str],
+        Field(description="Filter by name, hostname, IP, or MAC (case-insensitive substring match)"),
+    ] = None,
     limit: Annotated[int, Field(description="Maximum number of clients to return (default 100)")] = 100,
+    fields: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Comma-separated list of fields to return per client (default: all). "
+                "Available: mac, name, hostname, ip, connection_type, status, last_seen, _id. "
+                "Wireless-only: essid, signal_dbm, channel, radio. "
+                "Example: fields='mac,name,ip' returns only those 3 fields."
+            )
+        ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Implementation for listing clients."""
     try:
@@ -101,26 +139,55 @@ async def list_clients(
         elif filter_type == "wired":
             clients_raw = [c for c in clients_raw if c.get("is_wired", False)]
 
+        # Filter by search term (name, hostname, IP, or MAC)
+        if search and search.strip():
+            search_lower = search.strip().lower()
+            clients_raw = [
+                c
+                for c in clients_raw
+                if search_lower in (c.get("name") or "").lower()
+                or search_lower in (c.get("hostname") or "").lower()
+                or search_lower in (c.get("ip") or "").lower()
+                or search_lower in (c.get("mac") or "").lower()
+            ]
+
+        total_count = len(clients_raw)
         clients_raw = clients_raw[:limit]
+
+        # Parse requested fields for selective return
+        requested_fields = None
+        if fields and fields.strip():
+            requested_fields = set(f.strip() for f in fields.split(","))
 
         formatted_clients = []
         for client in clients_raw:
             shaped = client_from_controller(client)
-            formatted = shaped.model_dump(exclude_none=True)
+            full_data = shaped.model_dump(exclude_none=True)
             # Preserve wired/wireless display fields not in the base model
-            formatted["connection_type"] = "Wired" if client.get("is_wired", False) else "Wireless"
-            formatted["_id"] = client.get("_id")
+            full_data["connection_type"] = "Wired" if client.get("is_wired", False) else "Wireless"
+            full_data["_id"] = client.get("_id")
             if not client.get("is_wired", False):
-                formatted["essid"] = client.get("essid", "Unknown")
-                formatted["signal_dbm"] = client.get("signal")
-                formatted["channel"] = client.get("channel", "Unknown")
-                formatted["radio"] = client.get("radio", "Unknown")
+                full_data["essid"] = client.get("essid", "Unknown")
+                full_data["signal_dbm"] = client.get("signal")
+                full_data["channel"] = client.get("channel", "Unknown")
+                full_data["radio"] = client.get("radio", "Unknown")
+
+            if requested_fields:
+                formatted = {k: v for k, v in full_data.items() if k in requested_fields}
+            else:
+                formatted = full_data
+
             formatted_clients.append(formatted)
 
         return {
             "success": True,
             "site": client_manager._connection.site,
-            "count": len(formatted_clients),
+            "filter_type": filter_type,
+            "search": search,
+            "fields": fields,
+            "total_count": total_count,
+            "returned_count": len(formatted_clients),
+            "limit": limit,
             "clients": formatted_clients,
         }
     except Exception as e:
@@ -131,11 +198,12 @@ async def list_clients(
 @server.tool(
     name="unifi_get_client_details",
     description=(
-        "Returns the full raw client object for one client by MAC address — all "
-        "controller-reported fields including connection stats, DHCP info, "
-        "network/WLAN associations, traffic counters, signal/RSSI, and fixed-IP "
-        "settings. Merges live /stat/sta data with the /rest/user snapshot for "
-        "active clients. For a summary of all clients, use unifi_list_clients."
+        "Returns client data for one client by MAC address. By default (summary=false) "
+        "returns the full raw client object — all controller-reported fields, with the "
+        "typed/normalized shape (ISO timestamps, derived status, null-safe name/hostname) "
+        "layered on top of the merged live /stat/sta + /rest/user data. Set summary=true to "
+        "trim to selected sections via include (basic, network, wireless, traffic, "
+        "fingerprint, all). For a summary of all clients, use unifi_list_clients."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -143,6 +211,24 @@ async def get_client_details(
     mac_address: Annotated[
         str, Field(description="Client MAC address in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)")
     ],
+    include: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated sections to return when summary=true (default 'basic'). "
+                "Sections: basic, network, wireless, traffic, fingerprint, all."
+            )
+        ),
+    ] = "basic",
+    summary: Annotated[
+        bool,
+        Field(
+            description=(
+                "When false (default), returns the full raw client object. "
+                "When true, trims the response to the sections named in include."
+            )
+        ),
+    ] = False,
 ) -> Dict[str, Any]:
     """Implementation for getting client details."""
     try:
@@ -153,20 +239,104 @@ async def get_client_details(
                 if hasattr(client_obj, "raw") and isinstance(client_obj.raw, dict)
                 else (client_obj if isinstance(client_obj, dict) else {})
             )
-            shaped = client_from_controller(client_obj).model_dump(exclude_none=True)
-            # Honor the "full raw client object" promise: deliver all controller-reported
-            # fields. Selectively layer the typed/normalized shape on top only for fields
-            # where the shape adds value (ISO timestamps, derived status, null-safe alias).
-            # Leave raw fields like `ip`/`last_ip` distinct so the current-vs-historical
-            # distinction is preserved.
-            merged: Dict[str, Any] = dict(raw)
-            for key in ("last_seen", "first_seen", "status", "name", "hostname"):
-                if key in shaped:
-                    merged[key] = shaped[key]
+
+            if not summary:
+                shaped = client_from_controller(client_obj).model_dump(exclude_none=True)
+                # Honor the "full raw client object" promise: deliver all controller-reported
+                # fields. Selectively layer the typed/normalized shape on top only for fields
+                # where the shape adds value (ISO timestamps, derived status, null-safe alias).
+                # Leave raw fields like `ip`/`last_ip` distinct so the current-vs-historical
+                # distinction is preserved.
+                merged: Dict[str, Any] = dict(raw)
+                for key in ("last_seen", "first_seen", "status", "name", "hostname"):
+                    if key in shaped:
+                        merged[key] = shaped[key]
+                return {
+                    "success": True,
+                    "site": client_manager._connection.site,
+                    "client": merged,
+                }
+
+            # summary=true: opt-in section-trimmed view. The default path above is the
+            # full raw object; this branch only runs when the caller explicitly asks to trim.
+            sections = set(s.strip().lower() for s in include.split(","))
+            include_all = "all" in sections
+            client_data: Dict[str, Any] = {}
+
+            if include_all or "basic" in sections:
+                client_data.update(
+                    {
+                        "mac": raw.get("mac"),
+                        "name": raw.get("name") or raw.get("hostname", "Unknown"),
+                        "hostname": raw.get("hostname"),
+                        "ip": raw.get("ip"),
+                        "connection_type": "Wired" if raw.get("is_wired", False) else "Wireless",
+                        "status": "Online" if _is_online(raw) else "Offline",
+                        "last_seen": raw.get("last_seen"),
+                        "uptime": raw.get("uptime"),
+                        "first_seen": raw.get("first_seen"),
+                    }
+                )
+
+            if include_all or "network" in sections:
+                client_data.update(
+                    {
+                        "network_id": raw.get("network_id"),
+                        "network": raw.get("network"),
+                        "vlan": raw.get("vlan"),
+                        "use_fixedip": raw.get("use_fixedip", False),
+                        "fixed_ip": raw.get("fixed_ip"),
+                        "local_dns_record": raw.get("local_dns_record"),
+                    }
+                )
+
+            if (include_all or "wireless" in sections) and not raw.get("is_wired", False):
+                client_data.update(
+                    {
+                        "essid": raw.get("essid"),
+                        "bssid": raw.get("bssid"),
+                        "channel": raw.get("channel"),
+                        "radio": raw.get("radio"),
+                        "radio_proto": raw.get("radio_proto"),
+                        "signal": raw.get("signal"),
+                        "rssi": raw.get("rssi"),
+                        "noise": raw.get("noise"),
+                        "satisfaction": raw.get("satisfaction"),
+                        "ap_mac": raw.get("ap_mac"),
+                    }
+                )
+
+            if include_all or "traffic" in sections:
+                client_data.update(
+                    {
+                        "tx_bytes": raw.get("tx_bytes"),
+                        "rx_bytes": raw.get("rx_bytes"),
+                        "tx_packets": raw.get("tx_packets"),
+                        "rx_packets": raw.get("rx_packets"),
+                        "tx_rate": raw.get("tx_rate"),
+                        "rx_rate": raw.get("rx_rate"),
+                    }
+                )
+
+            if include_all or "fingerprint" in sections:
+                client_data.update(
+                    {
+                        "oui": raw.get("oui"),
+                        "os_name": raw.get("os_name"),
+                        "dev_cat": raw.get("dev_cat"),
+                        "dev_family": raw.get("dev_family"),
+                        "dev_vendor": raw.get("dev_vendor"),
+                        "dev_id": raw.get("dev_id"),
+                        "fingerprint_source": raw.get("fingerprint_source"),
+                    }
+                )
+
             return {
                 "success": True,
                 "site": client_manager._connection.site,
-                "client": merged,
+                "include": include,
+                "summary_mode": True,
+                "client": client_data,
             }
         return {
             "success": False,

--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -22,6 +22,7 @@ from unifi_core.network.models._actions import (
     UnblockClientInput,
 )
 from unifi_core.network.models.clients import (
+    _is_online,
     blocked_client_from_controller,
     client_from_controller,
     client_lookup_from_controller,
@@ -31,28 +32,6 @@ from unifi_core.network.models.clients import (
 from unifi_network_mcp.runtime import client_manager, server
 
 logger = logging.getLogger(__name__)
-
-_ACTIVE_CONNECTION_KEYS: tuple[str, ...] = (
-    "_uptime_by_uap",
-    "_uptime_by_usw",
-    "_uptime_by_ugw",
-    "uptime",
-)
-
-
-def _is_online(raw: dict) -> bool:
-    """Mirror of unifi_core.network.models.clients._is_online — derives
-    online status from a controller record, falling back to
-    active-connection indicators when ``is_online`` is omitted by the
-    controller firmware.
-    """
-    if raw.get("is_online") is True:
-        return True
-    for key in _ACTIVE_CONNECTION_KEYS:
-        v = raw.get(key)
-        if isinstance(v, (int, float)) and v > 0:
-            return True
-    return False
 
 
 @server.tool(
@@ -154,10 +133,27 @@ async def list_clients(
         total_count = len(clients_raw)
         clients_raw = clients_raw[:limit]
 
-        # Parse requested fields for selective return
+        # Parse requested fields for selective return + surface unknown tokens
+        # so LLM callers can self-correct typos (e.g. fields="mac,naame").
+        known_fields = {
+            "mac",
+            "name",
+            "hostname",
+            "ip",
+            "connection_type",
+            "status",
+            "last_seen",
+            "_id",
+            "essid",
+            "signal_dbm",
+            "channel",
+            "radio",
+        }
         requested_fields = None
+        unknown_fields: list[str] = []
         if fields and fields.strip():
             requested_fields = set(f.strip() for f in fields.split(","))
+            unknown_fields = sorted(requested_fields - known_fields)
 
         formatted_clients = []
         for client in clients_raw:
@@ -179,7 +175,7 @@ async def list_clients(
 
             formatted_clients.append(formatted)
 
-        return {
+        response = {
             "success": True,
             "site": client_manager._connection.site,
             "filter_type": filter_type,
@@ -187,9 +183,13 @@ async def list_clients(
             "fields": fields,
             "total_count": total_count,
             "returned_count": len(formatted_clients),
+            "count": len(formatted_clients),  # back-compat alias for returned_count
             "limit": limit,
             "clients": formatted_clients,
         }
+        if unknown_fields:
+            response["unknown_fields"] = unknown_fields
+        return response
     except Exception as e:
         logger.error("Error listing clients: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list clients: {e}"}
@@ -259,7 +259,9 @@ async def get_client_details(
 
             # summary=true: opt-in section-trimmed view. The default path above is the
             # full raw object; this branch only runs when the caller explicitly asks to trim.
+            known_sections = {"basic", "network", "wireless", "traffic", "fingerprint", "all"}
             sections = set(s.strip().lower() for s in include.split(","))
+            unknown_sections = sorted(sections - known_sections)
             include_all = "all" in sections
             client_data: Dict[str, Any] = {}
 
@@ -331,13 +333,16 @@ async def get_client_details(
                     }
                 )
 
-            return {
+            response = {
                 "success": True,
                 "site": client_manager._connection.site,
                 "include": include,
                 "summary_mode": True,
                 "client": client_data,
             }
+            if unknown_sections:
+                response["unknown_sections"] = unknown_sections
+            return response
         return {
             "success": False,
             "error": f"Client not found with MAC address: {mac_address}",

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -97,8 +97,9 @@ def get_wifi_bands(device: Dict[str, Any]) -> List[str]:
         "Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). "
         "Note: device_type=ap correctly excludes USP Smart Power strips. "
         "Use search to filter by name, IP, or MAC (case-insensitive). "
-        "Set include_details=true for compressed radio/port summaries and client counts; "
-        "use unifi_get_device_details(mac) for full raw port and radio tables."
+        "Set include_details=true for additional per-device fields: by default (summary=true) "
+        "compressed radio/port summaries; set summary=false to return the full raw tables "
+        "(radio_table, port_table, network_table, system_stats, wan1/wan2)."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -126,9 +127,20 @@ async def list_devices(
     include_details: Annotated[
         bool,
         Field(
-            description="When true, includes additional details with compressed radio/port summaries, WAN info (gateways), and client counts. Default false"
+            description="When true, includes additional per-device details (shape controlled by summary). Default false"
         ),
     ] = False,
+    summary: Annotated[
+        bool,
+        Field(
+            description=(
+                "Controls the shape of include_details (only applies when include_details=true). "
+                "When true (default), returns compressed summaries (counts, flattened uplink fields). "
+                "When false, returns the legacy raw tables (radio_table/port_table/network_table/"
+                "system_stats/wan1/wan2/poe_info)."
+            )
+        ),
+    ] = True,
 ) -> Dict[str, Any]:
     """Implementation for listing devices."""
     try:
@@ -238,56 +250,91 @@ async def list_devices(
                     "clients": device.get("num_sta", 0),
                 }
 
-                if category == "ap":
-                    # Summarize radio/vap tables - use get_device_details for full data
-                    radio_table = device.get("radio_table", [])
-                    vap_table = device.get("vap_table", [])
-                    details_to_add.update(
-                        {
-                            "radio_count": len(radio_table),
-                            "radios": [
-                                {"band": r.get("radio"), "channel": r.get("channel"), "tx_power": r.get("tx_power")}
-                                for r in radio_table
-                            ],
-                            "vap_count": len(vap_table),
-                            "wifi_bands": get_wifi_bands(device),
-                            "experience_score": device.get("satisfaction", 0),
-                            "num_clients": device.get("num_sta", 0),
-                        }
-                    )
-                elif category == "switch":
-                    # Summarize port table - use get_device_details for full port data
-                    port_table = device.get("port_table", [])
-                    ports_up = sum(1 for p in port_table if p.get("up", False))
-                    ports_poe = sum(1 for p in port_table if p.get("poe_enable", False))
-                    details_to_add.update(
-                        {
-                            "total_ports": len(port_table),
-                            "ports_up": ports_up,
-                            "ports_poe_enabled": ports_poe,
-                            "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                            "poe_power": device.get("poe_power"),
-                            "poe_voltage": device.get("poe_voltage"),
-                        }
-                    )
-                elif category == "gateway":
-                    # Summarize network/wan tables - use get_device_details for full data
-                    network_table = device.get("network_table", [])
-                    wan1 = device.get("wan1", {})
-                    wan2 = device.get("wan2", {})
-                    system_stats = device.get("system-stats", {})
-                    details_to_add.update(
-                        {
-                            "wan1_ip": wan1.get("ip") if wan1 else None,
-                            "wan1_up": wan1.get("up", False) if wan1 else None,
-                            "wan2_ip": wan2.get("ip") if wan2 else None,
-                            "wan2_up": wan2.get("up", False) if wan2 else None,
-                            "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                            "network_count": len(network_table),
-                            "cpu_usage": system_stats.get("cpu"),
-                            "mem_usage": system_stats.get("mem"),
-                        }
-                    )
+                if summary:
+                    # Compressed shape (default): summaries + counts, no raw tables.
+                    if category == "ap":
+                        radio_table = device.get("radio_table", [])
+                        vap_table = device.get("vap_table", [])
+                        details_to_add.update(
+                            {
+                                "radio_count": len(radio_table),
+                                "radios": [
+                                    {"band": r.get("radio"), "channel": r.get("channel"), "tx_power": r.get("tx_power")}
+                                    for r in radio_table
+                                ],
+                                "vap_count": len(vap_table),
+                                "wifi_bands": get_wifi_bands(device),
+                                "experience_score": device.get("satisfaction", 0),
+                                "num_clients": device.get("num_sta", 0),
+                            }
+                        )
+                    elif category == "switch":
+                        port_table = device.get("port_table", [])
+                        ports_up = sum(1 for p in port_table if p.get("up", False))
+                        ports_poe = sum(1 for p in port_table if p.get("poe_enable", False))
+                        details_to_add.update(
+                            {
+                                "total_ports": len(port_table),
+                                "ports_up": ports_up,
+                                "ports_poe_enabled": ports_poe,
+                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
+                                "poe_power": device.get("poe_power"),
+                                "poe_voltage": device.get("poe_voltage"),
+                            }
+                        )
+                    elif category == "gateway":
+                        network_table = device.get("network_table", [])
+                        wan1 = device.get("wan1", {})
+                        wan2 = device.get("wan2", {})
+                        system_stats = device.get("system-stats", {})
+                        details_to_add.update(
+                            {
+                                "wan1_ip": wan1.get("ip") if wan1 else None,
+                                "wan1_up": wan1.get("up", False) if wan1 else None,
+                                "wan2_ip": wan2.get("ip") if wan2 else None,
+                                "wan2_up": wan2.get("up", False) if wan2 else None,
+                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
+                                "network_count": len(network_table),
+                                "cpu_usage": system_stats.get("cpu"),
+                                "mem_usage": system_stats.get("mem"),
+                            }
+                        )
+                else:
+                    # Legacy raw shape (pre-PR upstream): full tables passthrough.
+                    if category == "ap":
+                        details_to_add.update(
+                            {
+                                "radio_table": device.get("radio_table", []),
+                                "vap_table": device.get("vap_table", []),
+                                "wifi_bands": get_wifi_bands(device),
+                                "experience_score": device.get("satisfaction", 0),
+                                "num_clients": device.get("num_sta", 0),
+                            }
+                        )
+                    elif category == "switch":
+                        details_to_add.update(
+                            {
+                                "ports": device.get("port_table", []),
+                                "total_ports": len(device.get("port_table", [])),
+                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
+                                "poe_info": {
+                                    "poe_current": device.get("poe_current"),
+                                    "poe_power": device.get("poe_power"),
+                                    "poe_voltage": device.get("poe_voltage"),
+                                },
+                            }
+                        )
+                    elif category == "gateway":
+                        details_to_add.update(
+                            {
+                                "wan1": device.get("wan1", {}),
+                                "wan2": device.get("wan2", {}),
+                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
+                                "network_table": device.get("network_table", []),
+                                "system_stats": device.get("system-stats", {}),
+                                "speedtest_status": device.get("speedtest-status", {}),
+                            }
+                        )
 
                 device_info.update(details_to_add)
 
@@ -301,6 +348,7 @@ async def list_devices(
             "search": search,
             "total_count": total_count,
             "returned_count": len(formatted_devices),
+            "count": len(formatted_devices),  # back-compat alias for returned_count
             "limit": limit,
             "devices": formatted_devices,
         }
@@ -312,15 +360,15 @@ async def list_devices(
 @server.tool(
     name="unifi_get_device_details",
     description=(
-        "Returns device data for one device by MAC address with section-based selection.\n\n"
-        "include: comma-separated sections (default 'basic,ports'). Sections: "
-        "basic, ports, radios, stats, uplink, lldp, all.\n"
-        "summary: when false, returns full raw data (for debugging).\n\n"
-        "Port fields:\n"
+        "Returns device data for one device by MAC address. By default (summary=false) returns the "
+        "full raw device object — all controller-reported fields including radio tables, port tables, "
+        "system stats, WAN info, firmware details. Set summary=true to trim to selected sections via "
+        "include (basic, ports, radios, stats, uplink, lldp, all).\n\n"
+        "Port fields (summary mode):\n"
         "- last_seen_mac: last MAC that sent traffic on port (may be wireless client traffic, not reliable)\n"
         "- lldp_neighbor: actual connected infrastructure device (from LLDP, reliable for switches/APs)\n\n"
-        "Examples: include='basic' (minimal); include='basic,ports' (switches); "
-        "include='basic,radios' (APs); include='all' (every section, still compressed)."
+        "Examples: <no args> (full raw); summary=true,include='basic' (minimal); "
+        "summary=true,include='basic,ports' (switches); summary=true,include='basic,radios' (APs)."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -333,15 +381,20 @@ async def get_device_details(
         str,
         Field(
             description=(
-                "Comma-separated sections to return (default 'basic,ports'). "
+                "Comma-separated sections to return when summary=true (default 'basic,ports'). "
                 "Sections: basic, ports, radios, stats, uplink, lldp, all."
             )
         ),
     ] = "basic,ports",
     summary: Annotated[
         bool,
-        Field(description="When true (default), compress large nested tables. Set false for full raw data."),
-    ] = True,
+        Field(
+            description=(
+                "When false (default), returns the full raw device object. "
+                "When true, trims to the sections named in include."
+            )
+        ),
+    ] = False,
 ) -> Dict[str, Any]:
     """Implementation for getting device details."""
     try:
@@ -358,7 +411,9 @@ async def get_device_details(
                     "device": device_raw,
                 }
 
+            known_sections = {"basic", "ports", "radios", "stats", "uplink", "lldp", "all"}
             sections = set(s.strip().lower() for s in include.split(","))
+            unknown_sections = sorted(sections - known_sections)
             include_all = "all" in sections
 
             device_data: Dict[str, Any] = {}
@@ -455,13 +510,16 @@ async def get_device_details(
                 if "lldp_table" in device_raw:
                     device_data["lldp_table"] = device_raw["lldp_table"]
 
-            return {
+            response = {
                 "success": True,
                 "site": device_manager._connection.site,
                 "include": include,
                 "summary_mode": True,
                 "device": device_data,
             }
+            if unknown_sections:
+                response["unknown_sections"] = unknown_sections
+            return response
         return {
             "success": False,
             "error": f"Device not found with MAC address: {mac_address}",

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -96,8 +96,9 @@ def get_wifi_bands(device: Dict[str, Any]) -> List[str]:
         "upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. "
         "Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). "
         "Note: device_type=ap correctly excludes USP Smart Power strips. "
-        "Set include_details=true for radio tables, port tables, and client counts. "
-        "For a single device's full raw object, use unifi_get_device_details."
+        "Use search to filter by name, IP, or MAC (case-insensitive). "
+        "Set include_details=true for compressed radio/port summaries and client counts; "
+        "use unifi_get_device_details(mac) for full raw port and radio tables."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -114,10 +115,18 @@ async def list_devices(
             description="Filter by device status: 'all' (default), 'online', 'offline', 'pending', 'adopting', 'provisioning', or 'upgrading'"
         ),
     ] = "all",
+    search: Annotated[
+        Optional[str],
+        Field(description="Filter by name, IP, or MAC (case-insensitive substring match)"),
+    ] = None,
+    limit: Annotated[
+        Optional[int],
+        Field(description="Maximum number of devices to return (default: all)"),
+    ] = None,
     include_details: Annotated[
         bool,
         Field(
-            description="When true, includes additional details like radio tables (APs), port tables (switches), WAN info (gateways), and client counts. Default false"
+            description="When true, includes additional details with compressed radio/port summaries, WAN info (gateways), and client counts. Default false"
         ),
     ] = False,
 ) -> Dict[str, Any]:
@@ -147,6 +156,22 @@ async def list_devices(
                 devices_raw = [d for d in devices_raw if d.get("state") == target_state]
             else:
                 logger.warning("Unknown status filter: %s", status)
+
+        # Filter by search term (name, IP, or MAC)
+        if search and search.strip():
+            search_lower = search.strip().lower()
+            devices_raw = [
+                d
+                for d in devices_raw
+                if search_lower in (d.get("name") or "").lower()
+                or search_lower in (d.get("ip") or "").lower()
+                or search_lower in (d.get("mac") or "").lower()
+            ]
+
+        # Capture total before applying limit
+        total_count = len(devices_raw)
+        if limit is not None:
+            devices_raw = devices_raw[:limit]
 
         formatted_devices = []
         state_map = {
@@ -214,37 +239,53 @@ async def list_devices(
                 }
 
                 if category == "ap":
+                    # Summarize radio/vap tables - use get_device_details for full data
+                    radio_table = device.get("radio_table", [])
+                    vap_table = device.get("vap_table", [])
                     details_to_add.update(
                         {
-                            "radio_table": device.get("radio_table", []),
-                            "vap_table": device.get("vap_table", []),
+                            "radio_count": len(radio_table),
+                            "radios": [
+                                {"band": r.get("radio"), "channel": r.get("channel"), "tx_power": r.get("tx_power")}
+                                for r in radio_table
+                            ],
+                            "vap_count": len(vap_table),
                             "wifi_bands": get_wifi_bands(device),
                             "experience_score": device.get("satisfaction", 0),
                             "num_clients": device.get("num_sta", 0),
                         }
                     )
                 elif category == "switch":
+                    # Summarize port table - use get_device_details for full port data
+                    port_table = device.get("port_table", [])
+                    ports_up = sum(1 for p in port_table if p.get("up", False))
+                    ports_poe = sum(1 for p in port_table if p.get("poe_enable", False))
                     details_to_add.update(
                         {
-                            "ports": device.get("port_table", []),
-                            "total_ports": len(device.get("port_table", [])),
+                            "total_ports": len(port_table),
+                            "ports_up": ports_up,
+                            "ports_poe_enabled": ports_poe,
                             "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                            "poe_info": {
-                                "poe_current": device.get("poe_current"),
-                                "poe_power": device.get("poe_power"),
-                                "poe_voltage": device.get("poe_voltage"),
-                            },
+                            "poe_power": device.get("poe_power"),
+                            "poe_voltage": device.get("poe_voltage"),
                         }
                     )
                 elif category == "gateway":
+                    # Summarize network/wan tables - use get_device_details for full data
+                    network_table = device.get("network_table", [])
+                    wan1 = device.get("wan1", {})
+                    wan2 = device.get("wan2", {})
+                    system_stats = device.get("system-stats", {})
                     details_to_add.update(
                         {
-                            "wan1": device.get("wan1", {}),
-                            "wan2": device.get("wan2", {}),
+                            "wan1_ip": wan1.get("ip") if wan1 else None,
+                            "wan1_up": wan1.get("up", False) if wan1 else None,
+                            "wan2_ip": wan2.get("ip") if wan2 else None,
+                            "wan2_up": wan2.get("up", False) if wan2 else None,
                             "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                            "network_table": device.get("network_table", []),
-                            "system_stats": device.get("system-stats", {}),
-                            "speedtest_status": device.get("speedtest-status", {}),
+                            "network_count": len(network_table),
+                            "cpu_usage": system_stats.get("cpu"),
+                            "mem_usage": system_stats.get("mem"),
                         }
                     )
 
@@ -257,7 +298,10 @@ async def list_devices(
             "site": device_manager._connection.site,
             "filter_type": device_type,
             "filter_status": status,
-            "count": len(formatted_devices),
+            "search": search,
+            "total_count": total_count,
+            "returned_count": len(formatted_devices),
+            "limit": limit,
             "devices": formatted_devices,
         }
     except Exception as e:
@@ -268,10 +312,15 @@ async def list_devices(
 @server.tool(
     name="unifi_get_device_details",
     description=(
-        "Returns the full raw device object for one device by MAC address — includes "
-        "radio tables, port tables, system stats, WAN info, firmware details, and all "
-        "controller-reported fields. Use when you need deep inspection of a specific "
-        "device. For a filtered overview of all devices, use unifi_list_devices."
+        "Returns device data for one device by MAC address with section-based selection.\n\n"
+        "include: comma-separated sections (default 'basic,ports'). Sections: "
+        "basic, ports, radios, stats, uplink, lldp, all.\n"
+        "summary: when false, returns full raw data (for debugging).\n\n"
+        "Port fields:\n"
+        "- last_seen_mac: last MAC that sent traffic on port (may be wireless client traffic, not reliable)\n"
+        "- lldp_neighbor: actual connected infrastructure device (from LLDP, reliable for switches/APs)\n\n"
+        "Examples: include='basic' (minimal); include='basic,ports' (switches); "
+        "include='basic,radios' (APs); include='all' (every section, still compressed)."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -280,14 +329,142 @@ async def get_device_details(
         str,
         Field(description="Device MAC address in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)"),
     ],
+    include: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated sections to return (default 'basic,ports'). "
+                "Sections: basic, ports, radios, stats, uplink, lldp, all."
+            )
+        ),
+    ] = "basic,ports",
+    summary: Annotated[
+        bool,
+        Field(description="When true (default), compress large nested tables. Set false for full raw data."),
+    ] = True,
 ) -> Dict[str, Any]:
     """Implementation for getting device details."""
     try:
         device = await device_manager.get_device_details(mac_address)
+        if device:
+            device_raw = device.raw if hasattr(device, "raw") else device
+
+            if not summary:
+                return {
+                    "success": True,
+                    "site": device_manager._connection.site,
+                    "include": "all",
+                    "summary_mode": False,
+                    "device": device_raw,
+                }
+
+            sections = set(s.strip().lower() for s in include.split(","))
+            include_all = "all" in sections
+
+            device_data: Dict[str, Any] = {}
+
+            # Basic — essential device info
+            if include_all or "basic" in sections:
+                state_map = {
+                    0: "offline",
+                    1: "online",
+                    2: "pending_adoption",
+                    4: "managed_by_other/adopting",
+                    5: "provisioning",
+                    6: "upgrading",
+                    11: "error/heartbeat_missed",
+                }
+                device_state = device_raw.get("state", 0)
+                device_data.update(
+                    {
+                        "mac": device_raw.get("mac"),
+                        "name": device_raw.get("name", device_raw.get("model", "Unknown")),
+                        "model": device_raw.get("model"),
+                        "type": device_raw.get("type"),
+                        "ip": device_raw.get("ip"),
+                        "status": state_map.get(device_state, f"unknown ({device_state})"),
+                        "uptime": str(timedelta(seconds=device_raw.get("uptime", 0)))
+                        if device_raw.get("uptime")
+                        else None,
+                        "firmware": device_raw.get("version"),
+                        "adopted": device_raw.get("adopted", False),
+                    }
+                )
+
+            # Ports — compressed port table (switches)
+            if (include_all or "ports" in sections) and "port_table" in device_raw:
+                # Build LLDP lookup by local port for accurate neighbor detection
+                lldp_by_port: Dict[int, Dict[str, Any]] = {}
+                for lldp_entry in device_raw.get("lldp_table", []):
+                    local_port = lldp_entry.get("local_port_idx")
+                    if local_port is not None:
+                        lldp_by_port[local_port] = {
+                            "mac": lldp_entry.get("chassis_id"),
+                            "name": lldp_entry.get("chassis_name"),
+                            "port": lldp_entry.get("port_id"),
+                        }
+
+                device_data["port_summary"] = [
+                    {
+                        "port_idx": p.get("port_idx"),
+                        "name": p.get("name"),
+                        "up": p.get("up"),
+                        "speed": p.get("speed"),
+                        "poe_enable": p.get("poe_enable"),
+                        "poe_power": p.get("poe_power"),
+                        # last_seen_mac: last MAC that sent traffic on this port (may be wireless client traffic)
+                        "last_seen_mac": p.get("last_connection", {}).get("mac"),
+                        # lldp_neighbor: actual directly connected device (infrastructure only)
+                        "lldp_neighbor": lldp_by_port.get(p.get("port_idx")),
+                    }
+                    for p in device_raw["port_table"]
+                ]
+                device_data["port_count"] = len(device_raw["port_table"])
+
+            # Radios — compressed radio table (APs)
+            if (include_all or "radios" in sections) and "radio_table" in device_raw:
+                device_data["radio_summary"] = [
+                    {
+                        "radio": r.get("radio"),
+                        "channel": r.get("channel"),
+                        "tx_power": r.get("tx_power"),
+                    }
+                    for r in device_raw["radio_table"]
+                ]
+                device_data["radio_count"] = len(device_raw["radio_table"])
+                if "vap_table" in device_raw:
+                    device_data["vap_count"] = len(device_raw["vap_table"])
+
+            if include_all or "stats" in sections:
+                if "system-stats" in device_raw:
+                    device_data["system_stats"] = device_raw["system-stats"]
+
+            if include_all or "uplink" in sections:
+                if "uplink" in device_raw:
+                    uplink = device_raw["uplink"]
+                    device_data["uplink"] = {
+                        "type": uplink.get("type"),
+                        "uplink_mac": uplink.get("uplink_mac"),
+                        "uplink_device_name": uplink.get("uplink_device_name"),
+                        "uplink_remote_port": uplink.get("uplink_remote_port"),
+                        "speed": uplink.get("speed"),
+                        "ip": uplink.get("ip"),
+                    }
+
+            if include_all or "lldp" in sections:
+                if "lldp_table" in device_raw:
+                    device_data["lldp_table"] = device_raw["lldp_table"]
+
+            return {
+                "success": True,
+                "site": device_manager._connection.site,
+                "include": include,
+                "summary_mode": True,
+                "device": device_data,
+            }
         return {
-            "success": True,
-            "site": device_manager._connection.site,
-            "device": device.raw if hasattr(device, "raw") else device,
+            "success": False,
+            "error": f"Device not found with MAC address: {mac_address}",
         }
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -67,7 +67,10 @@ def _detect_legacy_fields(data: Dict[str, Any]) -> str | None:
         "Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, "
         "IPs, network IDs).\n\n"
         "Filters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, "
-        "limit (default 50), include_predefined."
+        "limit (default 50), include_predefined. By default (summary=true) returns a curated "
+        "entry per policy (id, name, enabled, action, rule_index, description + source/destination "
+        "targeting). Set summary=false for the full fw_from_controller().model_dump() shape "
+        "including protocol, schedule, logging, ip_version, index, etc."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -85,6 +88,17 @@ async def list_firewall_policies(
         Field(description="If true, only return enabled policies. Default false."),
     ] = False,
     limit: Annotated[int, Field(description="Maximum number of policies to return (default 50)")] = 50,
+    summary: Annotated[
+        bool,
+        Field(
+            description=(
+                "Controls per-policy shape. When true (default), returns a curated 6-key entry "
+                "plus narrowed source/destination targeting. When false, returns the full "
+                "fw_from_controller().model_dump() shape (protocol, schedule, logging, ip_version, "
+                "index, full source/destination dicts)."
+            )
+        ),
+    ] = True,
     include_predefined: Annotated[
         bool,
         Field(
@@ -116,10 +130,14 @@ async def list_firewall_policies(
 
         formatted_policies = []
         for p in policies_raw:
-            # Source scalar fields through the typed model (validation/coercion). `description`
-            # is not a model field, so it stays read from raw; the V2 targeting dicts (passed
-            # through by the model) are narrowed to the useful subset below.
             shaped = fw_from_controller(p)
+            if not summary:
+                # Legacy/full shape: complete model dump (protocol, schedule, logging, ip_version,
+                # index, full source/destination dicts).
+                formatted_policies.append(shaped.model_dump(exclude_none=True))
+                continue
+            # Curated shape (default): narrow to the 6 most useful keys plus targeting subset.
+            # `description` is not a model field, so it stays read from raw.
             entry = {
                 "id": shaped.id,
                 "name": shaped.name,
@@ -154,6 +172,7 @@ async def list_firewall_policies(
             "enabled_only": enabled_only,
             "total_count": total_count,
             "returned_count": len(formatted_policies),
+            "count": len(formatted_policies),  # back-compat alias for returned_count
             "limit": limit,
             "policies": formatted_policies,
         }

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -5,7 +5,7 @@ Firewall policy tools for Unifi Network MCP server.
 import json
 import logging
 from collections import Counter
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -64,12 +64,27 @@ def _detect_legacy_fields(data: Dict[str, Any]) -> str | None:
     name="unifi_list_firewall_policies",
     description=(
         "List firewall policies configured on the Unifi Network controller. "
-        "Includes zone-based targeting details (zone_id, matching_target, matching_target_type, "
-        "IPs, network IDs) when present on newer firmware."
+        "Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, "
+        "IPs, network IDs).\n\n"
+        "Filters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, "
+        "limit (default 50), include_predefined."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
 async def list_firewall_policies(
+    search: Annotated[
+        Optional[str],
+        Field(description="Filter by policy name (case-insensitive substring match)"),
+    ] = None,
+    action: Annotated[
+        Optional[str],
+        Field(description="Filter by action: ALLOW, BLOCK, or REJECT (V2 firmware). Case-insensitive."),
+    ] = None,
+    enabled_only: Annotated[
+        bool,
+        Field(description="If true, only return enabled policies. Default false."),
+    ] = False,
+    limit: Annotated[int, Field(description="Maximum number of policies to return (default 50)")] = 50,
     include_predefined: Annotated[
         bool,
         Field(
@@ -79,18 +94,67 @@ async def list_firewall_policies(
 ) -> Dict[str, Any]:
     """Lists firewall policies for the current UniFi site.
 
-    Returns both legacy (ruleset-based) and zone-based policy fields.
-    Zone-based fields (zone_id, matching_target, matching_target_type) are
-    included in source/destination when present in the API response.
+    Returns V2 zone-based policy fields (zone_id, matching_target, matching_target_type)
+    in source/destination. Legacy V1 ruleset support was removed in #210.
     """
     try:
         policies = await firewall_manager.get_firewall_policies(include_predefined=include_predefined)
-        formatted_policies = [fw_from_controller(p).model_dump(exclude_none=True) for p in policies]
+        policies_raw = [p.raw if hasattr(p, "raw") else p for p in policies]
+
+        if enabled_only:
+            policies_raw = [p for p in policies_raw if p.get("enabled", False)]
+
+        if action and action.strip():
+            policies_raw = [p for p in policies_raw if p.get("action") == action.strip().upper()]
+
+        if search and search.strip():
+            search_lower = search.strip().lower()
+            policies_raw = [p for p in policies_raw if search_lower in (p.get("name") or "").lower()]
+
+        total_count = len(policies_raw)
+        policies_raw = policies_raw[:limit]
+
+        formatted_policies = []
+        for p in policies_raw:
+            # Source scalar fields through the typed model (validation/coercion). `description`
+            # is not a model field, so it stays read from raw; the V2 targeting dicts (passed
+            # through by the model) are narrowed to the useful subset below.
+            shaped = fw_from_controller(p)
+            entry = {
+                "id": shaped.id,
+                "name": shaped.name,
+                "enabled": shaped.enabled,
+                "action": shaped.action,
+                "rule_index": shaped.index,
+                "description": p.get("description", p.get("desc", "")),
+            }
+            for direction in ("source", "destination"):
+                ep = getattr(shaped, direction)
+                if ep and isinstance(ep, dict):
+                    targeting = {
+                        "zone_id": ep.get("zone_id"),
+                        "matching_target": ep.get("matching_target"),
+                    }
+                    if ep.get("matching_target_type"):
+                        targeting["matching_target_type"] = ep["matching_target_type"]
+                    if ep.get("ips"):
+                        targeting["ips"] = ep["ips"]
+                    if ep.get("network_ids"):
+                        targeting["network_ids"] = ep["network_ids"]
+                    if ep.get("client_macs"):
+                        targeting["client_macs"] = ep["client_macs"]
+                    entry[direction] = targeting
+            formatted_policies.append(entry)
 
         return {
             "success": True,
             "site": firewall_manager._connection.site,
-            "count": len(formatted_policies),
+            "search": search,
+            "action_filter": action,
+            "enabled_only": enabled_only,
+            "total_count": total_count,
+            "returned_count": len(formatted_policies),
+            "limit": limit,
             "policies": formatted_policies,
         }
     except Exception as e:

--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -7,7 +7,7 @@ including managing LAN networks and WLANs.
 
 import json
 import logging
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -45,15 +45,38 @@ logger = logging.getLogger(__name__)
 @server.tool(
     name="unifi_list_networks",
     description=(
-        "Returns all configured networks (LAN, WAN, VLAN-only) with name, purpose, "
+        "Returns configured networks (LAN, WAN, VLAN-only) with name, purpose, "
         "IP subnet, VLAN ID, DHCP settings, and enabled state. "
         "Use to understand network topology and VLAN layout. "
+        "Filters: search (name/VLAN substring), purpose (corporate/guest/wan/vlan-only), "
+        "limit (default 25), fields (comma-separated subset). "
         "For a single network's full config, use unifi_get_network_details. "
         "For wireless SSIDs, use unifi_list_wlans."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
-async def list_networks() -> Dict[str, Any]:
+async def list_networks(
+    search: Annotated[
+        Optional[str],
+        Field(description="Filter by name (case-insensitive substring) or VLAN ID (exact match, e.g. '20')"),
+    ] = None,
+    purpose: Annotated[
+        Optional[str],
+        Field(description="Filter by purpose (corporate, guest, wan, vlan-only)"),
+    ] = None,
+    limit: Annotated[int, Field(description="Maximum number of networks to return (default 25)")] = 25,
+    fields: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Comma-separated list of fields to return per network (default: all). "
+                "Available: _id, name, enabled, purpose, ip_subnet, vlan_enabled, vlan, "
+                "dhcpd_enabled, dhcpd_start, dhcpd_stop. "
+                "Example: fields='_id,name,vlan,purpose' returns only those fields."
+            )
+        ),
+    ] = None,
+) -> Dict[str, Any]:
     """Lists all networks configured on the UniFi Network controller for the current site using the V1 API structure.
 
     Returns:
@@ -113,12 +136,59 @@ async def list_networks() -> Dict[str, Any]:
     """
     try:
         networks_data = await network_manager.get_networks()
-        formatted = [network_from_controller(n).model_dump(exclude_none=True) for n in networks_data]
+        if purpose and purpose.strip():
+            networks_data = [n for n in networks_data if n.get("purpose") == purpose.strip().lower()]
+
+        if search and search.strip():
+            search_lower = search.strip().lower()
+            networks_data = [
+                n
+                for n in networks_data
+                if search_lower in (n.get("name") or "").lower() or search_lower == str(n.get("vlan") or "")
+            ]
+
+        total_count = len(networks_data)
+        networks_data = networks_data[:limit]
+
+        requested_fields = None
+        if fields and fields.strip():
+            requested_fields = set(f.strip() for f in fields.split(","))
+
+        formatted_networks = []
+        for network in networks_data:
+            # Source values through the typed model (validation/coercion); the list view
+            # then narrows to a curated subset and honors the optional `fields` selector.
+            shaped = network_from_controller(network)
+            full_data = {
+                "_id": shaped.id,
+                "name": shaped.name,
+                "enabled": shaped.enabled,
+                "purpose": shaped.purpose,
+                "ip_subnet": shaped.ip_subnet,
+                "vlan_enabled": shaped.vlan_enabled,
+                "vlan": shaped.vlan,
+                "dhcpd_enabled": shaped.dhcpd_enabled,
+                "dhcpd_start": shaped.dhcpd_start,
+                "dhcpd_stop": shaped.dhcpd_stop,
+            }
+
+            if requested_fields:
+                formatted = {k: v for k, v in full_data.items() if k in requested_fields}
+            else:
+                formatted = full_data
+
+            formatted_networks.append(formatted)
+
         return {
             "success": True,
             "site": network_manager._connection.site,
-            "count": len(formatted),
-            "networks": formatted,
+            "search": search,
+            "purpose_filter": purpose,
+            "fields": fields,
+            "total_count": total_count,
+            "returned_count": len(formatted_networks),
+            "limit": limit,
+            "networks": formatted_networks,
         }
     except Exception as e:
         logger.error("Error listing networks in tool: %s", e, exc_info=True)
@@ -127,11 +197,27 @@ async def list_networks() -> Dict[str, Any]:
 
 @server.tool(
     name="unifi_get_network_details",
-    description="Get details for a specific network by ID.",
+    description=(
+        "Get details for a specific network by ID with section-based selection.\n\n"
+        "include: comma-separated sections (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.\n"
+        "summary: when false, returns full raw data (for debugging).\n\n"
+        "Examples: include='basic' (minimal); include='basic,dhcp' (adds DHCP server config); "
+        "include='all' (all sections)."
+    ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
 async def get_network_details(
     network_id: Annotated[str, Field(description="Unique identifier (_id) of the network (from unifi_list_networks)")],
+    include: Annotated[
+        str,
+        Field(
+            description=("Comma-separated sections to return (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.")
+        ),
+    ] = "basic",
+    summary: Annotated[
+        bool,
+        Field(description="When true (default), filter to selected sections. Set false for full raw data."),
+    ] = True,
 ) -> Dict[str, Any]:
     """Gets the detailed configuration of a specific network by its ID.
 
@@ -171,15 +257,78 @@ async def get_network_details(
     try:
         if not network_id:
             return {"success": False, "error": "network_id is required"}
-        # Assuming manager get_network_details returns the raw dict or None
         network = await network_manager.get_network_details(network_id)
         if network:
-            # Ensure serializable
+            if not summary:
+                return {
+                    "success": True,
+                    "site": network_manager._connection.site,
+                    "network_id": network_id,
+                    "include": "all",
+                    "summary_mode": False,
+                    "details": json.loads(json.dumps(network, default=str)),
+                }
+
+            sections = set(s.strip().lower() for s in include.split(","))
+            include_all = "all" in sections
+
+            network_data: Dict[str, Any] = {}
+
+            if include_all or "basic" in sections:
+                network_data.update(
+                    {
+                        "_id": network.get("_id"),
+                        "name": network.get("name"),
+                        "enabled": network.get("enabled"),
+                        "purpose": network.get("purpose"),
+                        "ip_subnet": network.get("ip_subnet"),
+                        "vlan_enabled": network.get("vlan_enabled"),
+                        "vlan": network.get("vlan"),
+                        "domain_name": network.get("domain_name"),
+                        "is_nat": network.get("is_nat"),
+                        "network_isolation_enabled": network.get("network_isolation_enabled"),
+                    }
+                )
+
+            if include_all or "dhcp" in sections:
+                network_data.update(
+                    {
+                        "dhcpd_enabled": network.get("dhcpd_enabled"),
+                        "dhcpd_start": network.get("dhcpd_start"),
+                        "dhcpd_stop": network.get("dhcpd_stop"),
+                        "dhcpd_leasetime": network.get("dhcpd_leasetime"),
+                        "dhcpd_dns_enabled": network.get("dhcpd_dns_enabled"),
+                        "dhcpd_gateway_enabled": network.get("dhcpd_gateway_enabled"),
+                        "dhcpd_unifi_controller": network.get("dhcpd_unifi_controller"),
+                    }
+                )
+
+            if include_all or "ipv6" in sections:
+                network_data.update(
+                    {
+                        "ipv6_interface_type": network.get("ipv6_interface_type"),
+                        "ipv6_pd_start": network.get("ipv6_pd_start"),
+                        "ipv6_pd_stop": network.get("ipv6_pd_stop"),
+                        "ipv6_ra_enabled": network.get("ipv6_ra_enabled"),
+                    }
+                )
+
+            if include_all or "vpn" in sections:
+                network_data.update(
+                    {
+                        "vpn_type": network.get("vpn_type"),
+                        "remote_site_id": network.get("remote_site_id"),
+                        "remote_site_subnets": network.get("remote_site_subnets"),
+                    }
+                )
+
             return {
                 "success": True,
                 "site": network_manager._connection.site,
                 "network_id": network_id,
-                "details": json.loads(json.dumps(network, default=str)),
+                "include": include,
+                "summary_mode": True,
+                "details": network_data,
             }
         else:
             return {
@@ -550,10 +699,23 @@ async def create_network(
 
 @server.tool(
     name="unifi_list_wlans",
-    description="List all configured Wireless LANs (WLANs) on the Unifi Network controller.",
+    description=(
+        "List configured Wireless LANs (WLANs) on the Unifi Network controller.\n\n"
+        "Filters: search (SSID name substring), enabled_only, limit (default 25)."
+    ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
-async def list_wlans() -> Dict[str, Any]:
+async def list_wlans(
+    search: Annotated[
+        Optional[str],
+        Field(description="Filter by SSID name (case-insensitive substring match)"),
+    ] = None,
+    enabled_only: Annotated[
+        bool,
+        Field(description="If true, only return enabled WLANs. Default false."),
+    ] = False,
+    limit: Annotated[int, Field(description="Maximum number of WLANs to return (default 25)")] = 25,
+) -> Dict[str, Any]:
     """Lists all WLANs (Wireless SSIDs) configured on the UniFi Network controller.
 
     Returns:
@@ -591,6 +753,19 @@ async def list_wlans() -> Dict[str, Any]:
         wlans = await network_manager.get_wlans()
         # Ensure wlans are dictionaries
         wlans_raw = [w.raw if hasattr(w, "raw") else w for w in wlans]
+
+        # Filter by enabled_only
+        if enabled_only:
+            wlans_raw = [w for w in wlans_raw if w.get("enabled", False)]
+
+        # Filter by search term (SSID name)
+        if search and search.strip():
+            search_lower = search.strip().lower()
+            wlans_raw = [w for w in wlans_raw if search_lower in (w.get("name") or "").lower()]
+
+        total_count = len(wlans_raw)
+        wlans_raw = wlans_raw[:limit]
+
         formatted_wlans = [
             {
                 "id": w.get("_id"),
@@ -605,7 +780,11 @@ async def list_wlans() -> Dict[str, Any]:
         return {
             "success": True,
             "site": network_manager._connection.site,
-            "count": len(formatted_wlans),
+            "search": search,
+            "enabled_only": enabled_only,
+            "total_count": total_count,
+            "returned_count": len(formatted_wlans),
+            "limit": limit,
             "wlans": formatted_wlans,
         }
     except Exception as e:

--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -150,9 +150,23 @@ async def list_networks(
         total_count = len(networks_data)
         networks_data = networks_data[:limit]
 
+        known_fields = {
+            "_id",
+            "name",
+            "enabled",
+            "purpose",
+            "ip_subnet",
+            "vlan_enabled",
+            "vlan",
+            "dhcpd_enabled",
+            "dhcpd_start",
+            "dhcpd_stop",
+        }
         requested_fields = None
+        unknown_fields: list[str] = []
         if fields and fields.strip():
             requested_fields = set(f.strip() for f in fields.split(","))
+            unknown_fields = sorted(requested_fields - known_fields)
 
         formatted_networks = []
         for network in networks_data:
@@ -179,7 +193,7 @@ async def list_networks(
 
             formatted_networks.append(formatted)
 
-        return {
+        response = {
             "success": True,
             "site": network_manager._connection.site,
             "search": search,
@@ -187,9 +201,13 @@ async def list_networks(
             "fields": fields,
             "total_count": total_count,
             "returned_count": len(formatted_networks),
+            "count": len(formatted_networks),  # back-compat alias for returned_count
             "limit": limit,
             "networks": formatted_networks,
         }
+        if unknown_fields:
+            response["unknown_fields"] = unknown_fields
+        return response
     except Exception as e:
         logger.error("Error listing networks in tool: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list networks: {e}"}
@@ -198,11 +216,11 @@ async def list_networks(
 @server.tool(
     name="unifi_get_network_details",
     description=(
-        "Get details for a specific network by ID with section-based selection.\n\n"
-        "include: comma-separated sections (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.\n"
-        "summary: when false, returns full raw data (for debugging).\n\n"
-        "Examples: include='basic' (minimal); include='basic,dhcp' (adds DHCP server config); "
-        "include='all' (all sections)."
+        "Get details for a specific network by ID. By default (summary=false) returns the full raw "
+        "network configuration. Set summary=true to trim to selected sections via include "
+        "(basic, dhcp, ipv6, vpn, all).\n\n"
+        "Examples: <no args> (full raw); summary=true,include='basic' (minimal); "
+        "summary=true,include='basic,dhcp' (adds DHCP server config); summary=true,include='all'."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -211,13 +229,21 @@ async def get_network_details(
     include: Annotated[
         str,
         Field(
-            description=("Comma-separated sections to return (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.")
+            description=(
+                "Comma-separated sections to return when summary=true (default 'basic'). "
+                "Sections: basic, dhcp, ipv6, vpn, all."
+            )
         ),
     ] = "basic",
     summary: Annotated[
         bool,
-        Field(description="When true (default), filter to selected sections. Set false for full raw data."),
-    ] = True,
+        Field(
+            description=(
+                "When false (default), returns the full raw network object. "
+                "When true, trims to the sections named in include."
+            )
+        ),
+    ] = False,
 ) -> Dict[str, Any]:
     """Gets the detailed configuration of a specific network by its ID.
 
@@ -269,7 +295,9 @@ async def get_network_details(
                     "details": json.loads(json.dumps(network, default=str)),
                 }
 
+            known_sections = {"basic", "dhcp", "ipv6", "vpn", "all"}
             sections = set(s.strip().lower() for s in include.split(","))
+            unknown_sections = sorted(sections - known_sections)
             include_all = "all" in sections
 
             network_data: Dict[str, Any] = {}
@@ -322,7 +350,7 @@ async def get_network_details(
                     }
                 )
 
-            return {
+            response = {
                 "success": True,
                 "site": network_manager._connection.site,
                 "network_id": network_id,
@@ -330,6 +358,9 @@ async def get_network_details(
                 "summary_mode": True,
                 "details": network_data,
             }
+            if unknown_sections:
+                response["unknown_sections"] = unknown_sections
+            return response
         else:
             return {
                 "success": False,
@@ -784,6 +815,7 @@ async def list_wlans(
             "enabled_only": enabled_only,
             "total_count": total_count,
             "returned_count": len(formatted_wlans),
+            "count": len(formatted_wlans),  # back-compat alias for returned_count
             "limit": limit,
             "wlans": formatted_wlans,
         }

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -4842,14 +4842,22 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns the full raw client object for one client by MAC address \u2014 all controller-reported fields including connection stats, DHCP info, network/WLAN associations, traffic counters, signal/RSSI, and fixed-IP settings. Merges live /stat/sta data with the /rest/user snapshot for active clients. For a summary of all clients, use unifi_list_clients.",
+      "description": "Returns client data for one client by MAC address. By default (summary=false) returns the full raw client object \u2014 all controller-reported fields, with the typed/normalized shape (ISO timestamps, derived status, null-safe name/hostname) layered on top of the merged live /stat/sta + /rest/user data. Set summary=true to trim to selected sections via include (basic, network, wireless, traffic, fingerprint, all). For a summary of all clients, use unifi_list_clients.",
       "name": "unifi_get_client_details",
       "schema": {
         "input": {
           "properties": {
+            "include": {
+              "description": "Comma-separated sections to return when summary=true (default 'basic'). Sections: basic, network, wireless, traffic, fingerprint, all.",
+              "type": "string"
+            },
             "mac_address": {
               "description": "Client MAC address in format AA:BB:CC:DD:EE:FF (from unifi_list_clients)",
               "type": "string"
+            },
+            "summary": {
+              "description": "When false (default), returns the full raw client object. When true, trims the response to the sections named in include.",
+              "type": "boolean"
             }
           },
           "required": [
@@ -5587,14 +5595,22 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns the full raw device object for one device by MAC address \u2014 includes radio tables, port tables, system stats, WAN info, firmware details, and all controller-reported fields. Use when you need deep inspection of a specific device. For a filtered overview of all devices, use unifi_list_devices.",
+      "description": "Returns device data for one device by MAC address with section-based selection.\n\ninclude: comma-separated sections (default 'basic,ports'). Sections: basic, ports, radios, stats, uplink, lldp, all.\nsummary: when false, returns full raw data (for debugging).\n\nPort fields:\n- last_seen_mac: last MAC that sent traffic on port (may be wireless client traffic, not reliable)\n- lldp_neighbor: actual connected infrastructure device (from LLDP, reliable for switches/APs)\n\nExamples: include='basic' (minimal); include='basic,ports' (switches); include='basic,radios' (APs); include='all' (every section, still compressed).",
       "name": "unifi_get_device_details",
       "schema": {
         "input": {
           "properties": {
+            "include": {
+              "description": "Comma-separated sections to return (default 'basic,ports'). Sections: basic, ports, radios, stats, uplink, lldp, all.",
+              "type": "string"
+            },
             "mac_address": {
               "description": "Device MAC address in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
               "type": "string"
+            },
+            "summary": {
+              "description": "When true (default), compress large nested tables. Set false for full raw data.",
+              "type": "boolean"
             }
           },
           "required": [
@@ -6690,14 +6706,22 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get details for a specific network by ID.",
+      "description": "Get details for a specific network by ID with section-based selection.\n\ninclude: comma-separated sections (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.\nsummary: when false, returns full raw data (for debugging).\n\nExamples: include='basic' (minimal); include='basic,dhcp' (adds DHCP server config); include='all' (all sections).",
       "name": "unifi_get_network_details",
       "schema": {
         "input": {
           "properties": {
+            "include": {
+              "description": "Comma-separated sections to return (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.",
+              "type": "string"
+            },
             "network_id": {
               "description": "Unique identifier (_id) of the network (from unifi_list_networks)",
               "type": "string"
+            },
+            "summary": {
+              "description": "When true (default), filter to selected sections. Set false for full raw data.",
+              "type": "boolean"
             }
           },
           "required": [
@@ -9732,11 +9756,15 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns connected clients with mac, name, hostname, ip, status (online/offline), connection type (wired/wireless), and for wireless clients: ssid, signal_dbm, channel, radio. Filter by filter_type (all/wired/wireless), set include_offline=true for historical clients. For a single client's full raw object, use unifi_get_client_details. For IP-to-client lookup, use unifi_lookup_by_ip.",
+      "description": "Returns connected clients with mac, name, hostname, ip, status (online/offline), connection type (wired/wireless), and for wireless clients: ssid, signal_dbm, channel, radio. Filter by filter_type (all/wired/wireless), set include_offline=true for historical clients. Use search to filter by name/hostname/IP/MAC (case-insensitive). For a single client's full raw object, use unifi_get_client_details. For IP-to-client lookup, use unifi_lookup_by_ip.",
       "name": "unifi_list_clients",
       "schema": {
         "input": {
           "properties": {
+            "fields": {
+              "description": "Comma-separated list of fields to return per client (default: all). Available: mac, name, hostname, ip, connection_type, status, last_seen, _id. Wireless-only: essid, signal_dbm, channel, radio. Example: fields='mac,name,ip' returns only those 3 fields.",
+              "type": "string"
+            },
             "filter_type": {
               "description": "Filter clients by connection type: 'all' (default), 'wired', or 'wireless'",
               "type": "string"
@@ -9748,6 +9776,10 @@
             "limit": {
               "description": "Maximum number of clients to return (default 100)",
               "type": "integer"
+            },
+            "search": {
+              "description": "Filter by name, hostname, IP, or MAC (case-insensitive substring match)",
+              "type": "string"
             }
           },
           "type": "object"
@@ -9913,7 +9945,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_category (ap/switch/gateway/pdu), upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). Note: device_type=ap correctly excludes USP Smart Power strips. Set include_details=true for radio tables, port tables, and client counts. For a single device's full raw object, use unifi_get_device_details.",
+      "description": "Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_category (ap/switch/gateway/pdu), upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). Note: device_type=ap correctly excludes USP Smart Power strips. Use search to filter by name, IP, or MAC (case-insensitive). Set include_details=true for compressed radio/port summaries and client counts; use unifi_get_device_details(mac) for full raw port and radio tables.",
       "name": "unifi_list_devices",
       "schema": {
         "input": {
@@ -9923,8 +9955,16 @@
               "type": "string"
             },
             "include_details": {
-              "description": "When true, includes additional details like radio tables (APs), port tables (switches), WAN info (gateways), and client counts. Default false",
+              "description": "When true, includes additional details with compressed radio/port summaries, WAN info (gateways), and client counts. Default false",
               "type": "boolean"
+            },
+            "limit": {
+              "description": "Maximum number of devices to return (default: all)",
+              "type": "integer"
+            },
+            "search": {
+              "description": "Filter by name, IP, or MAC (case-insensitive substring match)",
+              "type": "string"
             },
             "status": {
               "description": "Filter by device status: 'all' (default), 'online', 'offline', 'pending', 'adopting', 'provisioning', or 'upgrading'",
@@ -10469,14 +10509,30 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List firewall policies configured on the Unifi Network controller. Includes zone-based targeting details (zone_id, matching_target, matching_target_type, IPs, network IDs) when present on newer firmware.",
+      "description": "List firewall policies configured on the Unifi Network controller. Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, IPs, network IDs).\n\nFilters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, limit (default 50), include_predefined.",
       "name": "unifi_list_firewall_policies",
       "schema": {
         "input": {
           "properties": {
+            "action": {
+              "description": "Filter by action: ALLOW, BLOCK, or REJECT (V2 firmware). Case-insensitive.",
+              "type": "string"
+            },
+            "enabled_only": {
+              "description": "If true, only return enabled policies. Default false.",
+              "type": "boolean"
+            },
             "include_predefined": {
               "description": "When true, includes predefined system policies in results. Default false (user-defined only)",
               "type": "boolean"
+            },
+            "limit": {
+              "description": "Maximum number of policies to return (default 50)",
+              "type": "integer"
+            },
+            "search": {
+              "description": "Filter by policy name (case-insensitive substring match)",
+              "type": "string"
             }
           },
           "type": "object"
@@ -10642,11 +10698,28 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns all configured networks (LAN, WAN, VLAN-only) with name, purpose, IP subnet, VLAN ID, DHCP settings, and enabled state. Use to understand network topology and VLAN layout. For a single network's full config, use unifi_get_network_details. For wireless SSIDs, use unifi_list_wlans.",
+      "description": "Returns configured networks (LAN, WAN, VLAN-only) with name, purpose, IP subnet, VLAN ID, DHCP settings, and enabled state. Use to understand network topology and VLAN layout. Filters: search (name/VLAN substring), purpose (corporate/guest/wan/vlan-only), limit (default 25), fields (comma-separated subset). For a single network's full config, use unifi_get_network_details. For wireless SSIDs, use unifi_list_wlans.",
       "name": "unifi_list_networks",
       "schema": {
         "input": {
-          "properties": {},
+          "properties": {
+            "fields": {
+              "description": "Comma-separated list of fields to return per network (default: all). Available: _id, name, enabled, purpose, ip_subnet, vlan_enabled, vlan, dhcpd_enabled, dhcpd_start, dhcpd_stop. Example: fields='_id,name,vlan,purpose' returns only those fields.",
+              "type": "string"
+            },
+            "limit": {
+              "description": "Maximum number of networks to return (default 25)",
+              "type": "integer"
+            },
+            "purpose": {
+              "description": "Filter by purpose (corporate, guest, wan, vlan-only)",
+              "type": "string"
+            },
+            "search": {
+              "description": "Filter by name (case-insensitive substring) or VLAN ID (exact match, e.g. '20')",
+              "type": "string"
+            }
+          },
           "type": "object"
         },
         "output": {
@@ -11663,11 +11736,24 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List all configured Wireless LANs (WLANs) on the Unifi Network controller.",
+      "description": "List configured Wireless LANs (WLANs) on the Unifi Network controller.\n\nFilters: search (SSID name substring), enabled_only, limit (default 25).",
       "name": "unifi_list_wlans",
       "schema": {
         "input": {
-          "properties": {},
+          "properties": {
+            "enabled_only": {
+              "description": "If true, only return enabled WLANs. Default false.",
+              "type": "boolean"
+            },
+            "limit": {
+              "description": "Maximum number of WLANs to return (default 25)",
+              "type": "integer"
+            },
+            "search": {
+              "description": "Filter by SSID name (case-insensitive substring match)",
+              "type": "string"
+            }
+          },
           "type": "object"
         },
         "output": {

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -5595,13 +5595,13 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns device data for one device by MAC address with section-based selection.\n\ninclude: comma-separated sections (default 'basic,ports'). Sections: basic, ports, radios, stats, uplink, lldp, all.\nsummary: when false, returns full raw data (for debugging).\n\nPort fields:\n- last_seen_mac: last MAC that sent traffic on port (may be wireless client traffic, not reliable)\n- lldp_neighbor: actual connected infrastructure device (from LLDP, reliable for switches/APs)\n\nExamples: include='basic' (minimal); include='basic,ports' (switches); include='basic,radios' (APs); include='all' (every section, still compressed).",
+      "description": "Returns device data for one device by MAC address. By default (summary=false) returns the full raw device object \u2014 all controller-reported fields including radio tables, port tables, system stats, WAN info, firmware details. Set summary=true to trim to selected sections via include (basic, ports, radios, stats, uplink, lldp, all).\n\nPort fields (summary mode):\n- last_seen_mac: last MAC that sent traffic on port (may be wireless client traffic, not reliable)\n- lldp_neighbor: actual connected infrastructure device (from LLDP, reliable for switches/APs)\n\nExamples: <no args> (full raw); summary=true,include='basic' (minimal); summary=true,include='basic,ports' (switches); summary=true,include='basic,radios' (APs).",
       "name": "unifi_get_device_details",
       "schema": {
         "input": {
           "properties": {
             "include": {
-              "description": "Comma-separated sections to return (default 'basic,ports'). Sections: basic, ports, radios, stats, uplink, lldp, all.",
+              "description": "Comma-separated sections to return when summary=true (default 'basic,ports'). Sections: basic, ports, radios, stats, uplink, lldp, all.",
               "type": "string"
             },
             "mac_address": {
@@ -5609,7 +5609,7 @@
               "type": "string"
             },
             "summary": {
-              "description": "When true (default), compress large nested tables. Set false for full raw data.",
+              "description": "When false (default), returns the full raw device object. When true, trims to the sections named in include.",
               "type": "boolean"
             }
           },
@@ -6706,13 +6706,13 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get details for a specific network by ID with section-based selection.\n\ninclude: comma-separated sections (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.\nsummary: when false, returns full raw data (for debugging).\n\nExamples: include='basic' (minimal); include='basic,dhcp' (adds DHCP server config); include='all' (all sections).",
+      "description": "Get details for a specific network by ID. By default (summary=false) returns the full raw network configuration. Set summary=true to trim to selected sections via include (basic, dhcp, ipv6, vpn, all).\n\nExamples: <no args> (full raw); summary=true,include='basic' (minimal); summary=true,include='basic,dhcp' (adds DHCP server config); summary=true,include='all'.",
       "name": "unifi_get_network_details",
       "schema": {
         "input": {
           "properties": {
             "include": {
-              "description": "Comma-separated sections to return (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.",
+              "description": "Comma-separated sections to return when summary=true (default 'basic'). Sections: basic, dhcp, ipv6, vpn, all.",
               "type": "string"
             },
             "network_id": {
@@ -6720,7 +6720,7 @@
               "type": "string"
             },
             "summary": {
-              "description": "When true (default), filter to selected sections. Set false for full raw data.",
+              "description": "When false (default), returns the full raw network object. When true, trims to the sections named in include.",
               "type": "boolean"
             }
           },
@@ -9945,7 +9945,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_category (ap/switch/gateway/pdu), upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). Note: device_type=ap correctly excludes USP Smart Power strips. Use search to filter by name, IP, or MAC (case-insensitive). Set include_details=true for compressed radio/port summaries and client counts; use unifi_get_device_details(mac) for full raw port and radio tables.",
+      "description": "Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_category (ap/switch/gateway/pdu), upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). Note: device_type=ap correctly excludes USP Smart Power strips. Use search to filter by name, IP, or MAC (case-insensitive). Set include_details=true for additional per-device fields: by default (summary=true) compressed radio/port summaries; set summary=false to return the full raw tables (radio_table, port_table, network_table, system_stats, wan1/wan2).",
       "name": "unifi_list_devices",
       "schema": {
         "input": {
@@ -9955,7 +9955,7 @@
               "type": "string"
             },
             "include_details": {
-              "description": "When true, includes additional details with compressed radio/port summaries, WAN info (gateways), and client counts. Default false",
+              "description": "When true, includes additional per-device details (shape controlled by summary). Default false",
               "type": "boolean"
             },
             "limit": {
@@ -9969,6 +9969,10 @@
             "status": {
               "description": "Filter by device status: 'all' (default), 'online', 'offline', 'pending', 'adopting', 'provisioning', or 'upgrading'",
               "type": "string"
+            },
+            "summary": {
+              "description": "Controls the shape of include_details (only applies when include_details=true). When true (default), returns compressed summaries (counts, flattened uplink fields). When false, returns the legacy raw tables (radio_table/port_table/network_table/system_stats/wan1/wan2/poe_info).",
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -10509,7 +10513,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List firewall policies configured on the Unifi Network controller. Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, IPs, network IDs).\n\nFilters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, limit (default 50), include_predefined.",
+      "description": "List firewall policies configured on the Unifi Network controller. Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, IPs, network IDs).\n\nFilters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, limit (default 50), include_predefined. By default (summary=true) returns a curated entry per policy (id, name, enabled, action, rule_index, description + source/destination targeting). Set summary=false for the full fw_from_controller().model_dump() shape including protocol, schedule, logging, ip_version, index, etc.",
       "name": "unifi_list_firewall_policies",
       "schema": {
         "input": {
@@ -10533,6 +10537,10 @@
             "search": {
               "description": "Filter by policy name (case-insensitive substring match)",
               "type": "string"
+            },
+            "summary": {
+              "description": "Controls per-policy shape. When true (default), returns a curated 6-key entry plus narrowed source/destination targeting. When false, returns the full fw_from_controller().model_dump() shape (protocol, schedule, logging, ip_version, index, full source/destination dicts).",
+              "type": "boolean"
             }
           },
           "type": "object"

--- a/apps/network/tests/unit/test_clients_filtering.py
+++ b/apps/network/tests/unit/test_clients_filtering.py
@@ -45,26 +45,23 @@ SAMPLE_CLIENTS = [
 ]
 
 
-def _patch_mgr(clients):
-    mock_conn = MagicMock()
-    mock_conn.site = "default"
-    p = patch("unifi_network_mcp.tools.clients.client_manager")
-    mock = p.start()
-    mock.get_clients = AsyncMock(return_value=list(clients))
-    mock.get_all_clients = AsyncMock(return_value=list(clients))
-    mock._connection = mock_conn
-    return p, mock
+def _mock_conn():
+    c = MagicMock()
+    c.site = "default"
+    return c
 
 
 @pytest.mark.asyncio
 async def test_search_filters_by_substring():
-    p, _ = _patch_mgr(SAMPLE_CLIENTS)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm.get_all_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import list_clients
 
         result = await list_clients(search="phone")
-    finally:
-        p.stop()
+
     assert result["success"] is True
     assert result["total_count"] == 1
     assert result["returned_count"] == 1
@@ -73,28 +70,34 @@ async def test_search_filters_by_substring():
 
 @pytest.mark.asyncio
 async def test_limit_truncates_but_reports_total():
-    p, _ = _patch_mgr(SAMPLE_CLIENTS)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm.get_all_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import list_clients
 
         result = await list_clients(limit=1)
-    finally:
-        p.stop()
+
     assert result["total_count"] == 3
     assert result["returned_count"] == 1
     assert result["limit"] == 1
+    # back-compat: legacy `count` key preserved alongside the new returned_count
+    assert result["count"] == result["returned_count"]
 
 
 @pytest.mark.asyncio
 async def test_fields_selects_subset():
     # Valid on this branch: upstream/main (post-#299) emits a distinct `name` key.
-    p, _ = _patch_mgr(SAMPLE_CLIENTS)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm.get_all_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import list_clients
 
         result = await list_clients(fields="mac,name")
-    finally:
-        p.stop()
+
     client = result["clients"][0]
     assert set(client.keys()) == {"mac", "name"}
 
@@ -102,13 +105,15 @@ async def test_fields_selects_subset():
 @pytest.mark.asyncio
 async def test_name_and_hostname_are_distinct_post_pr299():
     # Guards the #299 interaction: user alias (name) vs DHCP hostname stay separate.
-    p, _ = _patch_mgr(SAMPLE_CLIENTS)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm.get_all_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import list_clients
 
         result = await list_clients()
-    finally:
-        p.stop()
+
     laptop = next(c for c in result["clients"] if c.get("mac") == "aa:bb:cc:00:00:01")
     assert laptop["name"] == "Laptop"
     assert laptop["hostname"] == "laptop"
@@ -134,27 +139,18 @@ CLIENT_DETAIL_RAW = {
 }
 
 
-def _patch_detail(client):
-    mock_conn = MagicMock()
-    mock_conn.site = "default"
-    p = patch("unifi_network_mcp.tools.clients.client_manager")
-    mock = p.start()
-    mock.get_client_details = AsyncMock(return_value=client)
-    mock._connection = mock_conn
-    return p, mock
-
-
 @pytest.mark.asyncio
 async def test_get_client_details_default_preserves_pr300_full_object():
     # Regression guard: default (no args) must return the full raw object in the
     # {success, site, client} envelope — byte-for-byte the #300 behavior, no trimming.
-    p, _ = _patch_detail(CLIENT_DETAIL_RAW)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=CLIENT_DETAIL_RAW)
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import get_client_details
 
         result = await get_client_details("aa:bb:cc:00:00:01")
-    finally:
-        p.stop()
+
     assert result["success"] is True
     assert "summary_mode" not in result and "include" not in result
     client = result["client"]
@@ -167,13 +163,14 @@ async def test_get_client_details_default_preserves_pr300_full_object():
 @pytest.mark.asyncio
 async def test_get_client_details_summary_trims_to_sections():
     # New behavior: summary=true trims to the named sections.
-    p, _ = _patch_detail(CLIENT_DETAIL_RAW)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=CLIENT_DETAIL_RAW)
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import get_client_details
 
         result = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="basic")
-    finally:
-        p.stop()
+
     assert result["summary_mode"] is True
     client = result["client"]
     assert client["mac"] == "aa:bb:cc:00:00:01"
@@ -183,14 +180,72 @@ async def test_get_client_details_summary_trims_to_sections():
 
 
 @pytest.mark.asyncio
+async def test_get_client_details_explicit_summary_false_raw_passthrough():
+    # Explicit summary=False symmetric to devices/network: passes the full raw object
+    # through under `client`, with summary_mode absent (default-path envelope).
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=CLIENT_DETAIL_RAW)
+        mock_cm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:01", summary=False)
+
+    assert result["success"] is True
+    assert "summary_mode" not in result  # raw envelope
+    assert result["client"]["tx_bytes"] == 1000
+    assert result["client"]["oui"] == "Acme"
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_summary_include_all_returns_every_section():
+    # include="all" must populate every section: basic + network + wireless (wireless
+    # only when the client isn't wired) + traffic + fingerprint.
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=CLIENT_DETAIL_RAW)
+        mock_cm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="all")
+
+    c = result["client"]
+    assert c["mac"] == "aa:bb:cc:00:00:01"  # basic
+    assert c["network_id"] == "net1"  # network
+    assert c["essid"] == "Home"  # wireless (client is wireless)
+    assert c["tx_bytes"] == 1000  # traffic
+    assert c["oui"] == "Acme"  # fingerprint
+
+
+@pytest.mark.asyncio
+async def test_list_clients_zero_items_case():
+    # Controller returns empty -> total_count=0, returned_count=0, count=0, clients=[].
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_clients = AsyncMock(return_value=[])
+        mock_cm.get_all_clients = AsyncMock(return_value=[])
+        mock_cm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.clients import list_clients
+
+        result = await list_clients()
+
+    assert result["success"] is True
+    assert result["total_count"] == 0
+    assert result["returned_count"] == 0
+    assert result["count"] == 0
+    assert result["clients"] == []
+
+
+@pytest.mark.asyncio
 async def test_get_client_details_not_found():
-    p, _ = _patch_detail(None)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=None)
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import get_client_details
 
         result = await get_client_details("aa:bb:cc:99:99:99")
-    finally:
-        p.stop()
+
     assert result["success"] is False
     assert "aa:bb:cc:99:99:99" in result["error"]
 
@@ -200,40 +255,77 @@ async def test_get_client_details_summary_status_offline_without_signal():
     # Offline/historical clients lack `is_online` and active-connection counters;
     # status must be derived as Offline, not defaulted to Online.
     offline_raw = {"mac": "aa:bb:cc:00:00:05", "hostname": "ghost", "is_wired": True}
-    p, _ = _patch_detail(offline_raw)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=offline_raw)
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import get_client_details
 
         result = await get_client_details("aa:bb:cc:00:00:05", summary=True, include="basic")
-    finally:
-        p.stop()
+
     assert result["client"]["status"] == "Offline"
 
 
 @pytest.mark.asyncio
 async def test_get_client_details_summary_status_online_with_signal():
     online_raw = {"mac": "aa:bb:cc:00:00:06", "hostname": "live", "is_wired": True, "is_online": True}
-    p, _ = _patch_detail(online_raw)
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=online_raw)
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import get_client_details
 
         result = await get_client_details("aa:bb:cc:00:00:06", summary=True, include="basic")
-    finally:
-        p.stop()
+
     assert result["client"]["status"] == "Online"
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_surfaces_unknown_include_sections():
+    # Typos in include must surface as `unknown_sections` so LLM callers can self-correct.
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=CLIENT_DETAIL_RAW)
+        mock_cm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="basix,traffic")
+
+    # known section still applied (traffic counters present)
+    assert result["client"]["tx_bytes"] == 1000
+    # typo surfaced
+    assert result.get("unknown_sections") == ["basix"]
+
+
+@pytest.mark.asyncio
+async def test_list_clients_surfaces_unknown_fields():
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm.get_all_clients = AsyncMock(return_value=list(SAMPLE_CLIENTS))
+        mock_cm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.clients import list_clients
+
+        result = await list_clients(fields="mac,naame")
+
+    # known field returned
+    assert "mac" in result["clients"][0]
+    # typo surfaced
+    assert result.get("unknown_fields") == ["naame"]
 
 
 @pytest.mark.asyncio
 async def test_get_client_details_summary_sections_are_independent():
     # wireless requested but absent-when-wired stays out; traffic populates when requested.
-    p, _ = _patch_detail(CLIENT_DETAIL_RAW)  # wireless client with tx_bytes
-    try:
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(return_value=CLIENT_DETAIL_RAW)
+        mock_cm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.clients import get_client_details
 
         basic_only = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="basic")
         with_traffic = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="traffic")
-    finally:
-        p.stop()
+
     # basic excludes wireless + traffic sections
     assert "essid" not in basic_only["client"]
     assert "tx_bytes" not in basic_only["client"]

--- a/apps/network/tests/unit/test_clients_filtering.py
+++ b/apps/network/tests/unit/test_clients_filtering.py
@@ -1,0 +1,241 @@
+"""Tests for list_clients filtering and field selection."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+SAMPLE_CLIENTS = [
+    {
+        "mac": "aa:bb:cc:00:00:01",
+        "name": "Laptop",
+        "hostname": "laptop",
+        "ip": "192.0.2.10",
+        "is_wired": False,
+        "essid": "Home",
+        "signal": -55,
+        "channel": 36,
+        "radio": "na",
+        "_id": "c1",
+    },
+    {
+        "mac": "aa:bb:cc:00:00:02",
+        "name": "Printer",
+        "hostname": "printer",
+        "ip": "192.0.2.11",
+        "is_wired": True,
+        "_id": "c2",
+    },
+    {
+        "mac": "aa:bb:cc:00:00:03",
+        "name": "Phone",
+        "hostname": "phone",
+        "ip": "192.0.2.12",
+        "is_wired": False,
+        "essid": "Home",
+        "signal": -61,
+        "channel": 6,
+        "radio": "ng",
+        "_id": "c3",
+    },
+]
+
+
+def _patch_mgr(clients):
+    mock_conn = MagicMock()
+    mock_conn.site = "default"
+    p = patch("unifi_network_mcp.tools.clients.client_manager")
+    mock = p.start()
+    mock.get_clients = AsyncMock(return_value=list(clients))
+    mock.get_all_clients = AsyncMock(return_value=list(clients))
+    mock._connection = mock_conn
+    return p, mock
+
+
+@pytest.mark.asyncio
+async def test_search_filters_by_substring():
+    p, _ = _patch_mgr(SAMPLE_CLIENTS)
+    try:
+        from unifi_network_mcp.tools.clients import list_clients
+
+        result = await list_clients(search="phone")
+    finally:
+        p.stop()
+    assert result["success"] is True
+    assert result["total_count"] == 1
+    assert result["returned_count"] == 1
+    assert result["clients"][0]["name"] == "Phone"
+
+
+@pytest.mark.asyncio
+async def test_limit_truncates_but_reports_total():
+    p, _ = _patch_mgr(SAMPLE_CLIENTS)
+    try:
+        from unifi_network_mcp.tools.clients import list_clients
+
+        result = await list_clients(limit=1)
+    finally:
+        p.stop()
+    assert result["total_count"] == 3
+    assert result["returned_count"] == 1
+    assert result["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fields_selects_subset():
+    # Valid on this branch: upstream/main (post-#299) emits a distinct `name` key.
+    p, _ = _patch_mgr(SAMPLE_CLIENTS)
+    try:
+        from unifi_network_mcp.tools.clients import list_clients
+
+        result = await list_clients(fields="mac,name")
+    finally:
+        p.stop()
+    client = result["clients"][0]
+    assert set(client.keys()) == {"mac", "name"}
+
+
+@pytest.mark.asyncio
+async def test_name_and_hostname_are_distinct_post_pr299():
+    # Guards the #299 interaction: user alias (name) vs DHCP hostname stay separate.
+    p, _ = _patch_mgr(SAMPLE_CLIENTS)
+    try:
+        from unifi_network_mcp.tools.clients import list_clients
+
+        result = await list_clients()
+    finally:
+        p.stop()
+    laptop = next(c for c in result["clients"] if c.get("mac") == "aa:bb:cc:00:00:01")
+    assert laptop["name"] == "Laptop"
+    assert laptop["hostname"] == "laptop"
+
+
+# ---------------------------------------------------------------------------
+# get_client_details — opt-in section selection (default preserves #300 full object)
+# ---------------------------------------------------------------------------
+
+CLIENT_DETAIL_RAW = {
+    "mac": "aa:bb:cc:00:00:01",
+    "name": "Laptop",
+    "hostname": "laptop",
+    "ip": "192.0.2.10",
+    "is_wired": False,
+    "is_online": True,
+    "essid": "Home",
+    "signal": -55,
+    "tx_bytes": 1000,
+    "rx_bytes": 2000,
+    "oui": "Acme",
+    "network_id": "net1",
+}
+
+
+def _patch_detail(client):
+    mock_conn = MagicMock()
+    mock_conn.site = "default"
+    p = patch("unifi_network_mcp.tools.clients.client_manager")
+    mock = p.start()
+    mock.get_client_details = AsyncMock(return_value=client)
+    mock._connection = mock_conn
+    return p, mock
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_default_preserves_pr300_full_object():
+    # Regression guard: default (no args) must return the full raw object in the
+    # {success, site, client} envelope — byte-for-byte the #300 behavior, no trimming.
+    p, _ = _patch_detail(CLIENT_DETAIL_RAW)
+    try:
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:01")
+    finally:
+        p.stop()
+    assert result["success"] is True
+    assert "summary_mode" not in result and "include" not in result
+    client = result["client"]
+    # Full raw fields present (not trimmed away)
+    assert client["tx_bytes"] == 1000
+    assert client["oui"] == "Acme"
+    assert client["essid"] == "Home"
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_summary_trims_to_sections():
+    # New behavior: summary=true trims to the named sections.
+    p, _ = _patch_detail(CLIENT_DETAIL_RAW)
+    try:
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="basic")
+    finally:
+        p.stop()
+    assert result["summary_mode"] is True
+    client = result["client"]
+    assert client["mac"] == "aa:bb:cc:00:00:01"
+    # basic section excludes traffic + fingerprint
+    assert "tx_bytes" not in client
+    assert "oui" not in client
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_not_found():
+    p, _ = _patch_detail(None)
+    try:
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:99:99:99")
+    finally:
+        p.stop()
+    assert result["success"] is False
+    assert "aa:bb:cc:99:99:99" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_summary_status_offline_without_signal():
+    # Offline/historical clients lack `is_online` and active-connection counters;
+    # status must be derived as Offline, not defaulted to Online.
+    offline_raw = {"mac": "aa:bb:cc:00:00:05", "hostname": "ghost", "is_wired": True}
+    p, _ = _patch_detail(offline_raw)
+    try:
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:05", summary=True, include="basic")
+    finally:
+        p.stop()
+    assert result["client"]["status"] == "Offline"
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_summary_status_online_with_signal():
+    online_raw = {"mac": "aa:bb:cc:00:00:06", "hostname": "live", "is_wired": True, "is_online": True}
+    p, _ = _patch_detail(online_raw)
+    try:
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:00:00:06", summary=True, include="basic")
+    finally:
+        p.stop()
+    assert result["client"]["status"] == "Online"
+
+
+@pytest.mark.asyncio
+async def test_get_client_details_summary_sections_are_independent():
+    # wireless requested but absent-when-wired stays out; traffic populates when requested.
+    p, _ = _patch_detail(CLIENT_DETAIL_RAW)  # wireless client with tx_bytes
+    try:
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        basic_only = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="basic")
+        with_traffic = await get_client_details("aa:bb:cc:00:00:01", summary=True, include="traffic")
+    finally:
+        p.stop()
+    # basic excludes wireless + traffic sections
+    assert "essid" not in basic_only["client"]
+    assert "tx_bytes" not in basic_only["client"]
+    # traffic section populates byte counters
+    assert with_traffic["client"]["tx_bytes"] == 1000

--- a/apps/network/tests/unit/test_devices_filtering.py
+++ b/apps/network/tests/unit/test_devices_filtering.py
@@ -1,0 +1,162 @@
+"""Tests for list_devices compression and get_device_details section selection."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+SWITCH_RAW = {
+    "mac": "aa:bb:cc:00:00:10",
+    "name": "Switch-A",
+    "ip": "192.0.2.20",
+    "type": "usw",
+    "model": "US24",
+    "state": 1,
+    "version": "6.0.0",
+    "adopted": True,
+    "port_table": [
+        {
+            "port_idx": 1,
+            "name": "Port 1",
+            "up": True,
+            "speed": 1000,
+            "poe_enable": True,
+            "poe_power": "3.2",
+            "last_connection": {"mac": "aa:bb:cc:00:00:99"},
+        },
+        {"port_idx": 2, "name": "Port 2", "up": False, "speed": 0, "poe_enable": False},
+    ],
+    "lldp_table": [{"local_port_idx": 1, "chassis_id": "aa:bb:cc:00:00:11", "chassis_name": "AP-1", "port_id": "eth0"}],
+}
+
+GATEWAY_RAW = {
+    "mac": "aa:bb:cc:00:00:20",
+    "name": "UDM",
+    "ip": "192.0.2.1",
+    "type": "udm",
+    "model": "UDMPRO",
+    "state": 1,
+    "wan1": {"ip": "203.0.113.5", "up": True},
+    "wan2": {},
+    "network_table": [{"_id": "n1"}, {"_id": "n2"}],
+    "system-stats": {"cpu": "12.5", "mem": "40.0"},
+}
+
+
+def _detail_mock(raw):
+    d = MagicMock()
+    d.raw = raw
+    return d
+
+
+def _patch_mgr(devices=None, detail=None):
+    mock_conn = MagicMock()
+    mock_conn.site = "default"
+    p = patch("unifi_network_mcp.tools.devices.device_manager")
+    mock = p.start()
+    mock.get_devices = AsyncMock(return_value=list(devices or []))
+    mock.get_device_details = AsyncMock(return_value=detail)
+    mock._connection = mock_conn
+    return p, mock
+
+
+@pytest.mark.asyncio
+async def test_get_device_details_ports_resolves_lldp_neighbor():
+    p, _ = _patch_mgr(detail=_detail_mock(SWITCH_RAW))
+    try:
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:00:00:10", include="ports")
+    finally:
+        p.stop()
+    assert result["success"] is True and result["summary_mode"] is True
+    port1 = next(pp for pp in result["device"]["port_summary"] if pp["port_idx"] == 1)
+    assert port1["lldp_neighbor"]["name"] == "AP-1"
+    assert port1["last_seen_mac"] == "aa:bb:cc:00:00:99"
+    port2 = next(pp for pp in result["device"]["port_summary"] if pp["port_idx"] == 2)
+    assert port2["lldp_neighbor"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_device_details_summary_false_returns_raw():
+    p, _ = _patch_mgr(detail=_detail_mock(SWITCH_RAW))
+    try:
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:00:00:10", summary=False)
+    finally:
+        p.stop()
+    assert result["summary_mode"] is False
+    assert result["device"] == SWITCH_RAW
+
+
+@pytest.mark.asyncio
+async def test_list_devices_search_reports_total():
+    p, _ = _patch_mgr(devices=[SWITCH_RAW, GATEWAY_RAW])
+    try:
+        from unifi_network_mcp.tools.devices import list_devices
+
+        result = await list_devices(search="udm")
+    finally:
+        p.stop()
+    assert result["total_count"] == 1 and result["returned_count"] == 1
+    assert result["devices"][0]["name"] == "UDM"
+
+
+@pytest.mark.asyncio
+async def test_list_devices_switch_summary_replaces_raw_table():
+    p, _ = _patch_mgr(devices=[SWITCH_RAW])
+    try:
+        from unifi_network_mcp.tools.devices import list_devices
+
+        result = await list_devices(device_type="switch", include_details=True)
+    finally:
+        p.stop()
+    dev = result["devices"][0]
+    assert dev["total_ports"] == 2 and dev["ports_up"] == 1
+    assert "port_table" not in dev  # compressed, not raw
+
+
+@pytest.mark.asyncio
+async def test_list_devices_gateway_summary_flattened():
+    p, _ = _patch_mgr(devices=[GATEWAY_RAW])
+    try:
+        from unifi_network_mcp.tools.devices import list_devices
+
+        result = await list_devices(device_type="gateway", include_details=True)
+    finally:
+        p.stop()
+    dev = result["devices"][0]
+    assert dev["wan1_ip"] == "203.0.113.5" and dev["wan1_up"] is True
+    assert dev["network_count"] == 2 and dev["cpu_usage"] == "12.5"
+
+
+@pytest.mark.asyncio
+async def test_get_device_details_not_found_returns_failure():
+    # A falsy device must yield success=False, not a silent {success: True, device: None}.
+    p, _ = _patch_mgr(detail=None)
+    try:
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:99:99:99")
+    finally:
+        p.stop()
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_devices_returns_all_by_default():
+    # No limit by default — preserves upstream behavior (no silent truncation).
+    p, _ = _patch_mgr(devices=[SWITCH_RAW, GATEWAY_RAW])
+    try:
+        from unifi_network_mcp.tools.devices import list_devices
+
+        result = await list_devices()
+    finally:
+        p.stop()
+    assert result["total_count"] == 2 and result["returned_count"] == 2
+    assert result["limit"] is None

--- a/apps/network/tests/unit/test_devices_filtering.py
+++ b/apps/network/tests/unit/test_devices_filtering.py
@@ -47,32 +47,51 @@ GATEWAY_RAW = {
 }
 
 
+def _mock_conn():
+    c = MagicMock()
+    c.site = "default"
+    return c
+
+
 def _detail_mock(raw):
     d = MagicMock()
     d.raw = raw
     return d
 
 
-def _patch_mgr(devices=None, detail=None):
-    mock_conn = MagicMock()
-    mock_conn.site = "default"
-    p = patch("unifi_network_mcp.tools.devices.device_manager")
-    mock = p.start()
-    mock.get_devices = AsyncMock(return_value=list(devices or []))
-    mock.get_device_details = AsyncMock(return_value=detail)
-    mock._connection = mock_conn
-    return p, mock
+@pytest.mark.asyncio
+async def test_get_device_details_default_preserves_pre_pr_full_raw_object():
+    # Regression guard for the default contract: no-args must return the full raw
+    # device object (port_table present, port_summary absent). Existing callers
+    # of unifi_get_device_details before this PR received the full raw object.
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_device_details = AsyncMock(return_value=_detail_mock(SWITCH_RAW))
+        mock_dm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:00:00:10")
+
+    assert result["success"] is True
+    assert result["summary_mode"] is False
+    assert result["device"] == SWITCH_RAW
+    # raw keys present; summary keys absent
+    assert "port_table" in result["device"]
+    assert "lldp_table" in result["device"]
+    assert "port_summary" not in result["device"]
 
 
 @pytest.mark.asyncio
 async def test_get_device_details_ports_resolves_lldp_neighbor():
-    p, _ = _patch_mgr(detail=_detail_mock(SWITCH_RAW))
-    try:
+    # Opt-in summary path: summary=True, include="ports" -> port_summary with LLDP resolved.
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_device_details = AsyncMock(return_value=_detail_mock(SWITCH_RAW))
+        mock_dm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.devices import get_device_details
 
-        result = await get_device_details("aa:bb:cc:00:00:10", include="ports")
-    finally:
-        p.stop()
+        result = await get_device_details("aa:bb:cc:00:00:10", summary=True, include="ports")
+
     assert result["success"] is True and result["summary_mode"] is True
     port1 = next(pp for pp in result["device"]["port_summary"] if pp["port_idx"] == 1)
     assert port1["lldp_neighbor"]["name"] == "AP-1"
@@ -82,40 +101,31 @@ async def test_get_device_details_ports_resolves_lldp_neighbor():
 
 
 @pytest.mark.asyncio
-async def test_get_device_details_summary_false_returns_raw():
-    p, _ = _patch_mgr(detail=_detail_mock(SWITCH_RAW))
-    try:
-        from unifi_network_mcp.tools.devices import get_device_details
-
-        result = await get_device_details("aa:bb:cc:00:00:10", summary=False)
-    finally:
-        p.stop()
-    assert result["summary_mode"] is False
-    assert result["device"] == SWITCH_RAW
-
-
-@pytest.mark.asyncio
 async def test_list_devices_search_reports_total():
-    p, _ = _patch_mgr(devices=[SWITCH_RAW, GATEWAY_RAW])
-    try:
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_devices = AsyncMock(return_value=[SWITCH_RAW, GATEWAY_RAW])
+        mock_dm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.devices import list_devices
 
         result = await list_devices(search="udm")
-    finally:
-        p.stop()
+
     assert result["total_count"] == 1 and result["returned_count"] == 1
     assert result["devices"][0]["name"] == "UDM"
+    # back-compat: legacy `count` key preserved alongside returned_count
+    assert result["count"] == result["returned_count"]
 
 
 @pytest.mark.asyncio
 async def test_list_devices_switch_summary_replaces_raw_table():
-    p, _ = _patch_mgr(devices=[SWITCH_RAW])
-    try:
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_devices = AsyncMock(return_value=[SWITCH_RAW])
+        mock_dm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.devices import list_devices
 
         result = await list_devices(device_type="switch", include_details=True)
-    finally:
-        p.stop()
+
     dev = result["devices"][0]
     assert dev["total_ports"] == 2 and dev["ports_up"] == 1
     assert "port_table" not in dev  # compressed, not raw
@@ -123,40 +133,157 @@ async def test_list_devices_switch_summary_replaces_raw_table():
 
 @pytest.mark.asyncio
 async def test_list_devices_gateway_summary_flattened():
-    p, _ = _patch_mgr(devices=[GATEWAY_RAW])
-    try:
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_devices = AsyncMock(return_value=[GATEWAY_RAW])
+        mock_dm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.devices import list_devices
 
         result = await list_devices(device_type="gateway", include_details=True)
-    finally:
-        p.stop()
+
     dev = result["devices"][0]
     assert dev["wan1_ip"] == "203.0.113.5" and dev["wan1_up"] is True
     assert dev["network_count"] == 2 and dev["cpu_usage"] == "12.5"
 
 
 @pytest.mark.asyncio
+async def test_get_device_details_surfaces_unknown_include_sections():
+    # Typos in include must surface as `unknown_sections` so LLM callers can self-correct.
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_device_details = AsyncMock(return_value=_detail_mock(SWITCH_RAW))
+        mock_dm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:00:00:10", summary=True, include="basic,prts")
+
+    # known section still applied (basic fields present)
+    assert result["device"]["mac"] == SWITCH_RAW["mac"]
+    # typo surfaced
+    assert result.get("unknown_sections") == ["prts"]
+
+
+@pytest.mark.asyncio
 async def test_get_device_details_not_found_returns_failure():
     # A falsy device must yield success=False, not a silent {success: True, device: None}.
-    p, _ = _patch_mgr(detail=None)
-    try:
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_device_details = AsyncMock(return_value=None)
+        mock_dm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.devices import get_device_details
 
         result = await get_device_details("aa:bb:cc:99:99:99")
-    finally:
-        p.stop()
+
     assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_devices_include_details_summary_false_returns_raw_tables():
+    # summary=False with include_details=True returns the pre-PR legacy raw shape
+    # (port_table, wan1, network_table, system_stats) instead of the compressed
+    # summaries; lets callers who need full tables opt out of compression.
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_devices = AsyncMock(return_value=[SWITCH_RAW, GATEWAY_RAW])
+        mock_dm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.devices import list_devices
+
+        result = await list_devices(include_details=True, summary=False)
+
+    sw = next(d for d in result["devices"] if d["name"] == "Switch-A")
+    gw = next(d for d in result["devices"] if d["name"] == "UDM")
+    # switch: raw port table present (under legacy 'ports' key), compressed keys absent
+    assert sw["ports"] == SWITCH_RAW["port_table"]
+    assert sw["total_ports"] == len(SWITCH_RAW["port_table"])
+    assert "ports_up" not in sw
+    assert "ports_poe_enabled" not in sw
+    # legacy poe_info wrapper present
+    assert "poe_info" in sw and isinstance(sw["poe_info"], dict)
+    # gateway: raw wan/network tables present, flattened keys absent
+    assert gw["wan1"] == GATEWAY_RAW["wan1"]
+    assert gw["network_table"] == GATEWAY_RAW["network_table"]
+    assert gw["system_stats"] == GATEWAY_RAW["system-stats"]
+    assert "wan1_ip" not in gw
+    assert "network_count" not in gw
+    assert "cpu_usage" not in gw
+
+
+@pytest.mark.asyncio
+async def test_get_device_details_summary_include_all_returns_every_section():
+    # include="all" populates every section: basic + ports + radios (if any) + stats +
+    # uplink (if any) + lldp.
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_device_details = AsyncMock(return_value=_detail_mock(SWITCH_RAW))
+        mock_dm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:00:00:10", summary=True, include="all")
+
+    d = result["device"]
+    assert d["mac"] == SWITCH_RAW["mac"]  # basic
+    assert d["port_count"] == len(SWITCH_RAW["port_table"])  # ports
+    assert d["lldp_table"] == SWITCH_RAW["lldp_table"]  # lldp
+
+
+@pytest.mark.asyncio
+async def test_get_device_details_port_last_seen_mac_without_lldp_neighbor():
+    # When a port has last_seen_mac but no LLDP entry, lldp_neighbor must be None
+    # (wireless client traffic case — last_seen_mac is the wireless client's MAC,
+    # not infrastructure).
+    raw = {
+        **SWITCH_RAW,
+        "port_table": [
+            {
+                "port_idx": 7,
+                "name": "Port 7",
+                "up": True,
+                "speed": 100,
+                "poe_enable": False,
+                # last_seen_mac is a wireless client's MAC -> no LLDP entry expected
+                "last_connection": {"mac": "aa:bb:cc:00:00:cc"},
+            },
+        ],
+        "lldp_table": [],  # no LLDP infrastructure on this port
+    }
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_device_details = AsyncMock(return_value=_detail_mock(raw))
+        mock_dm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.devices import get_device_details
+
+        result = await get_device_details("aa:bb:cc:00:00:10", summary=True, include="ports")
+
+    port = result["device"]["port_summary"][0]
+    assert port["last_seen_mac"] == "aa:bb:cc:00:00:cc"
+    assert port["lldp_neighbor"] is None  # not infrastructure — wireless client traffic
+
+
+@pytest.mark.asyncio
+async def test_list_devices_zero_items_case():
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_devices = AsyncMock(return_value=[])
+        mock_dm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.devices import list_devices
+
+        result = await list_devices()
+
+    assert result["total_count"] == 0 and result["returned_count"] == 0
+    assert result["count"] == 0
+    assert result["devices"] == []
 
 
 @pytest.mark.asyncio
 async def test_list_devices_returns_all_by_default():
     # No limit by default — preserves upstream behavior (no silent truncation).
-    p, _ = _patch_mgr(devices=[SWITCH_RAW, GATEWAY_RAW])
-    try:
+    with patch("unifi_network_mcp.tools.devices.device_manager") as mock_dm:
+        mock_dm.get_devices = AsyncMock(return_value=[SWITCH_RAW, GATEWAY_RAW])
+        mock_dm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.devices import list_devices
 
         result = await list_devices()
-    finally:
-        p.stop()
+
     assert result["total_count"] == 2 and result["returned_count"] == 2
     assert result["limit"] is None

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -92,6 +92,8 @@ class TestListFirewallPolicies:
         assert result["success"] is True
         assert result["total_count"] == 1
         assert result["returned_count"] == 1
+        # back-compat: legacy `count` key preserved alongside returned_count
+        assert result["count"] == result["returned_count"]
         policy = result["policies"][0]
         # Model-based shaping: id, name, action, enabled surface correctly
         assert policy["id"] == "pol_legacy_001"
@@ -157,6 +159,94 @@ class TestListFirewallPolicies:
 
         assert block_result["returned_count"] == 1
         assert block_result["policies"][0]["id"] == "pol_block"
+
+    @pytest.mark.asyncio
+    async def test_filter_composition_action_enabled_only_search(self):
+        """action + enabled_only + search compose correctly (all three must match)."""
+        # 4 policies covering the truth table of the composed filter.
+        p_match = {
+            **SAMPLE_ZONE_POLICY_RAW,
+            "_id": "p_match",
+            "name": "match-target",
+            "enabled": True,
+            "action": "ALLOW",
+        }
+        p_wrong_action = {
+            **SAMPLE_ZONE_POLICY_RAW,
+            "_id": "p_wa",
+            "name": "match-target",
+            "enabled": True,
+            "action": "BLOCK",
+        }
+        p_disabled = {
+            **SAMPLE_ZONE_POLICY_RAW,
+            "_id": "p_dis",
+            "name": "match-target",
+            "enabled": False,
+            "action": "ALLOW",
+        }
+        p_wrong_name = {**SAMPLE_ZONE_POLICY_RAW, "_id": "p_wn", "name": "no-match", "enabled": True, "action": "ALLOW"}
+        policies = [_make_policy(p) for p in (p_match, p_wrong_action, p_disabled, p_wrong_name)]
+
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=policies)
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+            result = await list_firewall_policies(
+                action="ALLOW", enabled_only=True, search="match-target", include_predefined=False
+            )
+
+        assert result["returned_count"] == 1
+        assert result["policies"][0]["id"] == "p_match"
+
+    @pytest.mark.asyncio
+    async def test_zero_items_case(self):
+        """Controller returns no policies -> total_count=0, returned_count=0, policies=[]."""
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[])
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+            result = await list_firewall_policies(include_predefined=False)
+
+        assert result["total_count"] == 0 and result["returned_count"] == 0
+        assert result["count"] == 0
+        assert result["policies"] == []
+
+    @pytest.mark.asyncio
+    async def test_summary_false_returns_full_model_dump(self):
+        """summary=False returns the legacy fw_from_controller().model_dump() shape —
+        protocol/ip_version/logging/index present, not narrowed to the curated 6 keys."""
+        mock_policy = _make_policy(SAMPLE_ZONE_POLICY_RAW)
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+            curated = await list_firewall_policies(include_predefined=False)  # default summary=True
+            raw = await list_firewall_policies(summary=False, include_predefined=False)
+
+        # curated path: narrowed 6-key entry + targeting; protocol/logging absent
+        cp = curated["policies"][0]
+        assert "protocol" not in cp and "logging" not in cp and "ip_version" not in cp
+        # raw path: full model dump fields present
+        rp = raw["policies"][0]
+        assert rp.get("protocol") == "all"
+        assert rp.get("ip_version") == "BOTH"
+        assert rp.get("logging") is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -90,7 +90,8 @@ class TestListFirewallPolicies:
             result = await list_firewall_policies(include_predefined=False)
 
         assert result["success"] is True
-        assert result["count"] == 1
+        assert result["total_count"] == 1
+        assert result["returned_count"] == 1
         policy = result["policies"][0]
         # Model-based shaping: id, name, action, enabled surface correctly
         assert policy["id"] == "pol_legacy_001"
@@ -125,6 +126,37 @@ class TestListFirewallPolicies:
         assert policy["source"]["network_ids"] == ["iot-network-id"]
         assert policy["destination"]["matching_target"] == "IP"
         assert policy["destination"]["ips"] == ["192.168.1.100"]
+
+    @pytest.mark.asyncio
+    async def test_action_filter_uppercase_v2(self):
+        """Action filter must match V2 uppercase values (ALLOW/BLOCK/REJECT) case-insensitively."""
+        allow_policy_raw = {**SAMPLE_ZONE_POLICY_RAW, "_id": "pol_allow", "action": "ALLOW"}
+        block_policy_raw = {**SAMPLE_ZONE_POLICY_RAW, "_id": "pol_block", "action": "BLOCK"}
+        reject_policy_raw = {**SAMPLE_ZONE_POLICY_RAW, "_id": "pol_reject", "action": "REJECT"}
+        policies = [_make_policy(p) for p in (allow_policy_raw, block_policy_raw, reject_policy_raw)]
+
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=policies)
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+            uppercase_result = await list_firewall_policies(action="ALLOW", include_predefined=False)
+            lowercase_result = await list_firewall_policies(action="allow", include_predefined=False)
+            block_result = await list_firewall_policies(action="block", include_predefined=False)
+
+        assert uppercase_result["success"] is True
+        assert uppercase_result["returned_count"] == 1
+        assert uppercase_result["policies"][0]["id"] == "pol_allow"
+
+        assert lowercase_result["returned_count"] == 1
+        assert lowercase_result["policies"][0]["id"] == "pol_allow"
+
+        assert block_result["returned_count"] == 1
+        assert block_result["policies"][0]["id"] == "pol_block"
 
 
 # ---------------------------------------------------------------------------
@@ -1094,3 +1126,29 @@ class TestListFirewallZones:
         # Crucially: no silent empty-list-as-success.
         assert "zones" not in result or result.get("zones") in (None, [])
         assert result.get("count", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_firewall_policies_routes_through_typed_model():
+    """Discriminator for the model-routing path: FirewallRule coerces index str->int.
+
+    A raw `p.get("index")` would keep the string "3000"; routing through
+    fw_from_controller yields int 3000. This test fails if the tool reverts to
+    reading raw dict values directly.
+    """
+    raw = {"_id": "pol_x", "name": "X", "enabled": True, "action": "ALLOW", "index": "3000"}
+    mock_policy = _make_policy(raw)
+    mock_conn = MagicMock()
+    mock_conn.site = "default"
+
+    with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+        mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+        mock_fm._connection = mock_conn
+
+        from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+        result = await list_firewall_policies(include_predefined=False)
+
+    policy = result["policies"][0]
+    assert policy["rule_index"] == 3000
+    assert isinstance(policy["rule_index"], int)  # int (model coercion), not "3000" from raw

--- a/apps/network/tests/unit/test_network_filtering.py
+++ b/apps/network/tests/unit/test_network_filtering.py
@@ -1,0 +1,141 @@
+"""Tests for list_networks / get_network_details / list_wlans filtering."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+NETWORKS = [
+    {"_id": "n1", "name": "Default", "enabled": True, "purpose": "corporate", "vlan": 1, "ip_subnet": "192.0.2.0/24"},
+    {"_id": "n2", "name": "IoT", "enabled": True, "purpose": "corporate", "vlan": 20, "ip_subnet": "198.51.100.0/24"},
+    {"_id": "n3", "name": "Guest", "enabled": True, "purpose": "guest", "vlan": 30, "ip_subnet": "203.0.113.0/24"},
+]
+
+
+def _patch(networks=None, detail=None, wlans=None):
+    mock_conn = MagicMock()
+    mock_conn.site = "default"
+    p = patch("unifi_network_mcp.tools.network.network_manager")
+    mock = p.start()
+    mock.get_networks = AsyncMock(return_value=list(networks or []))
+    mock.get_network_details = AsyncMock(return_value=detail)
+    mock.get_wlans = AsyncMock(return_value=list(wlans or []))
+    mock._connection = mock_conn
+    return p, mock
+
+
+@pytest.mark.asyncio
+async def test_list_networks_purpose_and_fields():
+    p, _ = _patch(networks=NETWORKS)
+    try:
+        from unifi_network_mcp.tools.network import list_networks
+
+        result = await list_networks(purpose="guest", fields="_id,name")
+    finally:
+        p.stop()
+    assert result["total_count"] == 1
+    assert set(result["networks"][0].keys()) == {"_id", "name"}
+
+
+@pytest.mark.asyncio
+async def test_list_networks_purpose_is_case_insensitive():
+    # Mixed-case input must match the lowercase controller value, consistent with
+    # the search/action filters elsewhere (which normalize case).
+    p, _ = _patch(networks=NETWORKS)
+    try:
+        from unifi_network_mcp.tools.network import list_networks
+
+        result = await list_networks(purpose="Guest")
+    finally:
+        p.stop()
+    assert result["total_count"] == 1
+    assert result["networks"][0]["name"] == "Guest"
+
+
+@pytest.mark.asyncio
+async def test_list_networks_search_matches_vlan_id():
+    # Prod semantics: VLAN match is equality on str(vlan), name match is substring.
+    p, _ = _patch(networks=NETWORKS)
+    try:
+        from unifi_network_mcp.tools.network import list_networks
+
+        result = await list_networks(search="20")
+    finally:
+        p.stop()
+    assert result["total_count"] == 1
+    assert result["networks"][0]["name"] == "IoT"
+
+
+@pytest.mark.asyncio
+async def test_get_network_details_summary_false_returns_raw():
+    raw = {"_id": "n2", "name": "IoT", "dhcpd_enabled": True, "secret": "x"}
+    p, _ = _patch(detail=raw)
+    try:
+        from unifi_network_mcp.tools.network import get_network_details
+
+        result = await get_network_details("n2", summary=False)
+    finally:
+        p.stop()
+    assert result["summary_mode"] is False
+    assert result["details"]["secret"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_get_network_details_dhcp_section_is_independent():
+    # Each section is independent: include="dhcp" must NOT auto-add basic keys.
+    raw = {
+        "_id": "n2",
+        "name": "IoT",
+        "purpose": "corporate",
+        "dhcpd_enabled": True,
+        "dhcpd_start": "198.51.100.10",
+    }
+    p, _ = _patch(detail=raw)
+    try:
+        from unifi_network_mcp.tools.network import get_network_details
+
+        result = await get_network_details("n2", include="dhcp")
+    finally:
+        p.stop()
+    details = result["details"]
+    assert details["dhcpd_enabled"] is True
+    assert "name" not in details  # basic not requested
+
+
+@pytest.mark.asyncio
+async def test_list_wlans_enabled_only_and_search():
+    wlans = [
+        {"_id": "w1", "name": "Home", "enabled": True},
+        {"_id": "w2", "name": "Guest", "enabled": False},
+    ]
+    p, _ = _patch(wlans=wlans)
+    try:
+        from unifi_network_mcp.tools.network import list_wlans
+
+        enabled = await list_wlans(enabled_only=True)
+        searched = await list_wlans(search="guest")
+    finally:
+        p.stop()
+    assert enabled["total_count"] == 1 and enabled["wlans"][0]["id"] == "w1"
+    assert searched["total_count"] == 1 and searched["wlans"][0]["id"] == "w2"
+
+
+@pytest.mark.asyncio
+async def test_list_networks_routes_through_typed_model():
+    # Discriminator for the model-routing path: the Network model coerces vlan to str.
+    # A raw `.get("vlan")` would return int 20; routing through network_from_controller
+    # yields "20". This test fails if the tool reverts to reading raw dict values.
+    p, _ = _patch(networks=[{"_id": "n9", "name": "Lab", "vlan": 20, "enabled": True}])
+    try:
+        from unifi_network_mcp.tools.network import list_networks
+
+        result = await list_networks()
+    finally:
+        p.stop()
+    net = result["networks"][0]
+    assert net["_id"] == "n9"
+    assert net["vlan"] == "20"  # str (model coercion), not int 20 from raw

--- a/apps/network/tests/unit/test_network_filtering.py
+++ b/apps/network/tests/unit/test_network_filtering.py
@@ -16,42 +16,40 @@ NETWORKS = [
 ]
 
 
-def _patch(networks=None, detail=None, wlans=None):
-    mock_conn = MagicMock()
-    mock_conn.site = "default"
-    p = patch("unifi_network_mcp.tools.network.network_manager")
-    mock = p.start()
-    mock.get_networks = AsyncMock(return_value=list(networks or []))
-    mock.get_network_details = AsyncMock(return_value=detail)
-    mock.get_wlans = AsyncMock(return_value=list(wlans or []))
-    mock._connection = mock_conn
-    return p, mock
+def _mock_conn():
+    c = MagicMock()
+    c.site = "default"
+    return c
 
 
 @pytest.mark.asyncio
 async def test_list_networks_purpose_and_fields():
-    p, _ = _patch(networks=NETWORKS)
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_networks = AsyncMock(return_value=list(NETWORKS))
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import list_networks
 
         result = await list_networks(purpose="guest", fields="_id,name")
-    finally:
-        p.stop()
+
     assert result["total_count"] == 1
     assert set(result["networks"][0].keys()) == {"_id", "name"}
+    # back-compat: legacy `count` key preserved alongside returned_count
+    assert result["count"] == result["returned_count"]
 
 
 @pytest.mark.asyncio
 async def test_list_networks_purpose_is_case_insensitive():
     # Mixed-case input must match the lowercase controller value, consistent with
     # the search/action filters elsewhere (which normalize case).
-    p, _ = _patch(networks=NETWORKS)
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_networks = AsyncMock(return_value=list(NETWORKS))
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import list_networks
 
         result = await list_networks(purpose="Guest")
-    finally:
-        p.stop()
+
     assert result["total_count"] == 1
     assert result["networks"][0]["name"] == "Guest"
 
@@ -59,13 +57,14 @@ async def test_list_networks_purpose_is_case_insensitive():
 @pytest.mark.asyncio
 async def test_list_networks_search_matches_vlan_id():
     # Prod semantics: VLAN match is equality on str(vlan), name match is substring.
-    p, _ = _patch(networks=NETWORKS)
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_networks = AsyncMock(return_value=list(NETWORKS))
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import list_networks
 
         result = await list_networks(search="20")
-    finally:
-        p.stop()
+
     assert result["total_count"] == 1
     assert result["networks"][0]["name"] == "IoT"
 
@@ -73,20 +72,43 @@ async def test_list_networks_search_matches_vlan_id():
 @pytest.mark.asyncio
 async def test_get_network_details_summary_false_returns_raw():
     raw = {"_id": "n2", "name": "IoT", "dhcpd_enabled": True, "secret": "x"}
-    p, _ = _patch(detail=raw)
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_network_details = AsyncMock(return_value=raw)
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import get_network_details
 
         result = await get_network_details("n2", summary=False)
-    finally:
-        p.stop()
+
     assert result["summary_mode"] is False
     assert result["details"]["secret"] == "x"
 
 
 @pytest.mark.asyncio
+async def test_get_network_details_default_preserves_pre_pr_full_raw_object():
+    # Regression guard for the default contract: no-args must return the full raw
+    # network object (extra keys like 'secret' pass through). Pre-PR upstream
+    # returned the raw object via json.loads(json.dumps(network)).
+    raw = {"_id": "n2", "name": "IoT", "dhcpd_enabled": True, "secret": "x", "purpose": "corporate"}
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_network_details = AsyncMock(return_value=raw)
+        mock_nm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.network import get_network_details
+
+        result = await get_network_details("n2")
+
+    assert result["success"] is True
+    assert result["summary_mode"] is False
+    # extra/unknown keys preserved (raw passthrough)
+    assert result["details"]["secret"] == "x"
+    assert result["details"]["dhcpd_enabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_network_details_dhcp_section_is_independent():
-    # Each section is independent: include="dhcp" must NOT auto-add basic keys.
+    # Opt-in summary path: each section is independent. include="dhcp" must NOT
+    # auto-add basic keys; must request summary=True to enter the section path.
     raw = {
         "_id": "n2",
         "name": "IoT",
@@ -94,16 +116,48 @@ async def test_get_network_details_dhcp_section_is_independent():
         "dhcpd_enabled": True,
         "dhcpd_start": "198.51.100.10",
     }
-    p, _ = _patch(detail=raw)
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_network_details = AsyncMock(return_value=raw)
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import get_network_details
 
-        result = await get_network_details("n2", include="dhcp")
-    finally:
-        p.stop()
+        result = await get_network_details("n2", summary=True, include="dhcp")
+
     details = result["details"]
     assert details["dhcpd_enabled"] is True
     assert "name" not in details  # basic not requested
+
+
+@pytest.mark.asyncio
+async def test_get_network_details_surfaces_unknown_include_sections():
+    raw = {"_id": "n2", "name": "IoT", "purpose": "corporate", "dhcpd_enabled": True}
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_network_details = AsyncMock(return_value=raw)
+        mock_nm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.network import get_network_details
+
+        result = await get_network_details("n2", summary=True, include="dhcp,vpnn")
+
+    # known section applied
+    assert result["details"]["dhcpd_enabled"] is True
+    # typo surfaced
+    assert result.get("unknown_sections") == ["vpnn"]
+
+
+@pytest.mark.asyncio
+async def test_list_networks_surfaces_unknown_fields():
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_networks = AsyncMock(return_value=list(NETWORKS))
+        mock_nm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.network import list_networks
+
+        result = await list_networks(fields="name,vlann")
+
+    assert "name" in result["networks"][0]
+    assert result.get("unknown_fields") == ["vlann"]
 
 
 @pytest.mark.asyncio
@@ -112,16 +166,20 @@ async def test_list_wlans_enabled_only_and_search():
         {"_id": "w1", "name": "Home", "enabled": True},
         {"_id": "w2", "name": "Guest", "enabled": False},
     ]
-    p, _ = _patch(wlans=wlans)
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_wlans = AsyncMock(return_value=list(wlans))
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import list_wlans
 
         enabled = await list_wlans(enabled_only=True)
         searched = await list_wlans(search="guest")
-    finally:
-        p.stop()
+
     assert enabled["total_count"] == 1 and enabled["wlans"][0]["id"] == "w1"
     assert searched["total_count"] == 1 and searched["wlans"][0]["id"] == "w2"
+    # back-compat: legacy `count` key preserved on list_wlans
+    assert enabled["count"] == enabled["returned_count"]
+    assert searched["count"] == searched["returned_count"]
 
 
 @pytest.mark.asyncio
@@ -129,13 +187,14 @@ async def test_list_networks_routes_through_typed_model():
     # Discriminator for the model-routing path: the Network model coerces vlan to str.
     # A raw `.get("vlan")` would return int 20; routing through network_from_controller
     # yields "20". This test fails if the tool reverts to reading raw dict values.
-    p, _ = _patch(networks=[{"_id": "n9", "name": "Lab", "vlan": 20, "enabled": True}])
-    try:
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_nm:
+        mock_nm.get_networks = AsyncMock(return_value=[{"_id": "n9", "name": "Lab", "vlan": 20, "enabled": True}])
+        mock_nm._connection = _mock_conn()
+
         from unifi_network_mcp.tools.network import list_networks
 
         result = await list_networks()
-    finally:
-        p.stop()
+
     net = result["networks"][0]
     assert net["_id"] == "n9"
     assert net["vlan"] == "20"  # str (model coercion), not int 20 from raw

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -72,7 +72,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_device_details` | Read | Returns device data for one device by MAC address with section-based selection. |
+| `unifi_get_device_details` | Read | Returns device data for one device by MAC address. |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
 | `unifi_get_pdu_outlets` | Read | Return per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip). |
 | `unifi_get_rf_scan_results` | Read | Get RF spectrum scan results for an access point. |
@@ -140,7 +140,7 @@ Always available, regardless of registration mode.
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_ap_group_details` | Read | Get details of a specific AP group by ID, including member APs and WLANs. |
-| `unifi_get_network_details` | Read | Get details for a specific network by ID with section-based selection. |
+| `unifi_get_network_details` | Read | Get details for a specific network by ID. |
 | `unifi_get_wlan_details` | Read | Get details for a specific WLAN by ID. |
 | `unifi_list_ap_groups` | Read | List all AP groups configured on the controller. |
 | `unifi_list_networks` | Read | Returns configured networks (LAN, WAN, VLAN-only) with name, purpose, IP subnet, VLAN ID, DHCP settings, and enabled state. |

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -44,7 +44,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_client_details` | Read | Returns the full raw client object for one client by MAC address — all controller-reported fields including connection stats, DHCP info, ... |
+| `unifi_get_client_details` | Read | Returns client data for one client by MAC address. |
 | `unifi_list_blocked_clients` | Read | Lists clients/devices currently blocked from the network. |
 | `unifi_list_clients` | Read | Returns connected clients with mac, name, hostname, ip, status (online/offline), connection type (wired/wireless), and for wireless clien... |
 | `unifi_lookup_by_ip` | Read | Quick IP-to-client lookup. |
@@ -72,7 +72,7 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_device_details` | Read | Returns the full raw device object for one device by MAC address — includes radio tables, port tables, system stats, WAN info, firmware d... |
+| `unifi_get_device_details` | Read | Returns device data for one device by MAC address with section-based selection. |
 | `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
 | `unifi_get_pdu_outlets` | Read | Return per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip). |
 | `unifi_get_rf_scan_results` | Read | Get RF spectrum scan results for an access point. |
@@ -140,11 +140,11 @@ Always available, regardless of registration mode.
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_ap_group_details` | Read | Get details of a specific AP group by ID, including member APs and WLANs. |
-| `unifi_get_network_details` | Read | Get details for a specific network by ID. |
+| `unifi_get_network_details` | Read | Get details for a specific network by ID with section-based selection. |
 | `unifi_get_wlan_details` | Read | Get details for a specific WLAN by ID. |
 | `unifi_list_ap_groups` | Read | List all AP groups configured on the controller. |
-| `unifi_list_networks` | Read | Returns all configured networks (LAN, WAN, VLAN-only) with name, purpose, IP subnet, VLAN ID, DHCP settings, and enabled state. |
-| `unifi_list_wlans` | Read | List all configured Wireless LANs (WLANs) on the Unifi Network controller. |
+| `unifi_list_networks` | Read | Returns configured networks (LAN, WAN, VLAN-only) with name, purpose, IP subnet, VLAN ID, DHCP settings, and enabled state. |
+| `unifi_list_wlans` | Read | List configured Wireless LANs (WLANs) on the Unifi Network controller. |
 | `unifi_create_ap_group` | Mutate | Create a new AP group to control which APs broadcast which SSIDs. |
 | `unifi_create_network` | Mutate | Create a new network (LAN/VLAN) with schema validation. |
 | `unifi_create_wlan` | Mutate | Create a new Wireless LAN (WLAN/SSID) with schema validation. |


### PR DESCRIPTION
## Summary

The network read tools (`list_clients`, `list_devices`/`get_device_details`, `list_networks`/`get_network_details`, `list_wlans`, `list_firewall_policies`) can return very large controller payloads — full radio/port/network tables, every client, all raw fields. For MCP/LLM callers that's a lot of tokens for data they often don't need.

This PR adds **opt-in** controls to trim those responses, using one consistent pattern across the tools:

- **`search`** — case-insensitive substring filter (name/hostname/IP/MAC, or SSID/VLAN as appropriate).
- **`limit`** — cap rows, with `total_count` / `returned_count` in the response so truncation is explicit.
- **`fields`** — comma-separated subset of fields per row (where applicable).
- **`include`** — comma-separated section selector on the detail tools (`get_device_details`, `get_network_details`, `get_client_details`), with `summary=false` as a full-raw-data escape hatch. For `get_client_details`, `summary` defaults to `false`, so its default response is unchanged from #300 (the full raw object); trimming is strictly opt-in.
- **Compressed list summaries** for `list_devices` (`include_details=true`): AP radio/vap counts, switch port up/PoE counts, gateway WAN/stat flattening — instead of the full nested tables.

It also improves `get_device_details` port data with **LLDP neighbor resolution**: each `port_summary` entry distinguishes `last_seen_mac` (last MAC seen on the port — may be wireless client traffic, unreliable) from `lldp_neighbor` (the actual directly-connected infrastructure device, from the LLDP table).

These tools have been running in my deployment for ~a month; this PR ports them onto current `main` and adds the unit-test coverage they previously lacked.

## Points worth your attention (please weigh in)

1. **Could be split.** It's one cohesive theme, but if you'd rather review in pieces, the `get_device_details` LLDP-accuracy improvement is cleanly separable from the filtering work.

## Note on the list serializers

`list_networks` and `list_firewall_policies` still go through `network_from_controller` / `fw_from_controller`; they source values from the typed model and then narrow to a curated lean subset (the full model dump is the token bloat this PR targets), with `list_networks` also backing the optional `fields` selector. One small consequence: values reflect the model's coercion (e.g. `Network.vlan` is typed `str`, so the listed `vlan` is a string).

## Backward compatibility

Fully additive — all new parameters are optional and default to the existing behavior. `list_clients` keeps its default `limit` of 100; `list_devices` returns all devices unless `limit` is passed; `get_client_details` defaults to the full raw object. The one shape change is that list responses replace the `count` field with `total_count`/`returned_count`/`limit` (plus echoed filter values).

## Testing

- New: `test_clients_filtering.py`, `test_devices_filtering.py`, `test_network_filtering.py`; updated `test_firewall_tools.py` for the new response shape.
- Full `apps/network` suite passes (689 tests); `ruff format --check` and `ruff check` clean.
- `tools_manifest.json` regenerated.
