### PR TITLE
fix(api): unwrap dict-enveloped recognition list tools on the action endpoint

### DIFF
--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -17,6 +17,30 @@ from unifi_api.services.manifest import ToolNotFound
 router = APIRouter()
 
 
+def _coerce_list_result(result: object, tool_name: str, kind: str) -> list:
+    """Normalize a list-kind tool's manager output to a bare list.
+
+    Most list tools return a bare list. The Protect recognition list tools
+    (``protect_list_known_faces``, ``protect_list_known_license_plates``) return
+    a dict envelope — ``{<items_key>: [...], "count": int, "links": {...}}`` —
+    because their MCP surface carries pagination links. The GraphQL and REST
+    surfaces unwrap that envelope themselves; the action path normalizes it here
+    so all three behave the same. The envelope always holds exactly one
+    list-valued key alongside scalar/dict metadata, so that single list is the
+    item payload. Anything else (wrong shape, ambiguous multi-list dict) trips
+    the same contract error as before.
+    """
+    if isinstance(result, list):
+        return result
+    if isinstance(result, dict):
+        list_values = [value for value in result.values() if isinstance(value, list)]
+        if len(list_values) == 1:
+            return list_values[0]
+    raise SerializerContractError(
+        f"tool '{tool_name}' declared kind={kind} but manager returned {type(result).__name__}"
+    )
+
+
 class ActionIn(BaseModel):
     site: str
     controller: str
@@ -73,11 +97,8 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 type_class, kind = tool_type
                 hint = type_class.render_hint(kind)
                 if kind in ("list", "timeseries", "event_log"):
-                    if not isinstance(result, list):
-                        raise SerializerContractError(
-                            f"tool '{tool_name}' declared kind={kind} but manager returned {type(result).__name__}"
-                        )
-                    data = [type_class.from_manager_output(x).to_dict() for x in result]
+                    items = _coerce_list_result(result, tool_name, kind)
+                    data = [type_class.from_manager_output(x).to_dict() for x in items]
                 else:
                     data = type_class.from_manager_output(result).to_dict()
                 shaped = {"success": True, "data": data, "render_hint": hint}

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -154,6 +154,49 @@ async def test_action_endpoint_serializer_contract_error(tmp_path, monkeypatch) 
         assert action_rows[0].error_kind == "serializer_contract"
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "items_key", "item"),
+    [
+        ("protect_list_known_faces", "faces", {"id": "face-1", "name": "P", "matched_name": "Person One"}),
+        (
+            "protect_list_known_license_plates",
+            "license_plates",
+            {"id": "plate-1", "name": "Vehicle", "matched_name": "ABC1234"},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_action_endpoint_unwraps_recognition_list_envelope(
+    tmp_path, monkeypatch, tool_name, items_key, item
+) -> None:
+    """Recognition list tools return a ``{items_key: [...], count, links}`` dict
+    envelope (not a bare list); the action path must unwrap it rather than 500
+    with a serializer contract error. Regression for issue #312."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    from unifi_api.services import actions as actions_svc
+
+    envelope = {items_key: [item], "count": 1, "links": {}}
+    monkeypatch.setattr(actions_svc, "dispatch_action", AsyncMock(return_value=envelope))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post(
+            f"/v1/actions/{tool_name}",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {}, "confirm": False},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["render_hint"]["kind"] == "list"
+    assert isinstance(body["data"], list)
+    assert len(body["data"]) == 1
+    assert body["data"][0]["id"] == item["id"]
+    assert body["data"][0]["matched_name"] == item["matched_name"]
+
+
 @pytest.mark.asyncio
 async def test_action_endpoint_unknown_tool(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")


### PR DESCRIPTION
## What

`POST /v1/actions/{tool}` returned HTTP 500 (`serializer_contract_error: declared kind=list but manager returned dict`) for both Protect recognition list tools:

- `protect_list_known_faces`
- `protect_list_known_license_plates`

## Why

These two managers return a **dict envelope** — `{<items_key>: [...], "count": N, "links": {...}}` — because their MCP surface carries pagination `links`. Every other list tool's manager returns a **bare list**. `dispatch_action()` hands the manager output through unchanged, and the action route's `kind=list` path required a bare list, so it raised. GraphQL and REST were unaffected because each unwraps the envelope itself (`result.get("faces"/"license_plates", [])`).

`recognition_manager` is the only manager in the tree that uses this dict-envelope shape, so faces + plates are the only affected tools.

## Fix

Normalize in the action route (`_coerce_list_result`): a `kind=list` result that is a dict with **exactly one** list-valued key is unwrapped to that list; anything else (wrong shape, ambiguous multi-list dict) trips the same `SerializerContractError` as before — fail-loud preserved. No change to the manager contract, so the MCP surface keeps its `links`.

## Testing

- Parametrized regression test (`test_action_endpoint_unwraps_recognition_list_envelope`) covering both recognition tools.
- Existing `test_action_endpoint_serializer_contract_error` still passes (a dict with no list value still 500s).
- Full `apps/api` suite: 805 passed.
- **Verified live** (Protect 7.x): both action endpoints now return 200 with a list payload.

```
[ACTION] protect_list_known_faces           -> http=200 success=True data_is_list=True count=4 OK
[ACTION] protect_list_known_license_plates  -> http=200 success=True data_is_list=True count=2 OK
```

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)