### PR TITLE
feat(network,api): expose traffic-flows via MCP tool, GraphQL, and REST

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1153,6 +1153,9 @@ type NetworkQuery {
   """Get a client's current WiFi parameters (signal, rates)."""
   clientWifiDetails(controller: ID!, mac: ID!, site: String! = "default"): ClientWifiDetails
 
+  """Query historical traffic flows (Insights > Flows), paginated."""
+  trafficFlows(controller: ID!, site: String! = "default", withinHours: Int! = 24, timeFrom: Int = null, timeTo: Int = null, searchText: String = null, pageSize: Int! = 100, cursor: String = null): TrafficFlowPage!
+
   """List switch port profiles on the given controller/site (paginated)."""
   portProfiles(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortProfilePage!
 
@@ -1696,6 +1699,42 @@ type TopClient {
   totalBytes: Int
 }
 
+"""A single UniFi traffic-flow record."""
+type TrafficFlow {
+  id: String
+  action: String
+  risk: String
+  service: String
+  protocol: String
+  direction: String
+  count: Int
+  durationMilliseconds: Int
+  time: Int
+  flowStartTime: Int
+  flowEndTime: Int
+  bytesTotal: Int
+  bytesRx: Int
+  bytesTx: Int
+  source: TrafficFlowEndpoint!
+  destination: TrafficFlowEndpoint!
+}
+
+"""One side (source or destination) of a traffic flow."""
+type TrafficFlowEndpoint {
+  name: String
+  mac: String
+  ip: String
+  networkName: String
+  zoneName: String
+  domains: [String!]!
+}
+
+"""Paginated page of UniFi traffic flows."""
+type TrafficFlowPage {
+  items: [TrafficFlow!]!
+  nextCursor: String
+}
+
 """A traffic-route policy (V2 /trafficroutes entry)."""
 type TrafficRoute {
   id: ID
@@ -1993,6 +2032,7 @@ Read-only access to UniFi Network resources.
 - `switchPorts: SwitchPorts`  — Get the port-override wrapper for a switch (name/model + per-port overrides).
 - `systemInfo: SystemInfo`  — Get controller system info (build, uptime, hardware).
 - `topClients: [TopClient!]!`  — List top-traffic clients within a window.
+- `trafficFlows: TrafficFlowPage!`  — Query historical traffic flows (Insights > Flows), paginated.
 - `trafficRoute: TrafficRoute`  — Look up a single traffic-route policy by id.
 - `trafficRoutes: TrafficRoutePage!`  — List traffic-route policies (V2 /trafficroutes) (paginated).
 - `userGroup: UserGroup`  — Look up a single QoS user group by id.

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1267,6 +1267,26 @@ LIST kind per Phase 4A — manager returns multi-element list of subsystems.
 **Returns:** `object`
 
 
+## network/traffic-flows
+
+### `GET /v1/sites/{site_id}/traffic-flows` — Get Traffic Flows
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `within_hours` (query)
+- `time_from` (query)
+- `time_to` (query)
+- `search_text` (query)
+- `page_size` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_TrafficFlowModel_`
+
+
 ## network/vouchers
 
 ### `GET /v1/sites/{site_id}/voucher-details/{voucher_id}` — Get Voucher Details

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4576,6 +4576,46 @@
         "title": "Page[RouteModel]",
         "type": "object"
       },
+      "Page_TrafficFlowModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficFlowModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[TrafficFlowModel]",
+        "type": "object"
+      },
       "Page_TrafficRouteModel_": {
         "additionalProperties": true,
         "properties": {
@@ -5335,6 +5375,242 @@
           "settings"
         ],
         "title": "SettingsBody",
+        "type": "object"
+      },
+      "TrafficFlowEndpointModel": {
+        "additionalProperties": true,
+        "properties": {
+          "domains": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Domains",
+            "type": "array"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ip"
+          },
+          "mac": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "network_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Network Name"
+          },
+          "zone_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Zone Name"
+          }
+        },
+        "title": "TrafficFlowEndpointModel",
+        "type": "object"
+      },
+      "TrafficFlowModel": {
+        "additionalProperties": true,
+        "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "bytes_rx": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bytes Rx"
+          },
+          "bytes_total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bytes Total"
+          },
+          "bytes_tx": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bytes Tx"
+          },
+          "count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Count"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/TrafficFlowEndpointModel"
+          },
+          "direction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Direction"
+          },
+          "duration_milliseconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Milliseconds"
+          },
+          "flow_end_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow End Time"
+          },
+          "flow_start_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow Start Time"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "protocol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol"
+          },
+          "risk": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Risk"
+          },
+          "service": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service"
+          },
+          "source": {
+            "$ref": "#/components/schemas/TrafficFlowEndpointModel"
+          },
+          "time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time"
+          }
+        },
+        "title": "TrafficFlowModel",
         "type": "object"
       },
       "TrafficRouteModel": {
@@ -16539,6 +16815,154 @@
         "summary": "Get Top Clients",
         "tags": [
           "network/system"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/traffic-flows": {
+      "get": {
+        "operationId": "get_traffic_flows_v1_sites__site_id__traffic_flows_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "within_hours",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "maximum": 8760,
+              "minimum": 1,
+              "title": "Within Hours",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "time_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Time From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "time_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Time To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_text",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search Text"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_TrafficFlowModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Traffic Flows",
+        "tags": [
+          "network/traffic-flows"
         ]
       }
     },

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -18,6 +18,8 @@ follow-up dispatches.
 
 from __future__ import annotations
 
+import base64
+import time
 from typing import Any
 
 import strawberry
@@ -85,6 +87,7 @@ from unifi_api.graphql.types.network.system import (
     SystemInfo,
     TopClient,
 )
+from unifi_api.graphql.types.network.traffic_flow import TrafficFlow, TrafficFlowPage
 from unifi_api.graphql.types.network.voucher import Voucher
 from unifi_api.graphql.types.network.vpn import VpnClient, VpnServer
 from unifi_api.graphql.types.network.wlan import Wlan
@@ -623,6 +626,32 @@ async def _fetch_traffic_routes(
             return list(await mgr.get_traffic_routes())
 
     return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_traffic_flows(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    query: Any,
+) -> dict:
+    # Not routed through ctx.cache: the manager owns its own short-TTL cache,
+    # and results are specific to the (page, query) pair rather than a stable
+    # per-(controller, site) snapshot like the other LIST fetches.
+    async with ctx.sessionmaker() as session:
+        mgr = await ctx.manager_factory.get_domain_manager(
+            session,
+            controller,
+            "network",
+            "traffic_flow_manager",
+        )
+        cm = await ctx.manager_factory.get_connection_manager(
+            session,
+            controller,
+            "network",
+        )
+        if cm.site != site:
+            await cm.set_site(site)
+        return await mgr.get_traffic_flows(query)
 
 
 # ---- Cluster C fetch helpers (firewall / qos / dpi / cf / acl / oon / pf) -
@@ -2000,6 +2029,27 @@ def _decode_cursor(cursor: str | None):
         return Cursor.decode(cursor)
     except InvalidCursor:
         raise ValueError("invalid cursor")
+
+
+# ---- Traffic-flows cursor helpers ----------------------------------------
+#
+# The traffic-flows manager is already server-paginated (it owns page_number
+# / has_next), so the list-style ``paginate()`` is the wrong tool here. The
+# opaque cursor instead encodes the controller's 0-based page number.
+
+
+def _encode_flow_cursor(page: int) -> str:
+    return base64.urlsafe_b64encode(str(page).encode()).decode()
+
+
+def _decode_flow_cursor(cursor: str | None) -> int:
+    if not cursor:
+        return 0
+    try:
+        page = int(base64.urlsafe_b64decode(cursor.encode()).decode())
+    except Exception:
+        raise ValueError("invalid cursor")
+    return max(0, page)
 
 
 @strawberry.type(description="Read-only access to UniFi Network resources.")
@@ -3732,6 +3782,47 @@ class NetworkQuery:
         if raw is None:
             return None
         return ClientWifiDetails.from_manager_output(raw)
+
+    # ---- Traffic-flows domain -------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Query historical traffic flows (Insights > Flows), paginated.",
+    )
+    async def traffic_flows(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        within_hours: int = 24,
+        time_from: int | None = None,
+        time_to: int | None = None,
+        search_text: str | None = None,
+        page_size: int = 100,
+        cursor: str | None = None,
+    ) -> TrafficFlowPage:
+        from unifi_core.network.models.traffic_flows import TrafficFlowQuery
+
+        ctx: GraphQLContext = info.context
+        page = _decode_flow_cursor(cursor)
+        if (time_from is None) != (time_to is None):
+            raise ValueError("provide both time_from and time_to, or use within_hours")
+        if time_from is None:
+            if within_hours < 1 or within_hours > 8760:
+                raise ValueError("within_hours must be between 1 and 8760")
+            now_ms = int(time.time() * 1000)
+            time_from, time_to = now_ms - within_hours * 3600 * 1000, now_ms
+        query = TrafficFlowQuery(
+            time_from=time_from,
+            time_to=time_to,
+            page_number=page,
+            page_size=max(1, min(page_size, 1000)),
+            search_text=search_text,
+        )
+        result = await _fetch_traffic_flows(ctx, controller, site, query)
+        items = [TrafficFlow.from_manager_output(f) for f in result.get("flows", [])]
+        next_cursor = _encode_flow_cursor(page + 1) if result.get("has_next") else None
+        return TrafficFlowPage(items=items, next_cursor=next_cursor)
 
     # ---- Switch domain ---------------------------------------------------
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1142,6 +1142,9 @@ type NetworkQuery {
   """Get a client's current WiFi parameters (signal, rates)."""
   clientWifiDetails(controller: ID!, mac: ID!, site: String! = "default"): ClientWifiDetails
 
+  """Query historical traffic flows (Insights > Flows), paginated."""
+  trafficFlows(controller: ID!, site: String! = "default", withinHours: Int! = 24, timeFrom: Int = null, timeTo: Int = null, searchText: String = null, pageSize: Int! = 100, cursor: String = null): TrafficFlowPage!
+
   """List switch port profiles on the given controller/site (paginated)."""
   portProfiles(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortProfilePage!
 
@@ -1683,6 +1686,42 @@ type TopClient {
   txBytes: Int
   rxBytes: Int
   totalBytes: Int
+}
+
+"""A single UniFi traffic-flow record."""
+type TrafficFlow {
+  id: String
+  action: String
+  risk: String
+  service: String
+  protocol: String
+  direction: String
+  count: Int
+  durationMilliseconds: Int
+  time: Int
+  flowStartTime: Int
+  flowEndTime: Int
+  bytesTotal: Int
+  bytesRx: Int
+  bytesTx: Int
+  source: TrafficFlowEndpoint!
+  destination: TrafficFlowEndpoint!
+}
+
+"""One side (source or destination) of a traffic flow."""
+type TrafficFlowEndpoint {
+  name: String
+  mac: String
+  ip: String
+  networkName: String
+  zoneName: String
+  domains: [String!]!
+}
+
+"""Paginated page of UniFi traffic flows."""
+type TrafficFlowPage {
+  items: [TrafficFlow!]!
+  nextCursor: String
 }
 
 """A traffic-route policy (V2 /trafficroutes entry)."""

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -195,6 +195,9 @@ from unifi_api.graphql.types.network.system import (
 from unifi_api.graphql.types.network.system import (
     TopClient as NetworkTopClientType,
 )
+from unifi_api.graphql.types.network.traffic_flow import (
+    TrafficFlow as NetworkTrafficFlowType,
+)
 from unifi_api.graphql.types.network.voucher import (
     Voucher as NetworkVoucherType,
 )
@@ -300,6 +303,9 @@ def build_type_registry() -> TypeRegistry:
         "list",
     )
     reg.register_tool_type("unifi_lookup_by_ip", NetworkClientLookupType, "detail")
+
+    # network/traffic-flows
+    reg.register_tool_type("unifi_get_traffic_flows", NetworkTrafficFlowType, "list")
 
     # network/devices
     reg.register_type("network", "devices", NetworkDeviceType)

--- a/apps/api/src/unifi_api/graphql/types/network/traffic_flow.py
+++ b/apps/api/src/unifi_api/graphql/types/network/traffic_flow.py
@@ -1,0 +1,127 @@
+"""Strawberry types for network/traffic-flows.
+
+Read shape emitted by ``TrafficFlowManager.get_traffic_flows()`` (LIST). Each
+flow dict comes from ``traffic_flow_from_controller(...).model_dump(
+exclude_none=True)`` and carries scalar fields plus ``source`` / ``destination``
+endpoint sub-objects.
+
+- ``TrafficFlowEndpoint`` — one side of a flow (source or destination).
+- ``TrafficFlow`` — a single traffic-flow record.
+- ``TrafficFlowPage`` — paginated wrapper around ``TrafficFlow`` items.
+
+Each type's ``from_manager_output(raw)`` classmethod shapes the manager dict
+into the type; ``to_dict()`` exposes the dict contract the REST routes return.
+
+The manager's ``policies`` field is intentionally not projected here: its shape
+is firmware-variable, so it is omitted from the GraphQL type and REST rows for
+now and can be added later without a breaking change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+import strawberry
+
+
+def _get(obj: Any, *keys: str, default: Any = None) -> Any:
+    """Return the first non-None value among ``keys`` (dict input), else ``default``.
+
+    Matches the variadic helper convention in ``session.py`` so field aliases can
+    be added by listing extra keys rather than changing the signature.
+    """
+    if not isinstance(obj, dict):
+        return default
+    for k in keys:
+        v = obj.get(k)
+        if v is not None:
+            return v
+    return default
+
+
+@strawberry.type(description="One side (source or destination) of a traffic flow.")
+class TrafficFlowEndpoint:
+    name: str | None
+    mac: str | None
+    ip: str | None
+    network_name: str | None
+    zone_name: str | None
+    domains: list[str]
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "TrafficFlowEndpoint":
+        return cls(
+            name=_get(obj, "name"),
+            mac=_get(obj, "mac"),
+            ip=_get(obj, "ip"),
+            network_name=_get(obj, "network_name"),
+            zone_name=_get(obj, "zone_name"),
+            domains=_get(obj, "domains", default=[]),
+        )
+
+
+@strawberry.type(description="A single UniFi traffic-flow record.")
+class TrafficFlow:
+    id: str | None
+    action: str | None
+    risk: str | None
+    service: str | None
+    protocol: str | None
+    direction: str | None
+    count: int | None
+    duration_milliseconds: int | None
+    time: int | None
+    flow_start_time: int | None
+    flow_end_time: int | None
+    bytes_total: int | None
+    bytes_rx: int | None
+    bytes_tx: int | None
+    source: TrafficFlowEndpoint
+    destination: TrafficFlowEndpoint
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "primary_key": "id",
+            "display_columns": [
+                "time",
+                "source",
+                "destination",
+                "service",
+                "risk",
+                "action",
+            ],
+            "sort_default": "time:desc",
+        }
+
+    @classmethod
+    def from_manager_output(cls, record: Any) -> "TrafficFlow":
+        return cls(
+            id=_get(record, "id"),
+            action=_get(record, "action"),
+            risk=_get(record, "risk"),
+            service=_get(record, "service"),
+            protocol=_get(record, "protocol"),
+            direction=_get(record, "direction"),
+            count=_get(record, "count"),
+            duration_milliseconds=_get(record, "duration_milliseconds"),
+            time=_get(record, "time"),
+            flow_start_time=_get(record, "flow_start_time"),
+            flow_end_time=_get(record, "flow_end_time"),
+            bytes_total=_get(record, "bytes_total"),
+            bytes_rx=_get(record, "bytes_rx"),
+            bytes_tx=_get(record, "bytes_tx"),
+            source=TrafficFlowEndpoint.from_manager_output(_get(record, "source")),
+            destination=TrafficFlowEndpoint.from_manager_output(_get(record, "destination")),
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@strawberry.type(description="Paginated page of UniFi traffic flows.")
+class TrafficFlowPage:
+    items: list[TrafficFlow]
+    next_cursor: str | None = None

--- a/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
+++ b/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
@@ -1,0 +1,106 @@
+"""GET route for traffic flows (Insights > Flows).
+
+The traffic-flows manager is server-paginated (it owns ``page_number`` /
+``has_next``), so this route uses an opaque page cursor that encodes the
+controller's 0-based page number rather than the list-style ``paginate()``.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.traffic_flow import TrafficFlow
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pydantic_models import Page
+
+router = APIRouter()
+
+
+def _encode_flow_cursor(page: int) -> str:
+    return base64.urlsafe_b64encode(str(page).encode()).decode()
+
+
+def _decode_flow_cursor(cursor: str | None) -> int:
+    if not cursor:
+        return 0
+    try:
+        return max(0, int(base64.urlsafe_b64decode(cursor.encode()).decode()))
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/traffic-flows",
+    response_model=Page[to_pydantic_model(TrafficFlow)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/traffic-flows"],
+)
+async def get_traffic_flows(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    within_hours: int = Query(24, ge=1, le=8760),
+    time_from: int | None = Query(None),
+    time_to: int | None = Query(None),
+    search_text: str | None = Query(None),
+    page_size: int = Query(100, ge=1, le=1000),
+    cursor: str | None = Query(None),
+) -> dict:
+    from unifi_core.network.models.traffic_flows import TrafficFlowQuery
+
+    require_capability(controller, "network")
+    page = _decode_flow_cursor(cursor)
+    if (time_from is None) != (time_to is None):
+        raise HTTPException(
+            status_code=400,
+            detail="provide both time_from and time_to, or use within_hours",
+        )
+    if time_from is None:
+        now_ms = int(time.time() * 1000)
+        time_from, time_to = now_ms - within_hours * 3600 * 1000, now_ms
+    query = TrafficFlowQuery(
+        time_from=time_from,
+        time_to=time_to,
+        page_number=page,
+        page_size=page_size,
+        search_text=search_text,
+    )
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "network",
+            "traffic_flow_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        result = await mgr.get_traffic_flows(query)
+
+    type_registry = request.app.state.type_registry
+    tool_type = type_registry.lookup_tool("unifi_get_traffic_flows")
+    if tool_type is None:
+        # Registered at startup (discover_serializers refuses to boot otherwise);
+        # this guard makes a future registry regression fail loudly, not with a
+        # bare TypeError on the unpack below.
+        raise HTTPException(status_code=500, detail="traffic-flow projection not registered")
+    type_class, kind = tool_type
+    rows = [type_class.from_manager_output(f).to_dict() for f in result.get("flows", [])]
+    hint = type_class.render_hint(kind)
+    next_cursor = _encode_flow_cursor(page + 1) if result.get("has_next") else None
+    return {
+        "items": rows,
+        "next_cursor": next_cursor,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -147,6 +147,9 @@ from unifi_api.routes.resources.network import (
     system as net_system_routes,
 )
 from unifi_api.routes.resources.network import (
+    traffic_flows as net_traffic_flows_routes,
+)
+from unifi_api.routes.resources.network import (
     user_groups as net_user_groups_routes,
 )
 from unifi_api.routes.resources.network import (
@@ -495,6 +498,7 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_user_groups_routes,
         net_lookup_routes,
         net_routes_routes,
+        net_traffic_flows_routes,
         net_dns_routes,
         net_vpn_routes,
         net_ap_groups_routes,

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -61,6 +61,7 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
     from unifi_core.network.managers.stats_manager import StatsManager
     from unifi_core.network.managers.switch_manager import SwitchManager
     from unifi_core.network.managers.system_manager import SystemManager
+    from unifi_core.network.managers.traffic_flow_manager import TrafficFlowManager
     from unifi_core.network.managers.traffic_route_manager import TrafficRouteManager
     from unifi_core.network.managers.usergroup_manager import UsergroupManager
     from unifi_core.network.managers.vpn_manager import VpnManager
@@ -89,6 +90,7 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
         "stats_manager": lambda cm: StatsManager(cm, ClientManager(cm)),
         "switch_manager": lambda cm: SwitchManager(cm),
         "system_manager": lambda cm: SystemManager(cm),
+        "traffic_flow_manager": lambda cm: TrafficFlowManager(cm),
         "traffic_route_manager": lambda cm: TrafficRouteManager(cm),
         "usergroup_manager": lambda cm: UsergroupManager(cm),
         "vpn_manager": lambda cm: VpnManager(cm),

--- a/apps/api/tests/graphql/fixtures/network/test_traffic_flows.py
+++ b/apps/api/tests/graphql/fixtures/network/test_traffic_flows.py
@@ -1,0 +1,133 @@
+"""Fixture e2e tests for network/traffic-flows resolver.
+
+# tool: unifi_get_traffic_flows
+"""
+
+from __future__ import annotations
+
+import pytest
+from unifi_api.graphql.resolvers.network import _decode_flow_cursor
+
+from tests.graphql.fixtures._helpers import (
+    bootstrap,
+    graphql_query,
+    stub_managers,
+)
+
+
+@pytest.mark.asyncio
+async def test_traffic_flows_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "traffic_flow_manager", "get_traffic_flows"): {
+                "flows": [
+                    {
+                        "id": "flow-1",
+                        "action": "Allow",
+                        "service": "HTTPS",
+                        "source": {"name": "alpha", "ip": "10.0.0.5"},
+                        "destination": {"ip": "203.0.113.1", "domains": ["example.com"]},
+                    },
+                    {
+                        "id": "flow-2",
+                        "action": "Block",
+                        "service": "DNS",
+                        "source": {"name": "beta", "ip": "10.0.0.6"},
+                        "destination": {"ip": "198.51.100.1"},
+                    },
+                ],
+                "page_number": 0,
+                "total_element_count": 2,
+                "total_page_count": 1,
+                "has_next": False,
+                "or_more": False,
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ trafficFlows(controller: "{cid}", withinHours: 24, pageSize: 100) {{
+            items {{ id action service source {{ name ip }} destination {{ ip domains }} }}
+            nextCursor
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    page = body["data"]["network"]["trafficFlows"]
+    items = page["items"]
+    assert len(items) == 2
+    assert {it["id"] for it in items} == {"flow-1", "flow-2"}
+    assert items[0]["source"]["name"] == "alpha"
+    assert items[0]["destination"]["domains"] == ["example.com"]
+    assert page["nextCursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_traffic_flows_next_cursor(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "traffic_flow_manager", "get_traffic_flows"): {
+                "flows": [{"id": "flow-1", "action": "Allow"}],
+                "page_number": 0,
+                "total_element_count": 200,
+                "total_page_count": 2,
+                "has_next": True,
+                "or_more": True,
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ trafficFlows(controller: "{cid}", pageSize: 1) {{
+            items {{ id }}
+            nextCursor
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    page = body["data"]["network"]["trafficFlows"]
+    assert len(page["items"]) == 1
+    # has_next -> a cursor is returned; it must round-trip to page 1.
+    assert page["nextCursor"] is not None
+    assert _decode_flow_cursor(page["nextCursor"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_traffic_flows_partial_time_window_errors(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "traffic_flow_manager", "get_traffic_flows"): {
+                "flows": [],
+                "page_number": 0,
+                "total_element_count": 0,
+                "total_page_count": 0,
+                "has_next": False,
+                "or_more": False,
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ trafficFlows(controller: "{cid}", timeFrom: 1000) {{
+            items {{ id }}
+            nextCursor
+        }} }}
+    }}''',
+    )
+    # time_from set without time_to -> resolver raises ValueError -> GraphQL errors.
+    assert body.get("errors"), body

--- a/apps/api/tests/routes/resources/test_network_config.py
+++ b/apps/api/tests/routes/resources/test_network_config.py
@@ -555,3 +555,94 @@ async def test_get_ap_group_details_happy_path(tmp_path, monkeypatch) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["render_hint"]["kind"] == "detail"
+
+
+# ---------- traffic flows ----------
+
+
+@pytest.mark.asyncio
+async def test_get_traffic_flows_happy_path(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    envelope = {
+        "flows": [
+            {
+                "id": "flow-1",
+                "action": "Allow",
+                "service": "HTTPS",
+                "source": {"name": "alpha", "ip": "10.0.0.5"},
+                "destination": {"ip": "203.0.113.1", "domains": ["example.com"]},
+            }
+        ],
+        "page_number": 0,
+        "total_element_count": 1,
+        "total_page_count": 1,
+        "has_next": False,
+        "or_more": False,
+    }
+
+    async def fake_get(self, query):
+        return envelope
+
+    from unifi_core.network.managers.traffic_flow_manager import TrafficFlowManager
+
+    monkeypatch.setattr(TrafficFlowManager, "get_traffic_flows", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/traffic-flows?controller={cid}&within_hours=24",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    assert len(body["items"]) == 1
+    assert body["items"][0]["id"] == "flow-1"
+    assert body["items"][0]["destination"]["domains"] == ["example.com"]
+    assert body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_traffic_flows_next_cursor_and_window_guard(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    envelope = {
+        "flows": [{"id": "flow-1"}],
+        "page_number": 0,
+        "total_element_count": 200,
+        "total_page_count": 2,
+        "has_next": True,
+        "or_more": True,
+    }
+
+    async def fake_get(self, query):
+        return envelope
+
+    from unifi_core.network.managers.traffic_flow_manager import TrafficFlowManager
+
+    monkeypatch.setattr(TrafficFlowManager, "get_traffic_flows", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        # has_next -> an opaque next_cursor is returned
+        r = await c.get(
+            f"/v1/sites/default/traffic-flows?controller={cid}&page_size=1",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["next_cursor"] is not None
+        # time_from without time_to -> 400 from the window guard
+        r2 = await c.get(
+            f"/v1/sites/default/traffic-flows?controller={cid}&time_from=1000",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        # malformed cursor -> 400 (not an unhandled 500)
+        r3 = await c.get(
+            f"/v1/sites/default/traffic-flows?controller={cid}&cursor=!!!bad!!!",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r2.status_code == 400, r2.text
+    assert r3.status_code == 400, r3.text

--- a/apps/api/tests/serializers/test_network_traffic_flows.py
+++ b/apps/api/tests/serializers/test_network_traffic_flows.py
@@ -1,0 +1,90 @@
+"""Network traffic-flow type unit tests.
+
+Mirrors the ``ClientSession`` / ``ClientSessionPage`` pattern: the
+``TrafficFlow`` / ``TrafficFlowEndpoint`` / ``TrafficFlowPage`` Strawberry
+types map from the dict shape ``TrafficFlowManager.get_traffic_flows()``
+emits and expose a ``to_dict()`` dict contract for the REST routes.
+"""
+
+from unifi_api.graphql.types.network.traffic_flow import (
+    TrafficFlow,
+    TrafficFlowEndpoint,
+    TrafficFlowPage,
+)
+
+
+def test_from_manager_output_maps_core_fields() -> None:
+    raw = {
+        "id": "f1",
+        "action": "Allow",
+        "risk": "low",
+        "service": "HTTPS",
+        "bytes_total": 1234,
+        "source": {"name": "Lab-Laptop", "mac": "aa:bb:cc:00:00:01"},
+        "destination": {"domains": ["example.com"], "ip": "203.0.113.5"},
+    }
+    tf = TrafficFlow.from_manager_output(raw)
+    assert tf.id == "f1"
+    assert tf.action == "Allow"
+    assert tf.bytes_total == 1234
+    assert tf.source.name == "Lab-Laptop"
+    assert tf.destination.domains == ["example.com"]
+    d = tf.to_dict()
+    assert d["id"] == "f1" and "source" in d
+
+
+def test_to_dict_nests_endpoints() -> None:
+    raw = {
+        "id": "f2",
+        "source": {
+            "name": "AP-Office",
+            "mac": "aa:bb:cc:00:00:02",
+            "ip": "10.0.0.5",
+            "network_name": "LAN",
+            "zone_name": "Internal",
+            "domains": [],
+        },
+        "destination": {
+            "name": "ext",
+            "ip": "203.0.113.9",
+            "domains": ["example.com"],
+        },
+    }
+    d = TrafficFlow.from_manager_output(raw).to_dict()
+    assert isinstance(d["source"], dict)
+    assert d["source"]["network_name"] == "LAN"
+    assert d["source"]["zone_name"] == "Internal"
+    assert d["destination"]["domains"] == ["example.com"]
+
+
+def test_endpoint_handles_missing_fields() -> None:
+    ep = TrafficFlowEndpoint.from_manager_output({})
+    assert ep.name is None
+    assert ep.domains == []
+    none_ep = TrafficFlowEndpoint.from_manager_output(None)
+    assert none_ep.name is None
+    assert none_ep.domains == []
+
+
+def test_render_hint() -> None:
+    hint = TrafficFlow.render_hint("list")
+    assert hint == {
+        "kind": "list",
+        "primary_key": "id",
+        "display_columns": [
+            "time",
+            "source",
+            "destination",
+            "service",
+            "risk",
+            "action",
+        ],
+        "sort_default": "time:desc",
+    }
+
+
+def test_traffic_flow_page() -> None:
+    raw = {"id": "f3", "source": {}, "destination": {}}
+    page = TrafficFlowPage(items=[TrafficFlow.from_manager_output(raw)])
+    assert page.next_cursor is None
+    assert page.items[0].id == "f3"

--- a/apps/api/tests/unit/test_traffic_flow_cursor.py
+++ b/apps/api/tests/unit/test_traffic_flow_cursor.py
@@ -1,0 +1,28 @@
+"""Unit tests for the opaque traffic-flow cursor helpers."""
+
+from __future__ import annotations
+
+import pytest
+from unifi_api.graphql.resolvers.network import (
+    _decode_flow_cursor,
+    _encode_flow_cursor,
+)
+
+
+@pytest.mark.parametrize("page", [0, 1, 5, 42, 1000])
+def test_cursor_round_trip(page):
+    assert _decode_flow_cursor(_encode_flow_cursor(page)) == page
+
+
+def test_decode_empty_cursor_is_page_zero():
+    assert _decode_flow_cursor(None) == 0
+    assert _decode_flow_cursor("") == 0
+
+
+def test_decode_invalid_cursor_raises():
+    with pytest.raises(ValueError):
+        _decode_flow_cursor("!!!not-base64!!!")
+
+
+def test_decode_negative_page_clamps_to_zero():
+    assert _decode_flow_cursor(_encode_flow_cursor(-1)) == 0

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -50,6 +50,7 @@ from unifi_core.network.managers.routing_manager import RoutingManager
 from unifi_core.network.managers.stats_manager import StatsManager
 from unifi_core.network.managers.switch_manager import SwitchManager
 from unifi_core.network.managers.system_manager import SystemManager
+from unifi_core.network.managers.traffic_flow_manager import TrafficFlowManager
 from unifi_core.network.managers.traffic_route_manager import TrafficRouteManager
 from unifi_core.network.managers.usergroup_manager import UsergroupManager
 from unifi_core.network.managers.vpn_manager import VpnManager
@@ -262,6 +263,11 @@ def get_routing_manager() -> RoutingManager:
 
 
 @lru_cache
+def get_traffic_flow_manager() -> TrafficFlowManager:
+    return TrafficFlowManager(get_connection_manager())
+
+
+@lru_cache
 def get_traffic_route_manager() -> TrafficRouteManager:
     return TrafficRouteManager(get_connection_manager())
 
@@ -302,6 +308,7 @@ event_manager = get_event_manager()
 hotspot_manager = get_hotspot_manager()
 usergroup_manager = get_usergroup_manager()
 routing_manager = get_routing_manager()
+traffic_flow_manager = get_traffic_flow_manager()
 traffic_route_manager = get_traffic_route_manager()
 tool_registry = get_tool_registry()
 

--- a/apps/network/src/unifi_network_mcp/tools/traffic_flows.py
+++ b/apps/network/src/unifi_network_mcp/tools/traffic_flows.py
@@ -1,0 +1,92 @@
+"""Traffic Flows reader tool for the UniFi Network MCP server.
+
+Read-only. Queries the private v2 /traffic-flows endpoint with a historical
+time window, server-side filters, and pagination. Returns one page of flows
+plus pagination metadata. Stateless — no caching.
+"""
+
+import logging
+import time
+from typing import Annotated, Any, Dict, List, Optional
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_core.network.models.traffic_flows import TrafficFlowQuery
+from unifi_network_mcp.runtime import server, traffic_flow_manager
+
+logger = logging.getLogger(__name__)
+
+
+def _as_list(value: Optional[str]) -> Optional[List[str]]:
+    return [value] if value else None
+
+
+@server.tool(
+    name="unifi_get_traffic_flows",
+    description=(
+        "Query historical UniFi Traffic Flows (Insights > Flows). Returns completed flow "
+        "records — source/destination (incl. resolved destination domains), service, risk, "
+        "action, bytes, and timestamps — for a time window, with server-side filtering and "
+        "pagination. Supply both time_from and time_to (epoch ms) for an explicit window, or "
+        "use within_hours. Read-only; one page per call (use page/total_page_count to paginate)."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_traffic_flows(
+    within_hours: Annotated[
+        int, Field(ge=1, le=8760, description="Look-back window in hours (used when time_from/time_to absent)")
+    ] = 24,
+    time_from: Annotated[Optional[int], Field(description="Explicit window start, epoch ms")] = None,
+    time_to: Annotated[Optional[int], Field(description="Explicit window end, epoch ms")] = None,
+    source_mac: Annotated[Optional[str], Field(description="Filter by source MAC")] = None,
+    source_ip: Annotated[Optional[str], Field(description="Filter by source IP")] = None,
+    source_name: Annotated[Optional[str], Field(description="Filter by source host/client name")] = None,
+    source_network_id: Annotated[Optional[str], Field(description="Filter by source network ID")] = None,
+    destination_domain: Annotated[Optional[str], Field(description="Filter by destination domain")] = None,
+    destination_ip: Annotated[Optional[str], Field(description="Filter by destination IP")] = None,
+    destination_region: Annotated[Optional[str], Field(description="Filter by destination region/country")] = None,
+    risk: Annotated[Optional[str], Field(description="Filter by risk (low/medium/high/critical)")] = None,
+    action: Annotated[Optional[str], Field(description="Filter by action (allow/block)")] = None,
+    service: Annotated[Optional[str], Field(description="Filter by service")] = None,
+    protocol: Annotated[Optional[str], Field(description="Filter by protocol")] = None,
+    direction: Annotated[Optional[str], Field(description="Filter by direction")] = None,
+    search_text: Annotated[Optional[str], Field(description="Free-text match (destination domain/host aware)")] = None,
+    page: Annotated[int, Field(ge=0, description="0-based page number")] = 0,
+    page_size: Annotated[int, Field(description="Rows per page (<=1000)")] = 100,
+) -> Dict[str, Any]:
+    """Query historical traffic flows."""
+    if (time_from is None) != (time_to is None):
+        return {"success": False, "error": "provide both time_from and time_to, or use within_hours"}
+    if time_from is None:
+        if within_hours <= 0:
+            return {"success": False, "error": "within_hours must be a positive integer"}
+        now_ms = int(time.time() * 1000)
+        time_from = now_ms - within_hours * 3600 * 1000
+        time_to = now_ms
+
+    try:
+        query = TrafficFlowQuery(
+            time_from=time_from,
+            time_to=time_to,
+            page_number=page,
+            page_size=max(1, min(page_size, 1000)),
+            search_text=search_text,
+            risk=_as_list(risk),
+            action=_as_list(action),
+            direction=_as_list(direction),
+            protocol=_as_list(protocol),
+            service=_as_list(service),
+            source_mac=_as_list(source_mac),
+            source_ip=_as_list(source_ip),
+            source_host=_as_list(source_name),
+            source_network_id=_as_list(source_network_id),
+            destination_domain=_as_list(destination_domain),
+            destination_ip=_as_list(destination_ip),
+            destination_region=_as_list(destination_region),
+        )
+        result = await traffic_flow_manager.get_traffic_flows(query)
+        return {"success": True, "site": traffic_flow_manager._connection.site, **result}
+    except Exception as e:
+        logger.error("Error getting traffic flows: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to get traffic flows: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 176,
+  "count": 177,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -86,6 +86,7 @@
     "unifi_get_switch_ports": "unifi_network_mcp.tools.switch",
     "unifi_get_system_info": "unifi_network_mcp.tools.system",
     "unifi_get_top_clients": "unifi_network_mcp.tools.stats",
+    "unifi_get_traffic_flows": "unifi_network_mcp.tools.traffic_flows",
     "unifi_get_traffic_route_details": "unifi_network_mcp.tools.traffic_routes",
     "unifi_get_usergroup_details": "unifi_network_mcp.tools.usergroups",
     "unifi_get_voucher_details": "unifi_network_mcp.tools.hotspot",
@@ -8512,6 +8513,163 @@
         }
       },
       "title": "Get Top Clients"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Query historical UniFi Traffic Flows (Insights > Flows). Returns completed flow records \u2014 source/destination (incl. resolved destination domains), service, risk, action, bytes, and timestamps \u2014 for a time window, with server-side filtering and pagination. Supply both time_from and time_to (epoch ms) for an explicit window, or use within_hours. Read-only; one page per call (use page/total_page_count to paginate).",
+      "name": "unifi_get_traffic_flows",
+      "schema": {
+        "input": {
+          "properties": {
+            "action": {
+              "description": "Filter by action (allow/block)",
+              "type": "string"
+            },
+            "destination_domain": {
+              "description": "Filter by destination domain",
+              "type": "string"
+            },
+            "destination_ip": {
+              "description": "Filter by destination IP",
+              "type": "string"
+            },
+            "destination_region": {
+              "description": "Filter by destination region/country",
+              "type": "string"
+            },
+            "direction": {
+              "description": "Filter by direction",
+              "type": "string"
+            },
+            "page": {
+              "description": "0-based page number",
+              "type": "integer"
+            },
+            "page_size": {
+              "description": "Rows per page (<=1000)",
+              "type": "integer"
+            },
+            "protocol": {
+              "description": "Filter by protocol",
+              "type": "string"
+            },
+            "risk": {
+              "description": "Filter by risk (low/medium/high/critical)",
+              "type": "string"
+            },
+            "search_text": {
+              "description": "Free-text match (destination domain/host aware)",
+              "type": "string"
+            },
+            "service": {
+              "description": "Filter by service",
+              "type": "string"
+            },
+            "source_ip": {
+              "description": "Filter by source IP",
+              "type": "string"
+            },
+            "source_mac": {
+              "description": "Filter by source MAC",
+              "type": "string"
+            },
+            "source_name": {
+              "description": "Filter by source host/client name",
+              "type": "string"
+            },
+            "source_network_id": {
+              "description": "Filter by source network ID",
+              "type": "string"
+            },
+            "time_from": {
+              "description": "Explicit window start, epoch ms",
+              "type": "integer"
+            },
+            "time_to": {
+              "description": "Explicit window end, epoch ms",
+              "type": "integer"
+            },
+            "within_hours": {
+              "description": "Look-back window in hours (used when time_from/time_to absent)",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Get Traffic Flows"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_traffic_flows_tool.py
+++ b/apps/network/tests/unit/test_traffic_flows_tool.py
@@ -1,0 +1,107 @@
+"""Tests for the unifi_get_traffic_flows tool."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unifi_network_mcp.runtime import traffic_flow_manager
+from unifi_network_mcp.tools.traffic_flows import get_traffic_flows
+
+# Patch the manager METHOD on the class so interception is robust regardless of
+# which TrafficFlowManager instance the tool resolves (real singleton vs mock)
+# or import/lazy-load ordering across the full suite.
+_MANAGER_METHOD = "unifi_core.network.managers.traffic_flow_manager.TrafficFlowManager.get_traffic_flows"
+
+# Distinct envelope so every pagination key is independently asserted (a tool
+# that dropped any of them would not silently pass).
+_ENVELOPE = {
+    "flows": [{"id": "f1"}],
+    "page_number": 3,
+    "total_element_count": 42,
+    "total_page_count": 5,
+    "has_next": True,
+    "or_more": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_tool_maps_params_and_returns_success():
+    with patch(_MANAGER_METHOD, new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = dict(_ENVELOPE)
+        out = await get_traffic_flows(
+            within_hours=2,
+            destination_domain="x.test",
+            source_name="host1",
+            risk="high",
+            source_mac="aa:bb:cc:dd:ee:ff",
+        )
+
+    assert out["success"] is True
+    assert out["site"] == traffic_flow_manager._connection.site
+    # Whole manager envelope must spread through unchanged (all 6 keys).
+    for key, value in _ENVELOPE.items():
+        assert out[key] == value
+
+    # AsyncMock on the class is not a descriptor, so self is not passed: args[0] is the query.
+    query = mock_get.call_args.args[0]
+    # Scalar filters are wrapped into single-element lists via _as_list.
+    assert query.destination_domain == ["x.test"]
+    assert query.risk == ["high"]
+    assert query.source_mac == ["aa:bb:cc:dd:ee:ff"]
+    # The one non-obvious rename: tool param source_name -> model field source_host.
+    assert query.source_host == ["host1"]
+    # Omitted filters stay None (not [] or [None]).
+    assert query.action is None
+    assert query.destination_ip is None
+    # within_hours=2 -> window is ~2h wide (allow small clock-skew).
+    assert query.time_from is not None and query.time_to is not None
+    assert abs((query.time_to - query.time_from) - 2 * 3600 * 1000) < 2000
+
+
+@pytest.mark.asyncio
+async def test_tool_rejects_half_specified_window():
+    # XOR guard must reject either half alone, symmetrically.
+    out_from = await get_traffic_flows(time_from=1000)  # time_to missing
+    assert out_from["success"] is False
+    assert "both time_from and time_to" in out_from["error"]
+
+    out_to = await get_traffic_flows(time_to=1000)  # time_from missing
+    assert out_to["success"] is False
+    assert "both time_from and time_to" in out_to["error"]
+
+
+@pytest.mark.asyncio
+async def test_tool_rejects_nonpositive_within_hours():
+    out = await get_traffic_flows(within_hours=0)
+    assert out["success"] is False
+    assert "within_hours" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_tool_clamps_page_size():
+    with patch(_MANAGER_METHOD, new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = dict(_ENVELOPE)
+        await get_traffic_flows(time_from=1, time_to=2, page_size=5000)
+        assert mock_get.call_args.args[0].page_size == 1000
+        await get_traffic_flows(time_from=1, time_to=2, page_size=0)
+        assert mock_get.call_args.args[0].page_size == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_negative_page_returns_error_envelope():
+    # page=-1 violates the model's page_number ge=0; the tool must surface this
+    # as the uniform error envelope, not let a ValidationError escape.
+    with patch(_MANAGER_METHOD, new_callable=AsyncMock) as mock_get:
+        out = await get_traffic_flows(time_from=1, time_to=2, page=-1)
+    assert out["success"] is False
+    assert "error" in out
+    mock_get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_manager_failure_returns_error_envelope():
+    with patch(_MANAGER_METHOD, new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = RuntimeError("boom")
+        out = await get_traffic_flows(time_from=1, time_to=2)
+    assert out["success"] is False
+    assert "Failed to get traffic flows" in out["error"]

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (176 tools)
+# Network Server Tool Reference (177 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -11,6 +11,7 @@ Complete reference for `unifi_*` tools. All read tools are always available. Mut
 - [DNS Records](#dns-records)
 - [Port Forwarding](#port-forwarding)
 - [QoS / Traffic Shaping](#qos--traffic-shaping)
+- [Traffic Flows](#traffic-flows)
 - [Traffic Routes](#traffic-routes)
 - [VPN](#vpn)
 - [Routing](#routing)
@@ -212,6 +213,18 @@ Manage static DNS A/AAAA/CNAME/MX/TXT/NS/SRV records on the controller's local D
 | `unifi_toggle_qos_rule_enabled` | Mutate | Enable or disable a specific QoS rule by ID. |
 | `unifi_update_qos_rule` | Mutate | Update specific fields of an existing QoS rule. |
 <!-- /AUTO:tools:qos -->
+
+---
+
+## Traffic Flows
+
+<!-- AUTO:tools:traffic_flows -->
+1 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_get_traffic_flows` | Read | Query historical UniFi Traffic Flows (Insights > Flows). |
+<!-- /AUTO:tools:traffic_flows -->
 
 ---
 


### PR DESCRIPTION
## What

Exposes UniFi **traffic-flows** (Insights → Flows) full-stack, wrapping the `TrafficFlowManager` added in #315:

- **MCP tool** `unifi_get_traffic_flows` (`apps/network`) — historical time window (`within_hours`, or explicit `time_from`/`time_to` epoch ms), server-side filters (source/destination MAC/IP/host/network, destination domain/region, service, risk, action, protocol, direction, free text), and pagination; returns one page of flows plus pagination metadata.
- **GraphQL** `network { trafficFlows(...) }` (`apps/api`) — `TrafficFlow` / `TrafficFlowEndpoint` / `TrafficFlowPage` types and a paginated resolver with an opaque page cursor.
- **REST** `GET /v1/sites/{site}/traffic-flows` — same window/cursor handling.

## Why one PR (network + api together)

A new tool can't land as a network-only change: `apps/api` `create_app()` refuses to start (`SerializerRegistryError`) unless every manifest tool has a GraphQL projection, and `test_resource_route_coverage` requires a REST route per read tool. So the MCP tool, its GraphQL projection, and its REST route are a single cross-package contract. Most of the diff is regenerated artifacts (`schema.graphql`, `graphql-reference.md`, `openapi-reference.md`, `openapi.json`, `tools_manifest.json`, skill-reference table).

## Notes

- `page` is bounded `ge=0` (matching the model's `page_number`); the MCP tool builds the query inside `try` so malformed input returns the uniform `{success: false}` envelope. The opaque REST/GraphQL cursor clamps page ≥ 0 and maps a bad cursor to HTTP 400 / a GraphQL error.
- `policies` is intentionally not projected on the GraphQL type (firmware-variable shape); it can be added later without a breaking change.
- No `categories.py` entry — the tool is read-only with no `permission_category`, so the permission map is never consulted for it.

## Test plan

- Unit/fixture: `apps/network` tool tests (param→query mapping incl. the `source_name`→`source_host` rename, the full pagination-envelope spread, the window XOR guard, page-size clamp, manager-error envelope); `apps/api` cursor round-trip, type projection, GraphQL e2e fixtures, and REST route tests (incl. bad-cursor → 400).
- Full `apps/network` + `apps/api` suites green; `ruff format --check` / `ruff check` clean; SDL / docs / openapi / skill-reference drift + resolver / serializer / resource-route coverage gates all green.
- **Live**: exercised against a real controller — the MCP tool returns real flows with server-side filtering; the GraphQL `trafficFlows` query and the REST `/traffic-flows` route both return 200 with projected flows and pagination.
