### PR TITLE
chore: reconcile uv.lock drift + add lockfile gate to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,13 @@ jobs:
       with:
         enable-cache: true
 
+    # Fail when uv.lock has drifted from the pyproject sources (e.g. a dependency
+    # bump that updated the lock's requires-dist specifier but not the declaring
+    # pyproject, or vice versa). Catches the drift at PR time instead of letting
+    # it merge green and churn on every local `uv run`/`uv sync`.
+    - name: Check lockfile is in sync
+      run: uv lock --check
+
     - name: Install workspace
       run: uv sync --all-packages
 

--- a/uv.lock
+++ b/uv.lock
@@ -2044,7 +2044,7 @@ requires-dist = [
     { name = "py-unifi-access", marker = "extra == 'access'", specifier = ">=1.1.1" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=10.6.0" },
+    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=10.5.0" },
 ]
 provides-extras = ["access", "network", "protect"]
 


### PR DESCRIPTION
## Problem

`uv.lock` recorded `uiprotect>=10.6.0` in its `requires-dist`, but the source pin in `packages/unifi-core/pyproject.toml` was `uiprotect>=10.5.0`. uv derives `requires-dist` from pyproject, so **every `uv run`/`uv sync` rewrote the lock back to `>=10.5.0`** — recurring, confusing working-tree churn (kept reappearing during PR #311/#313 work and had to be reverted each time).

It's **metadata drift, not a real downgrade** — the resolved version is `10.6.0` in both states.

### How it got there
The #309 Dependabot bump (`ca5df9a`, "bump the python-minor group") raised the `uiprotect` floor *inside the lockfile* to `>=10.6.0` but left the declaring `pyproject.toml` at `>=10.5.0`. Nothing caught it because CI installs with `uv sync` and never verifies lock⇄pyproject consistency (`uv lock --check` exits 1 on this drift; it wasn't run anywhere).

## Fix

1. **Reconcile the lock** to the pyproject source of truth (`>=10.5.0`). The floor is intentionally kept conservative: `unifi-core` is a published library, so its declared minimum should reflect what the code actually requires, while the lock pins the exact resolved version (`10.6.0`). Raising the floor for an automated minor bump would needlessly over-constrain downstream consumers.

2. **Add a `uv lock --check` gate** to the lint workflow (runs on every PR). It exits non-zero when the lock and pyproject disagree, so this class of drift fails at PR time — e.g. the next Dependabot bump that touches a workspace-member pin — instead of merging green and churning locally.

## Verification

```
$ uv lock --check        # before: drift
The lockfile at `uv.lock` needs to be updated  (exit 1)

$ uv lock && uv lock --check   # after: consistent
Resolved 104 packages  (exit 0)
```

- Lock diff is a single line (`>=10.6.0` → `>=10.5.0`); resolved `uiprotect` version unchanged at `10.6.0`.
- `uv run` no longer rewrites the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)