### PR TITLE
fix(protect): use api_request_raw for known-face merge (empty-body)

### DIFF
--- a/apps/protect/tests/unit/test_recognition.py
+++ b/apps/protect/tests/unit/test_recognition.py
@@ -223,19 +223,21 @@ class TestRecognitionManager:
             await RecognitionManager(mock_cm).merge_known_faces("face-1", "face-1")
 
     @pytest.mark.asyncio
-    async def test_apply_merge_known_faces_posts_validated_payload(self, mock_cm):
+    async def test_apply_merge_known_faces_uses_raw_post(self, mock_cm):
+        """merge-group returns an empty body on success; must use api_request_raw
+        to avoid a spurious 'Could not decode JSON' after a successful merge."""
         from unifi_core.protect.managers.recognition_manager import RecognitionManager
 
         mock_cm.client.api_request.side_effect = [
             {"groups": [{"id": "source", "name": "Source"}]},
             {"groups": [{"id": "target", "name": "Target"}]},
-            None,
         ]
+        mock_cm.client.api_request_raw = AsyncMock(return_value=None)
 
         result = await RecognitionManager(mock_cm).apply_merge_known_faces("source", "target")
 
         assert result["merged"] is True
-        mock_cm.client.api_request.assert_any_await(
+        mock_cm.client.api_request_raw.assert_awaited_once_with(
             "recognition/v2/merge-group",
             method="post",
             json={"fromGroupIds": ["source"], "toGroupId": "target"},

--- a/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/recognition_manager.py
@@ -225,9 +225,15 @@ class RecognitionManager:
         }
 
     async def apply_merge_known_faces(self, source_face_id: str, target_face_id: str) -> Dict[str, Any]:
-        """Merge one Protect face group into another."""
+        """Merge one Protect face group into another.
+
+        The merge-group endpoint returns an empty body on success, so use
+        ``api_request_raw`` (not ``api_request``) to avoid a spurious
+        'Could not decode JSON' error after the merge has already succeeded.
+        Mirrors the recognition-group delete paths; the response is unused.
+        """
         preview = await self.merge_known_faces(source_face_id, target_face_id)
-        await self._cm.client.api_request(
+        await self._cm.client.api_request_raw(
             "recognition/v2/merge-group",
             method="post",
             json={"fromGroupIds": [source_face_id], "toGroupId": target_face_id},


### PR DESCRIPTION
## What
`apply_merge_known_faces` POSTed `recognition/v2/merge-group` through `api_request`, which JSON-decodes the response. The merge-group endpoint returns an **empty body** on success, so it raised a spurious `Could not decode JSON` *after* the merge had already succeeded. Switch to `api_request_raw`.

## Why it's safe
The method discards the POST response (it returns the preview snapshot), so `api_request_raw` loses nothing — it only removes the spurious decode error. Same pattern as the recognition-group delete fixes (#316/#319) and the alarm-rule delete.

## Testing
- `test_apply_merge_known_faces_uses_raw_post` updated to assert the raw-post path.
- Full unifi-core (340) + protect (396) suites green; ruff clean.

This closes the last empty-body audit follow-up. (Live destructive verification needs two disposable face groups to merge; deferred — the change is provably non-regressive regardless.)