### PR TITLE
fix(protect): fall back to legacy automations when v2 Alarm Manager is empty/unavailable

### DIFF
--- a/apps/protect/src/unifi_protect_mcp/tools/alarm.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/alarm.py
@@ -36,10 +36,15 @@ from unifi_protect_mcp.runtime import alarm_facade, alarm_manager, server
 logger = logging.getLogger(__name__)
 
 # Standard MCP _meta key (reverse-DNS, project-owned) signalling that the active
-# alarm backend is the limited one — AI-powered alarms are not visible without a
-# SuperAdmin credential. Anchored in the MCP _meta convention (see tasks.py).
+# alarm backend is the legacy one — used when the UniFi-OS Alarm Manager (v2)
+# returns no rules on this console, so any AI-powered alarms are not included.
+# Anchored in the MCP _meta convention (see tasks.py).
 _ALARM_COVERAGE_META = "com.github.sirkirby.unifi-mcp/alarm-coverage"
-_ALARM_COVERAGE_NOTICE = "AI-powered alarms are not included; viewing them requires a SuperAdmin credential."
+_ALARM_COVERAGE_NOTICE = (
+    "Showing legacy Protect automations: the UniFi-OS Alarm Manager (/api/v2/alarms) "
+    "returned no rules or is unavailable on this console, so AI-powered alarms "
+    "(where supported) are not included."
+)
 
 
 @server.tool(

--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
@@ -1,17 +1,22 @@
 """Version-agnostic alarm-rule façade.
 
 Presents a single capability — alarm rules — over the two UniFi alarm APIs.
-Prefers the UniFi-OS Alarm Manager (complete, incl. AI-powered alarms) when the
-credential allows it, and transparently falls back to the legacy automations API
-otherwise. Either way the result is the one canonical AlarmRule shape. Callers
+Prefers the UniFi-OS Alarm Manager (``/api/v2/alarms``) when it actually serves
+rules, and falls back to the legacy automations API when v2 is empty or
+unavailable on this console (e.g. Protect not yet migrated to v2, or the request
+is rejected). Either way the result is the one canonical AlarmRule shape. Callers
 never see which backend served the request; the tool/GraphQL layer surfaces the
-``complete`` flag via standard MCP ``_meta`` when the limited backend is used.
+``complete`` flag via standard MCP ``_meta`` when the legacy backend is used.
+Transient/server errors (5xx) are not masked — they propagate.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from uiprotect.exceptions import BadRequest
+
+from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.alarm_manager import AlarmManager
 from unifi_core.protect.managers.alarm_manager_service import AlarmManagerPermissionError, AlarmManagerService
 from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
@@ -30,18 +35,37 @@ class AlarmRulesFacade:
         return cls(AlarmManagerService(connection_manager), AlarmManager(connection_manager))
 
     async def list_rules(self) -> tuple[list[dict[str, Any]], bool]:
-        """Return ``(rules, complete)``. ``complete`` is False on the legacy fallback."""
+        """Return ``(rules, complete)``.
+
+        Prefer the v2 Alarm Manager, but fall back to the legacy automations API
+        whenever v2 cannot serve the rules on this console — that is, when it
+        returns an empty list (endpoint present but unpopulated, e.g. Protect not
+        yet migrated to ``/api/v2/alarms``) or rejects the request (any 4xx,
+        incl. permission and global-alarm-manager mode). ``complete`` is True
+        only when v2 actually served the rules.
+
+        Transient/server failures (5xx, timeouts -> ``NvrError``) are NOT masked:
+        they propagate so a real v2 outage is never silently hidden behind legacy.
+        """
         try:
-            return await self._service.list_rules(), True
-        except AlarmManagerPermissionError:
-            raw = await self._legacy.list_rules()
-            rules = [alarm_rule_from_legacy(rule).model_dump(exclude_none=True) for rule in raw]
-            return rules, False
+            rules = await self._service.list_rules()
+        except (AlarmManagerPermissionError, BadRequest):
+            rules = None
+        if rules:
+            return rules, True
+        raw = await self._legacy.list_rules()
+        return [alarm_rule_from_legacy(rule).model_dump(exclude_none=True) for rule in raw], False
 
     async def get_rule(self, rule_id: str) -> tuple[dict[str, Any], bool]:
-        """Return ``(rule, complete)`` for one rule by id."""
+        """Return ``(rule, complete)`` for one rule by id.
+
+        Fall back to the legacy automations API when v2 does not have the rule
+        (empty / not-yet-migrated -> not found) or rejects the request (any 4xx,
+        incl. permission). Transient/server failures (``NvrError``) propagate
+        rather than being masked by legacy.
+        """
         try:
             return await self._service.get_rule(rule_id), True
-        except AlarmManagerPermissionError:
+        except (AlarmManagerPermissionError, BadRequest, UniFiNotFoundError):
             raw = await self._legacy.get_rule(rule_id)
             return alarm_rule_from_legacy(raw).model_dump(exclude_none=True), False

--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager_service.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager_service.py
@@ -4,9 +4,13 @@ Reads the modern UniFi-OS alarm surface via ``uiprotect``'s ``api_request`` with
 an ``api_path`` override (lib-native; no bespoke client). This is the AI-capable
 Alarm Manager, distinct from the legacy Protect automations in ``alarm_manager``.
 
-**Requires a SuperAdmin credential.** A Protect-scoped account receives 403
-Forbidden, which is surfaced as :class:`AlarmManagerPermissionError` carrying
-actionable guidance so callers (and agents) can self-diagnose.
+A Protect-scoped account receives 403 Forbidden, surfaced as
+:class:`AlarmManagerPermissionError` with actionable guidance. An adequate
+(e.g. SuperAdmin) credential is necessary but not sufficient: on a console where
+Protect has not migrated to the Alarm Manager, this endpoint returns ``200 []``
+even when legacy automations exist, so an empty result here does not mean
+"no rules." :class:`~unifi_core.protect.managers.alarm_facade.AlarmRulesFacade`
+falls back to the legacy automations API on both 403 and empty/4xx for this reason.
 """
 
 import logging

--- a/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
@@ -3,6 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from uiprotect.exceptions import BadRequest, NvrError
+from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.alarm_facade import AlarmRulesFacade
 from unifi_core.protect.managers.alarm_manager_service import AlarmManagerPermissionError
 
@@ -16,15 +18,24 @@ _RAW_LEGACY = {
 }
 
 
-def _facade(*, service_list=None, service_err=False, legacy_list=None, service_get=None, legacy_get=None):
+def _facade(
+    *,
+    service_list=None,
+    service_err=False,
+    legacy_list=None,
+    service_get=None,
+    legacy_get=None,
+    list_exc=None,
+    get_exc=None,
+):
     service = MagicMock()
     legacy = MagicMock()
-    service.list_rules = AsyncMock(
-        side_effect=AlarmManagerPermissionError("x") if service_err else None, return_value=service_list
-    )
-    service.get_rule = AsyncMock(
-        side_effect=AlarmManagerPermissionError("x") if service_err else None, return_value=service_get
-    )
+    # service_err is shorthand for a v2 403; list_exc/get_exc inject other v2 errors.
+    # They are mutually exclusive — combining them would silently ignore service_err.
+    assert not (service_err and (list_exc or get_exc)), "pass service_err OR list_exc/get_exc, not both"
+    _perm = AlarmManagerPermissionError("x") if service_err else None
+    service.list_rules = AsyncMock(side_effect=list_exc or _perm, return_value=service_list)
+    service.get_rule = AsyncMock(side_effect=get_exc or _perm, return_value=service_get)
     legacy.list_rules = AsyncMock(return_value=legacy_list)
     legacy.get_rule = AsyncMock(return_value=legacy_get)
     return AlarmRulesFacade(service, legacy)
@@ -32,9 +43,11 @@ def _facade(*, service_list=None, service_err=False, legacy_list=None, service_g
 
 @pytest.mark.asyncio
 async def test_list_rules_prefers_alarm_manager_and_reports_complete():
-    rules, complete = await _facade(service_list=[_CANONICAL]).list_rules()
+    facade = _facade(service_list=[_CANONICAL])
+    rules, complete = await facade.list_rules()
     assert complete is True
     assert rules[0]["id"] == "uuid-1"
+    facade._legacy.list_rules.assert_not_called()  # v2 served -> legacy untouched
 
 
 @pytest.mark.asyncio
@@ -58,3 +71,44 @@ async def test_get_rule_falls_back_to_legacy_normalized():
     rule, complete = await _facade(service_err=True, legacy_get=_RAW_LEGACY).get_rule("66a5c92a0022f903e4000400")
     assert complete is False
     assert rule["title"] == "Motion"
+
+
+@pytest.mark.asyncio
+async def test_list_rules_falls_back_to_legacy_when_v2_empty():
+    # v2 endpoint exists but is unpopulated on this console (e.g. Protect not yet
+    # migrated to /api/v2/alarms) -> [] must fall back to legacy, not report 0 rules.
+    rules, complete = await _facade(service_list=[], legacy_list=[_RAW_LEGACY]).list_rules()
+    assert complete is False
+    assert rules[0]["id"] == "66a5c92a0022f903e4000400"
+    assert rules[0]["title"] == "Motion"
+
+
+@pytest.mark.asyncio
+async def test_list_rules_falls_back_on_v2_client_error():
+    # v2 4xx (e.g. 404 not found, 400 global-alarm-manager) -> BadRequest -> use legacy.
+    rules, complete = await _facade(list_exc=BadRequest("404"), legacy_list=[_RAW_LEGACY]).list_rules()
+    assert complete is False
+    assert rules[0]["title"] == "Motion"
+
+
+@pytest.mark.asyncio
+async def test_list_rules_propagates_v2_server_error():
+    # v2 5xx (NvrError) is a real/transient outage -> surface it; do NOT mask with legacy.
+    with pytest.raises(NvrError):
+        await _facade(list_exc=NvrError("500"), legacy_list=[_RAW_LEGACY]).list_rules()
+
+
+@pytest.mark.asyncio
+async def test_get_rule_falls_back_when_v2_not_found():
+    # v2 unpopulated -> service.get_rule raises NotFound -> fall back to legacy.
+    rule, complete = await _facade(
+        get_exc=UniFiNotFoundError("alarm rule", "66a5c92a0022f903e4000400"), legacy_get=_RAW_LEGACY
+    ).get_rule("66a5c92a0022f903e4000400")
+    assert complete is False
+    assert rule["title"] == "Motion"
+
+
+@pytest.mark.asyncio
+async def test_get_rule_propagates_v2_server_error():
+    with pytest.raises(NvrError):
+        await _facade(get_exc=NvrError("500"), legacy_get=_RAW_LEGACY).get_rule("x")


### PR DESCRIPTION
## Summary

- `AlarmRulesFacade` now falls back to the legacy automations API whenever the v2 Alarm Manager (`/api/v2/alarms`) cannot serve rules on this console — an empty result or any 4xx — not only on a 403.
- v2 5xx / transient errors (`NvrError`) now propagate instead of being masked by a legacy fallback.
- Corrected the misleading "Requires a SuperAdmin credential" framing in both the `_meta` coverage notice and the `AlarmManagerService` docstring — an empty v2 result is a not-migrated console, not a permission problem.
- Added five RED-first façade tests covering the empty / 4xx / 5xx / `get_rule` paths.

Regression from #320.

## Root Cause

#320 repointed the alarm-rule tools at the v2 Alarm Manager (`AlarmManagerService` → `/api/v2/alarms/protect`). On a console where Protect still serves rules only through the legacy automations API, `/api/v2/alarms/protect` returns `200 []` — the endpoint exists but is unpopulated. The façade fell back to legacy only on `AlarmManagerPermissionError` (403), so an empty v2 response was surfaced as "no rules," hiding the automations that are actually configured. `protect_alarm_list_rules` returned 0 even with many legacy rules present.

## Fix

`AlarmRulesFacade.list_rules` / `get_rule` prefer v2 when it serves rules, and fall back to legacy when it cannot:

- Empty v2 (`[]`) → legacy (endpoint present but unpopulated, e.g. Protect not yet migrated to `/api/v2/alarms`).
- Any v2 4xx — `BadRequest` (incl. 404 not-found and the 400 global-alarm-manager mode) and `AlarmManagerPermissionError` (403) → legacy.
- v2 5xx / transient (`NvrError`) → propagate; a real v2 outage must not be silently hidden behind legacy.

`complete` is `True` only when v2 served the rules; legacy responses are flagged through the existing `_meta` coverage key.

## Validation

- `uv run --directory packages/unifi-core --frozen --extra protect pytest tests/protect -k alarm -q` — 113 passed
- `uv run --directory apps/protect --frozen pytest tests -k alarm -q` — 22 passed
- `uv run --directory apps/api --frozen pytest tests -k alarm -q` — 21 passed
- `ruff format --check .` and `ruff check .` — clean
- Live, against a UniFi OS console where Protect has not migrated to `/api/v2/alarms`: `protect_alarm_list_rules` returned the full set of configured legacy automations (previously `0`), each normalized to the canonical `AlarmRule` shape with 24-hex legacy ids, and the response carried the `_meta` coverage flag.
