### PR TITLE
feat(protect): add Find Anything detection search (tools + GraphQL + REST)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 
 | Server | Status | Tools | Package |
 |--------|--------|-------|---------|
-| [Network](apps/network/) | Stable | 169 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
-| [Protect](apps/protect/) | Beta | 43 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
-| [Access](apps/access/) | Beta | 29 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
+| [Network](apps/network/) | Stable | 177 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
+| [Protect](apps/protect/) | Beta | 58 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
+| [Access](apps/access/) | Beta | 34 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
 
 ## Cloud Relay
 
@@ -166,10 +166,12 @@ Once connected, just ask your AI agent in natural language:
 > "Show me all clients on the Guest VLAN with their signal strength and data usage"
 > "Create a firewall rule that blocks IoT devices from reaching the internet between midnight and 6 AM"
 > "Audit my firewall policies — are there any redundant or conflicting rules?"
+> "Show me the top traffic flows from the last hour and group them by destination"
 
 **Protect**
 > "List all cameras that detected motion in the last hour"
 > "Show me smart detection events from the front door camera today — people and vehicles only"
+> "Find driveway detections for white vans this week"
 
 **Access**
 > "Who badged into the office today? Show me a timeline of all door access events"
@@ -229,9 +231,9 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 169 tools)
-  protect/          # UniFi Protect MCP server (beta, 56 tools)
-  access/           # UniFi Access MCP server (beta, 29 tools)
+  network/          # UniFi Network MCP server (stable, 177 tools)
+  protect/          # UniFi Protect MCP server (beta, 58 tools)
+  access/           # UniFi Access MCP server (beta, 34 tools)
   worker/           # Cloudflare Worker gateway + npm CLI
 packages/
   unifi-core/       # Shared UniFi connectivity (auth, detection, retry)

--- a/apps/access/README.md
+++ b/apps/access/README.md
@@ -161,7 +161,7 @@ No additional configuration is required — if both plugins are active, the skil
 
 - [Configuration](docs/configuration.md) -- Full env var reference, YAML config, Access-specific options
 - [Permissions](docs/permissions.md) -- Permission system, category defaults, how to enable mutations
-- [Tool Catalog](docs/tools.md) -- All 29 tools organized by category
+- [Tool Catalog](docs/tools.md) -- All 34 tools organized by category
 - [Event Streaming](docs/events.md) -- Real-time event architecture, WebSocket buffer, polling
 - [Troubleshooting](docs/troubleshooting.md) -- Connection issues, dual auth debugging, missing tools
 

--- a/apps/access/docs/tools.md
+++ b/apps/access/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Access MCP server exposes 29 tools, all prefixed with `access_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Access MCP server exposes 34 tools, all prefixed with `access_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy/meta-only workflows, call the `access_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_access_mcp/tools_manifest.json`.
 
@@ -48,7 +48,7 @@ In lazy mode, an additional meta-tool is available:
 - `access_create_credential` -- Create NFC card, PIN, or mobile credential. Confirm required. Proxy session only.
 - `access_revoke_credential` -- Permanently revoke a credential. Confirm required. Proxy session only.
 
-## Visitors (3 tools)
+## Visitors (4 tools)
 
 - `access_list_visitors` -- List all visitor passes with name, status, time range, and doors
 - `access_get_visitor` -- Detailed visitor pass info: name, access period, doors, status

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -57,6 +57,11 @@ Once you're signed in:
   - OpenAPI spec: `/v1/openapi.json`
   - Health: `/v1/health`
 
+Current Network and Protect read surfaces include Network Traffic Flows
+(`GET /v1/sites/{site_id}/traffic-flows`, `network.trafficFlows`) and Protect
+Find Anything detection search (`GET /v1/sites/{site_id}/detection-search`,
+`protect.searchDetections`).
+
 First GraphQL query:
 
 ```bash

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -480,6 +480,17 @@ type CredentialPage {
   nextCursor: String
 }
 
+"""Detection-search filter vocabulary (the 'Find Anything' label groups)."""
+type DetectionSearchLabels {
+  colors: JSON
+  vehicleTypes: JSON
+  smartDetectTypes: JSON
+  eventTypes: JSON
+  groupType: JSON
+  devices: JSON
+  doorAccess: JSON
+}
+
 """A UniFi network device (AP, switch, gateway)."""
 type Device {
   mac: ID
@@ -1359,6 +1370,14 @@ type ProtectQuery {
   """
   knownLicensePlates(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownLicensePlatePage!
 
+  """
+  Search detections across cameras via Protect's 'Find Anything' filter vocabulary. Pass labels of the form 'prefix:value' (e.g. 'vehicleType:truck'); use detectionSearchLabels to discover legal values.
+  """
+  searchDetections(controller: ID!, labels: [String!]!, limit: Int! = 100, order: String! = "desc", excludeMotion: Boolean! = true): [SmartDetection!]!
+
+  """The detection-search filter vocabulary ('Find Anything' label groups)."""
+  detectionSearchLabels(controller: ID!): DetectionSearchLabels!
+
   """List paired Protect chimes (paginated)."""
   chimes(controller: ID!, limit: Int! = 50, cursor: String = null): ChimePage!
 
@@ -2024,6 +2043,7 @@ Read-only access to UniFi Protect resources.
 - `cameraStreams: CameraStreams`  — Get the stream catalog (channels + RTSPS URLs) for a camera.
 - `cameras: CameraPage!`  — List cameras on the Protect controller (paginated).
 - `chimes: ChimePage!`  — List paired Protect chimes (paginated).
+- `detectionSearchLabels: DetectionSearchLabels!`  — The detection-search filter vocabulary ('Find Anything' label groups).
 - `event: Event`  — Look up a single Protect event by id.
 - `eventThumbnail: EventThumbnail`  — Get the thumbnail for a Protect event.
 - `events: EventPage!`  — List Protect events (paginated, most recent first).
@@ -2035,6 +2055,7 @@ Read-only access to UniFi Protect resources.
 - `liveviews: LiveviewPage!`  — List Protect liveviews (multi-camera grid layouts).
 - `recordingStatus: RecordingStatusList`  — Get current recording state for one or all cameras ({cameras, count}).
 - `recordings: RecordingPage!`  — List Protect recording windows for a camera. UniFi Protect exposes a single continuous recording window per camera.
+- `searchDetections: [SmartDetection!]!`  — Search detections across cameras via Protect's 'Find Anything' filter vocabulary. Pass labels of the form 'prefix:value' (e.g. 'vehicleType:truck'); use detectionSearchLabels to discover legal values.
 - `sensors: SensorPage!`  — List Protect sensors (motion / leak / temperature).
 - `smartDetections: SmartDetectionPage!`  — List Protect smart-detection events (paginated, most recent first).
 - `snapshot: Snapshot`  — Capture a JPEG snapshot from a camera (metadata only).

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1373,7 +1373,7 @@ type ProtectQuery {
   """
   Search detections across cameras via Protect's 'Find Anything' filter vocabulary. Pass labels of the form 'prefix:value' (e.g. 'vehicleType:truck'); use detectionSearchLabels to discover legal values.
   """
-  searchDetections(controller: ID!, labels: [String!]!, limit: Int! = 100, order: String! = "desc", excludeMotion: Boolean! = true): [SmartDetection!]!
+  searchDetections(controller: ID!, labels: [String!]!, limit: Int! = 100, order: String! = "desc", excludeMotion: Boolean! = true, minConfidence: Int = null): [SmartDetection!]!
 
   """The detection-search filter vocabulary ('Find Anything' label groups)."""
   detectionSearchLabels(controller: ID!): DetectionSearchLabels!

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1700,6 +1700,34 @@ No native ``protect_get_liveview`` tool — filter from LIST.
 
 ## protect/recognition
 
+### `GET /v1/sites/{site_id}/detection-search` — Search Detections
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `labels` (query) (required)
+- `search_limit` (query)
+- `order` (query)
+- `exclude_motion` (query)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_SmartDetectionModel_`
+
+### `GET /v1/sites/{site_id}/detection-search-labels` — Detection Search Labels
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `DetectionSearchLabelsModel`
+
 ### `GET /v1/sites/{site_id}/known-faces` — List Known Faces
 
 

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1710,6 +1710,7 @@ No native ``protect_get_liveview`` tool — filter from LIST.
 - `search_limit` (query)
 - `order` (query)
 - `exclude_motion` (query)
+- `min_confidence` (query)
 - `limit` (query)
 - `cursor` (query)
 - `controller` (query)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -10365,6 +10365,24 @@
           },
           {
             "in": "query",
+            "name": "min_confidence",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Confidence"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1733,6 +1733,76 @@
         "title": "Detail[WlanModel]",
         "type": "object"
       },
+      "DetectionSearchLabelsModel": {
+        "additionalProperties": true,
+        "properties": {
+          "colors": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Colors"
+          },
+          "devices": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Devices"
+          },
+          "door_access": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Door Access"
+          },
+          "event_types": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Types"
+          },
+          "group_type": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group Type"
+          },
+          "smart_detect_types": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Smart Detect Types"
+          },
+          "vehicle_types": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vehicle Types"
+          }
+        },
+        "title": "DetectionSearchLabelsModel",
+        "type": "object"
+      },
       "DeviceModel": {
         "additionalProperties": true,
         "properties": {
@@ -4576,6 +4646,46 @@
         "title": "Page[RouteModel]",
         "type": "object"
       },
+      "Page_SmartDetectionModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SmartDetectionModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[SmartDetectionModel]",
+        "type": "object"
+      },
       "Page_TrafficRouteModel_": {
         "additionalProperties": true,
         "properties": {
@@ -5335,6 +5445,141 @@
           "settings"
         ],
         "title": "SettingsBody",
+        "type": "object"
+      },
+      "SmartDetectionModel": {
+        "additionalProperties": true,
+        "properties": {
+          "camera": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Camera"
+          },
+          "detected_thumbnail_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detected Thumbnail Id"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "recognized_person_confidence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Person Confidence"
+          },
+          "recognized_person_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Person Id"
+          },
+          "recognized_person_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Person Name"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "smart_detect_types": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Smart Detect Types",
+            "type": "array"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "thumbnail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thumbnail"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "SmartDetectionModel",
         "type": "object"
       },
       "TrafficRouteModel": {
@@ -10056,6 +10301,200 @@
         "summary": "Get Credential",
         "tags": [
           "access/credentials"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/detection-search": {
+      "get": {
+        "operationId": "search_detections_v1_sites__site_id__detection_search_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter labels of the form 'prefix:value' (e.g. ['vehicleType:truck', 'color:black']). At least one is required; all are applied together. Use the detection-search-labels endpoint to discover legal values.",
+            "in": "query",
+            "name": "labels",
+            "required": true,
+            "schema": {
+              "description": "Filter labels of the form 'prefix:value' (e.g. ['vehicleType:truck', 'color:black']). At least one is required; all are applied together. Use the detection-search-labels endpoint to discover legal values.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Labels",
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Search Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "title": "Order",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "exclude_motion",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Exclude Motion",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_SmartDetectionModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Search Detections",
+        "tags": [
+          "protect/recognition"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/detection-search-labels": {
+      "get": {
+        "operationId": "detection_search_labels_v1_sites__site_id__detection_search_labels_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectionSearchLabelsModel"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Detection Search Labels",
+        "tags": [
+          "protect/recognition"
         ]
       }
     },

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -53,7 +53,11 @@ from unifi_api.graphql.types.protect.events import (
 )
 from unifi_api.graphql.types.protect.lights import Light
 from unifi_api.graphql.types.protect.liveviews import Liveview
-from unifi_api.graphql.types.protect.recognition import KnownFace, KnownLicensePlate
+from unifi_api.graphql.types.protect.recognition import (
+    DetectionSearchLabels,
+    KnownFace,
+    KnownLicensePlate,
+)
 from unifi_api.graphql.types.protect.recordings import (
     Recording,
     RecordingStatusList,
@@ -634,6 +638,62 @@ async def _fetch_recording_status(
     return await ctx.cache.get_or_fetch(key, _do)
 
 
+async def _fetch_detection_search(
+    ctx: GraphQLContext,
+    controller: str,
+    labels: list[str],
+    limit: int,
+    order: str,
+    exclude_motion: bool,
+) -> list:
+    labels_key = ",".join(labels)
+    key = f"protect/detection-search/{controller}/{labels_key}/{limit}/{order}/{exclude_motion}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "protect",
+                "event_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "protect",
+            )
+            result = await mgr.search_detections(
+                labels=labels,
+                limit=limit,
+                order=order,
+                exclude_motion=exclude_motion,
+            )
+            return list(result.get("detections", []))
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_detection_search_labels(ctx: GraphQLContext, controller: str) -> Any:
+    key = f"protect/detection-search-labels/{controller}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "protect",
+                "event_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "protect",
+            )
+            return await mgr.get_detection_search_labels()
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
 async def _fetch_lights(ctx: GraphQLContext, controller: str) -> list:
     key = f"protect/lights/{controller}"
 
@@ -1043,6 +1103,47 @@ class ProtectQuery:
             items=[KnownLicensePlate.from_manager_output(plate) for plate in page],
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "Search detections across cameras via Protect's 'Find Anything' filter vocabulary. "
+            "Pass labels of the form 'prefix:value' (e.g. 'vehicleType:truck'); use "
+            "detectionSearchLabels to discover legal values."
+        ),
+    )
+    async def search_detections(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        labels: list[str],
+        limit: int = 100,
+        order: str = "desc",
+        exclude_motion: bool = True,
+    ) -> list[SmartDetection]:
+        ctx: GraphQLContext = info.context
+        detections = await _fetch_detection_search(
+            ctx,
+            str(controller),
+            labels,
+            limit,
+            order,
+            exclude_motion,
+        )
+        return [SmartDetection.from_manager_output(d) for d in detections]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="The detection-search filter vocabulary ('Find Anything' label groups).",
+    )
+    async def detection_search_labels(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+    ) -> DetectionSearchLabels:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_detection_search_labels(ctx, str(controller))
+        return DetectionSearchLabels.from_manager_output(raw)
 
     # ---- Chimes ----------------------------------------------------------
 

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -645,9 +645,10 @@ async def _fetch_detection_search(
     limit: int,
     order: str,
     exclude_motion: bool,
+    min_confidence: int | None,
 ) -> list:
     labels_key = ",".join(labels)
-    key = f"protect/detection-search/{controller}/{labels_key}/{limit}/{order}/{exclude_motion}"
+    key = f"protect/detection-search/{controller}/{labels_key}/{limit}/{order}/{exclude_motion}/{min_confidence}"
 
     async def _do() -> list:
         async with ctx.sessionmaker() as session:
@@ -667,6 +668,7 @@ async def _fetch_detection_search(
                 limit=limit,
                 order=order,
                 exclude_motion=exclude_motion,
+                min_confidence=min_confidence,
             )
             return list(result.get("detections", []))
 
@@ -1120,6 +1122,7 @@ class ProtectQuery:
         limit: int = 100,
         order: str = "desc",
         exclude_motion: bool = True,
+        min_confidence: int | None = None,
     ) -> list[SmartDetection]:
         ctx: GraphQLContext = info.context
         detections = await _fetch_detection_search(
@@ -1129,6 +1132,7 @@ class ProtectQuery:
             limit,
             order,
             exclude_motion,
+            min_confidence,
         )
         return [SmartDetection.from_manager_output(d) for d in detections]
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1362,7 +1362,7 @@ type ProtectQuery {
   """
   Search detections across cameras via Protect's 'Find Anything' filter vocabulary. Pass labels of the form 'prefix:value' (e.g. 'vehicleType:truck'); use detectionSearchLabels to discover legal values.
   """
-  searchDetections(controller: ID!, labels: [String!]!, limit: Int! = 100, order: String! = "desc", excludeMotion: Boolean! = true): [SmartDetection!]!
+  searchDetections(controller: ID!, labels: [String!]!, limit: Int! = 100, order: String! = "desc", excludeMotion: Boolean! = true, minConfidence: Int = null): [SmartDetection!]!
 
   """The detection-search filter vocabulary ('Find Anything' label groups)."""
   detectionSearchLabels(controller: ID!): DetectionSearchLabels!

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -469,6 +469,17 @@ type CredentialPage {
   nextCursor: String
 }
 
+"""Detection-search filter vocabulary (the 'Find Anything' label groups)."""
+type DetectionSearchLabels {
+  colors: JSON
+  vehicleTypes: JSON
+  smartDetectTypes: JSON
+  eventTypes: JSON
+  groupType: JSON
+  devices: JSON
+  doorAccess: JSON
+}
+
 """A UniFi network device (AP, switch, gateway)."""
 type Device {
   mac: ID
@@ -1347,6 +1358,14 @@ type ProtectQuery {
   List UniFi Protect license-plate identities (vehicle recognition groups). Each entry's id is the value to use in a `license_plate_known` alarm-rule condition.
   """
   knownLicensePlates(controller: ID!, limit: Int! = 50, cursor: String = null, minConfidence: Int! = 30, includeInterest: Boolean! = true, groupTypes: [String!] = null, orderBy: String! = "name", orderDirection: String! = "asc"): KnownLicensePlatePage!
+
+  """
+  Search detections across cameras via Protect's 'Find Anything' filter vocabulary. Pass labels of the form 'prefix:value' (e.g. 'vehicleType:truck'); use detectionSearchLabels to discover legal values.
+  """
+  searchDetections(controller: ID!, labels: [String!]!, limit: Int! = 100, order: String! = "desc", excludeMotion: Boolean! = true): [SmartDetection!]!
+
+  """The detection-search filter vocabulary ('Find Anything' label groups)."""
+  detectionSearchLabels(controller: ID!): DetectionSearchLabels!
 
   """List paired Protect chimes (paginated)."""
   chimes(controller: ID!, limit: Int! = 50, cursor: String = null): ChimePage!

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -250,6 +250,9 @@ from unifi_api.graphql.types.protect.liveviews import (
     Liveview as ProtectLiveviewType,
 )
 from unifi_api.graphql.types.protect.recognition import (
+    DetectionSearchLabels as ProtectDetectionSearchLabelsType,
+)
+from unifi_api.graphql.types.protect.recognition import (
     KnownFace as ProtectKnownFaceType,
 )
 from unifi_api.graphql.types.protect.recognition import (
@@ -642,6 +645,8 @@ def build_type_registry() -> TypeRegistry:
     reg.register_tool_type("protect_list_known_faces", ProtectKnownFaceType, "list")
     reg.register_type("protect", "known_license_plates", ProtectKnownLicensePlateType)
     reg.register_tool_type("protect_list_known_license_plates", ProtectKnownLicensePlateType, "list")
+    reg.register_tool_type("protect_search_detections", ProtectSmartDetectionType, "list")
+    reg.register_tool_type("protect_detection_search_labels", ProtectDetectionSearchLabelsType, "detail")
 
     # protect/system (tool-keyed only) + viewers resource
     reg.register_type("protect", "viewers", ProtectViewerType)

--- a/apps/api/src/unifi_api/graphql/types/protect/recognition.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/recognition.py
@@ -62,6 +62,62 @@ class KnownFace:
 
 
 @strawberry.type(
+    description="Detection-search filter vocabulary (the 'Find Anything' label groups).",
+)
+class DetectionSearchLabels:
+    """Wrapper-dict pass-through for ``protect_detection_search_labels``.
+
+    The manager hands back the already-``model_dump``-ed
+    :class:`unifi_core.protect.models.detection_search.DetectionSearchLabels`
+    dict — snake_case group lists (``colors``, ``vehicle_types``,
+    ``smart_detect_types``, ``event_types``, ``group_type``, ``devices``,
+    ``door_access``), each a list of ``{label, value}`` items. The groups are
+    surfaced as JSON sub-maps and ``to_dict`` re-emits the verbatim dict so the
+    response round-trips byte-for-byte (mirrors the ``RecordingStatusList``
+    pass-through pattern).
+    """
+
+    colors: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    vehicle_types: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    smart_detect_types: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    event_types: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    group_type: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    devices: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+    door_access: strawberry.scalars.JSON | None  # type: ignore[name-defined]
+
+    _raw: strawberry.Private[dict[str, Any] | None] = None
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {"kind": kind}
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "DetectionSearchLabels":
+        if isinstance(obj, dict):
+            payload = obj
+        elif hasattr(obj, "model_dump"):
+            payload = obj.model_dump()
+        else:
+            payload = {}
+        inst = cls(
+            colors=payload.get("colors"),
+            vehicle_types=payload.get("vehicle_types"),
+            smart_detect_types=payload.get("smart_detect_types"),
+            event_types=payload.get("event_types"),
+            group_type=payload.get("group_type"),
+            devices=payload.get("devices"),
+            door_access=payload.get("door_access"),
+        )
+        inst._raw = dict(payload)
+        return inst
+
+    def to_dict(self) -> dict:
+        if self._raw is not None:
+            return self._raw
+        return {}
+
+
+@strawberry.type(
     description="A UniFi Protect license-plate identity (vehicle recognition group).",
 )
 class KnownLicensePlate:

--- a/apps/api/src/unifi_api/routes/resources/protect/recognition.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recognition.py
@@ -7,7 +7,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.graphql.pydantic_export import to_pydantic_model
-from unifi_api.graphql.types.protect.recognition import KnownFace, KnownLicensePlate
+from unifi_api.graphql.types.protect.events import SmartDetection
+from unifi_api.graphql.types.protect.recognition import (
+    DetectionSearchLabels,
+    KnownFace,
+    KnownLicensePlate,
+)
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
@@ -161,3 +166,100 @@ async def list_known_license_plates(
         "next_cursor": next_cursor.encode() if next_cursor else None,
         "render_hint": hint,
     }
+
+
+def _detection_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("id") or "")
+
+
+@router.get(
+    "/sites/{site_id}/detection-search",
+    response_model=Page[to_pydantic_model(SmartDetection)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/recognition"],
+)
+async def search_detections(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    labels: list[str] = Query(
+        ...,
+        description=(
+            "Filter labels of the form 'prefix:value' (e.g. ['vehicleType:truck', 'color:black']). "
+            "At least one is required; all are applied together. Use the detection-search-labels "
+            "endpoint to discover legal values."
+        ),
+    ),
+    search_limit: int = Query(100, ge=1, le=1000),
+    order: str = Query("desc"),
+    exclude_motion: bool = Query(True),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "protect",
+            "event_manager",
+        )
+        await factory.get_connection_manager(session, controller.id, "protect")
+        try:
+            result = await mgr.search_detections(
+                labels=labels,
+                limit=search_limit,
+                order=order,
+                exclude_motion=exclude_motion,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(result.get("detections", [])),
+        limit=limit,
+        cursor=cursor_obj,
+        key_fn=_detection_key,
+    )
+
+    type_class = request.app.state.type_registry.lookup_tool("protect_search_detections")[0]
+    items = [type_class.from_manager_output(d).to_dict() for d in page]
+    hint = type_class.render_hint("list")
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/detection-search-labels",
+    response_model=to_pydantic_model(DetectionSearchLabels),
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["protect/recognition"],
+)
+async def detection_search_labels(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "protect")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "protect",
+            "event_manager",
+        )
+        await factory.get_connection_manager(session, controller.id, "protect")
+        raw = await mgr.get_detection_search_labels()
+
+    type_class = request.app.state.type_registry.lookup_tool("protect_detection_search_labels")[0]
+    return type_class.from_manager_output(raw).to_dict()

--- a/apps/api/src/unifi_api/routes/resources/protect/recognition.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/recognition.py
@@ -194,6 +194,7 @@ async def search_detections(
     search_limit: int = Query(100, ge=1, le=1000),
     order: str = Query("desc"),
     exclude_motion: bool = Query(True),
+    min_confidence: int | None = Query(None, ge=0, le=100),
     limit: int = Query(50, ge=1, le=200),
     cursor: str | None = Query(None),
 ) -> dict:
@@ -214,6 +215,7 @@ async def search_detections(
                 limit=search_limit,
                 order=order,
                 exclude_motion=exclude_motion,
+                min_confidence=min_confidence,
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e

--- a/apps/api/tests/graphql/fixtures/protect/test_recognition.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_recognition.py
@@ -2,6 +2,8 @@
 
 # tool: protect_list_known_faces
 # tool: protect_list_known_license_plates
+# tool: protect_search_detections
+# tool: protect_detection_search_labels
 """
 
 from __future__ import annotations
@@ -91,3 +93,71 @@ async def test_protect_known_license_plates_list(tmp_path, monkeypatch):
     assert items[0]["id"] == "plate-uuid-1"
     assert items[0]["matchedName"] == "ABC1234"
     assert items[0]["detectionsCount"] == 42
+
+
+@pytest.mark.asyncio
+async def test_protect_search_detections(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "search_detections"): {
+                "detections": [
+                    {
+                        "id": "det-1",
+                        "type": "smartDetectZone",
+                        "start": "2026-05-29T00:00:00+00:00",
+                        "end": "2026-05-29T00:00:05+00:00",
+                        "score": 88,
+                        "smart_detect_types": ["vehicle"],
+                        "camera_id": "cam-1",
+                    }
+                ],
+                "count": 1,
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ searchDetections(controller: "{cid}", labels: ["vehicleType:truck"]) {{
+            id type score smartDetectTypes camera
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    items = body["data"]["protect"]["searchDetections"]
+    assert len(items) == 1
+    assert items[0]["id"] == "det-1"
+    assert items[0]["smartDetectTypes"] == ["vehicle"]
+    assert items[0]["camera"] == "cam-1"
+
+
+@pytest.mark.asyncio
+async def test_protect_detection_search_labels(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "get_detection_search_labels"): {
+                "colors": [{"label": "Black", "value": "color:black"}],
+                "vehicle_types": [{"label": "Truck", "value": "vehicleType:truck"}],
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ detectionSearchLabels(controller: "{cid}") {{
+            colors vehicleTypes
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    data = body["data"]["protect"]["detectionSearchLabels"]
+    assert data["colors"] == [{"label": "Black", "value": "color:black"}]
+    assert data["vehicleTypes"] == [{"label": "Truck", "value": "vehicleType:truck"}]

--- a/apps/api/tests/graphql/test_detection_search_type_registry.py
+++ b/apps/api/tests/graphql/test_detection_search_type_registry.py
@@ -1,0 +1,20 @@
+"""Type-registry coverage for the detection-search read tools.
+
+``protect_search_detections`` and ``protect_detection_search_labels`` are
+read tools, so their projection is a Strawberry type registered in the
+type registry (mirroring ``protect_list_known_license_plates``). Without the
+registration the CI ``validate_manifest`` gate in
+``test_serializer_coverage`` would reject the manifest.
+"""
+
+from unifi_api.graphql.type_registry_init import build_type_registry
+
+
+def test_search_detections_registered_as_read_tool() -> None:
+    reg = build_type_registry()
+    assert "protect_search_detections" in set(reg.all_tools())
+
+
+def test_detection_search_labels_registered_as_read_tool() -> None:
+    reg = build_type_registry()
+    assert "protect_detection_search_labels" in set(reg.all_tools())

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -5,7 +5,7 @@
   <img src="../../assets/hero-network.svg" alt="UniFi Network MCP Server" width="720">
 </p>
 
-MCP server exposing 169 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
+MCP server exposing 177 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
 
 ## Install
 
@@ -66,6 +66,8 @@ Once connected, just ask your AI agent in natural language:
 > "Rename the device at 192.168.1.45 to 'Living Room TV' and show me its traffic stats"
 
 > "What changed on my network in the last 24 hours? Show me new clients and config changes."
+
+> "Show me the largest traffic flows from the last hour and summarize who talked to what."
 
 All mutations (firewall rules, device changes, client blocking) use a **preview-then-confirm** flow — you see exactly what will change before anything is applied.
 
@@ -213,7 +215,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 169 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 177 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 169 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 177 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy/meta-only workflows, call the `unifi_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`.
 
@@ -79,6 +79,10 @@ These are always registered regardless of mode:
 - `unifi_create_traffic_route` — Create with full schema
 - `unifi_create_simple_traffic_route` — Create with simplified schema
 - `unifi_update_traffic_route` — Update route settings
+
+## Traffic Flows (1 tool)
+
+- `unifi_get_traffic_flows` — Query historical UniFi Traffic Flows from Insights > Flows, with pagination and filters for time range, client, host, port, protocol, application, and direction
 
 ## Port Forwarding (6 tools)
 

--- a/apps/protect/README.md
+++ b/apps/protect/README.md
@@ -5,7 +5,7 @@
   <img src="../../assets/hero-protect.svg" alt="UniFi Protect MCP Server" width="720">
 </p>
 
-MCP server exposing UniFi Protect tools for LLMs, agents, and automation platforms. Query cameras, events, smart detections, recordings, lights, sensors, chimes, Known Faces, and the Alarm Manager -- with safe-by-default permissions and preview-before-confirm for all mutations.
+MCP server exposing UniFi Protect tools for LLMs, agents, and automation platforms. Query cameras, events, smart detections, Find Anything detection search, recordings, lights, sensors, chimes, Known Faces, license plates, and the Alarm Manager -- with safe-by-default permissions and preview-before-confirm for all mutations.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
@@ -61,6 +61,8 @@ Once connected, just ask your AI agent in natural language:
 > "List all cameras that detected motion in the last hour"
 
 > "Show me smart detection events from the front door camera today — people and vehicles only"
+
+> "Find driveway detections for white vans this week"
 
 > "Which cameras have the most motion events this week? Any unusual patterns?"
 
@@ -128,7 +130,7 @@ Add to `claude_desktop_config.json`:
 ## Features
 
 - **Cameras** -- list, inspect, snapshot, RTSP streams, PTZ control, settings, recording toggle, reboot
-- **Events** -- query historical events, smart detections (person/vehicle/animal/package), thumbnails
+- **Events** -- query historical events, smart detections (person/vehicle/animal/package), Find Anything detection search, thumbnails
 - **Real-time streaming** -- websocket event buffer with MCP resource subscriptions and polling
 - **Recordings** -- status, availability, clip export with timelapse support
 - **Known Faces** -- list, rename, merge, and remove face recognition groups
@@ -198,7 +200,7 @@ Compact mode is the recommended default when building summaries or feeding event
 
 - [Configuration](docs/configuration.md) -- Full env var reference, YAML config, Protect-specific options
 - [Permissions](docs/permissions.md) -- Permission system, category defaults, how to enable mutations
-- [Tool Catalog](docs/tools.md) -- All 56 tools organized by category
+- [Tool Catalog](docs/tools.md) -- All 58 tools organized by category
 - [Event Streaming](docs/events.md) -- Real-time event architecture, MCP resources, polling
 - [Troubleshooting](docs/troubleshooting.md) -- Connection issues, SSL, missing tools
 

--- a/apps/protect/docs/events.md
+++ b/apps/protect/docs/events.md
@@ -63,6 +63,8 @@ A lightweight summary of the buffer: total event count, breakdown by event type,
 | `protect_recent_events` | Websocket buffer | Real-time monitoring with filters |
 | `protect_list_events` | NVR REST API | Historical queries with time ranges |
 | `protect_list_smart_detections` | NVR REST API | Filtered smart detection history |
+| `protect_detection_search_labels` | NVR REST API | Discover Find Anything labels supported by this controller |
+| `protect_search_detections` | NVR REST API | Find Anything searches with labels such as color, vehicle type, detection type, or device |
 | `protect_subscribe_events` | -- | Getting subscription instructions |
 
 ### protect_recent_events vs protect_list_events
@@ -72,6 +74,8 @@ A lightweight summary of the buffer: total event count, breakdown by event type,
 - **`protect_list_events`** queries the NVR's REST API. It can access the full event history stored on disk. Supports filtering by time range, event type, camera, and result limit.
 
 Use `protect_recent_events` for near-real-time monitoring. Use `protect_list_events` for historical analysis.
+
+Use `protect_list_smart_detections` when a simple detection-type timeline is enough. Use `protect_detection_search_labels` followed by `protect_search_detections` when the user asks for Protect's richer Find Anything filters, such as vehicle type, color, device-specific labels, or controller-specific recognition categories. The label `value` fields returned by `protect_detection_search_labels` are safe to pass directly back in the `labels` argument.
 
 ## Recommended Client Pattern
 

--- a/apps/protect/docs/tools.md
+++ b/apps/protect/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Protect MCP server exposes 56 tools (including 5 meta-tools), all prefixed with `protect_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Protect MCP server exposes 58 tools (including 5 meta-tools), all prefixed with `protect_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy/meta-only workflows, call the `protect_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_protect_mcp/tools_manifest.json`.
 
@@ -31,12 +31,14 @@ In lazy mode, an additional meta-tool is available:
 - `protect_ptz_preset` -- Move PTZ camera to a saved preset position (confirm required)
 - `protect_reboot_camera` -- Reboot a camera; interrupts active recordings (confirm required)
 
-## Events (7 tools)
+## Events (9 tools)
 
 - `protect_list_events` -- Query events from NVR with filters (time range, type, camera, limit)
 - `protect_get_event` -- Get single event details by ID
 - `protect_get_event_thumbnail` -- Get event thumbnail as base64 JPEG
 - `protect_list_smart_detections` -- List smart detections (person, vehicle, animal, package) with confidence filter
+- `protect_detection_search_labels` -- List Find Anything filter labels accepted by this controller
+- `protect_search_detections` -- Search detections across cameras with Find Anything labels such as `vehicleType:truck` or `color:white`
 - `protect_recent_events` -- Get events from the in-memory websocket buffer (fast, no API call)
 - `protect_subscribe_events` -- Get instructions for real-time event subscription via MCP resources
 - `protect_acknowledge_event` -- Mark event as favorite/acknowledged (confirm required)

--- a/apps/protect/src/unifi_protect_mcp/tools/events.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/events.py
@@ -321,14 +321,33 @@ async def protect_search_detections(
         bool,
         Field(description="When true (default), exclude plain motion events so only smart detections are returned."),
     ] = True,
+    min_confidence: Annotated[
+        Optional[int],
+        Field(description="Minimum confidence score (0-100) to include. Omit to apply no confidence filter."),
+    ] = None,
+    start: Annotated[
+        Optional[str],
+        Field(
+            description="Only include detections at/after this time, as an ISO 8601 timestamp (e.g., 2026-03-17T00:00:00Z). Omit for no lower bound."
+        ),
+    ] = None,
+    end: Annotated[
+        Optional[str],
+        Field(
+            description="Only include detections at/before this time, as an ISO 8601 timestamp (e.g., 2026-03-17T23:59:59Z). Omit for no upper bound."
+        ),
+    ] = None,
 ) -> Dict[str, Any]:
     """Search detections via the controller's detection-search endpoint."""
     logger.info(
-        "protect_search_detections called (labels=%s, limit=%s, order=%s, exclude_motion=%s)",
+        "protect_search_detections called (labels=%s, limit=%s, order=%s, exclude_motion=%s, min_confidence=%s, start=%s, end=%s)",
         labels,
         limit,
         order,
         exclude_motion,
+        min_confidence,
+        start,
+        end,
     )
     try:
         result = await event_manager.search_detections(
@@ -336,6 +355,9 @@ async def protect_search_detections(
             limit=limit,
             order=order,
             exclude_motion=exclude_motion,
+            min_confidence=min_confidence,
+            start=_parse_datetime(start),
+            end=_parse_datetime(end),
         )
         detections = [d.model_dump(exclude_none=True) for d in result["detections"]]
         return {"success": True, "data": {"detections": detections, "count": len(detections)}}

--- a/apps/protect/src/unifi_protect_mcp/tools/events.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/events.py
@@ -286,6 +286,90 @@ async def protect_list_smart_detections(
 
 
 @server.tool(
+    name="protect_search_detections",
+    description=(
+        "Search detections across all cameras using Protect's 'Find Anything' "
+        "filter vocabulary. Pass one or more labels of the form 'prefix:value' "
+        "(e.g. 'vehicleType:truck', 'color:black', 'smartDetectType:vehicle'); "
+        "labels are applied conjunctively. Call protect_detection_search_labels "
+        "first to discover the legal labels for this controller. Returns matching "
+        "smart detection events. excludeMotion defaults to true so plain motion "
+        "events are filtered out."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def protect_search_detections(
+    labels: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Filter labels of the form 'prefix:value' (e.g. ['vehicleType:truck', "
+                "'color:black']). At least one is required; all are applied together. "
+                "Use protect_detection_search_labels to discover legal values."
+            )
+        ),
+    ],
+    limit: Annotated[
+        int,
+        Field(description="Maximum number of detections to return (1-1000, default 100).", ge=1, le=1000),
+    ] = 100,
+    order: Annotated[
+        str,
+        Field(description="Result ordering by time: 'desc' (newest first, default) or 'asc' (oldest first)."),
+    ] = "desc",
+    exclude_motion: Annotated[
+        bool,
+        Field(description="When true (default), exclude plain motion events so only smart detections are returned."),
+    ] = True,
+) -> Dict[str, Any]:
+    """Search detections via the controller's detection-search endpoint."""
+    logger.info(
+        "protect_search_detections called (labels=%s, limit=%s, order=%s, exclude_motion=%s)",
+        labels,
+        limit,
+        order,
+        exclude_motion,
+    )
+    try:
+        result = await event_manager.search_detections(
+            labels=labels,
+            limit=limit,
+            order=order,
+            exclude_motion=exclude_motion,
+        )
+        detections = [d.model_dump(exclude_none=True) for d in result["detections"]]
+        return {"success": True, "data": {"detections": detections, "count": len(detections)}}
+    except (UniFiNotFoundError, ValueError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error searching detections: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to search detections: {e}"}
+
+
+@server.tool(
+    name="protect_detection_search_labels",
+    description=(
+        "List the detection-search filter vocabulary supported by this controller. "
+        "Returns the legal label values (colors, vehicle types, smart detection "
+        "types, event types, etc.) that the 'Find Anything' panel offers. Use the "
+        "returned values as labels for protect_search_detections."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def protect_detection_search_labels() -> Dict[str, Any]:
+    """List the detection-search filter vocabulary."""
+    logger.info("protect_detection_search_labels called")
+    try:
+        labels = await event_manager.get_detection_search_labels()
+        return {"success": True, "data": labels}
+    except (UniFiNotFoundError, ValueError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error listing detection search labels: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list detection search labels: {e}"}
+
+
+@server.tool(
     name="protect_recent_events",
     description=(
         "Get recent events from the in-memory websocket buffer. This is fast "
@@ -467,5 +551,6 @@ async def protect_acknowledge_event(
 logger.info(
     "Event tools registered: protect_list_events, protect_get_event, "
     "protect_get_event_thumbnail, protect_list_smart_detections, "
+    "protect_search_detections, protect_detection_search_labels, "
     "protect_recent_events, protect_subscribe_events, protect_acknowledge_event"
 )

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 56,
+  "count": 58,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "protect_acknowledge_event": "unifi_protect_mcp.tools.events",
@@ -4527,6 +4527,10 @@
       "schema": {
         "input": {
           "properties": {
+            "end": {
+              "description": "Only include detections at/before this time, as an ISO 8601 timestamp (e.g., 2026-03-17T23:59:59Z). Omit for no upper bound.",
+              "type": "string"
+            },
             "exclude_motion": {
               "description": "When true (default), exclude plain motion events so only smart detections are returned.",
               "type": "boolean"
@@ -4539,8 +4543,16 @@
               "description": "Maximum number of detections to return (1-1000, default 100).",
               "type": "integer"
             },
+            "min_confidence": {
+              "description": "Minimum confidence score (0-100) to include. Omit to apply no confidence filter.",
+              "type": "integer"
+            },
             "order": {
               "description": "Result ordering by time: 'desc' (newest first, default) or 'asc' (oldest first).",
+              "type": "string"
+            },
+            "start": {
+              "description": "Only include detections at/after this time, as an ISO 8601 timestamp (e.g., 2026-03-17T00:00:00Z). Omit for no lower bound.",
               "type": "string"
             }
           },

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -17,6 +17,7 @@
     "protect_delete_known_license_plate": "unifi_protect_mcp.tools.recognition",
     "protect_delete_liveview": "unifi_protect_mcp.tools.liveviews",
     "protect_delete_recording": "unifi_protect_mcp.tools.recordings",
+    "protect_detection_search_labels": "unifi_protect_mcp.tools.events",
     "protect_export_clip": "unifi_protect_mcp.tools.recordings",
     "protect_get_camera": "unifi_protect_mcp.tools.cameras",
     "protect_get_camera_analytics": "unifi_protect_mcp.tools.cameras",
@@ -45,6 +46,7 @@
     "protect_ptz_zoom": "unifi_protect_mcp.tools.cameras",
     "protect_reboot_camera": "unifi_protect_mcp.tools.cameras",
     "protect_recent_events": "unifi_protect_mcp.tools.events",
+    "protect_search_detections": "unifi_protect_mcp.tools.events",
     "protect_subscribe_events": "unifi_protect_mcp.tools.events",
     "protect_toggle_recording": "unifi_protect_mcp.tools.cameras",
     "protect_trigger_chime": "unifi_protect_mcp.tools.devices",
@@ -1628,6 +1630,90 @@
         }
       },
       "title": "Delete Recording"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List the detection-search filter vocabulary supported by this controller. Returns the legal label values (colors, vehicle types, smart detection types, event types, etc.) that the 'Find Anything' panel offers. Use the returned values as labels for protect_search_detections.",
+      "name": "protect_detection_search_labels",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Detection Search Labels"
     },
     {
       "annotations": {
@@ -4430,6 +4516,110 @@
         }
       },
       "title": "Recent Events"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Search detections across all cameras using Protect's 'Find Anything' filter vocabulary. Pass one or more labels of the form 'prefix:value' (e.g. 'vehicleType:truck', 'color:black', 'smartDetectType:vehicle'); labels are applied conjunctively. Call protect_detection_search_labels first to discover the legal labels for this controller. Returns matching smart detection events. excludeMotion defaults to true so plain motion events are filtered out.",
+      "name": "protect_search_detections",
+      "schema": {
+        "input": {
+          "properties": {
+            "exclude_motion": {
+              "description": "When true (default), exclude plain motion events so only smart detections are returned.",
+              "type": "boolean"
+            },
+            "labels": {
+              "description": "Filter labels of the form 'prefix:value' (e.g. ['vehicleType:truck', 'color:black']). At least one is required; all are applied together. Use protect_detection_search_labels to discover legal values.",
+              "type": "array"
+            },
+            "limit": {
+              "description": "Maximum number of detections to return (1-1000, default 100).",
+              "type": "integer"
+            },
+            "order": {
+              "description": "Result ordering by time: 'desc' (newest first, default) or 'asc' (oldest first).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "labels"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Search Detections"
     },
     {
       "annotations": {

--- a/apps/protect/tests/unit/test_detection_search.py
+++ b/apps/protect/tests/unit/test_detection_search.py
@@ -66,6 +66,83 @@ class TestSearchDetections:
         assert ("orderDirection", "ASC") in params
 
     @pytest.mark.asyncio
+    async def test_min_confidence_appended(self, mock_cm):
+        mock_cm.client.api_request.return_value = {"events": []}
+
+        await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+            min_confidence=70,
+        )
+
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert ("minConfidence", "70") in params
+
+    @pytest.mark.asyncio
+    async def test_min_confidence_zero_is_accepted(self, mock_cm):
+        mock_cm.client.api_request.return_value = {"events": []}
+
+        await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+            min_confidence=0,
+        )
+
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert ("minConfidence", "0") in params
+
+    @pytest.mark.asyncio
+    async def test_start_end_serialized_as_epoch_millis(self, mock_cm):
+        from datetime import datetime, timezone
+
+        mock_cm.client.api_request.return_value = {"events": []}
+
+        await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+            start=datetime(2026, 5, 28, 7, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 6, 4, 13, 51, 59, 999000, tzinfo=timezone.utc),
+        )
+
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        # detection-search wants epoch-millis (captured live from the Find Anything UI).
+        assert ("start", "1779951600000") in params
+        assert ("end", "1780581119999") in params
+
+    @pytest.mark.asyncio
+    async def test_optional_filters_omitted_by_default(self, mock_cm):
+        mock_cm.client.api_request.return_value = {"events": []}
+
+        await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+        )
+
+        keys = [key for key, _ in mock_cm.client.api_request.await_args.kwargs["params"]]
+        assert "minConfidence" not in keys
+        assert "start" not in keys
+        assert "end" not in keys
+
+    @pytest.mark.asyncio
+    async def test_rejects_min_confidence_out_of_range(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=["color:black"],
+                limit=50,
+                order="desc",
+                exclude_motion=True,
+                min_confidence=150,
+            )
+
+    @pytest.mark.asyncio
     async def test_coalesces_events_into_detections(self, mock_cm):
         mock_cm.client.api_request.return_value = {
             "events": [

--- a/apps/protect/tests/unit/test_detection_search.py
+++ b/apps/protect/tests/unit/test_detection_search.py
@@ -1,0 +1,241 @@
+"""Tests for EventManager.search_detections (detection-search endpoint)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_cm():
+    cm = MagicMock()
+    cm.client.api_request = AsyncMock()
+    return cm
+
+
+def _make_manager(mock_cm):
+    from unifi_core.protect.managers.event_manager import EventManager
+
+    return EventManager(mock_cm)
+
+
+class TestSearchDetections:
+    @pytest.mark.asyncio
+    async def test_repeats_labels_param(self, mock_cm):
+        mock_cm.client.api_request.return_value = {"events": []}
+
+        await _make_manager(mock_cm).search_detections(
+            labels=["vehicleType:truck", "color:black"],
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+        )
+
+        mock_cm.client.api_request.assert_awaited_once()
+        args, kwargs = mock_cm.client.api_request.await_args
+        assert args[0] == "detection-search"
+        assert kwargs["method"] == "get"
+
+        params = kwargs["params"]
+        # Must be a list of (key, value) tuples so aiohttp repeats the key.
+        assert isinstance(params, list)
+        for key, value in params:
+            assert isinstance(key, str)
+            assert isinstance(value, str)
+
+        label_values = [value for key, value in params if key == "labels"]
+        assert label_values == ["vehicleType:truck", "color:black"]
+        assert ("excludeMotion", "true") in params
+        assert ("limit", "50") in params
+        assert ("orderDirection", "DESC") in params
+
+    @pytest.mark.asyncio
+    async def test_exclude_motion_false_and_asc_order(self, mock_cm):
+        mock_cm.client.api_request.return_value = {"events": []}
+
+        await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=10,
+            order="asc",
+            exclude_motion=False,
+        )
+
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        assert ("excludeMotion", "false") in params
+        assert ("orderDirection", "ASC") in params
+
+    @pytest.mark.asyncio
+    async def test_coalesces_events_into_detections(self, mock_cm):
+        mock_cm.client.api_request.return_value = {
+            "events": [
+                {"id": "d1", "type": "smartDetectZone", "smartDetectTypes": ["vehicle"]},
+                {"id": "d2", "type": "smartDetectZone"},
+            ]
+        }
+
+        result = await _make_manager(mock_cm).search_detections(
+            labels=["vehicleType:truck"],
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+        )
+
+        assert result["count"] == 2
+        assert len(result["detections"]) == 2
+        assert result["detections"][0].id == "d1"
+        assert result["detections"][1].id == "d2"
+        # detection-search returns camelCase smartDetectTypes; it must survive coalescing.
+        assert result["detections"][0].smart_detect_types == ["vehicle"]
+        assert result["detections"][1].smart_detect_types == []
+
+    @pytest.mark.asyncio
+    async def test_non_dict_envelope_yields_empty(self, mock_cm):
+        mock_cm.client.api_request.return_value = [{"id": "x", "type": "smartDetectZone"}]
+
+        result = await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=10,
+            order="desc",
+            exclude_motion=True,
+        )
+
+        assert result == {"detections": [], "count": 0}
+
+    @pytest.mark.asyncio
+    async def test_missing_events_key_yields_empty(self, mock_cm):
+        mock_cm.client.api_request.return_value = {}
+
+        result = await _make_manager(mock_cm).search_detections(
+            labels=["color:black"],
+            limit=10,
+            order="desc",
+            exclude_motion=True,
+        )
+
+        assert result == {"detections": [], "count": 0}
+
+    @pytest.mark.asyncio
+    async def test_accepts_all_allowed_prefixes(self, mock_cm):
+        mock_cm.client.api_request.return_value = {"events": []}
+        allowed = [
+            "vehicleType:truck",
+            "color:black",
+            "smartDetectType:vehicle",
+            "eventType:motion",
+            "groupType:vehicle",
+            "camera:cam1",
+            "zone:z1",
+            "line:l1",
+            "loiterZone:lz1",
+            "doorAccess:granted",
+        ]
+
+        await _make_manager(mock_cm).search_detections(
+            labels=allowed,
+            limit=50,
+            order="desc",
+            exclude_motion=True,
+        )
+
+        params = mock_cm.client.api_request.await_args.kwargs["params"]
+        label_values = [value for key, value in params if key == "labels"]
+        assert label_values == allowed
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_label_prefix(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=["bogusPrefix:value"],
+                limit=50,
+                order="desc",
+                exclude_motion=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_label_without_prefix(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=["truck"],
+                limit=50,
+                order="desc",
+                exclude_motion=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_labels(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=[],
+                limit=50,
+                order="desc",
+                exclude_motion=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_limit_too_low(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=["color:black"],
+                limit=0,
+                order="desc",
+                exclude_motion=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_limit_too_high(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=["color:black"],
+                limit=1001,
+                order="desc",
+                exclude_motion=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_order(self, mock_cm):
+        with pytest.raises(ValueError):
+            await _make_manager(mock_cm).search_detections(
+                labels=["color:black"],
+                limit=50,
+                order="sideways",
+                exclude_motion=True,
+            )
+
+
+class TestGetDetectionSearchLabels:
+    @pytest.mark.asyncio
+    async def test_requests_labels_endpoint(self, mock_cm):
+        mock_cm.client.api_request.return_value = {}
+
+        await _make_manager(mock_cm).get_detection_search_labels()
+
+        mock_cm.client.api_request.assert_awaited_once()
+        args, kwargs = mock_cm.client.api_request.await_args
+        assert args[0] == "detection-search/labels"
+        assert kwargs["method"] == "get"
+
+    @pytest.mark.asyncio
+    async def test_returns_serialized_vocabulary(self, mock_cm):
+        from unifi_core.protect.models.detection_search import from_controller
+
+        raw = {
+            "colors": [{"label": "Black", "value": "color:black"}],
+            "vehicleTypes": [{"label": "Truck", "value": "vehicleType:truck"}],
+        }
+        mock_cm.client.api_request.return_value = raw
+
+        result = await _make_manager(mock_cm).get_detection_search_labels()
+
+        assert result == from_controller(raw).model_dump(exclude_none=True)
+        assert result["colors"] == [{"label": "Black", "value": "color:black"}]
+        assert result["vehicle_types"] == [{"label": "Truck", "value": "vehicleType:truck"}]
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_yields_empty_groups(self, mock_cm):
+        mock_cm.client.api_request.return_value = ["unexpected"]
+
+        result = await _make_manager(mock_cm).get_detection_search_labels()
+
+        assert result["colors"] == []
+        assert result["vehicle_types"] == []

--- a/apps/protect/tests/unit/test_detection_search_tools.py
+++ b/apps/protect/tests/unit/test_detection_search_tools.py
@@ -81,6 +81,56 @@ class TestProtectSearchDetections:
         assert call_kwargs["exclude_motion"] is False
 
     @pytest.mark.asyncio
+    async def test_passes_optional_filters_through(self, mock_event_manager):
+        from datetime import datetime
+
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(return_value={"detections": [], "count": 0})
+
+        await protect_search_detections(
+            labels=["color:black"],
+            min_confidence=70,
+            start="2026-05-28T07:00:00+00:00",
+            end="2026-06-04T13:51:59.999+00:00",
+        )
+
+        call_kwargs = mock_event_manager.search_detections.call_args.kwargs
+        assert call_kwargs["min_confidence"] == 70
+        # The tool parses ISO strings into datetimes before handing off to the manager.
+        assert isinstance(call_kwargs["start"], datetime)
+        assert isinstance(call_kwargs["end"], datetime)
+        assert call_kwargs["start"].isoformat().startswith("2026-05-28T07:00:00")
+
+    @pytest.mark.asyncio
+    async def test_optional_filters_default_to_none(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(return_value={"detections": [], "count": 0})
+
+        await protect_search_detections(labels=["color:black"])
+
+        call_kwargs = mock_event_manager.search_detections.call_args.kwargs
+        assert call_kwargs["min_confidence"] is None
+        assert call_kwargs["start"] is None
+        assert call_kwargs["end"] is None
+
+    @pytest.mark.asyncio
+    async def test_unparseable_start_end_coerce_to_none(self, mock_event_manager):
+        # Mirrors protect_list_events/list_smart_detections: an unparseable ISO
+        # timestamp is coerced to None (no bound) rather than raising.
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(return_value={"detections": [], "count": 0})
+
+        result = await protect_search_detections(labels=["color:black"], start="not-a-date", end="garbage")
+
+        assert result["success"] is True
+        call_kwargs = mock_event_manager.search_detections.call_args.kwargs
+        assert call_kwargs["start"] is None
+        assert call_kwargs["end"] is None
+
+    @pytest.mark.asyncio
     async def test_defaults_passed_through(self, mock_event_manager):
         from unifi_protect_mcp.tools.events import protect_search_detections
 

--- a/apps/protect/tests/unit/test_detection_search_tools.py
+++ b/apps/protect/tests/unit/test_detection_search_tools.py
@@ -1,0 +1,189 @@
+"""Tests for the detection-search MCP tools.
+
+Covers protect_search_detections and protect_detection_search_labels, which
+wrap EventManager.search_detections / get_detection_search_labels and apply the
+standard {"success": ..., "data"/"error": ...} envelope.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeDetection:
+    """Stand-in for a SmartDetection model with a model_dump method."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def model_dump(self, *, exclude_none: bool = False) -> dict:
+        if exclude_none:
+            return {k: v for k, v in self._payload.items() if v is not None}
+        return dict(self._payload)
+
+
+@pytest.fixture
+def mock_event_manager():
+    """Patch the event_manager singleton imported into the tools module."""
+    mgr = MagicMock()
+    with patch("unifi_protect_mcp.tools.events.event_manager", mgr):
+        yield mgr
+
+
+# ---------------------------------------------------------------------------
+# protect_search_detections
+# ---------------------------------------------------------------------------
+
+
+class TestProtectSearchDetections:
+    @pytest.mark.asyncio
+    async def test_success_serializes_detections_and_count(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(
+            return_value={
+                "detections": [
+                    _FakeDetection({"id": "d1", "type": "smartDetectZone", "score": None}),
+                    _FakeDetection({"id": "d2", "type": "smartDetectZone", "score": 90}),
+                ],
+                "count": 2,
+            }
+        )
+
+        result = await protect_search_detections(labels=["vehicleType:truck"])
+
+        assert result["success"] is True
+        assert result["data"]["count"] == 2
+        assert len(result["data"]["detections"]) == 2
+        # model_dump(exclude_none=True) drops the None score on d1
+        assert result["data"]["detections"][0] == {"id": "d1", "type": "smartDetectZone"}
+        assert result["data"]["detections"][1] == {"id": "d2", "type": "smartDetectZone", "score": 90}
+
+    @pytest.mark.asyncio
+    async def test_passes_params_through_to_manager(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(return_value={"detections": [], "count": 0})
+
+        await protect_search_detections(
+            labels=["color:black", "vehicleType:truck"],
+            limit=50,
+            order="asc",
+            exclude_motion=False,
+        )
+
+        call_kwargs = mock_event_manager.search_detections.call_args.kwargs
+        assert call_kwargs["labels"] == ["color:black", "vehicleType:truck"]
+        assert call_kwargs["limit"] == 50
+        assert call_kwargs["order"] == "asc"
+        assert call_kwargs["exclude_motion"] is False
+
+    @pytest.mark.asyncio
+    async def test_defaults_passed_through(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(return_value={"detections": [], "count": 0})
+
+        await protect_search_detections(labels=["color:black"])
+
+        call_kwargs = mock_event_manager.search_detections.call_args.kwargs
+        assert call_kwargs["labels"] == ["color:black"]
+        assert call_kwargs["limit"] == 100
+        assert call_kwargs["order"] == "desc"
+        assert call_kwargs["exclude_motion"] is True
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(return_value={"detections": [], "count": 0})
+
+        result = await protect_search_detections(labels=["color:black"])
+
+        assert result["success"] is True
+        assert result["data"]["count"] == 0
+        assert result["data"]["detections"] == []
+
+    @pytest.mark.asyncio
+    async def test_value_error_returns_clean_error(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(side_effect=ValueError("unknown label prefix 'bogus'"))
+
+        result = await protect_search_detections(labels=["bogus:value"])
+
+        assert result["success"] is False
+        assert result["error"] == "unknown label prefix 'bogus'"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_returns_failure(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_search_detections
+
+        mock_event_manager.search_detections = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        result = await protect_search_detections(labels=["color:black"])
+
+        assert result["success"] is False
+        assert "connection lost" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_read_only_annotation(self):
+        from unifi_protect_mcp.runtime import server
+
+        tools = {tool.name: tool for tool in await server.list_tools()}
+        assert tools["protect_search_detections"].annotations.readOnlyHint is True
+        assert tools["protect_search_detections"].annotations.openWorldHint is False
+
+
+# ---------------------------------------------------------------------------
+# protect_detection_search_labels
+# ---------------------------------------------------------------------------
+
+
+class TestProtectDetectionSearchLabels:
+    @pytest.mark.asyncio
+    async def test_success_returns_vocabulary(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_detection_search_labels
+
+        labels = {
+            "colors": [{"label": "Black", "value": "color:black"}],
+            "vehicle_types": [{"label": "Truck", "value": "vehicleType:truck"}],
+        }
+        mock_event_manager.get_detection_search_labels = AsyncMock(return_value=labels)
+
+        result = await protect_detection_search_labels()
+
+        assert result["success"] is True
+        assert result["data"] == labels
+
+    @pytest.mark.asyncio
+    async def test_value_error_returns_clean_error(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_detection_search_labels
+
+        mock_event_manager.get_detection_search_labels = AsyncMock(side_effect=ValueError("bad"))
+
+        result = await protect_detection_search_labels()
+
+        assert result["success"] is False
+        assert result["error"] == "bad"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_returns_failure(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_detection_search_labels
+
+        mock_event_manager.get_detection_search_labels = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        result = await protect_detection_search_labels()
+
+        assert result["success"] is False
+        assert "connection lost" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_read_only_annotation(self):
+        from unifi_protect_mcp.runtime import server
+
+        tools = {tool.name: tool for tool in await server.list_tools()}
+        assert tools["protect_detection_search_labels"].annotations.readOnlyHint is True
+        assert tools["protect_detection_search_labels"].annotations.openWorldHint is False

--- a/apps/protect/tests/unit/test_detection_search_tools.py
+++ b/apps/protect/tests/unit/test_detection_search_tools.py
@@ -130,6 +130,11 @@ class TestProtectSearchDetections:
 
     @pytest.mark.asyncio
     async def test_read_only_annotation(self):
+        # Importing the tools module runs its @server.tool registrations on THIS
+        # worker. Without it the test only imports runtime.server and depends on
+        # another test having imported tools.events first, which pytest-xdist
+        # load-distribution (-n auto) does not guarantee.
+        import unifi_protect_mcp.tools.events  # noqa: F401
         from unifi_protect_mcp.runtime import server
 
         tools = {tool.name: tool for tool in await server.list_tools()}
@@ -182,6 +187,11 @@ class TestProtectDetectionSearchLabels:
 
     @pytest.mark.asyncio
     async def test_read_only_annotation(self):
+        # Importing the tools module runs its @server.tool registrations on THIS
+        # worker. Without it the test only imports runtime.server and depends on
+        # another test having imported tools.events first, which pytest-xdist
+        # load-distribution (-n auto) does not guarantee.
+        import unifi_protect_mcp.tools.events  # noqa: F401
         from unifi_protect_mcp.runtime import server
 
         tools = {tool.name: tool for tool in await server.list_tools()}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Used by: `apps/network`, `apps/protect`, `apps/access`.
 
 ### apps/network
 
-The UniFi Network MCP server. 169 tools across 21 categories covering firewall, clients, devices, networks, VPNs, routing, stats, and more.
+The UniFi Network MCP server. 177 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
 
 - `src/unifi_network_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch
@@ -69,7 +69,7 @@ The UniFi Network MCP server. 169 tools across 21 categories covering firewall, 
 
 ### apps/protect
 
-The UniFi Protect MCP server. 56 tools across 8 categories covering cameras, events, recordings, devices (lights/sensors/chimes), liveviews, system status, recognition (faces + license plates), and the Alarm Manager (including AI-powered alarms, which require a SuperAdmin credential). Connects via `uiprotect` (pyunifiprotect) for websocket-based real-time event streaming.
+The UniFi Protect MCP server. 58 tools across 8 categories covering cameras, events, Find Anything detection search, recordings, devices (lights/sensors/chimes), liveviews, system status, recognition (faces + license plates), and the Alarm Manager (including AI-powered alarms, which require a SuperAdmin credential). Connects via `uiprotect` (pyunifiprotect) for websocket-based real-time event streaming.
 
 - `src/unifi_protect_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch
@@ -85,7 +85,7 @@ The UniFi Protect MCP server. 56 tools across 8 categories covering cameras, eve
 
 ### apps/access
 
-The UniFi Access MCP server. 29 tools across 7 categories covering doors, policies, credentials, visitors, events, devices, and system. Uses a **dual-path authentication** model: API key auth on the dedicated Access port (12445) via `py-unifi-access`, and a local proxy session on port 443 for mutations.
+The UniFi Access MCP server. 34 tools across 7 categories covering doors, policies, credentials, visitors, events, devices, and system. Uses a **dual-path authentication** model: API key auth on the dedicated Access port (12445) via `py-unifi-access`, and a local proxy session on port 443 for mutations.
 
 - `src/unifi_access_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch

--- a/docs/index.html
+++ b/docs/index.html
@@ -171,18 +171,18 @@
         </div>
         <h3>Network</h3>
         <div class="sc-meta">
-          <b>161 tools</b><span class="dot"></span>
+          <b>177 tools</b><span class="dot"></span>
           <span>unifi-network-mcp</span> <span class="ver-chip" data-pkg-version="unifi-network-mcp"></span><span class="dot"></span>
           <span>PyPI · Docker · Plugin</span>
         </div>
-        <p class="desc">Full UniFi Network controller coverage. Devices, clients, firewall, port-forwards, VLANs, WLANs, DPI stats, traffic identification, alarms, and policy templates — all readable, with mutations gated by preview-then-confirm.</p>
+        <p class="desc">Full UniFi Network controller coverage. Devices, clients, firewall, port-forwards, VLANs, WLANs, DPI stats, Traffic Flows, alarms, and policy templates — all readable, with mutations gated by preview-then-confirm.</p>
         <div class="sc-tools">
           <span class="chip acc">unifi.list_clients</span>
           <span class="chip">unifi.get_firewall_policies</span>
           <span class="chip acc">unifi.create_port_forward</span>
           <span class="chip">unifi.dpi_stats</span>
-          <span class="chip acc">unifi.run_diagnostic</span>
-          <span class="chip">+156 more</span>
+          <span class="chip acc">unifi.traffic_flows</span>
+          <span class="chip">+172 more</span>
         </div>
 
         <div class="sc-prompt">
@@ -218,15 +218,15 @@
         </div>
         <h3>Protect</h3>
         <div class="sc-meta">
-          <b>56 tools</b><span class="dot"></span>
+          <b>58 tools</b><span class="dot"></span>
           <span>unifi-protect-mcp</span> <span class="ver-chip" data-pkg-version="unifi-protect-mcp"></span>
         </div>
-        <p class="desc">Cameras, snapshots, motion events, smart detections, recordings, and live event streams. Hand your agent a question — get back a timeline, not 800 frames.</p>
+        <p class="desc">Cameras, snapshots, motion events, smart detections, Find Anything search, recordings, and live event streams. Hand your agent a question — get back a timeline, not 800 frames.</p>
         <div class="sc-tools">
           <span class="chip acc">protect.list_cameras</span>
           <span class="chip acc">protect.smart_detections</span>
+          <span class="chip">protect.search_detections</span>
           <span class="chip">protect.snapshot</span>
-          <span class="chip">protect.timeline</span>
         </div>
         <a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/protect" class="sc-link">
           Explore Protect
@@ -247,7 +247,7 @@
         </div>
         <h3>Access</h3>
         <div class="sc-meta">
-          <b>29 tools</b><span class="dot"></span>
+          <b>34 tools</b><span class="dot"></span>
           <span>unifi-access-mcp</span> <span class="ver-chip" data-pkg-version="unifi-access-mcp"></span>
         </div>
         <p class="desc">Doors, hubs, readers, credentials, visitors, and policies. Issue a guest pass, audit a badge timeline, or revoke a credential — in plain English.</p>

--- a/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
@@ -16,8 +16,35 @@ from typing import Any, Callable
 from uiprotect.data import Event, EventType, ModelType, SmartDetectObjectType, WSAction, WSSubscriptionMessage
 
 from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.protect.models.detection_search import from_controller as detection_search_from_controller
+from unifi_core.protect.models.events import smart_detection_from_controller
 
 logger = logging.getLogger(__name__)
+
+# Allowed label prefixes for the detection-search endpoint. Each label is a
+# ``prefix:value`` token; the prefix selects which filter category the value
+# applies to (e.g. ``vehicleType:truck``).
+_VALID_DETECTION_LABEL_PREFIXES = frozenset(
+    {
+        "vehicleType",
+        "color",
+        "smartDetectType",
+        "eventType",
+        "groupType",
+        "camera",
+        "zone",
+        "line",
+        "loiterZone",
+        "doorAccess",
+    }
+)
+
+# Sort directions accepted by detection-search (lowercased on input, sent uppercased).
+_VALID_DETECTION_ORDERS = frozenset({"asc", "desc"})
+
+# Inclusive bounds for the detection-search result limit.
+_DETECTION_LIMIT_MIN = 1
+_DETECTION_LIMIT_MAX = 1000
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -774,6 +801,87 @@ class EventManager:
 
         await self._apply_known_face_names(uiprotect_results)
         return uiprotect_results
+
+    def _build_detection_search_params(
+        self,
+        *,
+        labels: list[str],
+        limit: int,
+        order: str,
+        exclude_motion: bool,
+    ) -> list[tuple[str, str]]:
+        """Validate inputs and build the detection-search query params.
+
+        Returns a list of ``(key, value)`` tuples with stringified values so the
+        ``labels`` key is repeated once per label by the underlying HTTP client
+        (the controller applies the labels conjunctively).
+        """
+        normalized_labels = [label.strip() for label in labels if label and label.strip()]
+        if not normalized_labels:
+            raise ValueError("At least one label is required.")
+        for label in normalized_labels:
+            prefix = label.split(":", 1)[0] if ":" in label else ""
+            if prefix not in _VALID_DETECTION_LABEL_PREFIXES:
+                raise ValueError(
+                    f"Invalid label {label!r}. Labels must be 'prefix:value' with prefix "
+                    f"in {sorted(_VALID_DETECTION_LABEL_PREFIXES)}."
+                )
+
+        if not (_DETECTION_LIMIT_MIN <= limit <= _DETECTION_LIMIT_MAX):
+            raise ValueError(f"limit must be between {_DETECTION_LIMIT_MIN} and {_DETECTION_LIMIT_MAX}, got {limit}.")
+
+        normalized_order = order.strip().lower()
+        if normalized_order not in _VALID_DETECTION_ORDERS:
+            raise ValueError(f"Invalid order {order!r}. Valid orders: {sorted(_VALID_DETECTION_ORDERS)}.")
+
+        params: list[tuple[str, str]] = [("excludeMotion", "true" if exclude_motion else "false")]
+        params.extend(("labels", label) for label in normalized_labels)
+        params.append(("limit", str(limit)))
+        params.append(("orderDirection", normalized_order.upper()))
+        return params
+
+    async def search_detections(
+        self,
+        *,
+        labels: list[str],
+        limit: int,
+        order: str,
+        exclude_motion: bool,
+    ) -> dict[str, Any]:
+        """Search detections via the controller's detection-search endpoint.
+
+        The ``labels`` query key is repeated once per label so the controller
+        applies them conjunctively. Returns a ``{"detections": [...], "count": n}``
+        envelope of :class:`SmartDetection` items parsed from the
+        ``{"events": [...]}`` response shape.
+
+        Additional filters (e.g. confidence, time window) are intentionally not
+        wired yet; the keyword-only signature keeps them addable without breaking
+        callers.
+        """
+        params = self._build_detection_search_params(
+            labels=labels,
+            limit=limit,
+            order=order,
+            exclude_motion=exclude_motion,
+        )
+        data = await self._cm.client.api_request("detection-search", method="get", params=params)
+        if not isinstance(data, dict):
+            data = {}
+        events = data.get("events") or []
+        detections = [smart_detection_from_controller(event) for event in events]
+        return {"detections": detections, "count": len(detections)}
+
+    async def get_detection_search_labels(self) -> dict[str, Any]:
+        """Return the detection-search filter vocabulary from the controller.
+
+        Wraps the ``detection-search/labels`` endpoint, which lists the legal
+        filter values (colors, vehicle types, smart-detect types, ...) the
+        "Find Anything" panel offers. The raw response is normalised through
+        :func:`detection_search_from_controller` into snake_case group lists.
+        """
+        raw = await self._cm.client.api_request("detection-search/labels", method="get")
+        return detection_search_from_controller(raw).model_dump(exclude_none=True)
 
     async def acknowledge_event(self, event_id: str) -> dict[str, Any]:
         """Mark an event as acknowledged/favorite on the NVR.

--- a/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
@@ -46,6 +46,10 @@ _VALID_DETECTION_ORDERS = frozenset({"asc", "desc"})
 _DETECTION_LIMIT_MIN = 1
 _DETECTION_LIMIT_MAX = 1000
 
+# Inclusive bounds for the detection-search minimum-confidence filter (percent).
+_DETECTION_CONFIDENCE_MIN = 0
+_DETECTION_CONFIDENCE_MAX = 100
+
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
     if obj is None:
@@ -809,6 +813,9 @@ class EventManager:
         limit: int,
         order: str,
         exclude_motion: bool,
+        min_confidence: int | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
     ) -> list[tuple[str, str]]:
         """Validate inputs and build the detection-search query params.
 
@@ -834,10 +841,25 @@ class EventManager:
         if normalized_order not in _VALID_DETECTION_ORDERS:
             raise ValueError(f"Invalid order {order!r}. Valid orders: {sorted(_VALID_DETECTION_ORDERS)}.")
 
+        if min_confidence is not None and not (
+            _DETECTION_CONFIDENCE_MIN <= min_confidence <= _DETECTION_CONFIDENCE_MAX
+        ):
+            raise ValueError(
+                f"min_confidence must be between {_DETECTION_CONFIDENCE_MIN} and "
+                f"{_DETECTION_CONFIDENCE_MAX}, got {min_confidence}."
+            )
+
         params: list[tuple[str, str]] = [("excludeMotion", "true" if exclude_motion else "false")]
         params.extend(("labels", label) for label in normalized_labels)
         params.append(("limit", str(limit)))
         params.append(("orderDirection", normalized_order.upper()))
+        if min_confidence is not None:
+            params.append(("minConfidence", str(min_confidence)))
+        # The controller's detection-search endpoint expects epoch-millisecond bounds.
+        if start is not None:
+            params.append(("start", str(int(start.timestamp() * 1000))))
+        if end is not None:
+            params.append(("end", str(int(end.timestamp() * 1000))))
         return params
 
     async def search_detections(
@@ -847,6 +869,9 @@ class EventManager:
         limit: int,
         order: str,
         exclude_motion: bool,
+        min_confidence: int | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
     ) -> dict[str, Any]:
         """Search detections via the controller's detection-search endpoint.
 
@@ -855,15 +880,18 @@ class EventManager:
         envelope of :class:`SmartDetection` items parsed from the
         ``{"events": [...]}`` response shape.
 
-        Additional filters (e.g. confidence, time window) are intentionally not
-        wired yet; the keyword-only signature keeps them addable without breaking
-        callers.
+        Optional ``min_confidence`` (0-100) maps to the ``minConfidence`` query
+        param; ``start``/``end`` map to the ``start``/``end`` epoch-millisecond
+        bounds. All three are omitted from the request when ``None``.
         """
         params = self._build_detection_search_params(
             labels=labels,
             limit=limit,
             order=order,
             exclude_motion=exclude_motion,
+            min_confidence=min_confidence,
+            start=start,
+            end=end,
         )
         data = await self._cm.client.api_request("detection-search", method="get", params=params)
         if not isinstance(data, dict):

--- a/packages/unifi-core/src/unifi_core/protect/models/detection_search.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/detection_search.py
@@ -85,7 +85,14 @@ def _label_values(raw: Any, *keys: str) -> list[DetectionSearchLabelValue]:
     for entry in group:
         if not isinstance(entry, dict):
             continue
-        items.append(DetectionSearchLabelValue(label=entry.get("label"), value=entry.get("value")))
+        label = entry.get("label")
+        value = entry.get("value")
+        # Some firmware returns the usable prefix:value token in "label" while
+        # "value" contains only the suffix. Expose a value callers can pass
+        # directly back to detection-search.
+        if isinstance(label, str) and ":" in label and not (isinstance(value, str) and ":" in value):
+            value = label
+        items.append(DetectionSearchLabelValue(label=label, value=value))
     return items
 
 

--- a/packages/unifi-core/src/unifi_core/protect/models/detection_search.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/detection_search.py
@@ -1,0 +1,105 @@
+"""Shared models for the UniFi Protect detection-search filter vocabulary.
+
+The ``detection-search/labels`` endpoint returns the legal filter values the
+"Find Anything" panel offers, grouped by category (colors, vehicleTypes,
+smartDetectTypes, eventTypes, groupType, devices, doorAccess, ...). Each group
+is a list of ``{label, value}`` items where ``value`` is the ``key:value``
+string passed back to ``detection-search`` via the repeated ``labels`` query
+param (e.g. ``vehicleType:truck``).
+
+Detection *results* reuse the existing event models (``SmartDetection`` /
+``smart_detection_from_controller`` in :mod:`unifi_core.protect.models.events`);
+only the filter vocabulary needs a dedicated model.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DetectionSearchLabelValue(BaseModel):
+    """A single selectable filter value from the detection-search vocabulary."""
+
+    label: Optional[str] = Field(
+        default=None, description="Human-readable filter label", json_schema_extra={"mutable": False}
+    )
+    value: Optional[str] = Field(
+        default=None,
+        description="Filter token in 'key:value' form (e.g. vehicleType:truck)",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class DetectionSearchLabels(BaseModel):
+    """Canonical detection-search filter vocabulary, grouped by category."""
+
+    colors: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Vehicle/object color filters", json_schema_extra={"mutable": False}
+    )
+    vehicle_types: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Vehicle type filters", json_schema_extra={"mutable": False}
+    )
+    smart_detect_types: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Smart-detection type filters", json_schema_extra={"mutable": False}
+    )
+    event_types: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Event type filters", json_schema_extra={"mutable": False}
+    )
+    group_type: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Recognition group type filters", json_schema_extra={"mutable": False}
+    )
+    devices: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Camera/device filters", json_schema_extra={"mutable": False}
+    )
+    door_access: list[DetectionSearchLabelValue] = Field(
+        default_factory=list, description="Door access filters", json_schema_extra={"mutable": False}
+    )
+
+
+# Deliberately a local copy of the trivial dict/attr accessor (the event
+# manager has its own). Keeping it here avoids a cross-module import from a
+# manager into a model for three lines, and lets the model stay
+# self-contained. The two copies are intentionally allowed to drift if their
+# needs differ (e.g. None-handling).
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _label_values(raw: Any, *keys: str) -> list[DetectionSearchLabelValue]:
+    """Coalesce a controller group (first matching key) into label/value items."""
+    group: Any = None
+    for key in keys:
+        candidate = _get(raw, key)
+        if candidate is not None:
+            group = candidate
+            break
+
+    if not isinstance(group, list):
+        return []
+
+    items: list[DetectionSearchLabelValue] = []
+    for entry in group:
+        if not isinstance(entry, dict):
+            continue
+        items.append(DetectionSearchLabelValue(label=entry.get("label"), value=entry.get("value")))
+    return items
+
+
+def from_controller(raw: Any) -> DetectionSearchLabels:
+    """Build DetectionSearchLabels from a Protect detection-search/labels response."""
+    if not isinstance(raw, dict):
+        raw = {}
+
+    return DetectionSearchLabels(
+        colors=_label_values(raw, "colors"),
+        vehicle_types=_label_values(raw, "vehicle_types", "vehicleTypes"),
+        smart_detect_types=_label_values(raw, "smart_detect_types", "smartDetectTypes"),
+        event_types=_label_values(raw, "event_types", "eventTypes"),
+        group_type=_label_values(raw, "group_type", "groupType"),
+        devices=_label_values(raw, "devices"),
+        door_access=_label_values(raw, "door_access", "doorAccess"),
+    )

--- a/packages/unifi-core/src/unifi_core/protect/models/events.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/events.py
@@ -221,7 +221,7 @@ def from_controller(raw: Any) -> Event:
 
 def smart_detection_from_controller(raw: Any) -> SmartDetection:
     """Build a SmartDetection from a uiprotect / manager dict or object."""
-    sdt = _get(raw, "smart_detect_types")
+    sdt = _get_any(raw, "smart_detect_types", "smartDetectTypes")
     if not isinstance(sdt, list):
         sdt = []
 

--- a/packages/unifi-core/tests/protect/models/test_detection_search.py
+++ b/packages/unifi-core/tests/protect/models/test_detection_search.py
@@ -1,0 +1,105 @@
+"""Tests for the Protect detection-search labels vocabulary model."""
+
+from __future__ import annotations
+
+from unifi_core.protect.models.detection_search import (
+    DetectionSearchLabels,
+    DetectionSearchLabelValue,
+    from_controller,
+)
+
+
+class TestDetectionSearchLabelValue:
+    def test_label_value_round_trips(self):
+        item = DetectionSearchLabelValue(label="Truck", value="vehicleType:truck")
+        assert item.label == "Truck"
+        assert item.value == "vehicleType:truck"
+
+    def test_label_value_allows_missing_fields(self):
+        item = DetectionSearchLabelValue()
+        assert item.label is None
+        assert item.value is None
+
+
+class TestDetectionSearchLabelsFromController:
+    def _raw(self):
+        return {
+            "colors": [
+                {"label": "Black", "value": "color:black"},
+                {"label": "White", "value": "color:white"},
+            ],
+            "vehicleTypes": [
+                {"label": "Truck", "value": "vehicleType:truck"},
+                {"label": "SUV", "value": "vehicleType:suv"},
+            ],
+            "smartDetectTypes": [
+                {"label": "Vehicle", "value": "smartDetectType:vehicle"},
+            ],
+            "eventTypes": [
+                {"label": "Ring", "value": "eventType:ring"},
+            ],
+            "groupType": [
+                {"label": "Known", "value": "groupType:known"},
+            ],
+            "devices": [
+                {"label": "Front Cam", "type": "camera", "value": "camera:abc123"},
+            ],
+            "doorAccess": [
+                {"label": "Granted", "value": "doorAccess:granted"},
+            ],
+        }
+
+    def test_maps_camelcase_groups_into_typed_snake_case_lists(self):
+        labels = from_controller(self._raw())
+
+        assert isinstance(labels, DetectionSearchLabels)
+        assert [c.value for c in labels.colors] == ["color:black", "color:white"]
+        assert [v.label for v in labels.vehicle_types] == ["Truck", "SUV"]
+        assert labels.smart_detect_types[0].value == "smartDetectType:vehicle"
+        assert labels.event_types[0].value == "eventType:ring"
+        assert labels.group_type[0].value == "groupType:known"
+        assert labels.devices[0].value == "camera:abc123"
+        assert labels.door_access[0].value == "doorAccess:granted"
+
+    def test_items_are_label_value_models(self):
+        labels = from_controller(self._raw())
+        assert isinstance(labels.colors[0], DetectionSearchLabelValue)
+        assert labels.colors[0].label == "Black"
+
+    def test_missing_groups_default_to_empty_lists(self):
+        labels = from_controller({"colors": [{"label": "Black", "value": "color:black"}]})
+
+        assert [c.value for c in labels.colors] == ["color:black"]
+        assert labels.vehicle_types == []
+        assert labels.smart_detect_types == []
+        assert labels.event_types == []
+        assert labels.group_type == []
+        assert labels.devices == []
+        assert labels.door_access == []
+
+    def test_non_dict_input_yields_empty_model(self):
+        labels = from_controller(None)
+        assert labels.colors == []
+        assert labels.vehicle_types == []
+
+    def test_ignores_non_list_group_values(self):
+        labels = from_controller({"colors": "not-a-list", "vehicleTypes": None})
+        assert labels.colors == []
+        assert labels.vehicle_types == []
+
+    def test_skips_non_dict_items(self):
+        labels = from_controller({"colors": ["not-a-dict", {"label": "Black", "value": "color:black"}]})
+        assert [c.value for c in labels.colors] == ["color:black"]
+
+    def test_model_dump_exclude_none_round_trips(self):
+        labels = from_controller(self._raw())
+        dumped = labels.model_dump(exclude_none=True)
+
+        assert dumped["colors"] == [
+            {"label": "Black", "value": "color:black"},
+            {"label": "White", "value": "color:white"},
+        ]
+        assert dumped["vehicle_types"][0] == {"label": "Truck", "value": "vehicleType:truck"}
+        # snake_case keys are used in the serialized output
+        assert "smart_detect_types" in dumped
+        assert "vehicleTypes" not in dumped

--- a/packages/unifi-core/tests/protect/models/test_detection_search.py
+++ b/packages/unifi-core/tests/protect/models/test_detection_search.py
@@ -61,6 +61,21 @@ class TestDetectionSearchLabelsFromController:
         assert labels.devices[0].value == "camera:abc123"
         assert labels.door_access[0].value == "doorAccess:granted"
 
+    def test_uses_prefixed_label_when_controller_value_is_suffix_only(self):
+        labels = from_controller(
+            {
+                "colors": [{"label": "color:black", "value": "black"}],
+                "vehicleTypes": [{"label": "vehicleType:truck", "value": "truck"}],
+                "smartDetectTypes": [{"label": "smartDetectType:animal", "value": "animal"}],
+                "devices": [{"label": "camera:abc123", "value": "abc123"}],
+            }
+        )
+
+        assert labels.colors[0].value == "color:black"
+        assert labels.vehicle_types[0].value == "vehicleType:truck"
+        assert labels.smart_detect_types[0].value == "smartDetectType:animal"
+        assert labels.devices[0].value == "camera:abc123"
+
     def test_items_are_label_value_models(self):
         labels = from_controller(self._raw())
         assert isinstance(labels.colors[0], DetectionSearchLabelValue)

--- a/plugins/unifi-access/skills/unifi-access/SKILL.md
+++ b/plugins/unifi-access/skills/unifi-access/SKILL.md
@@ -5,7 +5,7 @@ description: How to manage UniFi Access door control — locks, credentials, vis
 
 # UniFi Access MCP Server
 
-You have access to a UniFi Access MCP server that lets you query and manage a UniFi Access controller. It provides 29 tools covering doors, locks, credentials, visitors, access policies, and events.
+You have access to a UniFi Access MCP server that lets you query and manage a UniFi Access controller. It provides 34 tools covering doors, locks, credentials, visitors, access policies, events, devices, and system health.
 
 ## Tool Discovery
 
@@ -81,4 +81,4 @@ Access readers are network clients — if a reader appears offline, the Network 
 
 ## Tool Reference
 
-For the complete list of all 29 tools organized by category with descriptions, tips, and common scenarios, read `references/access-tools.md`.
+For the complete list of all 34 tools organized by category with descriptions, tips, and common scenarios, read `references/access-tools.md`.

--- a/plugins/unifi-network/skills/unifi-network/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: unifi-network
-description: How to manage UniFi network infrastructure — devices, clients, firewall, VPN, routing, WLANs, and statistics. Use this skill when the user mentions UniFi, Ubiquiti, network management, WiFi configuration, firewall rules, port forwarding, VPN, QoS, bandwidth, connected clients, network devices, or any UniFi networking task.
+description: How to manage UniFi network infrastructure — devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, and statistics. Use this skill when the user mentions UniFi, Ubiquiti, network management, WiFi configuration, firewall rules, port forwarding, VPN, QoS, bandwidth, traffic flows, connected clients, network devices, or any UniFi networking task.
 ---
 
 # UniFi Network MCP Server
 
-You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 169 tools covering devices, clients, firewall, VPN, routing, WLANs, statistics, and more.
+You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 177 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
 
 ## Tool Discovery
 
@@ -62,6 +62,7 @@ Additional enriched fields: `upgradable` (bool), `connection_network` (VLAN name
 - **`unifi_lookup_by_ip`** — faster than listing all clients when you know the IP
 - **Use filters** — most list tools accept time range, type, and ID parameters
 - **`unifi_get_top_clients`** — fastest way to find bandwidth hogs
+- **`unifi_get_traffic_flows`** — query historical Insights > Flows records when the user asks who talked to what, which ports/protocols were used, or where traffic went
 - **Check health first** — `unifi_get_network_health` for quick "is everything OK?"
 - **Device counts** — use `device_category` field, not `type`, for accurate AP/switch/PDU counts
 
@@ -86,4 +87,4 @@ Cameras and access readers appear as network clients — use `unifi_lookup_by_ip
 
 ## Tool Reference
 
-For the complete list of all 169 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.
+For the complete list of all 177 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.

--- a/plugins/unifi-protect/skills/unifi-protect/SKILL.md
+++ b/plugins/unifi-protect/skills/unifi-protect/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: unifi-protect
-description: How to manage UniFi Protect cameras and NVR — view cameras, smart detections, recordings, snapshots, lights, sensors, Known Faces, and the Alarm Manager. Use this skill when the user mentions UniFi cameras, security cameras, NVR, recordings, motion detection, person detection, face recognition, Known Faces, snapshots, RTSP streams, floodlights, sensors, chimes, arming/disarming the alarm, or any UniFi Protect task.
+description: How to manage UniFi Protect cameras and NVR — view cameras, smart detections, Find Anything detection search, recordings, snapshots, lights, sensors, Known Faces, license plates, and the Alarm Manager. Use this skill when the user mentions UniFi cameras, security cameras, NVR, recordings, motion detection, person detection, vehicle search, face recognition, Known Faces, license plates, snapshots, RTSP streams, floodlights, sensors, chimes, arming/disarming the alarm, or any UniFi Protect task.
 ---
 
 # UniFi Protect MCP Server
 
-You have access to a UniFi Protect MCP server that lets you query and manage a UniFi Protect NVR. It provides 43 tools covering cameras, smart detections, recordings, snapshots, lights, sensors, chimes, Known Faces, and the Alarm Manager (arm/disarm).
+You have access to a UniFi Protect MCP server that lets you query and manage a UniFi Protect NVR. It provides 58 tools covering cameras, smart detections, Find Anything detection search, recordings, snapshots, lights, sensors, chimes, Known Faces, license plates, and the Alarm Manager (arm/disarm).
 
 ## Tool Discovery
 
@@ -49,6 +49,7 @@ All tools return: `{"success": true, "data": ...}`, `{"success": false, "error":
 - **Snapshots:** `protect_get_snapshot` with `include_image=true` returns base64 JPEG inline
 - **RTSP streams:** `protect_get_camera_streams` gives stream URLs for video player integration
 - **Smart detections:** `protect_list_smart_detections` filters by type (person, vehicle, animal, package, face, licensePlate). These are the highest-signal events — prioritize over raw motion.
+- **Find Anything search:** use `protect_detection_search_labels` to discover controller-supported label values, then pass those values to `protect_search_detections` for richer searches by vehicle type, color, device, or other Protect labels.
 - **Event camera names:** All event responses include `camera_name` alongside `camera_id` — no need to call `protect_list_cameras` separately to resolve names.
 - **Real-time events:** `protect_recent_events` reads from websocket buffer instantly (no API call). Buffer holds ~100 events with 5-minute TTL. Use `protect_list_events` for historical queries.
 - **Video export:** `protect_export_clip` returns metadata (not video data — too large for MCP). Max 2 hours, supports timelapse (fps: 4=60x, 8=120x, 20=300x)
@@ -59,6 +60,7 @@ All tools return: `{"success": true, "data": ...}`, `{"success": false, "error":
 
 - **Use `protect_batch` for parallel queries** — biggest performance win. Batch smart detections + events in one call.
 - **Prefer `protect_list_smart_detections` over `protect_list_events`** for security analysis — smart detections are pre-classified (person, vehicle, etc.) and higher signal than raw motion.
+- **Use `protect_search_detections` for Find Anything questions** — if the user asks for "white vans", "animals in the driveway", or other attribute searches, discover labels first and reuse the returned `value` strings.
 - **`protect_recent_events` is fast but small** — only a few minutes of buffered data. For anything beyond real-time monitoring, use `protect_list_events` with time range filters.
 - **Limit results** — event queries default to 30 but can return large payloads. Use `limit` parameter to keep responses focused.
 - **Security digest** — for comprehensive event summaries, use the `security-digest` skill which handles batch calls, severity classification, and cross-product correlation.
@@ -84,4 +86,4 @@ Cameras are network clients — if a camera appears offline, the Network server 
 
 ## Tool Reference
 
-For the complete list of all 43 tools organized by category with descriptions, tips, and common scenarios, read `references/protect-tools.md`.
+For the complete list of all 58 tools organized by category with descriptions, tips, and common scenarios, read `references/protect-tools.md`.

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -1,4 +1,4 @@
-# Protect Server Tool Reference (56 tools)
+# Protect Server Tool Reference (58 tools)
 
 Complete reference for `protect_*` tools. All read tools are always available. All mutations are **disabled by default** — the user must explicitly enable them because Protect controls physical security hardware.
 

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -81,6 +81,7 @@ Always available, regardless of registration mode.
 
 **Tips:**
 - **Real-time vs historical**: Use `protect_recent_events` for "what just happened?" (instant, from websocket buffer). Use `protect_list_events` for "what happened last Tuesday?" (API query, slower)
+- **Find Anything searches**: Call `protect_detection_search_labels` first, then pass the returned `value` strings to `protect_search_detections` for attribute searches such as vehicle type, color, device, or smart-detection type.
 - Smart detection types: `person`, `vehicle`, `animal`, `package`, `face`, `licensePlate`
 - `min_confidence` parameter filters out low-confidence detections (default threshold: 50)
 - Event types for filtering: `motion`, `smartDetectZone`, `ring`, `sensorMotion`, `sensorContact`, `sensorDoorbell`

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -64,15 +64,17 @@ Always available, regardless of registration mode.
 ## Events
 
 <!-- AUTO:tools:events -->
-7 tools.
+9 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
+| `protect_detection_search_labels` | Read | List the detection-search filter vocabulary supported by this controller. |
 | `protect_get_event` | Read | Get detailed information for a single event by ID. |
 | `protect_get_event_thumbnail` | Read | Get the thumbnail image for an event. |
 | `protect_list_events` | Read | Query events from the NVR with optional filters. |
 | `protect_list_smart_detections` | Read | List smart detection events (person, vehicle, animal, package, etc.) with optional filters. |
 | `protect_recent_events` | Read | Get recent events from the in-memory websocket buffer. |
+| `protect_search_detections` | Read | Search detections across all cameras using Protect's 'Find Anything' filter vocabulary. |
 | `protect_subscribe_events` | Read | Returns instructions for subscribing to real-time Protect events. |
 | `protect_acknowledge_event` | Mutate | Acknowledge an event by marking it as a favorite on the NVR. |
 <!-- /AUTO:tools:events -->

--- a/scripts/live_api_smoke.py
+++ b/scripts/live_api_smoke.py
@@ -615,6 +615,116 @@ async def run_protect_assertions(  # noqa: C901
         retry=retry,
     )
 
+    # 9a. REST detection-search labels vocabulary (Find Anything)
+    async def _rest_detection_search_labels():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=base) as c:
+            r = await c.get(
+                f"/v1/sites/default/detection-search-labels?controller={cid}",
+                headers=headers,
+            )
+            assert r.status_code == 200, f"status={r.status_code}"
+            body = r.json()
+            assert "vehicle_types" in body, f"missing 'vehicle_types': {list(body)[:8]}"
+            return {"vehicle_type_count": len(body.get("vehicle_types") or [])}
+
+    await _run_assertion(
+        report,
+        "REST detection-search-labels (vocabulary)",
+        "protect",
+        "rest",
+        _rest_detection_search_labels,
+        retry=retry,
+    )
+
+    # 9b. REST detection-search — Page envelope (Find Anything)
+    async def _rest_detection_search():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=base) as c:
+            r = await c.get(
+                f"/v1/sites/default/detection-search?controller={cid}&labels=smartDetectType:vehicle&limit=5",
+                headers=headers,
+            )
+            assert r.status_code == 200, f"status={r.status_code}"
+            body = r.json()
+            assert "items" in body, f"missing 'items': {body}"
+            assert "next_cursor" in body, f"missing 'next_cursor': {body}"
+            return {"item_count": len(body["items"])}
+
+    await _run_assertion(
+        report,
+        "REST detection-search (Page envelope)",
+        "protect",
+        "rest",
+        _rest_detection_search,
+        retry=retry,
+    )
+
+    # 9c. REST detection-search with min_confidence filter (Find Anything)
+    async def _rest_detection_search_min_confidence():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=base) as c:
+            r = await c.get(
+                f"/v1/sites/default/detection-search?controller={cid}&labels=smartDetectType:vehicle&min_confidence=50&limit=5",
+                headers=headers,
+            )
+            assert r.status_code == 200, f"status={r.status_code}"
+            body = r.json()
+            assert "items" in body, f"missing 'items': {body}"
+            assert "next_cursor" in body, f"missing 'next_cursor': {body}"
+            return {"item_count": len(body["items"])}
+
+    await _run_assertion(
+        report,
+        "REST detection-search (min_confidence)",
+        "protect",
+        "rest",
+        _rest_detection_search_min_confidence,
+        retry=retry,
+    )
+
+    # 9d. GraphQL searchDetections query (Find Anything, incl minConfidence)
+    async def _gql_search_detections():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=base) as c:
+            q = (
+                f'{{ protect {{ searchDetections(controller: "{cid}", '
+                f'labels: ["smartDetectType:vehicle"], limit: 5, minConfidence: 50) '
+                f"{{ id type smartDetectTypes }} }} }}"
+            )
+            r = await c.post("/v1/graphql", headers=headers, json={"query": q})
+            assert r.status_code == 200, f"status={r.status_code}"
+            body = r.json()
+            assert not body.get("errors"), f"GraphQL errors: {body.get('errors')}"
+            items = body["data"]["protect"]["searchDetections"]
+            return {"item_count": len(items)}
+
+    await _run_assertion(
+        report,
+        "GraphQL protect.searchDetections query",
+        "protect",
+        "graphql",
+        _gql_search_detections,
+        retry=retry,
+    )
+
+    # 9e. GraphQL detectionSearchLabels query (Find Anything)
+    async def _gql_detection_search_labels():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=base) as c:
+            # vehicleTypes/colors are JSON-scalar sub-maps on DetectionSearchLabels — no subfield selection.
+            q = f'{{ protect {{ detectionSearchLabels(controller: "{cid}") {{ vehicleTypes colors }} }} }}'
+            r = await c.post("/v1/graphql", headers=headers, json={"query": q})
+            assert r.status_code == 200, f"status={r.status_code}"
+            body = r.json()
+            assert not body.get("errors"), f"GraphQL errors: {body.get('errors')}"
+            vts = body["data"]["protect"]["detectionSearchLabels"]["vehicleTypes"]
+            return {"vehicle_type_count": len(vts)}
+
+    await _run_assertion(
+        report,
+        "GraphQL protect.detectionSearchLabels query",
+        "protect",
+        "graphql",
+        _gql_detection_search_labels,
+        retry=retry,
+    )
+
     # 10. Auth scope rejection
     async def _auth_rejection():
         async with AsyncClient(transport=ASGITransport(app=app), base_url=base) as c:


### PR DESCRIPTION
## Summary

Adds the UniFi Protect "Find Anything" detection search to the Protect MCP, with
matching GraphQL and REST surfaces. Two read-only tools wrap the controller's
`detection-search` endpoints so callers can query historical detections across all
cameras by attribute, rather than paging raw events.

## Tools

**`protect_search_detections`** — wraps `GET /proxy/protect/api/detection-search`.
- `labels` (required): repeatable `prefix:value` filters, applied conjunctively.
  Valid prefixes: `vehicleType`, `color`, `smartDetectType`, `eventType`,
  `groupType`, `camera`, `zone`, `line`, `loiterZone`, `doorAccess`.
- `limit` (1–1000, default 100), `order` (`desc`/`asc`), `exclude_motion`
  (default `true` — drops plain motion so only smart detections return).
- `min_confidence` (0–100) → `minConfidence`.
- `start` / `end` (ISO‑8601) → epoch‑millisecond `start`/`end` bounds.

**`protect_detection_search_labels`** — wraps `GET …/detection-search/labels`;
returns the controller's filter vocabulary (colors, vehicle types, smart‑detect
types, event types, group types, cameras, door access) so callers can discover
the legal `labels` values.

The repeated `labels` query key is sent as a list of tuples so the controller
applies the filters conjunctively; the `{ "events": [...] }` response is coalesced
into the existing `SmartDetection` model.

## Layers

- `packages/unifi-core` — `DetectionSearchLabels` model + `EventManager.search_detections`
  / `get_detection_search_labels`.
- `apps/protect` — the two `@server.tool` read‑only tools.
- `apps/api` — GraphQL `query.protect.searchDetections` / `detectionSearchLabels`
  and REST `GET /sites/{site_id}/detection-search` / `…/detection-search-labels`.
  `min_confidence` is exposed on the GraphQL field and REST route; `start`/`end`
  remain tool‑level, mirroring `list_smart_detections`.

## Notes

- Manager `ValueError`s (invalid label prefix, out‑of‑range limit/confidence,
  empty labels) surface as a clean error envelope at the tool layer and as
  HTTP 400 at the REST layer, mirroring the existing `_decode_cursor` pattern.
- Generated artifacts (`tools_manifest.json`, skill references, GraphQL SDL,
  OpenAPI spec, reference docs) are regenerated and pass `make check-generated`
  and the SDL/OpenAPI/docs drift gates.

## Testing

- Unit + integration tests for the manager, tools, and the GraphQL type‑registry
  wiring (param serialization, conjunctive labels, epoch‑ms conversion,
  confidence bounds, error paths).
- Extended `scripts/live_api_smoke.py` with REST + GraphQL `detection-search`
  assertions (incl. `min_confidence`).
- Validated end‑to‑end against a live UniFi Protect controller: label vocabulary,
  single + conjunctive label search, `asc`/`desc` ordering, `exclude_motion`,
  `min_confidence` thresholding, `start`/`end` windowing, the error envelopes, and
  the GraphQL + REST surfaces via the smoke harness (all assertions passing).
