### PR TITLE
Fix Protect API key client wiring

### DIFF
--- a/apps/protect/tests/unit/test_connection_manager.py
+++ b/apps/protect/tests/unit/test_connection_manager.py
@@ -117,12 +117,20 @@ class TestInitialize:
         with patch(
             "unifi_core.protect.managers.connection_manager.ProtectApiClient",
             return_value=mock_client,
-        ):
+        ) as protect_client:
             result = await cm.initialize()
 
         assert result is True
         assert cm._initialized is True
         assert cm._client is mock_client
+        protect_client.assert_called_once_with(
+            host="192.168.1.1",
+            port=443,
+            username="admin",
+            password="secret",
+            api_key="test-api-key",
+            verify_ssl=False,
+        )
         mock_client.update.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/packages/unifi-core/src/unifi_core/protect/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/connection_manager.py
@@ -93,6 +93,7 @@ class ProtectConnectionManager:
                 port=self.port,
                 username=self.username,
                 password=self.password,
+                api_key=self._api_key,
                 verify_ssl=self.verify_ssl,
             )
             # update() authenticates + fetches the full bootstrap (NVR, cameras, etc.)


### PR DESCRIPTION
## Summary

- Forward the configured Protect API key into `ProtectApiClient` during `ProtectConnectionManager.initialize()`.
- Add regression coverage so initialization asserts the key is passed to the upstream client.

Fixes #318.

## Root Cause

`ProtectConnectionManager` stored the API key and used it for its separate `api_session`, but the primary `uiprotect.ProtectApiClient` was constructed without `api_key`. Upstream `uiprotect` requires that key for `public_api=True` calls, including Protect PTZ preset operations routed through the integration API.

## Validation

- `uv run pytest apps/protect/tests/unit/test_connection_manager.py -q` - 21 passed
- `uv run pytest apps/protect/tests/unit/test_cameras.py -q` - 63 passed
- `uv run python scripts/live_smoke.py --server protect --phase readonly` - passed, 45 ok / 2 skipped, artifact `live-smoke-results/protect-2026-06-04T140911.031123Z.json`
- Targeted public API client check - passed: the `ProtectApiClient` created by this branch had `_api_key` populated, `client.get_cameras_public()` returned 14 cameras, and raw `client.api_request('/v1/cameras', public_api=True)` returned 14 cameras. Artifact: `live-smoke-results/protect-targeted-public-api-client-2026-06-04T141632.997065Z.json`
- Targeted `protect_ptz_preset` tool check against the live PTZ camera reached the public integration endpoint with auth, then failed because the camera has no saved preset slot: `404 Entity 'preset' not found`. Artifact: `live-smoke-results/protect-targeted-ptz-public-api-2026-06-04T141734.086779Z.json`

## Live Smoke Note

I also ran `uv run python scripts/live_smoke.py --server protect --phase safe`. It connected and completed the read-only paths, but exited non-zero because this live Protect environment has no Alarm Manager arm profiles configured: `protect_alarm_arm` preview returned `No arm profiles found. Configure Alarm Manager in the Protect UI first, or pass profile_id explicitly.` The artifact is `live-smoke-results/protect-2026-06-04T140814.746156Z.json`. That failure is unrelated to this API-key wiring change.
