### PR TITLE
feat(protect): list known license plates via recognition/vehicle/groups, plus GraphQL/REST exposure

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -759,6 +759,31 @@ type KnownFacePage {
   nextCursor: String
 }
 
+"""A UniFi Protect license-plate identity (vehicle recognition group)."""
+type KnownLicensePlate {
+  id: ID
+  name: String
+  matchedName: String
+  type: String
+  imagePath: String
+  enhancedPath: String
+  detectionsCount: Int
+  firstDetectedAt: String
+  lastDetectedAt: String
+  isNotificationEnabled: Boolean
+  isDegraded: Boolean
+  tags: JSON
+  description: String
+  createdAt: String
+  metadata: JSON
+}
+
+"""Paginated page of UniFi Protect license-plate identities."""
+type KnownLicensePlatePage {
+  items: [KnownLicensePlate!]!
+  nextCursor: String
+}
+
 """A UniFi Protect light (PIR-triggered floodlight)."""
 type Light {
   id: ID
@@ -1309,6 +1334,11 @@ type ProtectQuery {
 
   """List assigned Protect Known Faces / named face recognition groups."""
   knownFaces(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownFacePage!
+
+  """
+  List UniFi Protect license-plate identities (vehicle recognition groups). Each entry's id is the value to use in a `license_plate_known` alarm-rule condition.
+  """
+  knownLicensePlates(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownLicensePlatePage!
 
   """List paired Protect chimes (paginated)."""
   chimes(controller: ID!, limit: Int! = 50, cursor: String = null): ChimePage!
@@ -1971,6 +2001,7 @@ Read-only access to UniFi Protect resources.
 - `firmwareStatus: FirmwareStatus`  — Get firmware status for the NVR plus its devices.
 - `health: ProtectHealth`  — Get the NVR health snapshot (cpu / memory / storage).
 - `knownFaces: KnownFacePage!`  — List assigned Protect Known Faces / named face recognition groups.
+- `knownLicensePlates: KnownLicensePlatePage!`  — List UniFi Protect license-plate identities (vehicle recognition groups). Each entry's id is the value to use in a `license_plate_known` alarm-rule condition.
 - `lights: LightPage!`  — List Protect lights (PIR-triggered floodlights).
 - `liveviews: LiveviewPage!`  — List Protect liveviews (multi-camera grid layouts).
 - `recordingStatus: RecordingStatusList`  — Get current recording state for one or all cameras ({cameras, count}).

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1718,6 +1718,24 @@ No native ``protect_get_liveview`` tool — filter from LIST.
 
 **Returns:** `Page_KnownFaceModel_`
 
+### `GET /v1/sites/{site_id}/known-license-plates` — List Known License Plates
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `min_confidence` (query)
+- `include_interest` (query)
+- `group_types` (query)
+- `order_by` (query)
+- `order_direction` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_KnownLicensePlateModel_`
+
 
 ## protect/sensors
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2728,6 +2728,174 @@
         "title": "KnownFaceModel",
         "type": "object"
       },
+      "KnownLicensePlateModel": {
+        "additionalProperties": true,
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "detections_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detections Count"
+          },
+          "enhanced_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enhanced Path"
+          },
+          "first_detected_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Detected At"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "is_degraded": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Degraded"
+          },
+          "is_notification_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Notification Enabled"
+          },
+          "last_detected_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Detected At"
+          },
+          "matched_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Name"
+          },
+          "metadata": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "tags": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "KnownLicensePlateModel",
+        "type": "object"
+      },
       "NetworkModel": {
         "additionalProperties": true,
         "properties": {
@@ -4086,6 +4254,46 @@
           "items"
         ],
         "title": "Page[KnownFaceModel]",
+        "type": "object"
+      },
+      "Page_KnownLicensePlateModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/KnownLicensePlateModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[KnownLicensePlateModel]",
         "type": "object"
       },
       "Page_NetworkModel_": {
@@ -11910,6 +12118,157 @@
           }
         },
         "summary": "List Known Faces",
+        "tags": [
+          "protect/recognition"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/known-license-plates": {
+      "get": {
+        "operationId": "list_known_license_plates_v1_sites__site_id__known_license_plates_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_confidence",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "maximum": 100,
+              "minimum": 0,
+              "title": "Min Confidence",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_interest",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Include Interest",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Explicit recognition group types to list. Supported values: known, interest, unknown. When set, this overrides include_interest.",
+            "in": "query",
+            "name": "group_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit recognition group types to list. Supported values: known, interest, unknown. When set, this overrides include_interest.",
+              "title": "Group Types"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "default": "name",
+              "title": "Order By",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_direction",
+            "required": false,
+            "schema": {
+              "default": "asc",
+              "title": "Order Direction",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_KnownLicensePlateModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Known License Plates",
         "tags": [
           "protect/recognition"
         ]

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -48,7 +48,7 @@ from unifi_api.graphql.types.protect.events import (
 )
 from unifi_api.graphql.types.protect.lights import Light
 from unifi_api.graphql.types.protect.liveviews import Liveview
-from unifi_api.graphql.types.protect.recognition import KnownFace
+from unifi_api.graphql.types.protect.recognition import KnownFace, KnownLicensePlate
 from unifi_api.graphql.types.protect.recordings import (
     Recording,
     RecordingStatusList,
@@ -284,6 +284,47 @@ async def _fetch_known_faces(
                 order_direction=order_direction,
             )
             return list(result.get("faces", []))
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_known_license_plates(
+    ctx: GraphQLContext,
+    controller: str,
+    min_confidence: int,
+    include_interest: bool,
+    group_types: list[str] | None,
+    order_by: str,
+    order_direction: str,
+) -> list:
+    group_types_key = ",".join(group_types) if group_types else ""
+    key = (
+        f"protect/known-license-plates/{controller}/{min_confidence}/"
+        f"{include_interest}/{group_types_key}/{order_by}/{order_direction}"
+    )
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "protect",
+                "recognition_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "protect",
+            )
+            result = await mgr.list_known_license_plates(
+                page_size=1000,
+                min_confidence=min_confidence,
+                include_interest=include_interest,
+                group_types=group_types,
+                order_by=order_by,
+                order_direction=order_direction,
+            )
+            return list(result.get("license_plates", []))
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -750,6 +791,12 @@ class KnownFacePage:
     next_cursor: str | None
 
 
+@strawberry.type(description="Paginated page of UniFi Protect license-plate identities.")
+class KnownLicensePlatePage:
+    items: list[KnownLicensePlate]
+    next_cursor: str | None
+
+
 # ---------------------------------------------------------------------------
 # ProtectQuery
 # ---------------------------------------------------------------------------
@@ -901,6 +948,50 @@ class ProtectQuery:
         )
         return KnownFacePage(
             items=[KnownFace.from_manager_output(face) for face in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "List UniFi Protect license-plate identities (vehicle recognition groups). "
+            "Each entry's id is the value to use in a `license_plate_known` alarm-rule condition."
+        ),
+    )
+    async def known_license_plates(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        limit: int = 50,
+        cursor: str | None = None,
+        min_confidence: int = 30,
+        include_interest: bool = True,
+        group_types: list[str] | None = None,
+        order_by: str = "name",
+        order_direction: str = "asc",
+    ) -> KnownLicensePlatePage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_known_license_plates(
+            ctx,
+            str(controller),
+            min_confidence,
+            include_interest,
+            group_types,
+            order_by,
+            order_direction,
+        )
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw),
+            limit=limit,
+            cursor=cursor_obj,
+            key_fn=_id_key,
+        )
+        return KnownLicensePlatePage(
+            items=[KnownLicensePlate.from_manager_output(plate) for plate in page],
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -748,6 +748,31 @@ type KnownFacePage {
   nextCursor: String
 }
 
+"""A UniFi Protect license-plate identity (vehicle recognition group)."""
+type KnownLicensePlate {
+  id: ID
+  name: String
+  matchedName: String
+  type: String
+  imagePath: String
+  enhancedPath: String
+  detectionsCount: Int
+  firstDetectedAt: String
+  lastDetectedAt: String
+  isNotificationEnabled: Boolean
+  isDegraded: Boolean
+  tags: JSON
+  description: String
+  createdAt: String
+  metadata: JSON
+}
+
+"""Paginated page of UniFi Protect license-plate identities."""
+type KnownLicensePlatePage {
+  items: [KnownLicensePlate!]!
+  nextCursor: String
+}
+
 """A UniFi Protect light (PIR-triggered floodlight)."""
 type Light {
   id: ID
@@ -1298,6 +1323,11 @@ type ProtectQuery {
 
   """List assigned Protect Known Faces / named face recognition groups."""
   knownFaces(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownFacePage!
+
+  """
+  List UniFi Protect license-plate identities (vehicle recognition groups). Each entry's id is the value to use in a `license_plate_known` alarm-rule condition.
+  """
+  knownLicensePlates(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownLicensePlatePage!
 
   """List paired Protect chimes (paginated)."""
   chimes(controller: ID!, limit: Int! = 50, cursor: String = null): ChimePage!

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -246,6 +246,9 @@ from unifi_api.graphql.types.protect.liveviews import (
 from unifi_api.graphql.types.protect.recognition import (
     KnownFace as ProtectKnownFaceType,
 )
+from unifi_api.graphql.types.protect.recognition import (
+    KnownLicensePlate as ProtectKnownLicensePlateType,
+)
 from unifi_api.graphql.types.protect.recordings import (
     Recording as ProtectRecordingType,
 )
@@ -621,6 +624,8 @@ def build_type_registry() -> TypeRegistry:
     # protect/recognition
     reg.register_type("protect", "known_faces", ProtectKnownFaceType)
     reg.register_tool_type("protect_list_known_faces", ProtectKnownFaceType, "list")
+    reg.register_type("protect", "known_license_plates", ProtectKnownLicensePlateType)
+    reg.register_tool_type("protect_list_known_license_plates", ProtectKnownLicensePlateType, "list")
 
     # protect/system (tool-keyed only) + viewers resource
     reg.register_type("protect", "viewers", ProtectViewerType)

--- a/apps/api/src/unifi_api/graphql/types/protect/recognition.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/recognition.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import strawberry
 from unifi_core.protect.models.recognition import from_controller as known_face_from_controller
+from unifi_core.protect.models.recognition import license_plate_from_controller
 
 
 @strawberry.type(description="A UniFi Protect Known Face / assigned face recognition group.")
@@ -38,6 +39,59 @@ class KnownFace:
     @classmethod
     def from_manager_output(cls, obj: Any) -> "KnownFace":
         model = known_face_from_controller(obj)
+        return cls(
+            id=model.id,
+            name=model.name,
+            matched_name=model.matched_name,
+            type=model.type,
+            image_path=model.image_path,
+            enhanced_path=model.enhanced_path,
+            detections_count=model.detections_count,
+            first_detected_at=model.first_detected_at,
+            last_detected_at=model.last_detected_at,
+            is_notification_enabled=model.is_notification_enabled,
+            is_degraded=model.is_degraded,
+            tags=model.tags,
+            description=model.description,
+            created_at=model.created_at,
+            metadata=model.metadata,
+        )
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in asdict(self).items() if not k.startswith("_") and not callable(v)}
+
+
+@strawberry.type(
+    description="A UniFi Protect license-plate identity (vehicle recognition group).",
+)
+class KnownLicensePlate:
+    id: strawberry.ID | None
+    name: str | None
+    matched_name: str | None
+    type: str | None
+    image_path: str | None
+    enhanced_path: str | None
+    detections_count: int | None
+    first_detected_at: str | None
+    last_detected_at: str | None
+    is_notification_enabled: bool | None
+    is_degraded: bool | None
+    tags: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    description: str | None
+    created_at: str | None
+    metadata: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "primary_key": "id",
+            "display_columns": ["name", "matched_name", "detections_count", "last_detected_at"],
+        }
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "KnownLicensePlate":
+        model = license_plate_from_controller(obj)
         return cls(
             id=model.id,
             name=model.name,

--- a/apps/api/src/unifi_api/routes/resources/protect/recognition.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recognition.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.graphql.pydantic_export import to_pydantic_model
-from unifi_api.graphql.types.protect.recognition import KnownFace
+from unifi_api.graphql.types.protect.recognition import KnownFace, KnownLicensePlate
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
@@ -19,6 +19,11 @@ router = APIRouter()
 
 
 def _known_face_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+def _known_license_plate_key(obj) -> tuple:
     raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
     return (0, raw.get("id") or "")
 
@@ -86,6 +91,69 @@ async def list_known_faces(
 
     type_class = request.app.state.type_registry.lookup("protect", "known_faces")
     items = [type_class.from_manager_output(face).to_dict() for face in page]
+    hint = type_class.render_hint("list")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/known-license-plates",
+    response_model=Page[to_pydantic_model(KnownLicensePlate)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/recognition"],
+)
+async def list_known_license_plates(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+    min_confidence: int = Query(30, ge=0, le=100),
+    include_interest: bool = Query(True),
+    group_types: list[str] | None = Query(
+        None,
+        description=(
+            "Explicit recognition group types to list. Supported values: known, interest, unknown. "
+            "When set, this overrides include_interest."
+        ),
+    ),
+    order_by: str = Query("name"),
+    order_direction: str = Query("asc"),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "protect",
+            "recognition_manager",
+        )
+        await factory.get_connection_manager(session, controller.id, "protect")
+        result = await mgr.list_known_license_plates(
+            page_size=1000,
+            min_confidence=min_confidence,
+            include_interest=include_interest,
+            group_types=group_types,
+            order_by=order_by,
+            order_direction=order_direction,
+        )
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(result.get("license_plates", [])),
+        limit=limit,
+        cursor=cursor_obj,
+        key_fn=_known_license_plate_key,
+    )
+
+    type_class = request.app.state.type_registry.lookup("protect", "known_license_plates")
+    items = [type_class.from_manager_output(plate).to_dict() for plate in page]
     hint = type_class.render_hint("list")
 
     return {

--- a/apps/api/tests/graphql/fixtures/protect/test_recognition.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_recognition.py
@@ -1,6 +1,7 @@
 """Fixture e2e tests for protect/recognition resolvers.
 
 # tool: protect_list_known_faces
+# tool: protect_list_known_license_plates
 """
 
 from __future__ import annotations
@@ -49,3 +50,44 @@ async def test_protect_known_faces_list(tmp_path, monkeypatch):
     assert items[0]["id"] == "face-1"
     assert items[0]["matchedName"] == "Person One"
     assert items[0]["detectionsCount"] == 9
+
+
+@pytest.mark.asyncio
+async def test_protect_known_license_plates_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "recognition_manager", "list_known_license_plates"): {
+                "license_plates": [
+                    {
+                        "id": "plate-uuid-1",
+                        "name": "Example Vehicle",
+                        "matched_name": "ABC1234",
+                        "type": "vehicle",
+                        "detections_count": 42,
+                        "last_detected_at": 1778700000000,
+                        "metadata": {"color": {"val": "gray", "confidence": 73}},
+                    }
+                ],
+                "count": 1,
+                "links": {},
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ knownLicensePlates(controller: "{cid}", limit: 10, groupTypes: ["known"]) {{
+            items {{ id name matchedName detectionsCount lastDetectedAt metadata }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    items = body["data"]["protect"]["knownLicensePlates"]["items"]
+    assert len(items) == 1
+    assert items[0]["id"] == "plate-uuid-1"
+    assert items[0]["matchedName"] == "ABC1234"
+    assert items[0]["detectionsCount"] == 42

--- a/apps/api/tests/routes/resources/test_protect_resources.py
+++ b/apps/api/tests/routes/resources/test_protect_resources.py
@@ -249,6 +249,86 @@ async def test_list_known_faces_group_types_filter(tmp_path, monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_list_known_license_plates_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    fake_plates = [
+        {
+            "id": f"plate-{i}",
+            "name": f"Vehicle {i}",
+            "matched_name": f"ABC123{i}",
+            "type": "vehicle",
+            "detections_count": i + 1,
+            "last_detected_at": str(1778700000000 + i),
+            "metadata": {"color": {"val": "black", "confidence": 80}},
+        }
+        for i in range(3)
+    ]
+
+    async def fake_list(self, *a, **kw):
+        return {"license_plates": fake_plates, "count": len(fake_plates), "links": {}}
+
+    from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+    monkeypatch.setattr(RecognitionManager, "list_known_license_plates", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/known-license-plates?controller={cid}&limit=2",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["items"]) == 2
+    assert {item["id"] for item in body["items"]} == {"plate-1", "plate-2"}
+    assert {item["matched_name"] for item in body["items"]} == {"ABC1231", "ABC1232"}
+    assert body["next_cursor"] is not None
+    assert body["render_hint"]["kind"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_list_known_license_plates_group_types_filter(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    calls: list[dict] = []
+
+    async def fake_list(self, *a, **kw):
+        calls.append(kw)
+        return {
+            "license_plates": [
+                {
+                    "id": "plate-427",
+                    "type": "vehicle",
+                    "detections_count": 14,
+                    "metadata": {},
+                }
+            ],
+            "count": 1,
+            "links": {},
+        }
+
+    from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+    monkeypatch.setattr(RecognitionManager, "list_known_license_plates", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/known-license-plates?controller={cid}&group_types=unknown",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["items"][0]["id"] == "plate-427"
+    assert calls[0]["group_types"] == ["unknown"]
+
+
+@pytest.mark.asyncio
 async def test_list_events_happy_path(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)

--- a/apps/protect/src/unifi_protect_mcp/tools/recognition.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/recognition.py
@@ -97,6 +97,99 @@ async def protect_list_known_faces(
 
 
 @server.tool(
+    name="protect_list_known_license_plates",
+    description=(
+        "List UniFi Protect license-plate identities (vehicle recognition groups), "
+        "including named/known license plates by default and unlabeled plate groups when "
+        "group_types includes unknown. Each entry's `id` is the value to use in a "
+        "`license_plate_known` alarm-rule condition. Returns metadata (incl. color/vehicle_type "
+        "when Protect provides them) and controller image references only; image bytes are not fetched."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+    permission_category="recognition",
+)
+async def protect_list_known_license_plates(
+    page: Annotated[
+        Optional[int],
+        Field(description="Optional 1-based Protect recognition page number."),
+    ] = None,
+    page_size: Annotated[
+        int,
+        Field(
+            description="Maximum number of license-plate groups to return (default 100).",
+            ge=1,
+            le=1000,
+        ),
+    ] = 100,
+    min_confidence: Annotated[
+        int,
+        Field(
+            description="Minimum recognition confidence filter used by Protect (0-100, default 30).",
+            ge=0,
+            le=100,
+        ),
+    ] = 30,
+    include_interest: Annotated[
+        bool,
+        Field(
+            description=(
+                "Backward-compatible filter used when group_types is omitted. "
+                "When true, include known and interest groups. When false, only known groups."
+            )
+        ),
+    ] = True,
+    group_types: Annotated[
+        Optional[List[str]],
+        Field(
+            description=(
+                "Optional explicit recognition group types to list. Supported values: known, "
+                "interest, unknown. When set, this overrides include_interest."
+            )
+        ),
+    ] = None,
+    order_by: Annotated[
+        str,
+        Field(description="Sort field: name, createdAt, firstDetectedAt, lastDetectedAt, or detectionsCount."),
+    ] = "name",
+    order_direction: Annotated[
+        str,
+        Field(description="Sort direction: asc or desc."),
+    ] = "asc",
+) -> Dict[str, Any]:
+    """List Protect License Plate Identities (vehicle recognition groups)."""
+    logger.info(
+        "protect_list_known_license_plates called (page=%s, page_size=%s, min_confidence=%s)",
+        page,
+        page_size,
+        min_confidence,
+    )
+    try:
+        raw = await recognition_manager.list_known_license_plates(
+            page=page,
+            page_size=page_size,
+            min_confidence=min_confidence,
+            include_interest=include_interest,
+            group_types=group_types,
+            order_by=order_by,
+            order_direction=order_direction,  # type: ignore[arg-type]
+        )
+        # Manager already serializes via license_plate_from_controller + model_dump,
+        # so pass through directly (no redundant re-serialization).
+        plates = raw.get("license_plates", [])
+        return {
+            "success": True,
+            "data": {
+                "license_plates": plates,
+                "count": len(plates),
+                "links": raw.get("links", {}),
+            },
+        }
+    except Exception as e:
+        logger.error("Error listing known license plates: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list known license plates: {e}"}
+
+
+@server.tool(
     name="protect_update_known_face",
     description=(
         "Update UniFi Protect Known Face metadata. Pass only the fields you want to change; "

--- a/apps/protect/src/unifi_protect_mcp/tools/recognition.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/recognition.py
@@ -102,7 +102,7 @@ async def protect_list_known_faces(
         "List UniFi Protect license-plate identities (vehicle recognition groups), "
         "including named/known license plates by default and unlabeled plate groups when "
         "group_types includes unknown. Each entry's `id` is the value to use in a "
-        "`license_plate_known` alarm-rule condition. Returns metadata (incl. color/vehicle_type "
+        "`license_plate_known` alarm-rule condition. Returns metadata (incl. color/vehicleType "
         "when Protect provides them) and controller image references only; image bytes are not fetched."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -2501,7 +2501,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List UniFi Protect license-plate identities (vehicle recognition groups), including named/known license plates by default and unlabeled plate groups when group_types includes unknown. Each entry's `id` is the value to use in a `license_plate_known` alarm-rule condition. Returns metadata (incl. color/vehicle_type when Protect provides them) and controller image references only; image bytes are not fetched.",
+      "description": "List UniFi Protect license-plate identities (vehicle recognition groups), including named/known license plates by default and unlabeled plate groups when group_types includes unknown. Each entry's `id` is the value to use in a `license_plate_known` alarm-rule condition. Returns metadata (incl. color/vehicleType when Protect provides them) and controller image references only; image bytes are not fetched.",
       "name": "protect_list_known_license_plates",
       "schema": {
         "input": {

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 48,
+  "count": 49,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "protect_acknowledge_event": "unifi_protect_mcp.tools.events",
@@ -26,6 +26,7 @@
     "protect_list_chimes": "unifi_protect_mcp.tools.devices",
     "protect_list_events": "unifi_protect_mcp.tools.events",
     "protect_list_known_faces": "unifi_protect_mcp.tools.recognition",
+    "protect_list_known_license_plates": "unifi_protect_mcp.tools.recognition",
     "protect_list_lights": "unifi_protect_mcp.tools.devices",
     "protect_list_liveviews": "unifi_protect_mcp.tools.liveviews",
     "protect_list_recordings": "unifi_protect_mcp.tools.recordings",
@@ -2494,6 +2495,119 @@
         }
       },
       "title": "List Known Faces"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List UniFi Protect license-plate identities (vehicle recognition groups), including named/known license plates by default and unlabeled plate groups when group_types includes unknown. Each entry's `id` is the value to use in a `license_plate_known` alarm-rule condition. Returns metadata (incl. color/vehicle_type when Protect provides them) and controller image references only; image bytes are not fetched.",
+      "name": "protect_list_known_license_plates",
+      "schema": {
+        "input": {
+          "properties": {
+            "group_types": {
+              "description": "Optional explicit recognition group types to list. Supported values: known, interest, unknown. When set, this overrides include_interest.",
+              "type": "array"
+            },
+            "include_interest": {
+              "description": "Backward-compatible filter used when group_types is omitted. When true, include known and interest groups. When false, only known groups.",
+              "type": "boolean"
+            },
+            "min_confidence": {
+              "description": "Minimum recognition confidence filter used by Protect (0-100, default 30).",
+              "type": "integer"
+            },
+            "order_by": {
+              "description": "Sort field: name, createdAt, firstDetectedAt, lastDetectedAt, or detectionsCount.",
+              "type": "string"
+            },
+            "order_direction": {
+              "description": "Sort direction: asc or desc.",
+              "type": "string"
+            },
+            "page": {
+              "description": "Optional 1-based Protect recognition page number.",
+              "type": "integer"
+            },
+            "page_size": {
+              "description": "Maximum number of license-plate groups to return (default 100).",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "List Known License Plates"
     },
     {
       "annotations": {

--- a/apps/protect/tests/unit/test_recognition.py
+++ b/apps/protect/tests/unit/test_recognition.py
@@ -558,3 +558,65 @@ class TestRecognitionManagerLicensePlates:
         assert result["count"] == 0
         params = mock_cm.client.api_request.await_args.kwargs["params"]
         assert params["labels"] == "groupType:unknown"
+
+
+class TestProtectListKnownLicensePlatesTool:
+    """Tool-layer tests for the pass-through wrapping that diverges from the faces tool.
+
+    The plates tool intentionally does NOT re-serialize the manager output (the faces
+    tool double-dumps), so the tool's own wrapping (license_plates/count/links + the
+    error handler) is exercised here, separately from the manager tests above.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success(self, mock_recognition_manager):
+        from unifi_protect_mcp.tools.recognition import protect_list_known_license_plates
+
+        mock_recognition_manager.list_known_license_plates = AsyncMock(
+            return_value={
+                "license_plates": [{"id": "plate-uuid-1", "name": "Example Vehicle", "matched_name": "ABC1234"}],
+                "count": 1,
+                "links": {},
+            }
+        )
+
+        result = await protect_list_known_license_plates(page_size=25, min_confidence=40)
+
+        assert result["success"] is True
+        assert result["data"]["count"] == 1
+        assert result["data"]["license_plates"][0]["id"] == "plate-uuid-1"
+        mock_recognition_manager.list_known_license_plates.assert_awaited_once_with(
+            page=None,
+            page_size=25,
+            min_confidence=40,
+            include_interest=True,
+            group_types=None,
+            order_by="name",
+            order_direction="asc",
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_recognition_manager):
+        from unifi_protect_mcp.tools.recognition import protect_list_known_license_plates
+
+        mock_recognition_manager.list_known_license_plates = AsyncMock(
+            return_value={"license_plates": [], "count": 0, "links": {}}
+        )
+
+        result = await protect_list_known_license_plates()
+
+        assert result["success"] is True
+        assert result["data"]["count"] == 0
+        assert result["data"]["license_plates"] == []
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_recognition_manager):
+        from unifi_protect_mcp.tools.recognition import protect_list_known_license_plates
+
+        mock_recognition_manager.list_known_license_plates = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        result = await protect_list_known_license_plates()
+
+        assert result["success"] is False
+        assert "Failed to list known license plates" in result["error"]
+        assert "connection lost" in result["error"]

--- a/apps/protect/tests/unit/test_recognition.py
+++ b/apps/protect/tests/unit/test_recognition.py
@@ -473,3 +473,88 @@ class TestProtectKnownFaceMutationTools:
 
         assert result["success"] is False
         assert "Failed to merge known faces" in result["error"]
+
+
+class TestRecognitionManagerLicensePlates:
+    """Tests for the license-plate recognition group manager method.
+
+    Mirrors the Known Faces shape (``recognition/face/groups``); license plates
+    live behind ``recognition/vehicle/groups`` with the same ``labels`` /
+    ``minConfidence`` / pagination params.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_known_license_plates_success(self, mock_cm):
+        from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+        mock_cm.client.api_request.return_value = {
+            "groups": [
+                {
+                    "id": "plate-uuid-1",
+                    "name": "Example Vehicle",
+                    "matchedName": "ABC1234",
+                    "type": "vehicle",
+                    "imagePath": "/proxy/protect/api/recognition/vehicle/groups/plate-uuid-1/image",
+                    "enhancedPath": None,
+                    "detectionsCount": 42,
+                    "firstDetectedAt": 1778700000000,
+                    "lastDetectedAt": 1778701000000,
+                    "isNotificationEnabled": False,
+                    "isDegraded": False,
+                    "tags": [],
+                    "description": None,
+                    "createdAt": 1778690000000,
+                    "metadata": {
+                        "color": {"val": "black", "confidence": 80},
+                        "vehicleType": {"val": "suv", "confidence": 95},
+                    },
+                }
+            ],
+            "links": {"prev": None, "next": None},
+        }
+
+        result = await RecognitionManager(mock_cm).list_known_license_plates(page=2, page_size=50)
+
+        assert result["count"] == 1
+        assert result["links"] == {}
+        plate = result["license_plates"][0]
+        assert plate["id"] == "plate-uuid-1"
+        assert plate["name"] == "Example Vehicle"
+        assert plate["matched_name"] == "ABC1234"
+        assert plate["detections_count"] == 42
+        mock_cm.client.api_request.assert_awaited_once_with(
+            "recognition/vehicle/groups",
+            method="get",
+            params={
+                "labels": "groupType:known,groupType:interest",
+                "minConfidence": 30,
+                "orderBy": "name",
+                "orderDirection": "asc",
+                "pageSize": 50,
+                "page": 2,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_known_license_plates_known_only(self, mock_cm):
+        from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+        mock_cm.client.api_request.return_value = {"groups": [], "links": {"prev": None, "next": None}}
+
+        result = await RecognitionManager(mock_cm).list_known_license_plates(include_interest=False)
+
+        assert result["count"] == 0
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert params["labels"] == "groupType:known"
+
+    @pytest.mark.asyncio
+    async def test_list_known_license_plates_unknown_group_type(self, mock_cm):
+        from unifi_core.protect.managers.recognition_manager import RecognitionManager
+
+        mock_cm.client.api_request.return_value = {"groups": [], "links": {"prev": None, "next": None}}
+
+        result = await RecognitionManager(mock_cm).list_known_license_plates(group_types=["unknown"])
+
+        assert result["count"] == 0
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert params["labels"] == "groupType:unknown"

--- a/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
@@ -11,7 +11,12 @@ from typing import Any, Dict, Literal
 
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
-from unifi_core.protect.models.recognition import from_controller, links_from_controller, to_controller_update
+from unifi_core.protect.models.recognition import (
+    from_controller,
+    license_plate_from_controller,
+    links_from_controller,
+    to_controller_update,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +107,68 @@ class RecognitionManager:
         return {
             "faces": faces,
             "count": len(faces),
+            "links": links,
+        }
+
+    async def list_known_license_plates(
+        self,
+        *,
+        page: int | None = None,
+        page_size: int = 100,
+        min_confidence: int = 30,
+        include_interest: bool = True,
+        group_types: list[str] | None = None,
+        order_by: str = "name",
+        order_direction: Literal["asc", "desc"] = "asc",
+    ) -> Dict[str, Any]:
+        """Return Protect license-plate recognition groups.
+
+        Uses the private ``recognition/vehicle/groups`` endpoint, which mirrors
+        ``recognition/face/groups`` in shape and params. Pass ``group_types`` to
+        explicitly include other group types (e.g. unlabeled/unknown plate
+        clusters). Image bytes are never fetched — only reference paths.
+        """
+        if page is not None and page < 1:
+            raise ValueError("page must be greater than or equal to 1")
+        if page_size < 1 or page_size > 1000:
+            raise ValueError("page_size must be between 1 and 1000")
+        if min_confidence < 0 or min_confidence > 100:
+            raise ValueError("min_confidence must be between 0 and 100")
+        if order_by not in _VALID_ORDER_BY:
+            raise ValueError(f"order_by must be one of {sorted(_VALID_ORDER_BY)}")
+        if order_direction not in _VALID_ORDER_DIRECTION:
+            raise ValueError("order_direction must be 'asc' or 'desc'")
+
+        labels = _build_group_labels(group_types, include_interest)
+        params: dict[str, Any] = {
+            "labels": labels,
+            "minConfidence": min_confidence,
+            "orderBy": order_by,
+            "orderDirection": order_direction,
+            "pageSize": page_size,
+        }
+        if page is not None:
+            params["page"] = page
+
+        data = await self._cm.client.api_request("recognition/vehicle/groups", method="get", params=params)
+        if not isinstance(data, dict):
+            logger.warning("Unexpected recognition/vehicle/groups shape: %r", type(data))
+            data = {}
+
+        groups = data.get("groups")
+        if not isinstance(groups, list):
+            groups = []
+
+        plates = [
+            license_plate_from_controller(group).model_dump(exclude_none=True)
+            for group in groups
+            if isinstance(group, dict)
+        ]
+        links = links_from_controller(data.get("links")).model_dump(exclude_none=True)
+
+        return {
+            "license_plates": plates,
+            "count": len(plates),
             "links": links,
         }
 

--- a/packages/unifi-core/src/unifi_core/protect/models/recognition.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/recognition.py
@@ -59,6 +59,64 @@ class KnownFace(BaseModel):
     )
 
 
+class KnownLicensePlate(BaseModel):
+    """Canonical Protect License Plate Identity / vehicle recognition group row.
+
+    Mirrors :class:`KnownFace` exactly — the underlying Protect endpoint
+    (``recognition/vehicle/groups``) returns the same group shape as
+    ``recognition/face/groups``, just keyed by a license plate (``matched_name``)
+    instead of a recognized face. ``metadata`` typically carries vehicle
+    attributes (e.g. ``color`` and ``vehicleType`` sub-dicts) for plated vehicles.
+    """
+
+    id: Optional[str] = Field(
+        default=None,
+        description="License-plate identity id (UUID or 'vehicle_LPR-<PLATE>' string)",
+        json_schema_extra={"mutable": False},
+    )
+    name: Optional[str] = Field(default=None, description="Assigned license-plate identity name")
+    matched_name: Optional[str] = Field(
+        default=None, description="Recognized license plate text", json_schema_extra={"mutable": False}
+    )
+    type: Optional[str] = Field(
+        default=None, description="Recognition group type", json_schema_extra={"mutable": False}
+    )
+    image_path: Optional[str] = Field(
+        default=None, description="Controller image reference path", json_schema_extra={"mutable": False}
+    )
+    enhanced_path: Optional[str] = Field(
+        default=None, description="Controller enhanced image reference path", json_schema_extra={"mutable": False}
+    )
+    detections_count: Optional[int] = Field(
+        default=None, description="Number of detections in this group", json_schema_extra={"mutable": False}
+    )
+    first_detected_at: Optional[str] = Field(
+        default=None,
+        description="First detection timestamp in epoch milliseconds",
+        json_schema_extra={"mutable": False},
+    )
+    last_detected_at: Optional[str] = Field(
+        default=None, description="Last detection timestamp in epoch milliseconds", json_schema_extra={"mutable": False}
+    )
+    is_notification_enabled: Optional[bool] = Field(
+        default=None,
+        description="Whether notifications are enabled for this group",
+    )
+    is_degraded: Optional[bool] = Field(
+        default=None, description="Whether Protect marks this group as degraded", json_schema_extra={"mutable": False}
+    )
+    tags: list[Any] = Field(default_factory=list, description="Recognition tags", json_schema_extra={"mutable": False})
+    description: Optional[str] = Field(default=None, description="Optional group description")
+    created_at: Optional[str] = Field(
+        default=None, description="Creation timestamp in epoch milliseconds", json_schema_extra={"mutable": False}
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional controller metadata (e.g. color, vehicleType for vehicles)",
+        json_schema_extra={"mutable": False},
+    )
+
+
 class KnownFaceUpdate(BaseModel):
     """Mutable fields accepted by Known Face update operations."""
 
@@ -113,6 +171,35 @@ def from_controller(raw: Any) -> KnownFace:
         metadata = {}
 
     return KnownFace(
+        id=_get(raw, "id"),
+        name=_get(raw, "name"),
+        matched_name=_get_any(raw, "matched_name", "matchedName"),
+        type=_get(raw, "type"),
+        image_path=_get_any(raw, "image_path", "imagePath"),
+        enhanced_path=_get_any(raw, "enhanced_path", "enhancedPath"),
+        detections_count=_get_any(raw, "detections_count", "detectionsCount"),
+        first_detected_at=_stringify(_get_any(raw, "first_detected_at", "firstDetectedAt")),
+        last_detected_at=_stringify(_get_any(raw, "last_detected_at", "lastDetectedAt")),
+        is_notification_enabled=_get_any(raw, "is_notification_enabled", "isNotificationEnabled"),
+        is_degraded=_get_any(raw, "is_degraded", "isDegraded"),
+        tags=tags,
+        description=_get(raw, "description"),
+        created_at=_stringify(_get_any(raw, "created_at", "createdAt")),
+        metadata=metadata,
+    )
+
+
+def license_plate_from_controller(raw: Any) -> KnownLicensePlate:
+    """Build a KnownLicensePlate from a Protect recognition/vehicle group object."""
+    tags = _get(raw, "tags")
+    if not isinstance(tags, list):
+        tags = []
+
+    metadata = _get(raw, "metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    return KnownLicensePlate(
         id=_get(raw, "id"),
         name=_get(raw, "name"),
         matched_name=_get_any(raw, "matched_name", "matchedName"),

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -1,4 +1,4 @@
-# Protect Server Tool Reference (48 tools)
+# Protect Server Tool Reference (49 tools)
 
 Complete reference for `protect_*` tools. All read tools are always available. All mutations are **disabled by default** — the user must explicitly enable them because Protect controls physical security hardware.
 
@@ -191,11 +191,12 @@ Controls the UniFi Protect Alarm Manager (Protect 6.1+). Requires arm profiles c
 Lists and manages UniFi Protect Known Faces / named face recognition groups. Read tools return metadata and controller image references only; mutations use preview-then-confirm.
 
 <!-- AUTO:tools:recognition -->
-4 tools.
+5 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `protect_list_known_faces` | Read | List UniFi Protect face recognition groups, including assigned Known Faces by default and unlabeled groups when group_types includes unkn... |
+| `protect_list_known_license_plates` | Read | List UniFi Protect license-plate identities (vehicle recognition groups), including named/known license plates by default and unlabeled p... |
 | `protect_delete_known_face` | Mutate | Delete or remove a UniFi Protect face recognition group. |
 | `protect_merge_known_faces` | Mutate | Merge one UniFi Protect face group into another. |
 | `protect_update_known_face` | Mutate | Update UniFi Protect Known Face metadata. |


### PR DESCRIPTION
## Summary

Add `protect_list_known_license_plates`, a read-only MCP tool that lists Protect's license-plate identities (vehicle recognition groups) via the private `recognition/vehicle/groups` endpoint. The new tool mirrors the existing `protect_list_known_faces` exactly -- same parameter signature, same pagination/ordering/group-type filters, same response shape modulo the rename `faces` → `license_plates`.

## Motivation

The Protect alarm-rule schema supports a `license_plate_known` condition that references a specific recognized-vehicle identity by id. Without a discovery tool, an MCP caller has no way to know what id values exist on the controller -- they would have to inspect existing rules in the UI and copy id strings out by hand. This tool closes that gap so an LLM (or any caller) can:

1. List the registered plates with `protect_list_known_license_plates`
2. Pick the id of the vehicle to match
3. Create an alarm rule with a `license_plate_known` condition whose `value` is that id

This mirrors the same workflow already supported for Known Faces via `protect_list_known_faces` (the existing tool's description language is preserved here for consistency). The shape of the underlying `recognition/vehicle/groups` endpoint is identical to `recognition/face/groups` -- both keyed by a stable group id, both returning the recognized text in `matched_name`, both surfacing controller image reference paths only (no image bytes fetched). The tool is `readOnlyHint=True, openWorldHint=False`.

## Implementation

- **`packages/unifi-core/src/unifi_core/protect/models/recognition.py`** -- new `KnownLicensePlate` Pydantic model, mirror of `KnownFace`. `matched_name` description clarifies it carries the recognized plate text (e.g. `"ABC1234"`). `metadata` typically carries vehicle attributes (`color`, `vehicleType` sub-dicts) for plated vehicles -- noted in the field description.
- **`packages/unifi-core/src/unifi_core/protect/models/recognition.py`** -- new `license_plate_from_controller(raw)` helper, parallel to `from_controller`, normalizing camelCase Protect fields into snake_case.
- **`packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py`** -- new `list_known_license_plates` method on `RecognitionManager`. Reuses the existing `_build_group_labels` helper (shared validation of `group_types` / `include_interest`) and the same `_VALID_ORDER_BY` / `_VALID_ORDER_DIRECTION` sets used by the faces method. Calls `recognition/vehicle/groups` with the same param shape (`labels`, `minConfidence`, `orderBy`, `orderDirection`, `pageSize`, optional `page`).
- **`apps/protect/src/unifi_protect_mcp/tools/recognition.py`** -- new `protect_list_known_license_plates` MCP tool registration. Same parameter signature as `protect_list_known_faces`; description explicitly cross-references that each entry's `id` is the value to use in a `license_plate_known` alarm-rule condition.

## Note on existing faces tool

The new tool intentionally does NOT double-serialize the way the existing `protect_list_known_faces` tool currently does (the existing tool calls `from_controller(face).model_dump(...)` again on already-dumped snake_case dicts from the manager -- safe but redundant). The new tool does a pass-through (`raw.get("license_plates", [])`) since the manager already serialized via `license_plate_from_controller + model_dump`. The pre-existing redundancy in the faces tool is not touched (out of scope); a small follow-up could trim it for consistency.

## Test coverage

- **`apps/protect/tests/unit/test_recognition.py`** -- new `TestRecognitionManagerLicensePlates` class:
  - `test_list_known_license_plates_success` -- mocks the group response, asserts the manager calls `recognition/vehicle/groups` with `labels="groupType:known,groupType:interest"`, validates the returned shape.
  - `test_list_known_license_plates_known_only` -- asserts `include_interest=False` builds `labels="groupType:known"`.
  - `test_list_known_license_plates_unknown_group_type` -- asserts `group_types=["unknown"]` builds `labels="groupType:unknown"` (override path).

Full apps/protect suite: 382/382 pass. Full unifi-core protect suite: 304/304 pass. `ruff format --check` and `ruff check` both clean (pinned version per uv.lock). Manifest regenerated via `make manifest`; `make check-generated` exit 0.

## Verified live

Verified end-to-end against a live Protect 7.x controller through three surfaces:
- **MCP tool** `protect_list_known_license_plates` -- returns the registered plates with the expected schema and pagination links.
- **GraphQL** `protect { knownLicensePlates(controller, limit, ...) { items { id name matchedName detectionsCount metadata } } }` -- returns the same plates with camelCase field names, full metadata (including `color` and `vehicleType` sub-dicts when Protect provides them).
- **REST** `GET /v1/sites/{site_id}/known-license-plates` -- returns the same plates with snake_case field names per the REST convention.

Two id formats observed in real Protect data: UUID (`697f9f5900c63903e419cb66`-style for older registered vehicles) and `vehicle_LPR-<PLATE>` (for newer registrations) -- both are accepted as the `value` in a `license_plate_known` condition. The id-format note is captured in the `KnownLicensePlate.id` field description.

## Out of scope

- **Vehicle attribute filtering (color / vehicleType).** Protect surfaces these as recognition metadata on the group object, but querying by them is a separate concern best served via smart detection event metadata rather than the recognition-group endpoint. Not added here.
- **Create / update / delete of license-plate identities.** Read-only intentionally for this PR -- mutating the recognition-group set is a richer workflow that deserves its own PR.

## Closes

(none -- complements the alarm-rule CRUD additions in the companion PR)
