### PR TITLE
fix(protect): use api_request_raw for known-face delete

### DIFF
--- a/apps/protect/tests/unit/test_recognition.py
+++ b/apps/protect/tests/unit/test_recognition.py
@@ -253,18 +253,18 @@ class TestRecognitionManager:
         assert result["warnings"]
 
     @pytest.mark.asyncio
-    async def test_apply_delete_known_face_calls_delete_endpoint(self, mock_cm):
+    async def test_apply_delete_known_face_uses_raw_delete(self, mock_cm):
+        """Face DELETE returns an empty body; must use api_request_raw to avoid a
+        spurious 'Could not decode JSON' error after a successful delete."""
         from unifi_core.protect.managers.recognition_manager import RecognitionManager
 
-        mock_cm.client.api_request.side_effect = [
-            {"groups": [{"id": "face-1", "name": "Assigned"}]},
-            None,
-        ]
+        mock_cm.client.api_request.return_value = {"groups": [{"id": "face-1", "name": "Assigned"}]}
+        mock_cm.client.api_request_raw = AsyncMock(return_value=None)
 
         result = await RecognitionManager(mock_cm).apply_delete_known_face("face-1")
 
         assert result["deleted"] is True
-        mock_cm.client.api_request.assert_any_await(
+        mock_cm.client.api_request_raw.assert_awaited_once_with(
             "recognition/face/groups/face-1",
             method="delete",
         )

--- a/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
@@ -252,9 +252,14 @@ class RecognitionManager:
         }
 
     async def apply_delete_known_face(self, face_id: str) -> Dict[str, Any]:
-        """Delete a Protect face group after confirmation."""
+        """Delete a Protect face group after confirmation.
+
+        The controller returns an empty body on success, so use ``api_request_raw``
+        (not ``api_request``) to avoid a spurious 'Could not decode JSON' error
+        after the delete has already succeeded. Mirrors the vehicle-group delete.
+        """
         preview = await self.delete_known_face(face_id)
-        await self._cm.client.api_request(
+        await self._cm.client.api_request_raw(
             f"recognition/face/groups/{face_id}",
             method="delete",
         )


### PR DESCRIPTION
## What

`apply_delete_known_face` routed its DELETE through `api_request`, which attempts to JSON-decode the response. Switch it to `api_request_raw`, matching the vehicle-group delete added in #316 and the existing alarm-rule delete.

## Why

Recognition-group deletes return an **empty body** on success. `api_request` then raises a spurious `Could not decode JSON` *after the delete has already succeeded* — surfacing as a failure from the shipped `protect_delete_known_face` tool even though the group was removed.

- `apply_delete_known_face` already **discards** the delete response (it returns the preview snapshot), so this change is safe regardless of body shape — it only removes the spurious decode error.
- After this, the face delete is consistent with the vehicle and alarm deletes, which already use `api_request_raw`.

## Testing

- `test_apply_delete_known_face_uses_raw_delete` updated to assert the raw-delete path (mirrors `test_apply_delete_known_license_plate_uses_raw_delete`).
- `ruff check`/`format` clean; full protect suite green (396 passed); CI green.
- **Live destructive cycle** against a live Protect controller on a disposable face group (maintainer-authorized): confirms the empty-body root cause and that the fixed path deletes cleanly.

<details>
<summary>Live delete cycle (identifiers redacted)</summary>

```
BEFORE: exists id='<redacted>' name='<redacted>'
DELETE PREVIEW ok: warnings=2
DELETE (fixed, api_request_raw): deleted=True  raw_type=bytes  status=None  body=None
AFTER: not-found confirmed (UniFiNotFoundError) -> group deleted
```

The raw DELETE response is empty `bytes` — i.e. no JSON to decode, which is what made the old `api_request` path raise. `api_request_raw` handles it and the group is verifiably removed.
</details>

## Follow-up (optional, out of scope)

Worth auditing the remaining Protect resource deletes (liveview / recording / chime) for the same empty-body-on-`api_request` pattern.