### PR TITLE
feat(protect): add alarm rule CRUD (list/get/create/update/delete) and GraphQL exposure

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -190,6 +190,28 @@ type AlarmProfileList {
   count: Int
 }
 
+"""
+A UniFi Protect alarm rule (Alarm Manager automation) — flat passthrough.
+"""
+type AlarmRule {
+  id: ID
+  name: String
+  enable: Boolean
+  isCreatedBySystem: Boolean
+  sources: JSON
+  conditions: JSON
+  historyConditions: JSON
+  schedules: JSON
+  actions: JSON
+  cooldown: JSON
+}
+
+"""Wrapper for protect_alarm_list_rules — {rules, count}."""
+type AlarmRuleList {
+  rules: JSON
+  count: Int
+}
+
 """UniFi Protect alarm system arm-state snapshot."""
 type AlarmStatus {
   armed: Boolean
@@ -1349,6 +1371,14 @@ type ProtectQuery {
   """List configured alarm profiles ({profiles, count})."""
   alarmProfiles(controller: ID!): AlarmProfileList
 
+  """
+  List configured alarm rules / Alarm Manager automations ({rules, count}).
+  """
+  alarmRules(controller: ID!): AlarmRuleList
+
+  """Fetch a single alarm rule (automation) by id."""
+  alarmRule(controller: ID!, id: ID!): AlarmRule
+
   """List Protect events (paginated, most recent first)."""
   events(controller: ID!, limit: Int! = 50, cursor: String = null, eventType: String = null, cameraId: String = null): EventPage!
 
@@ -1989,6 +2019,8 @@ Read-only access to UniFi Protect resources.
 **Fields:**
 
 - `alarmProfiles: AlarmProfileList`  — List configured alarm profiles ({profiles, count}).
+- `alarmRule: AlarmRule`  — Fetch a single alarm rule (automation) by id.
+- `alarmRules: AlarmRuleList`  — List configured alarm rules / Alarm Manager automations ({rules, count}).
 - `alarmStatus: AlarmStatus`  — Get the alarm system arm-state snapshot.
 - `camera: Camera`  — Look up a single Protect camera by id.
 - `cameraAnalytics: CameraAnalytics`  — Get analytics summary for a Protect camera.

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -33,7 +33,12 @@ from strawberry.types import Info
 
 from unifi_api.graphql.context import GraphQLContext
 from unifi_api.graphql.permissions import IsRead
-from unifi_api.graphql.types.protect.alarms import AlarmProfileList, AlarmStatus
+from unifi_api.graphql.types.protect.alarms import (
+    AlarmProfileList,
+    AlarmRule,
+    AlarmRuleList,
+    AlarmStatus,
+)
 from unifi_api.graphql.types.protect.cameras import (
     Camera,
     CameraAnalytics,
@@ -415,6 +420,48 @@ async def _fetch_alarm_profiles(ctx: GraphQLContext, controller: str) -> Any:
                 "protect",
             )
             return await mgr.list_arm_profiles()
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_alarm_rules(ctx: GraphQLContext, controller: str) -> Any:
+    key = f"protect/alarm-rules/{controller}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "protect",
+                "alarm_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "protect",
+            )
+            return await mgr.list_rules()
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_alarm_rule(ctx: GraphQLContext, controller: str, rule_id: str) -> Any:
+    key = f"protect/alarm-rules/{controller}/{rule_id}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "protect",
+                "alarm_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "protect",
+            )
+            return await mgr.get_rule(rule_id)
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -1056,6 +1103,45 @@ class ProtectQuery:
         if raw is None:
             return None
         return AlarmProfileList.from_manager_output(raw)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List configured alarm rules / Alarm Manager automations ({rules, count}).",
+    )
+    async def alarm_rules(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+    ) -> AlarmRuleList | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_alarm_rules(ctx, controller)
+        if raw is None:
+            return None
+        wrapped = (
+            raw
+            if isinstance(raw, dict) and "rules" in raw
+            else {
+                "rules": list(raw) if isinstance(raw, list) else [],
+                "count": len(raw) if isinstance(raw, list) else 0,
+            }
+        )
+        return AlarmRuleList.from_manager_output(wrapped)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Fetch a single alarm rule (automation) by id.",
+    )
+    async def alarm_rule(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+    ) -> AlarmRule | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_alarm_rule(ctx, controller, str(id))
+        if raw is None:
+            return None
+        return AlarmRule.from_manager_output(raw)
 
     # ---- Events ----------------------------------------------------------
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -179,6 +179,28 @@ type AlarmProfileList {
   count: Int
 }
 
+"""
+A UniFi Protect alarm rule (Alarm Manager automation) — flat passthrough.
+"""
+type AlarmRule {
+  id: ID
+  name: String
+  enable: Boolean
+  isCreatedBySystem: Boolean
+  sources: JSON
+  conditions: JSON
+  historyConditions: JSON
+  schedules: JSON
+  actions: JSON
+  cooldown: JSON
+}
+
+"""Wrapper for protect_alarm_list_rules — {rules, count}."""
+type AlarmRuleList {
+  rules: JSON
+  count: Int
+}
+
 """UniFi Protect alarm system arm-state snapshot."""
 type AlarmStatus {
   armed: Boolean
@@ -1337,6 +1359,14 @@ type ProtectQuery {
 
   """List configured alarm profiles ({profiles, count})."""
   alarmProfiles(controller: ID!): AlarmProfileList
+
+  """
+  List configured alarm rules / Alarm Manager automations ({rules, count}).
+  """
+  alarmRules(controller: ID!): AlarmRuleList
+
+  """Fetch a single alarm rule (automation) by id."""
+  alarmRule(controller: ID!, id: ID!): AlarmRule
 
   """List Protect events (paginated, most recent first)."""
   events(controller: ID!, limit: Int! = 50, cursor: String = null, eventType: String = null, cameraId: String = null): EventPage!

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -211,6 +211,12 @@ from unifi_api.graphql.types.protect.alarms import (
     AlarmProfileList as ProtectAlarmProfileListType,
 )
 from unifi_api.graphql.types.protect.alarms import (
+    AlarmRule as ProtectAlarmRuleType,
+)
+from unifi_api.graphql.types.protect.alarms import (
+    AlarmRuleList as ProtectAlarmRuleListType,
+)
+from unifi_api.graphql.types.protect.alarms import (
     AlarmStatus as ProtectAlarmStatusType,
 )
 from unifi_api.graphql.types.protect.cameras import (
@@ -603,6 +609,16 @@ def build_type_registry() -> TypeRegistry:
     reg.register_tool_type(
         "protect_alarm_list_profiles",
         ProtectAlarmProfileListType,
+        "detail",
+    )
+    reg.register_tool_type(
+        "protect_alarm_list_rules",
+        ProtectAlarmRuleListType,
+        "detail",
+    )
+    reg.register_tool_type(
+        "protect_alarm_get_rule",
+        ProtectAlarmRuleType,
         "detail",
     )
 

--- a/apps/api/src/unifi_api/graphql/types/protect/alarms.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/alarms.py
@@ -187,6 +187,159 @@ class AlarmProfile:
         return {}
 
 
+@strawberry.type(description="A UniFi Protect alarm rule (Alarm Manager automation) — flat passthrough.")
+class AlarmRule:
+    """DETAIL pass-through for a single alarm rule produced by the tool.
+
+    Deeply-nested fields (sources/conditions/actions/cooldown) are kept
+    as JSON because Protect adds new condition sources and action types
+    over time; we don't want a strict schema to break passthrough on a
+    new shape.
+    """
+
+    id: strawberry.ID | None
+    name: str | None
+    enable: bool | None
+    is_created_by_system: bool | None
+    sources: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    conditions: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    history_conditions: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    schedules: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    actions: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    cooldown: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+
+    _raw: strawberry.Private[dict[str, Any] | None] = None
+    _fallback: strawberry.Private[str | None] = None
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "primary_key": "id",
+            "display_columns": ["name", "enable"],
+        }
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "AlarmRule":
+        if isinstance(obj, dict):
+            # Accept BOTH snake_case (from rule_from_controller) and the
+            # raw Protect camelCase keys for fields that have a naming
+            # mismatch — the resolver passes the raw API dict directly.
+            inst = cls(
+                id=obj.get("id"),
+                name=obj.get("name"),
+                enable=obj.get("enable"),
+                is_created_by_system=(
+                    obj.get("is_created_by_system")
+                    if obj.get("is_created_by_system") is not None
+                    else obj.get("isCreatedBySystem")
+                ),
+                sources=obj.get("sources"),
+                conditions=obj.get("conditions"),
+                history_conditions=(
+                    obj.get("history_conditions")
+                    if obj.get("history_conditions") is not None
+                    else obj.get("historyConditions")
+                ),
+                schedules=obj.get("schedules"),
+                actions=obj.get("actions"),
+                cooldown=obj.get("cooldown"),
+            )
+            inst._raw = dict(obj)
+            return inst
+        if hasattr(obj, "model_dump"):
+            dumped = obj.model_dump()
+            inst = cls(
+                id=dumped.get("id"),
+                name=dumped.get("name"),
+                enable=dumped.get("enable"),
+                is_created_by_system=dumped.get("is_created_by_system"),
+                sources=dumped.get("sources"),
+                conditions=dumped.get("conditions"),
+                history_conditions=dumped.get("history_conditions"),
+                schedules=dumped.get("schedules"),
+                actions=dumped.get("actions"),
+                cooldown=dumped.get("cooldown"),
+            )
+            inst._raw = dict(dumped)
+            return inst
+        inst = cls(
+            id=None,
+            name=None,
+            enable=None,
+            is_created_by_system=None,
+            sources=None,
+            conditions=None,
+            history_conditions=None,
+            schedules=None,
+            actions=None,
+            cooldown=None,
+        )
+        inst._fallback = str(obj)
+        return inst
+
+    def to_dict(self) -> dict:
+        if self._raw is not None:
+            return self._raw
+        if self._fallback is not None:
+            return {"result": self._fallback}
+        return {}
+
+
+@strawberry.type(description="Wrapper for protect_alarm_list_rules — {rules, count}.")
+class AlarmRuleList:
+    """Wrapper-dict pass-through for ``{rules: [...], count}``.
+
+    Mirrors :class:`AlarmProfileList`: dict identity, list-coercion,
+    ``model_dump`` for pydantic, ``{"result": str(obj)}`` fallback. The
+    action endpoint surfaces the wrapper directly; per-rule projection
+    via :class:`AlarmRule` is used for the REST per-row view.
+    """
+
+    rules: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    count: int | None
+
+    _raw: strawberry.Private[dict[str, Any] | None] = None
+    _fallback: strawberry.Private[str | None] = None
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {"kind": kind}
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "AlarmRuleList":
+        if isinstance(obj, dict):
+            inst = cls(
+                rules=obj.get("rules") or [],
+                count=obj.get("count"),
+            )
+            inst._raw = dict(obj)
+            return inst
+        if isinstance(obj, list):
+            wrapper = {"rules": list(obj), "count": len(obj)}
+            inst = cls(rules=wrapper["rules"], count=wrapper["count"])
+            inst._raw = wrapper
+            return inst
+        if hasattr(obj, "model_dump"):
+            dumped = obj.model_dump()
+            inst = cls(
+                rules=dumped.get("rules") or [],
+                count=dumped.get("count"),
+            )
+            inst._raw = dict(dumped)
+            return inst
+        inst = cls(rules=None, count=None)
+        inst._fallback = str(obj)
+        return inst
+
+    def to_dict(self) -> dict:
+        if self._raw is not None:
+            return self._raw
+        if self._fallback is not None:
+            return {"result": self._fallback}
+        return {}
+
+
 @strawberry.type(description="Wrapper for protect_alarm_list_profiles — {profiles, count}.")
 class AlarmProfileList:
     """Wrapper-dict pass-through for ``{profiles: [...], count}``.

--- a/apps/api/src/unifi_api/serializers/protect/alarms.py
+++ b/apps/api/src/unifi_api/serializers/protect/alarms.py
@@ -21,10 +21,19 @@ from unifi_api.serializers._base import RenderKind, Serializer, register_seriali
     tools={
         "protect_alarm_arm": {"kind": RenderKind.DETAIL},
         "protect_alarm_disarm": {"kind": RenderKind.DETAIL},
+        "protect_alarm_update_rule": {"kind": RenderKind.DETAIL},
+        "protect_alarm_create_rule": {"kind": RenderKind.DETAIL},
+        "protect_alarm_delete_rule": {"kind": RenderKind.DETAIL},
     },
 )
 class AlarmMutationAckSerializer(Serializer):
-    """Pass-through for arm/disarm acks. Coerces a bare bool into a dict."""
+    """Pass-through for alarm mutation acks (arm/disarm + rule CRUD).
+
+    Coerces bare bools into ``{armed: bool}`` for backwards compatibility
+    with the historical arm/disarm shapes. Rule-CRUD tools always return
+    dicts (created/updated rule body or ``{deleted, rule_id}``) so they
+    flow through identity.
+    """
 
     kind = RenderKind.DETAIL
 

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -89,6 +89,9 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     # =========================================================================
     "protect_alarm_arm": ("alarm_manager", "arm"),
     "protect_alarm_disarm": ("alarm_manager", "disarm"),
+    # update/delete rule bodies await preview_* first; point dispatch at the mutation.
+    "protect_alarm_update_rule": ("alarm_manager", "update_rule"),
+    "protect_alarm_delete_rule": ("alarm_manager", "delete_rule"),
     "protect_ptz_move": ("camera_manager", "ptz_move"),
     "protect_ptz_preset": ("camera_manager", "ptz_goto_preset"),
     "protect_ptz_zoom": ("camera_manager", "ptz_zoom"),

--- a/apps/api/tests/graphql/fixtures/protect/test_events.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_events.py
@@ -6,6 +6,8 @@
 # tool: protect_list_smart_detections
 # tool: protect_alarm_get_status
 # tool: protect_alarm_list_profiles
+# tool: protect_alarm_list_rules
+# tool: protect_alarm_get_rule
 """
 
 from __future__ import annotations
@@ -204,9 +206,111 @@ async def test_protect_alarm_list_profiles(tmp_path, monkeypatch):
         f'''{{
         protect {{ alarmProfiles(controller: "{cid}") {{
             count
+            profiles
         }} }}
     }}''',
     )
     assert body.get("errors") is None, body
     result = body["data"]["protect"]["alarmProfiles"]
     assert result["count"] == 2
+    assert {p["id"] for p in result["profiles"]} == {"prof1", "prof2"}
+
+
+@pytest.mark.asyncio
+async def test_protect_alarm_list_rules(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "alarm_manager", "list_rules"): [
+                {"id": "rule1", "name": "Arrival", "enable": True},
+                {"id": "rule2", "name": "Departure", "enable": True},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ alarmRules(controller: "{cid}") {{
+            count
+            rules
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    result = body["data"]["protect"]["alarmRules"]
+    assert result["count"] == 2
+    assert {r["id"] for r in result["rules"]} == {"rule1", "rule2"}
+
+
+@pytest.mark.asyncio
+async def test_protect_alarm_get_rule(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "alarm_manager", "get_rule"): {
+                "id": "rule1",
+                "name": "Test Camera Vehicle Arrival",
+                "enable": True,
+                "sources": [{"device": "AABBCCDDEEFF", "type": "include"}],
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ alarmRule(controller: "{cid}", id: "rule1") {{
+            id
+            name
+            enable
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    result = body["data"]["protect"]["alarmRule"]
+    assert result["id"] == "rule1"
+    assert result["name"] == "Test Camera Vehicle Arrival"
+    assert result["enable"] is True
+
+
+@pytest.mark.asyncio
+async def test_protect_alarm_get_rule_translates_camelcase_keys(tmp_path, monkeypatch):
+    """Manager returns raw Protect API dict with camelCase keys
+    (isCreatedBySystem, historyConditions). The GraphQL type's
+    from_manager_output must accept these alongside snake_case so the
+    fields aren't silently dropped to null.
+    """
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "alarm_manager", "get_rule"): {
+                "id": "rule-builtin",
+                "name": "System-Created Rule",
+                "enable": True,
+                "isCreatedBySystem": True,
+                "historyConditions": [{"some": "history"}],
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ alarmRule(controller: "{cid}", id: "rule-builtin") {{
+            id
+            isCreatedBySystem
+            historyConditions
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    result = body["data"]["protect"]["alarmRule"]
+    assert result["isCreatedBySystem"] is True, "camelCase isCreatedBySystem from raw API dict was dropped to None"
+    assert result["historyConditions"] == [{"some": "history"}]

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -261,6 +261,12 @@ def test_dispatch_overrides_specific_targets() -> None:
     assert table["protect_update_known_face"].method == "apply_update_known_face"
     assert table["protect_merge_known_faces"].method == "apply_merge_known_faces"
     assert table["protect_delete_known_face"].method == "apply_delete_known_face"
+    # Alarm rule mutations: update/delete await the preview method first, so the
+    # AST captures preview_*; the override must point at the real mutation.
+    assert table["protect_alarm_update_rule"].method == "update_rule"
+    assert table["protect_alarm_delete_rule"].method == "delete_rule"
+    # create_rule's only await is the mutation itself — AST is correct, no override.
+    assert table["protect_alarm_create_rule"].method == "create_rule"
 
     # Access preview/execute split
     assert table["access_lock_door"].method == "apply_lock_door"

--- a/apps/protect/src/unifi_protect_mcp/tools/alarm.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/alarm.py
@@ -1,8 +1,12 @@
 """Alarm Manager tools for UniFi Protect MCP server.
 
-Provides tools to arm/disarm the UniFi Protect Alarm Manager and list
-configured arm profiles. Requires UniFi Protect 6.1+ with Alarm Manager
-profiles configured in the Protect web UI.
+Provides tools to:
+* arm/disarm the UniFi Protect Alarm Manager and list configured arm profiles
+* CRUD alarm rules (automations) — list, get, update, create, delete
+
+Requires UniFi Protect 6.1+ with Alarm Manager configured in the Protect
+web UI. The rule CRUD endpoints are private REST under
+``/proxy/protect/api/automations`` and not exposed by upstream uiprotect.
 """
 
 import logging
@@ -13,10 +17,20 @@ from pydantic import Field, ValidationError
 
 from unifi_core.confirmation import preview_response
 from unifi_core.exceptions import UniFiNotFoundError
-from unifi_core.protect.models._actions import AlarmArmInput, AlarmDisarmInput
+from unifi_core.protect.models._actions import (
+    AlarmArmInput,
+    AlarmCreateRuleInput,
+    AlarmDeleteRuleInput,
+    AlarmDisarmInput,
+    AlarmGetRuleInput,
+    AlarmUpdateRuleInput,
+)
 from unifi_core.protect.models.alarms import (
     profile_from_controller,
     profile_list_from_controller,
+    rule_from_controller,
+    rule_list_from_controller,
+    rule_to_controller,
     status_from_controller,
 )
 from unifi_protect_mcp.runtime import alarm_manager, server
@@ -173,6 +187,239 @@ async def protect_alarm_disarm(
         return {"success": False, "error": f"Failed to disarm alarm: {e}"}
 
 
+@server.tool(
+    name="protect_alarm_list_rules",
+    description=(
+        "Lists every alarm rule (automation) configured in the UniFi Protect "
+        "Alarm Manager. Each rule includes id, name, enable flag, sources "
+        "(camera scope), conditions (AND-list of triggers like license_plate_known "
+        "or smartDetectLine), actions (webhook URLs, etc.), and cooldown. "
+        "Use protect_alarm_get_rule for the full payload of a single rule "
+        "needed for the read-modify-write update flow."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def protect_alarm_list_rules() -> Dict[str, Any]:
+    """List all alarm rules."""
+    logger.info("protect_alarm_list_rules tool called")
+    try:
+        raw_rules = await alarm_manager.list_rules()
+        shaped_rules = [rule_from_controller(r).model_dump(exclude_none=True) for r in raw_rules]
+        shaped_wrapper = rule_list_from_controller({"rules": shaped_rules, "count": len(shaped_rules)})
+        return {
+            "success": True,
+            "data": {
+                **shaped_wrapper.model_dump(exclude_none=True),
+                "rules": shaped_rules,
+            },
+        }
+    except Exception as e:
+        logger.error("Error listing alarm rules: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list alarm rules: {e}"}
+
+
+@server.tool(
+    name="protect_alarm_get_rule",
+    description=(
+        "Fetches the full payload of a single alarm rule (automation) by id. "
+        "Use the returned dict as the basis for protect_alarm_update_rule's "
+        "body parameter — Protect requires the full rule body on PATCH."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def protect_alarm_get_rule(
+    rule_id: Annotated[
+        str,
+        Field(description="Alarm rule (automation) UUID from protect_alarm_list_rules"),
+    ],
+) -> Dict[str, Any]:
+    """Get a single alarm rule."""
+    logger.info("protect_alarm_get_rule tool called (rule_id=%s)", rule_id)
+    try:
+        try:
+            AlarmGetRuleInput(rule_id=rule_id)
+        except ValidationError as e:
+            return {"success": False, "error": f"Invalid input: {e.errors()[0]['msg']}"}
+        raw = await alarm_manager.get_rule(rule_id)
+        shaped = rule_from_controller(raw)
+        return {
+            "success": True,
+            "data": shaped.model_dump(exclude_none=True),
+        }
+    except (UniFiNotFoundError, ValueError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error getting alarm rule %s: %s", rule_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get alarm rule: {e}"}
+
+
+@server.tool(
+    name="protect_alarm_update_rule",
+    description=(
+        "Updates an alarm rule via PATCH. Protect requires the FULL rule "
+        "body — partial PATCH bodies are rejected by the controller. The "
+        "expected flow is: (1) call protect_alarm_get_rule to fetch the "
+        "current rule, (2) mutate the returned dict in-place, (3) pass the "
+        "mutated dict back here as body. Body keys may be snake_case (as "
+        "returned by get_rule) or camelCase; the tool normalizes to "
+        "camelCase before PATCHing. ``actions`` must be a non-empty list. "
+        "Requires confirm=True to apply — otherwise returns a preview "
+        "of current vs proposed."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+    permission_category="alarm",
+    permission_action="update",
+)
+async def protect_alarm_update_rule(
+    rule_id: Annotated[str, Field(description="Alarm rule (automation) UUID to update")],
+    body: Annotated[
+        Dict[str, Any],
+        Field(
+            description=("Full rule payload. Get the current rule via protect_alarm_get_rule, mutate, then pass here.")
+        ),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, applies the update. When false (default), returns a preview."),
+    ] = False,
+) -> Dict[str, Any]:
+    """Update an alarm rule (full-body PATCH)."""
+    logger.info("protect_alarm_update_rule tool called (rule_id=%s, confirm=%s)", rule_id, confirm)
+    try:
+        try:
+            AlarmUpdateRuleInput(rule_id=rule_id, body=body)
+        except ValidationError as e:
+            return {"success": False, "error": f"Invalid input: {e.errors()[0]['msg']}"}
+        # Translate ONCE so the preview's "proposed" and the actual PATCH
+        # show identical key shape (no snake/camel drift between them).
+        translated = rule_to_controller(body)
+        if not confirm:
+            preview_data = await alarm_manager.preview_update_rule(rule_id, translated)
+            return preview_response(
+                action="update",
+                resource_type="alarm_rule",
+                resource_id=rule_id,
+                current_state=preview_data["current"],
+                proposed_changes=preview_data["proposed"],
+                resource_name=preview_data["current"].get("name") or rule_id,
+            )
+
+        result = await alarm_manager.update_rule(rule_id, translated)
+        return {"success": True, "data": result}
+    except (UniFiNotFoundError, ValueError, TypeError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error updating alarm rule %s: %s", rule_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to update alarm rule: {e}"}
+
+
+@server.tool(
+    name="protect_alarm_create_rule",
+    description=(
+        "Creates a new alarm rule via POST. Body must be a full rule payload "
+        "matching the Protect automations schema: name, enable, sources "
+        "(scope), conditions (triggers), actions (webhook/etc), cooldown. "
+        "The server assigns the rule id and returns the created rule. "
+        "Body keys may be snake_case (as returned by protect_alarm_get_rule) "
+        "or camelCase (controller-native); the tool normalizes to camelCase "
+        "before POSTing, so the natural read-modify-write clone flow works. "
+        "``actions`` must be a non-empty list — the controller will accept "
+        "an empty actions list but the resulting rule cannot be opened in "
+        "the Protect UI. "
+        "Requires confirm=True to apply — otherwise returns a preview."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+    permission_category="alarm",
+    permission_action="create",
+)
+async def protect_alarm_create_rule(
+    body: Annotated[
+        Dict[str, Any],
+        Field(description="Full alarm rule payload (see Protect automations schema)"),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the rule. When false (default), returns a preview."),
+    ] = False,
+) -> Dict[str, Any]:
+    """Create a new alarm rule."""
+    logger.info("protect_alarm_create_rule tool called (confirm=%s)", confirm)
+    try:
+        try:
+            AlarmCreateRuleInput(body=body)
+        except ValidationError as e:
+            return {"success": False, "error": f"Invalid input: {e.errors()[0]['msg']}"}
+        # Translate ONCE so the preview's "proposed" exactly matches the
+        # body that would be POSTed on confirm (no snake/camel drift).
+        translated = rule_to_controller(body)
+        if not confirm:
+            return preview_response(
+                action="create",
+                resource_type="alarm_rule",
+                resource_id=translated.get("id") or "<server-assigned>",
+                current_state={},
+                proposed_changes=translated,
+                resource_name=translated.get("name") or "new alarm rule",
+            )
+
+        result = await alarm_manager.create_rule(translated)
+        return {"success": True, "data": result}
+    except (UniFiNotFoundError, ValueError, TypeError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error creating alarm rule: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to create alarm rule: {e}"}
+
+
+@server.tool(
+    name="protect_alarm_delete_rule",
+    description=(
+        "Deletes an alarm rule (automation) by id. Requires confirm=True to "
+        "apply — otherwise returns a preview showing the rule that would be "
+        "deleted. Destructive — the rule and its configured webhook actions "
+        "cannot be recovered through the API."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+    permission_category="alarm",
+    permission_action="delete",
+)
+async def protect_alarm_delete_rule(
+    rule_id: Annotated[str, Field(description="Alarm rule (automation) UUID to delete")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the rule. When false (default), returns a preview."),
+    ] = False,
+) -> Dict[str, Any]:
+    """Delete an alarm rule."""
+    logger.info("protect_alarm_delete_rule tool called (rule_id=%s, confirm=%s)", rule_id, confirm)
+    try:
+        try:
+            AlarmDeleteRuleInput(rule_id=rule_id)
+        except ValidationError as e:
+            return {"success": False, "error": f"Invalid input: {e.errors()[0]['msg']}"}
+        if not confirm:
+            preview_data = await alarm_manager.preview_delete_rule(rule_id)
+            return preview_response(
+                action="delete",
+                resource_type="alarm_rule",
+                resource_id=rule_id,
+                current_state={"name": preview_data["current_name"]},
+                proposed_changes=preview_data["proposed_changes"],
+                resource_name=preview_data["current_name"] or rule_id,
+            )
+
+        result = await alarm_manager.delete_rule(rule_id)
+        return {"success": True, "data": result}
+    except (UniFiNotFoundError, ValueError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error deleting alarm rule %s: %s", rule_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete alarm rule: {e}"}
+
+
 logger.info(
-    "Alarm tools registered: protect_alarm_list_profiles, protect_alarm_get_status, protect_alarm_arm, protect_alarm_disarm"
+    "Alarm tools registered: "
+    "protect_alarm_list_profiles, protect_alarm_get_status, protect_alarm_arm, protect_alarm_disarm, "
+    "protect_alarm_list_rules, protect_alarm_get_rule, protect_alarm_update_rule, "
+    "protect_alarm_create_rule, protect_alarm_delete_rule"
 )

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -1,12 +1,17 @@
 {
-  "count": 49,
+  "count": 54,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "protect_acknowledge_event": "unifi_protect_mcp.tools.events",
     "protect_alarm_arm": "unifi_protect_mcp.tools.alarm",
+    "protect_alarm_create_rule": "unifi_protect_mcp.tools.alarm",
+    "protect_alarm_delete_rule": "unifi_protect_mcp.tools.alarm",
     "protect_alarm_disarm": "unifi_protect_mcp.tools.alarm",
+    "protect_alarm_get_rule": "unifi_protect_mcp.tools.alarm",
     "protect_alarm_get_status": "unifi_protect_mcp.tools.alarm",
     "protect_alarm_list_profiles": "unifi_protect_mcp.tools.alarm",
+    "protect_alarm_list_rules": "unifi_protect_mcp.tools.alarm",
+    "protect_alarm_update_rule": "unifi_protect_mcp.tools.alarm",
     "protect_create_liveview": "unifi_protect_mcp.tools.liveviews",
     "protect_delete_known_face": "unifi_protect_mcp.tools.recognition",
     "protect_delete_liveview": "unifi_protect_mcp.tools.liveviews",
@@ -248,6 +253,206 @@
     {
       "annotations": {
         "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Creates a new alarm rule via POST. Body must be a full rule payload matching the Protect automations schema: name, enable, sources (scope), conditions (triggers), actions (webhook/etc), cooldown. The server assigns the rule id and returns the created rule. Body keys may be snake_case (as returned by protect_alarm_get_rule) or camelCase (controller-native); the tool normalizes to camelCase before POSTing, so the natural read-modify-write clone flow works. ``actions`` must be a non-empty list \u2014 the controller will accept an empty actions list but the resulting rule cannot be opened in the Protect UI. Requires confirm=True to apply \u2014 otherwise returns a preview.",
+      "name": "protect_alarm_create_rule",
+      "permission_action": "create",
+      "permission_category": "alarm",
+      "schema": {
+        "input": {
+          "properties": {
+            "body": {
+              "description": "Full alarm rule payload (see Protect automations schema)",
+              "type": "object"
+            },
+            "confirm": {
+              "description": "When true, creates the rule. When false (default), returns a preview.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "body"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Alarm Create Rule"
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Deletes an alarm rule (automation) by id. Requires confirm=True to apply \u2014 otherwise returns a preview showing the rule that would be deleted. Destructive \u2014 the rule and its configured webhook actions cannot be recovered through the API.",
+      "name": "protect_alarm_delete_rule",
+      "permission_action": "delete",
+      "permission_category": "alarm",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the rule. When false (default), returns a preview.",
+              "type": "boolean"
+            },
+            "rule_id": {
+              "description": "Alarm rule (automation) UUID to delete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Alarm Delete Rule"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false,
         "readOnlyHint": false
@@ -337,6 +542,98 @@
         }
       },
       "title": "Alarm Disarm"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Fetches the full payload of a single alarm rule (automation) by id. Use the returned dict as the basis for protect_alarm_update_rule's body parameter \u2014 Protect requires the full rule body on PATCH.",
+      "name": "protect_alarm_get_rule",
+      "schema": {
+        "input": {
+          "properties": {
+            "rule_id": {
+              "description": "Alarm rule (automation) UUID from protect_alarm_list_rules",
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Alarm Get Rule"
     },
     {
       "annotations": {
@@ -505,6 +802,195 @@
         }
       },
       "title": "Alarm List Profiles"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Lists every alarm rule (automation) configured in the UniFi Protect Alarm Manager. Each rule includes id, name, enable flag, sources (camera scope), conditions (AND-list of triggers like license_plate_known or smartDetectLine), actions (webhook URLs, etc.), and cooldown. Use protect_alarm_get_rule for the full payload of a single rule needed for the read-modify-write update flow.",
+      "name": "protect_alarm_list_rules",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Alarm List Rules"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Updates an alarm rule via PATCH. Protect requires the FULL rule body \u2014 partial PATCH bodies are rejected by the controller. The expected flow is: (1) call protect_alarm_get_rule to fetch the current rule, (2) mutate the returned dict in-place, (3) pass the mutated dict back here as body. Body keys may be snake_case (as returned by get_rule) or camelCase; the tool normalizes to camelCase before PATCHing. ``actions`` must be a non-empty list. Requires confirm=True to apply \u2014 otherwise returns a preview of current vs proposed.",
+      "name": "protect_alarm_update_rule",
+      "permission_action": "update",
+      "permission_category": "alarm",
+      "schema": {
+        "input": {
+          "properties": {
+            "body": {
+              "description": "Full rule payload. Get the current rule via protect_alarm_get_rule, mutate, then pass here.",
+              "type": "object"
+            },
+            "confirm": {
+              "description": "When true, applies the update. When false (default), returns a preview.",
+              "type": "boolean"
+            },
+            "rule_id": {
+              "description": "Alarm rule (automation) UUID to update",
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_id",
+            "body"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Alarm Update Rule"
     },
     {
       "annotations": {

--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager.py
@@ -1,16 +1,29 @@
 """Alarm Manager control for UniFi Protect.
 
-Wraps the private ``/proxy/protect/api/arm/*`` endpoints used by the
-UniFi Protect Alarm Manager (Protect 6.1+) to arm/disarm the system.
-The ``uiprotect`` library does not expose these endpoints natively, so
-this manager calls them directly via ``ProtectApiClient.api_request``.
+Wraps the private ``/proxy/protect/api/arm/*`` and
+``/proxy/protect/api/automations`` endpoints used by the UniFi Protect
+Alarm Manager (Protect 6.1+) to arm/disarm the system and to manage
+the underlying alarm rules (automations).
+
+The ``uiprotect`` library does not expose either set natively, so this
+manager calls them directly via ``ProtectApiClient.api_request``.
 
 Endpoints (verified against Protect 7.0)
 -----------------------------------------
-- ``GET  arm/profiles``    -- list all arm profile definitions
-- ``PATCH arm``            -- select active profile, body ``{"armProfileId": "..."}``
-- ``POST arm/enable``      -- arm the system (empty body)
-- ``POST arm/disable``     -- disarm the system (empty body)
+Arm/disarm:
+  - ``GET  arm/profiles``    -- list all arm profile definitions
+  - ``PATCH arm``            -- select active profile, body ``{"armProfileId": "..."}``
+  - ``POST arm/enable``      -- arm the system (empty body)
+  - ``POST arm/disable``     -- disarm the system (empty body)
+
+Rules (automations):
+  - ``GET    automations``         -- list all alarm rules
+  - ``GET    automations/{id}``    -- fetch a single rule
+  - ``POST   automations``         -- create a new rule (body = full payload)
+  - ``PATCH  automations/{id}``    -- update a rule (body = full payload;
+                                      Protect rejects partial bodies, so callers
+                                      should read-modify-write)
+  - ``DELETE automations/{id}``    -- delete a rule
 
 Current armed state lives in ``nvr.armMode`` (single state per system,
 not per-profile):
@@ -35,6 +48,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
 
 logger = logging.getLogger(__name__)
@@ -300,6 +314,115 @@ class AlarmManager:
 
         return {"armed": False}
 
+    # ------------------------------------------------------------------
+    # Rule (automation) CRUD
+    # ------------------------------------------------------------------
+
+    async def list_rules(self) -> List[Dict[str, Any]]:
+        """Return every alarm rule defined under Alarm Manager.
+
+        ``GET automations`` returns a flat array of rule payloads. Each entry
+        is passed through largely as-is; the tool/model layer is responsible
+        for coercing into :class:`AlarmRule`.
+        """
+        data = await self._cm.client.api_request("automations", method="get")
+        if not isinstance(data, list):
+            logger.warning("Unexpected automations shape: %r", type(data))
+            return []
+        return [r for r in data if isinstance(r, dict)]
+
+    async def get_rule(self, rule_id: str) -> Dict[str, Any]:
+        """Fetch a single alarm rule by id.
+
+        The controller exposes no per-rule GET endpoint — ``GET
+        automations/{id}`` returns 404 — so the full payload is only available
+        from the list endpoint. We fetch ``GET automations`` and filter by id.
+
+        Raises ``ValueError`` on empty id, ``UniFiNotFoundError`` if no rule
+        with that id exists.
+        """
+        _require_rule_id(rule_id)
+        for rule in await self.list_rules():
+            if rule.get("id") == rule_id:
+                return rule
+        raise UniFiNotFoundError("alarm rule", rule_id)
+
+    async def update_rule(self, rule_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Update an alarm rule via PATCH.
+
+        Protect's ``PATCH automations/{id}`` expects the FULL rule body
+        (verified via JeffSteinbok/hass-uiprotectalarms implementation).
+        Callers must perform a read-modify-write: call :meth:`get_rule`
+        first, mutate the returned dict, then pass it back here.
+        """
+        _require_rule_id(rule_id)
+        _require_dict_body(body, "body")
+        data = await self._cm.client.api_request(f"automations/{rule_id}", method="patch", json=body)
+        if not isinstance(data, dict):
+            # PATCH usually echoes the updated rule; if the controller returns
+            # something else, surface it but coerce to a safe shape so callers
+            # don't crash.
+            logger.warning(
+                "PATCH automations/%s returned non-dict %r; coercing to {} ",
+                rule_id,
+                type(data),
+            )
+            return {}
+        return data
+
+    async def create_rule(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new alarm rule via POST.
+
+        Body must be a full rule payload matching the Protect ``automations``
+        schema (sources / conditions / actions / cooldown / etc.). The server
+        assigns the rule ``id`` and returns the created rule.
+        """
+        _require_dict_body(body, "body")
+        data = await self._cm.client.api_request("automations", method="post", json=body)
+        if not isinstance(data, dict):
+            logger.warning(
+                "POST automations returned non-dict %r; coercing to {}",
+                type(data),
+            )
+            return {}
+        return data
+
+    async def delete_rule(self, rule_id: str) -> Dict[str, Any]:
+        """Delete an alarm rule by id.
+
+        The controller returns an empty body on a successful delete, so we use
+        ``api_request_raw`` (which does not attempt to decode JSON) to avoid a
+        spurious "Could not decode JSON" error on an otherwise-successful call.
+        """
+        _require_rule_id(rule_id)
+        await self._cm.client.api_request_raw(f"automations/{rule_id}", method="delete")
+        return {"deleted": True, "rule_id": rule_id}
+
+    # ------------------------------------------------------------------
+    # Rule preview helpers (for confirm=false tool responses)
+    # ------------------------------------------------------------------
+
+    async def preview_update_rule(self, rule_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Return current vs. proposed rule state for an update preview."""
+        _require_rule_id(rule_id)
+        _require_dict_body(body, "body")
+        current = await self.get_rule(rule_id)
+        return {
+            "rule_id": rule_id,
+            "current": current,
+            "proposed": body,
+        }
+
+    async def preview_delete_rule(self, rule_id: str) -> Dict[str, Any]:
+        """Return current rule + delete intent for a delete preview."""
+        _require_rule_id(rule_id)
+        current = await self.get_rule(rule_id)
+        return {
+            "rule_id": rule_id,
+            "current_name": current.get("name"),
+            "proposed_changes": {"deleted": True},
+        }
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -317,3 +440,15 @@ def _ms_to_iso(value: Any) -> Optional[str]:
     if ms <= 0:
         return None
     return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+
+
+def _require_rule_id(rule_id: Any) -> None:
+    """Validate ``rule_id`` is a non-empty string."""
+    if not isinstance(rule_id, str) or not rule_id.strip():
+        raise ValueError("rule_id must be a non-empty string")
+
+
+def _require_dict_body(body: Any, name: str) -> None:
+    """Validate that ``body`` is a dict (Protect rule payloads are objects)."""
+    if not isinstance(body, dict):
+        raise TypeError(f"{name} must be a dict, got {type(body).__name__}")

--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager.py
@@ -18,7 +18,9 @@ Arm/disarm:
 
 Rules (automations):
   - ``GET    automations``         -- list all alarm rules
-  - ``GET    automations/{id}``    -- fetch a single rule
+  - ``GET    automations/{id}``    -- 404s on this controller; there is no
+                                      per-rule GET, so ``get_rule`` fetches the
+                                      list and filters by id
   - ``POST   automations``         -- create a new rule (body = full payload)
   - ``PATCH  automations/{id}``    -- update a rule (body = full payload;
                                       Protect rejects partial bodies, so callers
@@ -341,7 +343,7 @@ class AlarmManager:
         Raises ``ValueError`` on empty id, ``UniFiNotFoundError`` if no rule
         with that id exists.
         """
-        _require_rule_id(rule_id)
+        rule_id = _require_rule_id(rule_id)
         for rule in await self.list_rules():
             if rule.get("id") == rule_id:
                 return rule
@@ -355,7 +357,7 @@ class AlarmManager:
         Callers must perform a read-modify-write: call :meth:`get_rule`
         first, mutate the returned dict, then pass it back here.
         """
-        _require_rule_id(rule_id)
+        rule_id = _require_rule_id(rule_id)
         _require_dict_body(body, "body")
         data = await self._cm.client.api_request(f"automations/{rule_id}", method="patch", json=body)
         if not isinstance(data, dict):
@@ -394,7 +396,7 @@ class AlarmManager:
         ``api_request_raw`` (which does not attempt to decode JSON) to avoid a
         spurious "Could not decode JSON" error on an otherwise-successful call.
         """
-        _require_rule_id(rule_id)
+        rule_id = _require_rule_id(rule_id)
         await self._cm.client.api_request_raw(f"automations/{rule_id}", method="delete")
         return {"deleted": True, "rule_id": rule_id}
 
@@ -404,7 +406,7 @@ class AlarmManager:
 
     async def preview_update_rule(self, rule_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
         """Return current vs. proposed rule state for an update preview."""
-        _require_rule_id(rule_id)
+        rule_id = _require_rule_id(rule_id)
         _require_dict_body(body, "body")
         current = await self.get_rule(rule_id)
         return {
@@ -415,7 +417,7 @@ class AlarmManager:
 
     async def preview_delete_rule(self, rule_id: str) -> Dict[str, Any]:
         """Return current rule + delete intent for a delete preview."""
-        _require_rule_id(rule_id)
+        rule_id = _require_rule_id(rule_id)
         current = await self.get_rule(rule_id)
         return {
             "rule_id": rule_id,
@@ -442,10 +444,16 @@ def _ms_to_iso(value: Any) -> Optional[str]:
     return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
 
 
-def _require_rule_id(rule_id: Any) -> None:
-    """Validate ``rule_id`` is a non-empty string."""
+def _require_rule_id(rule_id: Any) -> str:
+    """Validate ``rule_id`` is a non-empty string and return it stripped.
+
+    Returning the stripped value lets callers rebind ``rule_id`` so a padded id
+    like ``" rule-001 "`` matches the controller's id during list filtering
+    instead of silently missing.
+    """
     if not isinstance(rule_id, str) or not rule_id.strip():
         raise ValueError("rule_id must be a non-empty string")
+    return rule_id.strip()
 
 
 def _require_dict_body(body: Any, name: str) -> None:

--- a/packages/unifi-core/src/unifi_core/protect/models/_actions.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/_actions.py
@@ -14,7 +14,29 @@ from __future__ import annotations
 
 from typing import ClassVar, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+def _require_non_empty_actions(body: dict) -> None:
+    """Reject rule bodies that would brick the Protect UI.
+
+    Protect's controller accepts ``actions: []`` (and even a body with no
+    ``actions`` key at all) and returns a normal-looking rule on POST. But
+    the resulting rule cannot be opened in the Protect web UI -- clicking
+    it shows "We're Unable to Complete Your Request" and the rule becomes
+    only deletable via API. Found via live-test 2026-05-27. Reject here so
+    the failure mode never reaches a homelab.
+
+    ``body`` is already type-validated as ``dict`` by the calling Pydantic
+    model field, so this helper does not re-check that.
+    """
+    actions = body.get("actions")
+    if not isinstance(actions, list) or len(actions) == 0:
+        raise ValueError(
+            "body.actions must be a non-empty list. Protect accepts rules "
+            "with no actions, but the resulting rule cannot be opened in "
+            "the Protect UI."
+        )
 
 
 class PtzMoveInput(BaseModel):
@@ -79,6 +101,75 @@ class AlarmDisarmInput(BaseModel):
     """Input for ``protect_alarm_disarm`` (no parameters)."""
 
     __action_input__: ClassVar[bool] = True
+
+
+class AlarmGetRuleInput(BaseModel):
+    """Input for ``protect_alarm_get_rule``."""
+
+    __action_input__: ClassVar[bool] = True
+
+    rule_id: str = Field(description="Alarm rule (automation) UUID")
+
+
+class AlarmUpdateRuleInput(BaseModel):
+    """Input for ``protect_alarm_update_rule``.
+
+    Protect's PATCH endpoint requires the full rule payload, so ``body``
+    is the complete rule dict (typically produced by reading via
+    ``protect_alarm_get_rule`` and mutating the returned dict).
+    """
+
+    __action_input__: ClassVar[bool] = True
+
+    rule_id: str = Field(description="Alarm rule (automation) UUID")
+    body: dict = Field(
+        description=(
+            "Full rule payload (Protect rejects partial bodies). "
+            "Read-modify-write: call protect_alarm_get_rule, mutate, pass back here."
+        )
+    )
+
+    @model_validator(mode="after")
+    def _check_actions(self) -> "AlarmUpdateRuleInput":
+        _require_non_empty_actions(self.body)
+        return self
+
+
+class AlarmCreateRuleInput(BaseModel):
+    """Input for ``protect_alarm_create_rule``.
+
+    The tool layer translates snake_case keys in ``body`` (as returned by
+    ``protect_alarm_get_rule``) to the camelCase shape the controller
+    requires on POST, so a natural read-modify-write flow works for clone-
+    style creates. Both casings of a field are accepted; the camelCase
+    value wins if both are present.
+    """
+
+    __action_input__: ClassVar[bool] = True
+
+    body: dict = Field(
+        description=(
+            "Full rule payload matching the Protect automations schema "
+            "(name, enable, sources, conditions, actions, cooldown). "
+            "Server assigns the id and returns the created rule. "
+            "``actions`` MUST be a non-empty list -- the controller accepts "
+            "an empty actions list but the resulting rule cannot be opened "
+            "in the Protect UI."
+        )
+    )
+
+    @model_validator(mode="after")
+    def _check_actions(self) -> "AlarmCreateRuleInput":
+        _require_non_empty_actions(self.body)
+        return self
+
+
+class AlarmDeleteRuleInput(BaseModel):
+    """Input for ``protect_alarm_delete_rule``."""
+
+    __action_input__: ClassVar[bool] = True
+
+    rule_id: str = Field(description="Alarm rule (automation) UUID to delete")
 
 
 class TriggerChimeInput(BaseModel):

--- a/packages/unifi-core/src/unifi_core/protect/models/alarms.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/alarms.py
@@ -1,14 +1,26 @@
 """Shared field models for Protect alarms (read-only).
 
 ``protect_alarm_arm`` and ``protect_alarm_disarm`` are action tools; their
-input models live in ``_actions.py`` (Task 11). The three classes below
-cover the read shapes returned by ``protect_alarm_get_status`` and
-``protect_alarm_list_profiles``.
+input models live in ``_actions.py`` (Task 11). The classes below cover
+the read shapes returned by:
+
+* ``protect_alarm_get_status`` / ``protect_alarm_list_profiles`` — arm-state
+  surface (AlarmStatus / AlarmProfile / AlarmProfileList)
+* ``protect_alarm_list_rules`` / ``protect_alarm_get_rule`` — rule CRUD
+  surface (AlarmRule + nested AlarmRuleSource / AlarmRuleCondition /
+  AlarmRuleAction / AlarmRuleCooldown / AlarmRuleList)
+
+The rule shapes mirror the Protect private ``/proxy/protect/api/automations``
+payload schema. They are intentionally lossy on the deep ``condition``
+sub-fields (kept as a free-form ``dict`` rather than enumerating every
+possible source/type) because Protect adds new detection sources over
+time and we don't want a strict schema to break passthrough on a new
+condition type.
 """
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -89,12 +101,185 @@ class AlarmProfileList(BaseModel):
     )
 
 
+class AlarmRuleSource(BaseModel):
+    """Scope entry in an alarm rule (which camera/device the rule applies to)."""
+
+    device: Optional[str] = Field(
+        default=None,
+        description="Device MAC address or UUID this source targets",
+        json_schema_extra={"mutable": False},
+    )
+    type: Optional[str] = Field(
+        default=None,
+        description="Scope mode, typically 'include' or 'exclude'",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class AlarmRuleCondition(BaseModel):
+    """One AND-condition in an alarm rule.
+
+    The inner ``condition`` dict is kept opaque because Protect supports a
+    growing set of source/type combinations (license_plate_known, smartDetectLine,
+    Vehicle Description, etc.) and we don't want to enumerate them strictly.
+    """
+
+    condition: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Raw inner condition body (source/type/value triple)",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class AlarmRuleActionMetadata(BaseModel):
+    """Metadata block on an HTTP_REQUEST action (webhook config)."""
+
+    url: Optional[str] = Field(
+        default=None,
+        description="Absolute webhook URL with path",
+        json_schema_extra={"mutable": False},
+    )
+    method: Optional[str] = Field(
+        default=None,
+        description="HTTP method (typically 'POST' or 'GET')",
+        json_schema_extra={"mutable": False},
+    )
+    headers: Optional[List[Any]] = Field(
+        default=None,
+        description="Custom request headers list",
+        json_schema_extra={"mutable": False},
+    )
+    timeout: Optional[int] = Field(
+        default=None,
+        description="Request timeout in milliseconds",
+        json_schema_extra={"mutable": False},
+    )
+    use_thumbnail: Optional[bool] = Field(
+        default=None,
+        description="Whether to attach the event thumbnail to the webhook payload",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class AlarmRuleAction(BaseModel):
+    """One action attached to an alarm rule (webhook, notify, light, etc.)."""
+
+    type: Optional[str] = Field(
+        default=None,
+        description="Action kind, e.g. 'HTTP_REQUEST', 'NOTIFY', 'LIGHT', 'SOUND'",
+        json_schema_extra={"mutable": False},
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Action-specific metadata (kept opaque to support unknown action types)",
+        json_schema_extra={"mutable": False},
+    )
+    order: Optional[int] = Field(
+        default=None,
+        description="Action execution order (-1 = default)",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class AlarmRuleCooldown(BaseModel):
+    """Cooldown block — suppresses repeat fires within ``timeout`` ms."""
+
+    enable: Optional[bool] = Field(
+        default=None,
+        description="Whether cooldown is active",
+        json_schema_extra={"mutable": False},
+    )
+    timeout: Optional[int] = Field(
+        default=None,
+        description="Cooldown duration in milliseconds",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class AlarmRule(BaseModel):
+    """Canonical Protect alarm-manager rule (read-only).
+
+    Mirrors the ``/proxy/protect/api/automations`` payload schema.
+    Deeply-nested condition bodies are kept opaque (see module docstring).
+    """
+
+    id: Optional[str] = Field(default=None, description="Rule UUID", json_schema_extra={"mutable": False})
+    name: Optional[str] = Field(default=None, description="Rule display name", json_schema_extra={"mutable": False})
+    enable: Optional[bool] = Field(
+        default=None,
+        description="Whether the rule is currently enabled",
+        json_schema_extra={"mutable": False},
+    )
+    is_created_by_system: Optional[bool] = Field(
+        default=None,
+        description="True for built-in rules created by Protect itself",
+        json_schema_extra={"mutable": False},
+    )
+    sources: Optional[List[AlarmRuleSource]] = Field(
+        default=None,
+        description="Scope list: which cameras/devices this rule applies to",
+        json_schema_extra={"mutable": False},
+    )
+    conditions: Optional[List[AlarmRuleCondition]] = Field(
+        default=None,
+        description="AND-conditions that must all match for the rule to fire",
+        json_schema_extra={"mutable": False},
+    )
+    history_conditions: Optional[List[Any]] = Field(
+        default=None,
+        description="Historical/cross-event conditions (raw passthrough)",
+        json_schema_extra={"mutable": False},
+    )
+    schedules: Optional[List[Any]] = Field(
+        default=None,
+        description="Schedule windows when the rule is active (raw passthrough)",
+        json_schema_extra={"mutable": False},
+    )
+    actions: Optional[List[AlarmRuleAction]] = Field(
+        default=None,
+        description="Actions to execute when the rule fires",
+        json_schema_extra={"mutable": False},
+    )
+    cooldown: Optional[AlarmRuleCooldown] = Field(
+        default=None,
+        description="Cooldown configuration to suppress repeat fires",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class AlarmRuleList(BaseModel):
+    """Wrapper shape returned by ``protect_alarm_list_rules`` (read-only)."""
+
+    rules: Optional[List[Any]] = Field(
+        default=None,
+        description="List of alarm rule dicts",
+        json_schema_extra={"mutable": False},
+    )
+    count: Optional[int] = Field(
+        default=None,
+        description="Number of rules in the list",
+        json_schema_extra={"mutable": False},
+    )
+
+
 MUTABLE_FIELDS = frozenset()
 READ_ONLY_FIELDS = (
     frozenset(AlarmStatus.model_fields.keys())
     | frozenset(AlarmProfile.model_fields.keys())
     | frozenset(AlarmProfileList.model_fields.keys())
+    | frozenset(AlarmRule.model_fields.keys())
+    | frozenset(AlarmRuleList.model_fields.keys())
+    | frozenset(AlarmRuleSource.model_fields.keys())
+    | frozenset(AlarmRuleCondition.model_fields.keys())
+    | frozenset(AlarmRuleAction.model_fields.keys())
+    | frozenset(AlarmRuleActionMetadata.model_fields.keys())
+    | frozenset(AlarmRuleCooldown.model_fields.keys())
 )
+
+
+def _coerce_list(value: Any) -> Optional[List[Any]]:
+    """Return ``value`` if it's a list, otherwise None."""
+    return value if isinstance(value, list) else None
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -158,3 +343,146 @@ def profile_list_from_controller(raw: Any) -> AlarmProfileList:
         profiles=profiles,
         count=_get(raw, "count"),
     )
+
+
+def _rule_source_from(raw: Any) -> AlarmRuleSource:
+    return AlarmRuleSource(
+        device=_get(raw, "device"),
+        type=_get(raw, "type"),
+    )
+
+
+def _rule_condition_from(raw: Any) -> AlarmRuleCondition:
+    inner = _get(raw, "condition")
+    if not isinstance(inner, dict):
+        inner = None
+    return AlarmRuleCondition(condition=inner)
+
+
+def _rule_action_from(raw: Any) -> AlarmRuleAction:
+    metadata = _get(raw, "metadata")
+    if not isinstance(metadata, dict):
+        metadata = None
+    return AlarmRuleAction(
+        type=_get(raw, "type"),
+        metadata=metadata,
+        order=_get(raw, "order"),
+    )
+
+
+def _rule_cooldown_from(raw: Any) -> Optional[AlarmRuleCooldown]:
+    if not isinstance(raw, dict):
+        return None
+    return AlarmRuleCooldown(
+        enable=_get(raw, "enable"),
+        timeout=_get(raw, "timeout"),
+    )
+
+
+def rule_from_controller(raw: Any) -> AlarmRule:
+    """Build an AlarmRule from a raw Protect ``/automations`` payload dict."""
+    sources_raw = _coerce_list(_get(raw, "sources"))
+    conditions_raw = _coerce_list(_get(raw, "conditions"))
+    actions_raw = _coerce_list(_get(raw, "actions"))
+
+    sources = [_rule_source_from(s) for s in sources_raw] if sources_raw is not None else None
+    conditions = [_rule_condition_from(c) for c in conditions_raw] if conditions_raw is not None else None
+    actions = [_rule_action_from(a) for a in actions_raw] if actions_raw is not None else None
+
+    return AlarmRule(
+        id=_get(raw, "id"),
+        name=_get(raw, "name"),
+        enable=_get(raw, "enable"),
+        is_created_by_system=_get(raw, "isCreatedBySystem"),
+        sources=sources,
+        conditions=conditions,
+        history_conditions=_coerce_list(_get(raw, "historyConditions")),
+        schedules=_coerce_list(_get(raw, "schedules")),
+        actions=actions,
+        cooldown=_rule_cooldown_from(_get(raw, "cooldown")),
+    )
+
+
+def rule_list_from_controller(raw: Any) -> AlarmRuleList:
+    """Build an AlarmRuleList from a manager dict or object.
+
+    Accepts:
+    - a dict with ``rules`` (list) and ``count`` keys (wrapper shape)
+    - anything else: ``rules`` coalesces to None
+    """
+    rules = _get(raw, "rules")
+    if not isinstance(rules, list):
+        rules = None
+    return AlarmRuleList(
+        rules=rules,
+        count=_get(raw, "count"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# rule_to_controller: snake_case → camelCase normalization for POST/PATCH body
+# ---------------------------------------------------------------------------
+#
+# The read tools (``protect_alarm_list_rules`` / ``protect_alarm_get_rule``)
+# normalize controller payloads to snake_case via ``rule_from_controller``.
+# Protect's ``POST /automations`` endpoint is strict camelCase, so a naive
+# read → mutate → create round-trip fails with 400 "Failed to parse
+# 'request-body'" on the snake_case sibling fields (``is_created_by_system``,
+# ``history_conditions``, action metadata ``use_thumbnail``). ``PATCH`` is
+# permissive in practice today but the same translation defends against future
+# tightening. We rename ONLY the small fixed set of fields that differ in case
+# and pass everything else through untouched so unknown / future Protect
+# fields keep working.
+
+_RULE_TOP_LEVEL_RENAMES: dict[str, str] = {
+    "is_created_by_system": "isCreatedBySystem",
+    "history_conditions": "historyConditions",
+}
+
+_ACTION_METADATA_RENAMES: dict[str, str] = {
+    "use_thumbnail": "useThumbnail",
+}
+
+
+def _action_to_controller(action: Any) -> Any:
+    if not isinstance(action, dict):
+        return action
+    out: dict[str, Any] = {}
+    for key, value in action.items():
+        if key == "metadata" and isinstance(value, dict):
+            value = {_ACTION_METADATA_RENAMES.get(k, k): v for k, v in value.items()}
+        out[key] = value
+    return out
+
+
+def rule_to_controller(body: Any) -> Any:
+    """Translate a rule body to the camelCase shape Protect's controller expects.
+
+    Inverse of :func:`rule_from_controller`. Translates the few fields where
+    the read tools emit snake_case but the controller demands camelCase.
+    All other keys (including unknown / future fields) pass through
+    unchanged. If the caller provides BOTH the snake_case and camelCase form
+    of a field, the camelCase value wins (we never clobber an explicit
+    camelCase value with a stale snake_case sibling).
+
+    Non-dict inputs are returned as-is so the downstream call surfaces the
+    real type error instead of an opaque ``AttributeError``.
+    """
+    if not isinstance(body, dict):
+        return body
+
+    out: dict[str, Any] = {}
+    # First pass: process snake_case-translatable keys (so a later explicit
+    # camelCase write can override them).
+    for key in body:
+        if key in _RULE_TOP_LEVEL_RENAMES:
+            out[_RULE_TOP_LEVEL_RENAMES[key]] = body[key]
+    # Second pass: pass through everything else (and let any explicit
+    # camelCase form override the snake_case translation above).
+    for key, value in body.items():
+        if key in _RULE_TOP_LEVEL_RENAMES:
+            continue
+        if key == "actions" and isinstance(value, list):
+            value = [_action_to_controller(a) for a in value]
+        out[key] = value
+    return out

--- a/packages/unifi-core/src/unifi_core/protect/models/alarms.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/alarms.py
@@ -444,13 +444,36 @@ _ACTION_METADATA_RENAMES: dict[str, str] = {
 }
 
 
+def _metadata_to_controller(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Two-pass snake_case -> camelCase rename for action metadata.
+
+    Mirrors the top-level :func:`rule_to_controller` strategy: translate the
+    snake_case keys first, then pass through everything else so an explicit
+    camelCase sibling overrides the translated value. A single-pass
+    comprehension would let the snake_case form clobber the camelCase form (or
+    not) depending on dict insertion order — camelCase must always win.
+    """
+    out: dict[str, Any] = {}
+    # First pass: snake_case-translatable keys.
+    for key in metadata:
+        if key in _ACTION_METADATA_RENAMES:
+            out[_ACTION_METADATA_RENAMES[key]] = metadata[key]
+    # Second pass: pass through everything else; an explicit camelCase form
+    # overrides the snake_case translation above.
+    for key, value in metadata.items():
+        if key in _ACTION_METADATA_RENAMES:
+            continue
+        out[key] = value
+    return out
+
+
 def _action_to_controller(action: Any) -> Any:
     if not isinstance(action, dict):
         return action
     out: dict[str, Any] = {}
     for key, value in action.items():
         if key == "metadata" and isinstance(value, dict):
-            value = {_ACTION_METADATA_RENAMES.get(k, k): v for k, v in value.items()}
+            value = _metadata_to_controller(value)
         out[key] = value
     return out
 

--- a/packages/unifi-core/tests/protect/managers/test_alarm_manager_rules.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_manager_rules.py
@@ -1,0 +1,301 @@
+"""Tests for AlarmManager rule CRUD methods.
+
+Covers the ``/proxy/protect/api/automations`` endpoints wrapped by
+``AlarmManager.list_rules`` / ``get_rule`` / ``update_rule`` /
+``create_rule`` / ``delete_rule``. Manager methods stay close to the
+raw payload (returning ``Dict[str, Any]`` or ``List[Dict]``); the tool
+layer is responsible for coercing into the pydantic ``AlarmRule`` shapes
+via ``rule_from_controller`` / ``rule_list_from_controller``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.protect.managers.alarm_manager import AlarmManager
+
+
+def _make_manager() -> AlarmManager:
+    return AlarmManager(MagicMock())
+
+
+def _raw_rule(
+    rule_id: str = "rule-001",
+    name: str = "Test Rule",
+    enable: bool = True,
+) -> Dict[str, Any]:
+    """Minimal raw automation payload matching the Protect schema."""
+    return {
+        "id": rule_id,
+        "name": name,
+        "enable": enable,
+        "isCreatedBySystem": False,
+        "sources": [{"device": "AABBCCDDEEFF", "type": "include"}],
+        "conditions": [{"condition": {"source": "smartDetectLine", "type": "is", "value": "Arrival"}}],
+        "historyConditions": [],
+        "schedules": [],
+        "actions": [
+            {
+                "type": "HTTP_REQUEST",
+                "order": -1,
+                "metadata": {
+                    "url": "https://example.test/webhook",
+                    "method": "POST",
+                    "headers": [],
+                    "timeout": 30000,
+                    "useThumbnail": True,
+                },
+            }
+        ],
+        "cooldown": {"enable": False, "timeout": 600000},
+    }
+
+
+# -- list_rules -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_rules_returns_raw_dicts_from_get_automations() -> None:
+    mgr = _make_manager()
+    raw: List[Dict[str, Any]] = [_raw_rule("r-1"), _raw_rule("r-2", "Other")]
+    mgr._cm.client.api_request = AsyncMock(return_value=raw)
+
+    rules = await mgr.list_rules()
+
+    mgr._cm.client.api_request.assert_awaited_once_with("automations", method="get")
+    assert isinstance(rules, list)
+    assert len(rules) == 2
+    assert rules[0]["id"] == "r-1"
+    assert rules[1]["name"] == "Other"
+
+
+@pytest.mark.asyncio
+async def test_list_rules_non_list_response_returns_empty_list() -> None:
+    """A non-list response (controller error / unexpected shape) coalesces to []."""
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock(return_value={"error": "oops"})
+
+    rules = await mgr.list_rules()
+
+    assert rules == []
+
+
+@pytest.mark.asyncio
+async def test_list_rules_skips_non_dict_entries() -> None:
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock(return_value=[_raw_rule("r-1"), "garbage", 42, None])
+
+    rules = await mgr.list_rules()
+
+    assert len(rules) == 1
+    assert rules[0]["id"] == "r-1"
+
+
+# -- get_rule ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_rule_filters_from_list() -> None:
+    """The controller has no per-rule GET endpoint (``GET automations/{id}``
+    404s); get_rule fetches the full list (``GET automations``) and filters
+    by id."""
+    mgr = _make_manager()
+    raw = [_raw_rule("r-1", "First"), _raw_rule("rule-uuid-abc", "Test Vehicle Arrival")]
+    mgr._cm.client.api_request = AsyncMock(return_value=raw)
+
+    rule = await mgr.get_rule("rule-uuid-abc")
+
+    mgr._cm.client.api_request.assert_awaited_once_with("automations", method="get")
+    assert rule["id"] == "rule-uuid-abc"
+    assert rule["name"] == "Test Vehicle Arrival"
+
+
+@pytest.mark.asyncio
+async def test_get_rule_empty_id_rejected() -> None:
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock()
+
+    with pytest.raises(ValueError, match="rule_id"):
+        await mgr.get_rule("")
+
+    mgr._cm.client.api_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_rule_not_found_raises() -> None:
+    """An id absent from the list raises UniFiNotFoundError."""
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock(return_value=[_raw_rule("r-1"), _raw_rule("r-2")])
+
+    with pytest.raises(UniFiNotFoundError):
+        await mgr.get_rule("does-not-exist")
+
+
+@pytest.mark.asyncio
+async def test_get_rule_non_list_response_treated_as_not_found() -> None:
+    """A non-list response coalesces to an empty list (via list_rules), so the
+    id is simply not found."""
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock(return_value={"error": "oops"})
+
+    with pytest.raises(UniFiNotFoundError):
+        await mgr.get_rule("rule-001")
+
+
+# -- update_rule ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_rule_patches_with_full_body() -> None:
+    """PATCH expects the full rule body per JeffSteinbok's implementation."""
+    mgr = _make_manager()
+    body = _raw_rule("rule-001", enable=False)
+    mgr._cm.client.api_request = AsyncMock(return_value=body)
+
+    updated = await mgr.update_rule("rule-001", body)
+
+    mgr._cm.client.api_request.assert_awaited_once_with("automations/rule-001", method="patch", json=body)
+    assert updated["enable"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_rule_empty_id_rejected() -> None:
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock()
+
+    with pytest.raises(ValueError, match="rule_id"):
+        await mgr.update_rule("", _raw_rule())
+
+    mgr._cm.client.api_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_rule_non_dict_body_rejected() -> None:
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock()
+
+    with pytest.raises(TypeError, match="dict"):
+        await mgr.update_rule("rule-001", "not-a-dict")  # type: ignore[arg-type]
+
+    mgr._cm.client.api_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_rule_whitespace_only_id_rejected() -> None:
+    """``_require_rule_id`` strips whitespace before checking for empty —
+    confirm that '   ' is still rejected.
+    """
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock()
+
+    with pytest.raises(ValueError, match="rule_id"):
+        await mgr.update_rule("   ", _raw_rule())
+
+    mgr._cm.client.api_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_rule_non_dict_patch_response_coerces_to_empty_dict() -> None:
+    """PATCH normally echoes the rule body, but if the controller returns
+    something else (None / list / str) coerce to {} rather than crashing
+    callers that expect a dict.
+    """
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock(return_value=None)
+
+    result = await mgr.update_rule("rule-001", _raw_rule())
+
+    assert result == {}
+
+
+# -- create_rule ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rule_posts_body_and_returns_created_dict() -> None:
+    mgr = _make_manager()
+    new_body = _raw_rule("ignored-by-server", "New Rule")
+    # POST returns the server-assigned id
+    server_response = {**new_body, "id": "server-assigned-uuid"}
+    mgr._cm.client.api_request = AsyncMock(return_value=server_response)
+
+    created = await mgr.create_rule(new_body)
+
+    mgr._cm.client.api_request.assert_awaited_once_with("automations", method="post", json=new_body)
+    assert created["id"] == "server-assigned-uuid"
+    assert created["name"] == "New Rule"
+
+
+@pytest.mark.asyncio
+async def test_create_rule_non_dict_body_rejected() -> None:
+    mgr = _make_manager()
+    mgr._cm.client.api_request = AsyncMock()
+
+    with pytest.raises(TypeError, match="dict"):
+        await mgr.create_rule(["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+# -- delete_rule ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_rule_calls_delete_endpoint() -> None:
+    """The controller returns an empty body on a successful delete, so
+    delete_rule uses api_request_raw (no JSON decode) to avoid a spurious
+    'Could not decode JSON' error."""
+    mgr = _make_manager()
+    mgr._cm.client.api_request_raw = AsyncMock(return_value=None)
+
+    result = await mgr.delete_rule("rule-001")
+
+    mgr._cm.client.api_request_raw.assert_awaited_once_with("automations/rule-001", method="delete")
+    assert result == {"deleted": True, "rule_id": "rule-001"}
+
+
+@pytest.mark.asyncio
+async def test_delete_rule_empty_id_rejected() -> None:
+    mgr = _make_manager()
+    mgr._cm.client.api_request_raw = AsyncMock()
+
+    with pytest.raises(ValueError, match="rule_id"):
+        await mgr.delete_rule("")
+
+    mgr._cm.client.api_request_raw.assert_not_awaited()
+
+
+# -- preview helpers --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_update_rule_shows_diff() -> None:
+    """Preview should fetch current rule and report what would change."""
+    mgr = _make_manager()
+    current = _raw_rule("rule-001", "Old Name", enable=True)
+    # get_rule now fetches the list and filters, so mock the list response.
+    mgr._cm.client.api_request = AsyncMock(return_value=[current])
+
+    new_body = {**current, "name": "New Name", "enable": False}
+    preview = await mgr.preview_update_rule("rule-001", new_body)
+
+    assert preview["rule_id"] == "rule-001"
+    assert preview["current"]["name"] == "Old Name"
+    assert preview["current"]["enable"] is True
+    assert preview["proposed"]["name"] == "New Name"
+    assert preview["proposed"]["enable"] is False
+
+
+@pytest.mark.asyncio
+async def test_preview_delete_rule_shows_target() -> None:
+    mgr = _make_manager()
+    current = _raw_rule("rule-001", "To Be Deleted")
+    # get_rule now fetches the list and filters, so mock the list response.
+    mgr._cm.client.api_request = AsyncMock(return_value=[current])
+
+    preview = await mgr.preview_delete_rule("rule-001")
+
+    assert preview["rule_id"] == "rule-001"
+    assert preview["current_name"] == "To Be Deleted"
+    assert preview["proposed_changes"] == {"deleted": True}

--- a/packages/unifi-core/tests/protect/managers/test_alarm_manager_rules.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_manager_rules.py
@@ -114,6 +114,19 @@ async def test_get_rule_filters_from_list() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_rule_strips_padded_id() -> None:
+    """A padded id (`" rule-uuid-abc "`) is stripped before list filtering so it
+    matches the controller's id instead of silently missing."""
+    mgr = _make_manager()
+    raw = [_raw_rule("r-1", "First"), _raw_rule("rule-uuid-abc", "Test Vehicle Arrival")]
+    mgr._cm.client.api_request = AsyncMock(return_value=raw)
+
+    rule = await mgr.get_rule("  rule-uuid-abc  ")
+
+    assert rule["id"] == "rule-uuid-abc"
+
+
+@pytest.mark.asyncio
 async def test_get_rule_empty_id_rejected() -> None:
     mgr = _make_manager()
     mgr._cm.client.api_request = AsyncMock()

--- a/packages/unifi-core/tests/protect/models/test_actions.py
+++ b/packages/unifi-core/tests/protect/models/test_actions.py
@@ -5,7 +5,9 @@ from pydantic import ValidationError
 from unifi_core.protect.models._actions import (
     AcknowledgeEventInput,
     AlarmArmInput,
+    AlarmCreateRuleInput,
     AlarmDisarmInput,
+    AlarmUpdateRuleInput,
     DeleteLiveviewInput,
     DeleteRecordingInput,
     ExportClipInput,
@@ -16,6 +18,77 @@ from unifi_core.protect.models._actions import (
     ToggleRecordingInput,
     TriggerChimeInput,
 )
+
+
+def _valid_rule_body(actions: list | None = None) -> dict:
+    """Minimum body shape that satisfies the create/update validators.
+
+    Real Protect bodies are richer (sources/conditions/cooldown/etc.); we
+    only need enough here to drive the actions-non-empty validator.
+    """
+    return {
+        "name": "Test",
+        "enable": False,
+        "actions": [{"type": "HTTP_REQUEST", "metadata": {"url": "https://example.test/wh"}}]
+        if actions is None
+        else actions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AlarmCreateRuleInput — empty-actions rejection (live-test learning)
+# ---------------------------------------------------------------------------
+
+
+class TestAlarmCreateRuleInput:
+    def test_action_input_flag(self) -> None:
+        assert AlarmCreateRuleInput.__action_input__ is True
+
+    def test_valid_with_actions(self) -> None:
+        m = AlarmCreateRuleInput(body=_valid_rule_body())
+        assert m.body["actions"]
+
+    def test_rejects_empty_actions_list(self) -> None:
+        """Protect accepts ``actions: []`` server-side but the resulting rule
+        cannot be opened in the Protect UI ("We're Unable to Complete Your
+        Request"). Found via live-test 2026-05-27. Reject client-side."""
+        with pytest.raises(ValidationError, match="actions"):
+            AlarmCreateRuleInput(body=_valid_rule_body(actions=[]))
+
+    def test_rejects_missing_actions_key(self) -> None:
+        body = {"name": "x", "enable": False}
+        with pytest.raises(ValidationError, match="actions"):
+            AlarmCreateRuleInput(body=body)
+
+    def test_rejects_non_list_actions(self) -> None:
+        with pytest.raises(ValidationError, match="actions"):
+            AlarmCreateRuleInput(body=_valid_rule_body(actions="not-a-list"))  # type: ignore[arg-type]
+
+
+class TestAlarmUpdateRuleInput:
+    def test_action_input_flag(self) -> None:
+        assert AlarmUpdateRuleInput.__action_input__ is True
+
+    def test_valid_with_actions(self) -> None:
+        m = AlarmUpdateRuleInput(rule_id="r-1", body=_valid_rule_body())
+        assert m.rule_id == "r-1"
+
+    def test_rejects_empty_actions_list(self) -> None:
+        """Same brick-the-UI risk as create — reject empty actions on PATCH too."""
+        with pytest.raises(ValidationError, match="actions"):
+            AlarmUpdateRuleInput(rule_id="r-1", body=_valid_rule_body(actions=[]))
+
+    def test_rejects_missing_actions_key(self) -> None:
+        with pytest.raises(ValidationError, match="actions"):
+            AlarmUpdateRuleInput(rule_id="r-1", body={"name": "x"})
+
+    def test_rejects_non_list_actions(self) -> None:
+        with pytest.raises(ValidationError, match="actions"):
+            AlarmUpdateRuleInput(
+                rule_id="r-1",
+                body=_valid_rule_body(actions="not-a-list"),  # type: ignore[arg-type]
+            )
+
 
 # ---------------------------------------------------------------------------
 # PtzMoveInput

--- a/packages/unifi-core/tests/protect/models/test_alarms.py
+++ b/packages/unifi-core/tests/protect/models/test_alarms.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Protect AlarmStatus, AlarmProfile, and AlarmProfileList read-only models."""
+"""Unit tests for the Protect alarm read-only models (status/profile/rule)."""
 
 from __future__ import annotations
 
@@ -9,9 +9,18 @@ from unifi_core.protect.models.alarms import (
     READ_ONLY_FIELDS,
     AlarmProfile,
     AlarmProfileList,
+    AlarmRule,
+    AlarmRuleAction,
+    AlarmRuleActionMetadata,
+    AlarmRuleCondition,
+    AlarmRuleCooldown,
+    AlarmRuleList,
+    AlarmRuleSource,
     AlarmStatus,
     profile_from_controller,
     profile_list_from_controller,
+    rule_from_controller,
+    rule_list_from_controller,
     status_from_controller,
 )
 
@@ -32,13 +41,24 @@ class TestAlarmModelFields:
         for field_name in AlarmProfileList.model_fields:
             assert field_name in READ_ONLY_FIELDS
 
-    def test_read_only_fields_is_union_of_all_three_models(self) -> None:
+    def test_read_only_fields_is_union_of_all_models(self) -> None:
         expected = (
             frozenset(AlarmStatus.model_fields.keys())
             | frozenset(AlarmProfile.model_fields.keys())
             | frozenset(AlarmProfileList.model_fields.keys())
+            | frozenset(AlarmRule.model_fields.keys())
+            | frozenset(AlarmRuleList.model_fields.keys())
+            | frozenset(AlarmRuleSource.model_fields.keys())
+            | frozenset(AlarmRuleCondition.model_fields.keys())
+            | frozenset(AlarmRuleAction.model_fields.keys())
+            | frozenset(AlarmRuleActionMetadata.model_fields.keys())
+            | frozenset(AlarmRuleCooldown.model_fields.keys())
         )
         assert READ_ONLY_FIELDS == expected
+
+    def test_read_only_fields_contains_alarm_rule_fields(self) -> None:
+        for field_name in AlarmRule.model_fields:
+            assert field_name in READ_ONLY_FIELDS
 
 
 class TestStatusFromController:
@@ -239,3 +259,390 @@ class TestProfileListFromController:
         dumped = profile_list.model_dump(exclude_none=True)
         assert "profiles" not in dumped
         assert "count" in dumped
+
+
+# ---------------------------------------------------------------------------
+# Alarm rule (Alarm Manager automations) model tests
+# ---------------------------------------------------------------------------
+
+
+# Representative fixture matching the Protect ``/proxy/protect/api/automations``
+# payload schema. All values are synthetic.
+_VEHICLE_ARRIVAL_RULE_FIXTURE = {
+    "id": "rule-uuid-1234",
+    "name": "Example Vehicle Arrival Rule",
+    "enable": True,
+    "isCreatedBySystem": False,
+    "sources": [
+        {"device": "AABBCC001122", "type": "include"},
+    ],
+    "conditions": [
+        {
+            "condition": {
+                "source": "smartDetectLine",
+                "type": "is",
+                "value": "Arrival - down",
+            }
+        },
+        {
+            "condition": {
+                "source": "license_plate_known",
+                "type": "is",
+                "value": "vehicle_LPR-ABC1234",
+            }
+        },
+    ],
+    "historyConditions": [],
+    "schedules": [],
+    "actions": [
+        {
+            "type": "HTTP_REQUEST",
+            "order": -1,
+            "metadata": {
+                "url": "https://ha.example.test/api/webhook/test_vehicle_arriving",
+                "method": "POST",
+                "headers": [],
+                "timeout": 30000,
+                "useThumbnail": True,
+            },
+        },
+    ],
+    "cooldown": {"enable": False, "timeout": 600000},
+}
+
+
+class TestRuleFromController:
+    def test_full_vehicle_fixture(self) -> None:
+        rule = rule_from_controller(_VEHICLE_ARRIVAL_RULE_FIXTURE)
+        assert isinstance(rule, AlarmRule)
+        assert rule.id == "rule-uuid-1234"
+        assert rule.name == "Example Vehicle Arrival Rule"
+        assert rule.enable is True
+        assert rule.is_created_by_system is False
+        assert rule.history_conditions == []
+        assert rule.schedules == []
+
+    def test_sources_parsed_as_list_of_models(self) -> None:
+        rule = rule_from_controller(_VEHICLE_ARRIVAL_RULE_FIXTURE)
+        assert rule.sources is not None
+        assert len(rule.sources) == 1
+        assert isinstance(rule.sources[0], AlarmRuleSource)
+        assert rule.sources[0].device == "AABBCC001122"
+        assert rule.sources[0].type == "include"
+
+    def test_conditions_parsed_as_list_of_wrappers_keeping_inner_opaque(self) -> None:
+        rule = rule_from_controller(_VEHICLE_ARRIVAL_RULE_FIXTURE)
+        assert rule.conditions is not None
+        assert len(rule.conditions) == 2
+        first = rule.conditions[0]
+        assert isinstance(first, AlarmRuleCondition)
+        # Inner condition body stays as a dict — we intentionally don't
+        # enumerate every source/type combination.
+        assert first.condition == {
+            "source": "smartDetectLine",
+            "type": "is",
+            "value": "Arrival - down",
+        }
+        assert rule.conditions[1].condition == {
+            "source": "license_plate_known",
+            "type": "is",
+            "value": "vehicle_LPR-ABC1234",
+        }
+
+    def test_actions_parsed_with_metadata_kept_opaque(self) -> None:
+        rule = rule_from_controller(_VEHICLE_ARRIVAL_RULE_FIXTURE)
+        assert rule.actions is not None
+        assert len(rule.actions) == 1
+        action = rule.actions[0]
+        assert isinstance(action, AlarmRuleAction)
+        assert action.type == "HTTP_REQUEST"
+        assert action.order == -1
+        # Metadata is kept as dict on the action; the typed
+        # AlarmRuleActionMetadata is exported for callers who want to coerce
+        # but we don't force coercion at parse time.
+        assert isinstance(action.metadata, dict)
+        assert action.metadata["url"] == ("https://ha.example.test/api/webhook/test_vehicle_arriving")
+        assert action.metadata["method"] == "POST"
+        assert action.metadata["useThumbnail"] is True
+
+    def test_cooldown_parsed(self) -> None:
+        rule = rule_from_controller(_VEHICLE_ARRIVAL_RULE_FIXTURE)
+        assert isinstance(rule.cooldown, AlarmRuleCooldown)
+        assert rule.cooldown.enable is False
+        assert rule.cooldown.timeout == 600000
+
+    def test_empty_dict_coalesces_to_none(self) -> None:
+        rule = rule_from_controller({})
+        assert isinstance(rule, AlarmRule)
+        assert rule.id is None
+        assert rule.name is None
+        assert rule.enable is None
+        assert rule.sources is None
+        assert rule.conditions is None
+        assert rule.actions is None
+        assert rule.cooldown is None
+
+    def test_partial_dict_only_id_and_name(self) -> None:
+        rule = rule_from_controller({"id": "r-1", "name": "Test"})
+        assert rule.id == "r-1"
+        assert rule.name == "Test"
+        assert rule.enable is None
+        assert rule.sources is None
+        assert rule.conditions is None
+
+    def test_non_list_sources_coalesces_to_none(self) -> None:
+        rule = rule_from_controller({"id": "r-1", "sources": "not a list"})
+        assert rule.sources is None
+
+    def test_non_list_conditions_coalesces_to_none(self) -> None:
+        rule = rule_from_controller({"id": "r-1", "conditions": {"oops": "dict"}})
+        assert rule.conditions is None
+
+    def test_non_dict_cooldown_coalesces_to_none(self) -> None:
+        rule = rule_from_controller({"id": "r-1", "cooldown": "off"})
+        assert rule.cooldown is None
+
+    def test_condition_with_non_dict_inner_keeps_outer_but_drops_inner(self) -> None:
+        raw = {"id": "r-1", "conditions": [{"condition": "not a dict"}]}
+        rule = rule_from_controller(raw)
+        assert rule.conditions is not None
+        assert len(rule.conditions) == 1
+        assert rule.conditions[0].condition is None
+
+    def test_unknown_action_type_passthrough(self) -> None:
+        """A new/unknown action type should not break parsing."""
+        raw = {
+            "id": "r-1",
+            "actions": [{"type": "FUTURE_ACTION_KIND", "metadata": {"x": 1}}],
+        }
+        rule = rule_from_controller(raw)
+        assert rule.actions is not None
+        assert rule.actions[0].type == "FUTURE_ACTION_KIND"
+        assert rule.actions[0].metadata == {"x": 1}
+
+    def test_model_dump_excludes_none(self) -> None:
+        rule = rule_from_controller({"id": "r-1", "name": "Test", "enable": True})
+        dumped = rule.model_dump(exclude_none=True)
+        assert dumped["id"] == "r-1"
+        assert dumped["name"] == "Test"
+        assert dumped["enable"] is True
+        assert "sources" not in dumped
+        assert "conditions" not in dumped
+        assert "actions" not in dumped
+        assert "cooldown" not in dumped
+
+
+class TestRuleListFromController:
+    def test_full_wrapper_dict(self) -> None:
+        raw = {
+            "rules": [
+                {"id": "r-1", "name": "Arrival"},
+                {"id": "r-2", "name": "Departure"},
+            ],
+            "count": 2,
+        }
+        rule_list = rule_list_from_controller(raw)
+        assert isinstance(rule_list, AlarmRuleList)
+        assert rule_list.count == 2
+        assert len(rule_list.rules) == 2
+
+    def test_empty_rules_list(self) -> None:
+        rule_list = rule_list_from_controller({"rules": [], "count": 0})
+        assert rule_list.rules == []
+        assert rule_list.count == 0
+
+    def test_non_list_rules_coalesces_to_none(self) -> None:
+        rule_list = rule_list_from_controller({"rules": "oops", "count": 0})
+        assert rule_list.rules is None
+
+    def test_none_rules_coalesces_to_none(self) -> None:
+        rule_list = rule_list_from_controller({"rules": None, "count": 0})
+        assert rule_list.rules is None
+
+    def test_dict_rules_coalesces_to_none(self) -> None:
+        rule_list = rule_list_from_controller({"rules": {"x": 1}, "count": 1})
+        assert rule_list.rules is None
+
+    def test_empty_dict(self) -> None:
+        rule_list = rule_list_from_controller({})
+        assert isinstance(rule_list, AlarmRuleList)
+        assert rule_list.rules is None
+        assert rule_list.count is None
+
+    def test_model_dump_excludes_none(self) -> None:
+        rule_list = rule_list_from_controller({"rules": [{"id": "r-1"}], "count": 1})
+        dumped = rule_list.model_dump(exclude_none=True)
+        assert "rules" in dumped
+        assert "count" in dumped
+
+
+# ----------------------------------------------------------------------------
+# rule_to_controller: snake_case → camelCase normalization for POST/PATCH body
+# ----------------------------------------------------------------------------
+#
+# Background: the read tools (list_rules / get_rule) normalize controller
+# payloads to snake_case via ``rule_from_controller``. The Protect controller's
+# POST /automations endpoint is strict camelCase, so a naive read → mutate →
+# create round-trip fails with 400 "Failed to parse request-body" on the
+# ``is_created_by_system`` / ``history_conditions`` fields. ``rule_to_controller``
+# is the inverse: it translates the handful of fields that differ in case
+# back to camelCase so the round-trip works, leaving everything else untouched.
+
+
+class TestRuleToController:
+    def test_translates_top_level_snake_to_camel(self) -> None:
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {
+            "name": "R1",
+            "enable": True,
+            "is_created_by_system": False,
+            "history_conditions": [],
+            "schedules": [],
+        }
+        out = rule_to_controller(body)
+        assert "is_created_by_system" not in out
+        assert "history_conditions" not in out
+        assert out["isCreatedBySystem"] is False
+        assert out["historyConditions"] == []
+        # Passthrough fields are untouched
+        assert out["name"] == "R1"
+        assert out["enable"] is True
+        assert out["schedules"] == []
+
+    def test_translates_nested_action_metadata_use_thumbnail(self) -> None:
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {
+            "actions": [
+                {
+                    "type": "HTTP_REQUEST",
+                    "order": -1,
+                    "metadata": {
+                        "url": "https://example.test/wh",
+                        "method": "POST",
+                        "use_thumbnail": True,
+                    },
+                }
+            ],
+        }
+        out = rule_to_controller(body)
+        meta = out["actions"][0]["metadata"]
+        assert "use_thumbnail" not in meta
+        assert meta["useThumbnail"] is True
+        # Other metadata fields preserved
+        assert meta["url"] == "https://example.test/wh"
+        assert meta["method"] == "POST"
+
+    def test_camelcase_input_passthrough_unchanged(self) -> None:
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {
+            "name": "R2",
+            "isCreatedBySystem": True,
+            "historyConditions": ["something"],
+            "actions": [{"type": "HTTP_REQUEST", "metadata": {"useThumbnail": False}}],
+        }
+        out = rule_to_controller(body)
+        assert out["isCreatedBySystem"] is True
+        assert out["historyConditions"] == ["something"]
+        assert out["actions"][0]["metadata"]["useThumbnail"] is False
+        # No accidental snake_case sibling fields
+        assert "is_created_by_system" not in out
+        assert "history_conditions" not in out
+        assert "use_thumbnail" not in out["actions"][0]["metadata"]
+
+    def test_both_snake_and_camel_prefers_camel(self) -> None:
+        """If the caller (perversely) provides both forms, the explicit
+        camelCase value wins so we never accidentally clobber an
+        intentional value with a stale snake_case sibling."""
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {
+            "is_created_by_system": True,
+            "isCreatedBySystem": False,
+        }
+        out = rule_to_controller(body)
+        assert out["isCreatedBySystem"] is False
+        assert "is_created_by_system" not in out
+
+    def test_unknown_fields_passthrough(self) -> None:
+        """Future Protect fields we don't enumerate must round-trip untouched."""
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {"future_field": "x", "futureCamelField": "y"}
+        out = rule_to_controller(body)
+        assert out["future_field"] == "x"
+        assert out["futureCamelField"] == "y"
+
+    def test_empty_dict_returns_empty_dict(self) -> None:
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        assert rule_to_controller({}) == {}
+
+    def test_non_dict_input_passthrough(self) -> None:
+        """Defensive: non-dict input is returned as-is so callers see
+        a clear downstream error instead of an opaque AttributeError."""
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        assert rule_to_controller("not a dict") == "not a dict"  # type: ignore[arg-type]
+        assert rule_to_controller(None) is None  # type: ignore[arg-type]
+
+    def test_action_with_non_dict_metadata_unchanged(self) -> None:
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {"actions": [{"type": "SEND_NOTIFICATION", "metadata": None}]}
+        out = rule_to_controller(body)
+        assert out["actions"][0]["metadata"] is None
+
+    def test_actions_non_list_passthrough(self) -> None:
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {"actions": "not-a-list"}
+        out = rule_to_controller(body)
+        assert out["actions"] == "not-a-list"  # let downstream validation catch it
+
+    def test_round_trip_from_controller_to_controller(self) -> None:
+        """The canonical fix path: read via from_controller (snake_case),
+        mutate, send via to_controller (camelCase). Must yield a body the
+        live Protect POST endpoint accepts."""
+        from unifi_core.protect.models.alarms import rule_from_controller, rule_to_controller
+
+        # Simulate what list_rules / get_rule returns (snake_case-normalized)
+        as_read = rule_from_controller(
+            {
+                "id": "r-1",
+                "name": "Existing",
+                "enable": True,
+                "isCreatedBySystem": False,
+                "sources": [{"device": "AABBCCDDEEFF", "type": "include"}],
+                "conditions": [{"condition": {"source": "vehicle", "type": "is"}}],
+                "historyConditions": [],
+                "schedules": [],
+                "actions": [
+                    {
+                        "type": "HTTP_REQUEST",
+                        "order": -1,
+                        "metadata": {
+                            "url": "https://example.test/wh",
+                            "method": "POST",
+                            "useThumbnail": True,
+                        },
+                    }
+                ],
+                "cooldown": {"enable": False, "timeout": 600000},
+            }
+        ).model_dump(exclude_none=True)
+
+        # Caller mutates a couple of fields (e.g. clone-and-rename)
+        as_read["name"] = "Clone"
+        as_read.pop("id", None)
+
+        # Translate for POST
+        for_post = rule_to_controller(as_read)
+        assert "is_created_by_system" not in for_post
+        assert "history_conditions" not in for_post
+        assert for_post["isCreatedBySystem"] is False
+        assert for_post["historyConditions"] == []
+        assert for_post["actions"][0]["metadata"]["useThumbnail"] is True
+        assert "use_thumbnail" not in for_post["actions"][0]["metadata"]

--- a/packages/unifi-core/tests/protect/models/test_alarms.py
+++ b/packages/unifi-core/tests/protect/models/test_alarms.py
@@ -566,6 +566,34 @@ class TestRuleToController:
         assert out["isCreatedBySystem"] is False
         assert "is_created_by_system" not in out
 
+    def test_nested_both_snake_and_camel_prefers_camel(self) -> None:
+        """Nested action metadata must mirror the top-level two-pass rule:
+        an explicit camelCase value wins over its snake_case sibling
+        regardless of dict insertion order (a single-pass comprehension
+        would clobber by order)."""
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        # snake first, then camel
+        body = {"actions": [{"metadata": {"use_thumbnail": True, "useThumbnail": False}}]}
+        meta = rule_to_controller(body)["actions"][0]["metadata"]
+        assert meta["useThumbnail"] is False
+        assert "use_thumbnail" not in meta
+
+        # camel first, then snake — must still resolve to camel
+        body = {"actions": [{"metadata": {"useThumbnail": False, "use_thumbnail": True}}]}
+        meta = rule_to_controller(body)["actions"][0]["metadata"]
+        assert meta["useThumbnail"] is False
+        assert "use_thumbnail" not in meta
+
+    def test_nested_snake_only_translated(self) -> None:
+        """A lone snake_case metadata key is translated to camelCase."""
+        from unifi_core.protect.models.alarms import rule_to_controller
+
+        body = {"actions": [{"metadata": {"use_thumbnail": True}}]}
+        meta = rule_to_controller(body)["actions"][0]["metadata"]
+        assert meta["useThumbnail"] is True
+        assert "use_thumbnail" not in meta
+
     def test_unknown_fields_passthrough(self) -> None:
         """Future Protect fields we don't enumerate must round-trip untouched."""
         from unifi_core.protect.models.alarms import rule_to_controller

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -1,4 +1,4 @@
-# Protect Server Tool Reference (49 tools)
+# Protect Server Tool Reference (54 tools)
 
 Complete reference for `protect_*` tools. All read tools are always available. All mutations are **disabled by default** — the user must explicitly enable them because Protect controls physical security hardware.
 
@@ -168,14 +168,19 @@ Always available, regardless of registration mode.
 Controls the UniFi Protect Alarm Manager (Protect 6.1+). Requires arm profiles configured in the Protect web UI. Mutations gated by `UNIFI_POLICY_PROTECT_ALARM_UPDATE=true`.
 
 <!-- AUTO:tools:alarm -->
-4 tools.
+9 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
+| `protect_alarm_get_rule` | Read | Fetches the full payload of a single alarm rule (automation) by id. |
 | `protect_alarm_get_status` | Read | Returns the current armed/disarmed state of the UniFi Protect Alarm Manager, including the active profile, raw status string, armed-at ti... |
 | `protect_alarm_list_profiles` | Read | Lists all configured UniFi Protect Alarm Manager profiles with their id, name, activation delay, schedule count, and automation count. |
+| `protect_alarm_list_rules` | Read | Lists every alarm rule (automation) configured in the UniFi Protect Alarm Manager. |
 | `protect_alarm_arm` | Mutate | Arms the UniFi Protect Alarm Manager. |
+| `protect_alarm_create_rule` | Mutate | Creates a new alarm rule via POST. |
+| `protect_alarm_delete_rule` | Mutate | Deletes an alarm rule (automation) by id. |
 | `protect_alarm_disarm` | Mutate | Disarms the UniFi Protect Alarm Manager system-wide via POST arm/disable. |
+| `protect_alarm_update_rule` | Mutate | Updates an alarm rule via PATCH. |
 <!-- /AUTO:tools:alarm -->
 
 **Tips:**


### PR DESCRIPTION
## Summary

Extend the Protect Alarm Manager wrapper with read + write coverage of the private `/proxy/protect/api/automations` endpoint. The existing arm/disarm tools (Protect 6.1+ Alarm Manager) get five new siblings that round out programmatic control of alarm rules (automations):

| Tool | Endpoint | Notes |
|---|---|---|
| `protect_alarm_list_rules` | `GET automations` | Flat list of all rules |
| `protect_alarm_get_rule` | `GET automations` + filter | Per-rule fetch (see below) |
| `protect_alarm_create_rule` | `POST automations` | Full-body create |
| `protect_alarm_update_rule` | `PATCH automations/{id}` | Full-body PATCH (read-modify-write) |
| `protect_alarm_delete_rule` | `DELETE automations/{id}` | Idempotent delete |

The five tools are also exposed through GraphQL / the REST action surface (see "GraphQL / REST exposure" below).

## Motivation

The arm/disarm pair is useful but only exposes the system-wide state. Real automation needs to inspect and tune the rule definitions themselves -- the conditions that trigger an alarm, the actions taken, and the cooldown -- via API. With these five tools the full alarm-rule lifecycle is reachable from MCP.

## Endpoint behavior verified against a live Protect 7.x controller

A few quirks shaped the implementation:

- **`GET automations/{id}` is not routed.** The controller returns 404 for per-rule path requests. The per-rule fetch is `GET automations` then filter by id. `get_rule` does that and raises `UniFiNotFoundError` when no row matches.
- **`DELETE automations/{id}` returns an empty body on success.** Using the default `api_request` triggers a spurious "Could not decode JSON" error. `delete_rule` uses `api_request_raw` (no JSON decode) to avoid it.
- **`POST automations` is strict camelCase.** The controller's read response is camelCase (`isCreatedBySystem`, `historyConditions`, action metadata `useThumbnail`), and POST rejects snake_case with `400 Failed to parse 'request-body'`. Since this codebase normalizes read responses to snake_case via the existing `rule_from_controller` pattern (consistent with the rest of the protect models), `rule_to_controller` is the inverse: it translates the small set of case-mismatched fields back to camelCase before POST/PATCH and passes every other key through untouched. Both casings are accepted; if the caller provides both, the camelCase value wins. This means the natural read-modify-write clone flow (`get_rule` → mutate → `create_rule`) works directly.
- **Empty `actions` list bricks the Protect UI.** The controller accepts `actions: []` (or no `actions` key) and returns a normal-looking rule on POST. But the resulting rule cannot be opened in the Protect UI -- it shows the generic "We're Unable to Complete Your Request" error and the rule becomes only deletable via API. The input validators on `AlarmCreateRuleInput` and `AlarmUpdateRuleInput` reject this client-side before any controller call.

## Implementation

- **Lossy on deeply-nested condition bodies.** `AlarmRuleCondition.condition` is a free-form `Dict[str, Any]` rather than enumerating every Protect condition source/type combination. Protect adds new detection sources over time (`license_plate_known`, `smartDetectLine`, `Vehicle Description` specifics, etc.) and a strict schema would block passthrough of an unknown condition type. The list of valid sources is also documented in the create/update tool descriptions.
- **`rule_to_controller` is intentionally asymmetric with `rule_from_controller`.** The "from" path deeply normalizes all controller fields (id, timestamps, etc.) because the read tools need a stable snake_case surface. The "to" path only translates the small set of fields that actually cause a 400 (`is_created_by_system`, `history_conditions`, action metadata `use_thumbnail`). The `_RULE_TOP_LEVEL_RENAMES` dict makes the gap explicit and auditable.
- **Update is a full-body PATCH.** Protect rejects partial PATCH bodies. The expected flow is documented on the `update_rule` tool: (1) call `get_rule`, (2) mutate the returned dict, (3) pass back as `body`. The tool layer translates to camelCase once and shares the translated body between the preview and apply paths so the proposed-changes preview matches what actually gets PATCHed.
- **All write tools take `confirm: bool`.** Default false returns a preview (current vs proposed for update; proposed-only for create; warning + current state for delete). Matches the pattern used by the existing `apply_*` action tools.

## GraphQL / REST exposure

- `AlarmRule` plus nested `AlarmRuleSource` / `AlarmRuleCondition` / `AlarmRuleAction` / `AlarmRuleCooldown` are registered as Strawberry types in `apps/api/src/unifi_api/graphql/types/protect/alarms.py`.
- Read tools (`protect_alarm_list_rules`, `protect_alarm_get_rule`) are registered as Phase 6 type-migrated tools via `type_registry_init.py`, so they dispatch through the shared type registry for both REST and GraphQL.
- Mutation tools (`protect_alarm_create_rule` / `update_rule` / `delete_rule`) extend the existing `AlarmMutationAckSerializer` (which already covers arm/disarm).
- `dispatch_overrides.py` registers `update_rule` / `delete_rule` so the action endpoint targets the mutation method instead of the preview that the AST walker would otherwise capture (`create_rule` doesn't need an override -- its tool body's first manager await is `create_rule` itself, not a preview).
- `schema.graphql` and `graphql-reference.md` updated to match.

## Test coverage

Unit tests at three layers:

- **Manager (`test_alarm_manager_rules.py`)** -- 13 tests: list shape variants, get filter behavior + not-found, update happy path + non-dict response coercion + whitespace id, create happy path + non-dict body, delete happy path + empty body handling. All written against an `AsyncMock` of `connection_manager.client.api_request` / `api_request_raw` with raw camelCase payloads matching what the live controller returns.
- **Models (`test_alarms.py`)** -- 10 tests for `rule_to_controller` covering happy path, both-casings-provided (camelCase wins), unknown-fields passthrough, nested action metadata translation, non-dict / non-list edge cases, and the full `from_controller` → mutate → `to_controller` round-trip.
- **Input validators (`test_actions.py`)** -- 9 tests across `TestAlarmCreateRuleInput` / `TestAlarmUpdateRuleInput` covering valid input + empty-actions reject + missing-actions reject + non-list-actions reject.

Total new tests: 32. Full unifi-core protect suite: 324/324 pass. Full apps/protect suite: 379/379 pass. `ruff format --check` and `ruff check` both clean (pinned version per uv.lock).

## Verified live

All five MCP tools exercised end-to-end against a live Protect 7.x controller:
- `list_rules` -- returns the full rule set with the same shape as the test fixtures.
- `get_rule` -- per-rule fetch returns the row from the list. Not-found path returns a clean `UniFiNotFoundError`.
- `create_rule` -- exercised with both snake_case input (translated via `rule_to_controller`) and native camelCase. Controller returns 200 with the server-assigned id and the rule renders correctly in the Protect UI under the expected `Vehicle Description` / `Specific` binding for a `license_plate_known` condition.
- `update_rule` -- read-modify-write flow validated: `get_rule` (snake_case) → mutate (rename + cooldown bump) → `update_rule`. Re-read confirms persistence.
- `delete_rule` -- returns `{"deleted": true, "rule_id": ...}` and the rule is gone on the next `list_rules`.

Empty-actions rejection was also verified live: a body with `actions: []` is rejected client-side with the documented error, never reaching the controller (so the rule that would brick the UI never gets created).

The GraphQL/REST surface was exercised end-to-end against the same live controller through a running `apps/api` instance:
- GraphQL `alarmRules(controller)` -- returns the AlarmRuleList wrapper with the full set of automations from the controller.
- GraphQL `alarmRule(controller, id)` -- single-rule fetch returns the rule; not-found path propagates `UniFiNotFoundError` to a GraphQL error correctly.
- REST `POST /v1/actions/protect_alarm_create_rule` -- create-via-action with a snake_case body returned 200 with the server-assigned id (the `dispatch_overrides.py` routing and the snake/camel translation both engaged).
- REST `POST /v1/actions/protect_alarm_update_rule` -- rename + cooldown bump persisted; verified by re-reading via `alarmRule(id)` and by direct MCP read against the controller.
- REST `POST /v1/actions/protect_alarm_delete_rule` -- returns `{deleted: true, rule_id: ...}`; verified gone by `alarmRule(id)` (expected not-found) and by direct MCP read against the controller.

## Scope note

This is a larger-than-typical PR (~2.5k lines) because foundation (manager + models + their tests), the MCP tool layer + input models + manifest, AND the GraphQL/REST API exposure are interdependent: the `apps/api` `SerializerRegistry` enforces that every MCP tool in the manifest has a projection (Strawberry type or serializer), so adding the tools without the API surface fails CI. Splitting along those layer boundaries would create artificial dependency chains rather than independently-mergeable PRs.

## Out of scope (separate PRs)

- **License-plate identity lookup tool.** A companion `protect_list_known_license_plates` tool is in a sibling PR so an MCP caller can discover the `id` values needed for a `license_plate_known` condition. The two PRs are independent at the file level; this one only references the condition source by name in its tool description.
- **Arm-profile CRUD.** Out of scope here -- this PR is rule (automation) CRUD only. Arm profiles are the preset bundles (e.g. "Arm Night", "Arm All") that group automations together with an activation delay and schedule; arming with `PATCH arm + armProfileId` activates a profile's set. The existing `protect_alarm_list_profiles` already reads them, but creating / editing / deleting the profile definitions themselves is not covered here -- a reasonable follow-up PR.

## Closes

(none -- contributes to filling out the Alarm Manager surface)
