### PR TITLE
feat(protect): surface recognized license plate identity on events

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -643,6 +643,9 @@ type Event {
   recognizedPersonId: ID
   recognizedPersonName: String
   recognizedPersonConfidence: Int
+  recognizedPlateText: String
+  recognizedPlateGroupId: ID
+  recognizedPlateConfidence: Int
   detectedThumbnailId: ID
 }
 
@@ -1628,6 +1631,9 @@ type SmartDetection {
   recognizedPersonId: ID
   recognizedPersonName: String
   recognizedPersonConfidence: Int
+  recognizedPlateText: String
+  recognizedPlateGroupId: ID
+  recognizedPlateConfidence: Int
   detectedThumbnailId: ID
 }
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2270,6 +2270,39 @@
             ],
             "title": "Recognized Person Name"
           },
+          "recognized_plate_confidence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Plate Confidence"
+          },
+          "recognized_plate_group_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Plate Group Id"
+          },
+          "recognized_plate_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Plate Text"
+          },
           "score": {
             "anyOf": [
               {
@@ -5566,6 +5599,39 @@
               }
             ],
             "title": "Recognized Person Name"
+          },
+          "recognized_plate_confidence": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Plate Confidence"
+          },
+          "recognized_plate_group_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Plate Group Id"
+          },
+          "recognized_plate_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recognized Plate Text"
           },
           "score": {
             "anyOf": [

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -632,6 +632,9 @@ type Event {
   recognizedPersonId: ID
   recognizedPersonName: String
   recognizedPersonConfidence: Int
+  recognizedPlateText: String
+  recognizedPlateGroupId: ID
+  recognizedPlateConfidence: Int
   detectedThumbnailId: ID
 }
 
@@ -1617,6 +1620,9 @@ type SmartDetection {
   recognizedPersonId: ID
   recognizedPersonName: String
   recognizedPersonConfidence: Int
+  recognizedPlateText: String
+  recognizedPlateGroupId: ID
+  recognizedPlateConfidence: Int
   detectedThumbnailId: ID
 }
 

--- a/apps/api/src/unifi_api/graphql/types/protect/events.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/events.py
@@ -64,6 +64,9 @@ class Event:
     recognized_person_id: strawberry.ID | None
     recognized_person_name: str | None
     recognized_person_confidence: int | None
+    recognized_plate_text: str | None
+    recognized_plate_group_id: strawberry.ID | None
+    recognized_plate_confidence: int | None
     detected_thumbnail_id: strawberry.ID | None
 
     # Context for relationship edges — NOT in SDL, NOT in to_dict().
@@ -92,6 +95,9 @@ class Event:
             recognized_person_id=_get(obj, "recognized_person_id"),
             recognized_person_name=_get(obj, "recognized_person_name"),
             recognized_person_confidence=_get(obj, "recognized_person_confidence"),
+            recognized_plate_text=_get(obj, "recognized_plate_text"),
+            recognized_plate_group_id=_get(obj, "recognized_plate_group_id"),
+            recognized_plate_confidence=_get(obj, "recognized_plate_confidence"),
             detected_thumbnail_id=_get(obj, "detected_thumbnail_id"),
         )
 
@@ -108,6 +114,9 @@ class Event:
             "recognized_person_id": self.recognized_person_id,
             "recognized_person_name": self.recognized_person_name,
             "recognized_person_confidence": self.recognized_person_confidence,
+            "recognized_plate_text": self.recognized_plate_text,
+            "recognized_plate_group_id": self.recognized_plate_group_id,
+            "recognized_plate_confidence": self.recognized_plate_confidence,
             "detected_thumbnail_id": self.detected_thumbnail_id,
         }
 
@@ -130,6 +139,9 @@ class SmartDetection:
     recognized_person_id: strawberry.ID | None
     recognized_person_name: str | None
     recognized_person_confidence: int | None
+    recognized_plate_text: str | None
+    recognized_plate_group_id: strawberry.ID | None
+    recognized_plate_confidence: int | None
     detected_thumbnail_id: strawberry.ID | None
 
     @classmethod
@@ -155,6 +167,9 @@ class SmartDetection:
             recognized_person_id=_get(obj, "recognized_person_id"),
             recognized_person_name=_get(obj, "recognized_person_name"),
             recognized_person_confidence=_get(obj, "recognized_person_confidence"),
+            recognized_plate_text=_get(obj, "recognized_plate_text"),
+            recognized_plate_group_id=_get(obj, "recognized_plate_group_id"),
+            recognized_plate_confidence=_get(obj, "recognized_plate_confidence"),
             detected_thumbnail_id=_get(obj, "detected_thumbnail_id"),
         )
 
@@ -171,6 +186,9 @@ class SmartDetection:
             "recognized_person_id": self.recognized_person_id,
             "recognized_person_name": self.recognized_person_name,
             "recognized_person_confidence": self.recognized_person_confidence,
+            "recognized_plate_text": self.recognized_plate_text,
+            "recognized_plate_group_id": self.recognized_plate_group_id,
+            "recognized_plate_confidence": self.recognized_plate_confidence,
             "detected_thumbnail_id": self.detected_thumbnail_id,
         }
 

--- a/apps/api/tests/graphql/fixtures/protect/test_events.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_events.py
@@ -153,6 +153,79 @@ async def test_protect_smart_detections_list(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_protect_event_detail_surfaces_plate_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "list_events"): [
+                {
+                    "id": "evt1",
+                    "type": "smartDetectZone",
+                    "camera_id": "cam1",
+                    "start": 1000,
+                    "recognized_plate_text": "ABC123",
+                    "recognized_plate_group_id": "plate-group-1",
+                    "recognized_plate_confidence": 88,
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ event(controller: "{cid}", id: "evt1") {{
+            id recognizedPlateText recognizedPlateGroupId recognizedPlateConfidence
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    event = body["data"]["protect"]["event"]
+    assert event["recognizedPlateText"] == "ABC123"
+    assert event["recognizedPlateGroupId"] == "plate-group-1"
+    assert event["recognizedPlateConfidence"] == 88
+
+
+@pytest.mark.asyncio
+async def test_protect_smart_detections_surface_plate_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {
+            ("protect", "event_manager", "list_smart_detections"): [
+                {
+                    "id": "sd1",
+                    "type": "vehicle",
+                    "camera_id": "cam1",
+                    "start": 1000,
+                    "score": 90,
+                    "recognized_plate_text": "ABC123",
+                    "recognized_plate_group_id": "plate-group-1",
+                    "recognized_plate_confidence": 88,
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ smartDetections(controller: "{cid}", limit: 10) {{
+            items {{ id recognizedPlateText recognizedPlateGroupId recognizedPlateConfidence }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    item = body["data"]["protect"]["smartDetections"]["items"][0]
+    assert item["recognizedPlateText"] == "ABC123"
+    assert item["recognizedPlateGroupId"] == "plate-group-1"
+    assert item["recognizedPlateConfidence"] == 88
+
+
+@pytest.mark.asyncio
 async def test_protect_alarm_status(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="protect")

--- a/apps/api/tests/routes/resources/test_protect_events_system.py
+++ b/apps/api/tests/routes/resources/test_protect_events_system.py
@@ -201,6 +201,44 @@ async def test_get_event_happy_path(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_event_surfaces_plate_identity(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    payload = {
+        "id": "ev-2",
+        "type": "smartDetectZone",
+        "start": 1700000000,
+        "end": 1700000010,
+        "camera_id": "cam-1",
+        "score": 88,
+        "recognized_plate_text": "ABC123",
+        "recognized_plate_group_id": "plate-group-1",
+        "recognized_plate_confidence": 88,
+    }
+
+    async def fake(self, event_id):
+        assert event_id == "ev-2"
+        return payload
+
+    from unifi_core.protect.managers.event_manager import EventManager
+
+    monkeypatch.setattr(EventManager, "get_event", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/events/ev-2?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["data"]["recognized_plate_text"] == "ABC123"
+    assert body["data"]["recognized_plate_group_id"] == "plate-group-1"
+    assert body["data"]["recognized_plate_confidence"] == 88
+
+
+@pytest.mark.asyncio
 async def test_get_event_404_via_unifi_not_found(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)

--- a/apps/protect/src/unifi_protect_mcp/tools/events.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/events.py
@@ -57,7 +57,8 @@ def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
         "the Protect controller's database via REST API. Supports filtering by "
         "time range, event type (motion, smartDetectZone, ring, etc.), camera ID, "
         "and result limit. Face events include recognized Known Face identity "
-        "fields when Protect provides them. For real-time buffer events use "
+        "fields, and license-plate (LPR) events include recognized plate identity "
+        "fields, when Protect provides them. For real-time buffer events use "
         "protect_recent_events."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
@@ -132,7 +133,8 @@ async def protect_list_events(
     description=(
         "Get detailed information for a single event by ID. Returns event type, "
         "camera, timestamps, score, smart detection types, thumbnail info, and "
-        "recognized Known Face identity fields when Protect provides them."
+        "recognized Known Face and license-plate (LPR) identity fields when "
+        "Protect provides them."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -206,8 +208,9 @@ async def protect_get_event_thumbnail(
         "with optional filters. Filters by detection type, camera, confidence "
         "score, and time range. Only returns events above the minimum confidence "
         "threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE). "
-        "Face detections include recognized Known Face identity fields when "
-        "Protect provides them."
+        "Face detections include recognized Known Face identity fields, and "
+        "license-plate (LPR) detections include recognized plate identity fields, "
+        "when Protect provides them."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -397,7 +400,8 @@ async def protect_detection_search_labels() -> Dict[str, Any]:
         "Get recent events from the in-memory websocket buffer. This is fast "
         "(no API call) and returns events received via the real-time websocket "
         "stream. Supports filtering by event_type, camera_id, min_confidence, "
-        "and limit. Face events include recognized Known Face identity fields "
+        "and limit. Face events include recognized Known Face identity fields, "
+        "and license-plate (LPR) events include recognized plate identity fields, "
         "when Protect provides them. Use this for real-time monitoring; use "
         "protect_list_events for historical queries."
     ),

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -2139,7 +2139,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get detailed information for a single event by ID. Returns event type, camera, timestamps, score, smart detection types, thumbnail info, and recognized Known Face identity fields when Protect provides them.",
+      "description": "Get detailed information for a single event by ID. Returns event type, camera, timestamps, score, smart detection types, thumbnail info, and recognized Known Face and license-plate (LPR) identity fields when Protect provides them.",
       "name": "protect_get_event",
       "schema": {
         "input": {
@@ -2948,7 +2948,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Query events from the NVR with optional filters. Returns events from the Protect controller's database via REST API. Supports filtering by time range, event type (motion, smartDetectZone, ring, etc.), camera ID, and result limit. Face events include recognized Known Face identity fields when Protect provides them. For real-time buffer events use protect_recent_events.",
+      "description": "Query events from the NVR with optional filters. Returns events from the Protect controller's database via REST API. Supports filtering by time range, event type (motion, smartDetectZone, ring, etc.), camera ID, and result limit. Face events include recognized Known Face identity fields, and license-plate (LPR) events include recognized plate identity fields, when Protect provides them. For real-time buffer events use protect_recent_events.",
       "name": "protect_list_events",
       "schema": {
         "input": {
@@ -3639,7 +3639,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List smart detection events (person, vehicle, animal, package, etc.) with optional filters. Filters by detection type, camera, confidence score, and time range. Only returns events above the minimum confidence threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE). Face detections include recognized Known Face identity fields when Protect provides them.",
+      "description": "List smart detection events (person, vehicle, animal, package, etc.) with optional filters. Filters by detection type, camera, confidence score, and time range. Only returns events above the minimum confidence threshold (default 50, configurable via PROTECT_SMART_DETECTION_MIN_CONFIDENCE). Face detections include recognized Known Face identity fields, and license-plate (LPR) detections include recognized plate identity fields, when Protect provides them.",
       "name": "protect_list_smart_detections",
       "schema": {
         "input": {
@@ -4417,7 +4417,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by event_type, camera_id, min_confidence, and limit. Face events include recognized Known Face identity fields when Protect provides them. Use this for real-time monitoring; use protect_list_events for historical queries.",
+      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by event_type, camera_id, min_confidence, and limit. Face events include recognized Known Face identity fields, and license-plate (LPR) events include recognized plate identity fields, when Protect provides them. Use this for real-time monitoring; use protect_list_events for historical queries.",
       "name": "protect_recent_events",
       "schema": {
         "input": {

--- a/apps/protect/tests/unit/test_event_manager.py
+++ b/apps/protect/tests/unit/test_event_manager.py
@@ -364,6 +364,44 @@ class TestEventManagerGetEvent:
         cm.client.get_events.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_backfills_plate_metadata_from_list_path(self):
+        """get_event's detail endpoint drops the plate group id (keeps text +
+        confidence); recover the stable group id from the list/search path,
+        mirroring the face backfill."""
+        detail_event = _make_event(
+            id="evt-lpr-1",
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.LICENSE_PLATE, SmartDetectObjectType.VEHICLE],
+            # detail thumbnail carries the plate text + confidence but NO group.id
+            metadata={"detectedThumbnails": [{"type": "vehicle", "name": "ABC123", "confidence": 90}]},
+        )
+        list_event = _make_event(
+            id="evt-lpr-1",
+            type=EventType.SMART_DETECT,
+            smart_detect_types=[SmartDetectObjectType.LICENSE_PLATE, SmartDetectObjectType.VEHICLE],
+            metadata={
+                "detectedThumbnails": [
+                    {
+                        "type": "vehicle",
+                        "name": "ABC123",
+                        "group": {"id": "plate-group-1", "matchedName": "ABC123", "confidence": 91},
+                    }
+                ]
+            },
+        )
+        cm = _make_connection_manager()
+        cm.client.get_event = AsyncMock(return_value=detail_event)
+        cm.client.get_events = AsyncMock(return_value=[list_event])
+        mgr = EventManager(cm)
+
+        result = await mgr.get_event("evt-lpr-1")
+
+        assert result["recognized_plate_text"] == "ABC123"
+        assert result["recognized_plate_group_id"] == "plate-group-1"
+        assert result["recognized_plate_confidence"] == 91
+        cm.client.get_events.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_not_found(self):
         cm = _make_connection_manager()
         cm.client.get_event = AsyncMock(side_effect=Exception("404 Not Found"))

--- a/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
@@ -349,6 +349,68 @@ class EventManager:
             fields["detected_thumbnail_id"] = detected_thumbnail_id
         return fields
 
+    def _license_plate_recognition_fields(self, event: Event) -> dict[str, Any]:
+        """Extract recognized license-plate identity metadata from detected thumbnails.
+
+        Mirrors :meth:`_face_recognition_fields` but targets LPR detections. The
+        Protect API delivers the recognized plate text on the ``vehicle`` (or
+        occasionally ``licensePlate``) thumbnail inside ``event.metadata.detected_thumbnails``;
+        when present, it appears as ``thumbnail.name`` and/or
+        ``thumbnail.group.matched_name``. The plate's group UUID and the
+        recognition confidence are on the same ``group`` sub-object.
+        """
+        thumbnails = self._detected_thumbnails(event)
+        if not thumbnails:
+            return {}
+
+        smart_detect_types = set(_enum_values(_get_any(event, "smart_detect_types", "smartDetectTypes")))
+        if "licensePlate" not in smart_detect_types:
+            return {}
+
+        def _plate_text(thumb: Any) -> str | None:
+            group = _get(thumb, "group")
+            return _get_any(group, "matched_name", "matchedName", "name") or _get_any(
+                thumb, "matched_name", "matchedName", "name"
+            )
+
+        # On LPR events the carrying thumbnail.type is usually "vehicle", but
+        # accept "licensePlate" defensively; either way it must have a plate
+        # string to be considered a recognition payload.
+        candidates = [
+            thumb for thumb in thumbnails if _get(thumb, "type") in ("vehicle", "licensePlate") and _plate_text(thumb)
+        ]
+        if not candidates:
+            return {}
+
+        def _score(thumb: Any) -> tuple[int, int]:
+            group = _get(thumb, "group")
+            confidence = _coerce_int(
+                _get_any(group, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+                or _get_any(thumb, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+            )
+            group_id = _get_any(group, "id", "group_id", "groupId") or _get_any(thumb, "group_id", "groupId")
+            return (1 if group_id else 0, confidence or 0)
+
+        thumbnail = max(candidates, key=_score)
+        group = _get(thumbnail, "group")
+        plate_text = _plate_text(thumbnail)
+        plate_group_id = _stringify(
+            _get_any(group, "id", "group_id", "groupId") or _get_any(thumbnail, "group_id", "groupId")
+        )
+        plate_confidence = _coerce_int(
+            _get_any(group, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+            or _get_any(thumbnail, "confidence", "matched_group_confidence", "matchedGroupConfidence")
+        )
+
+        fields: dict[str, Any] = {}
+        if plate_text:
+            fields["recognized_plate_text"] = str(plate_text)
+        if plate_group_id:
+            fields["recognized_plate_group_id"] = plate_group_id
+        if plate_confidence is not None:
+            fields["recognized_plate_confidence"] = plate_confidence
+        return fields
+
     async def _lookup_event_recognition_fields(self, event: Event) -> dict[str, Any]:
         """Fetch the same face event from the list/search path when detail drops group metadata."""
         if "face" not in set(_enum_values(_get(event, "smart_detect_types"))):
@@ -374,6 +436,36 @@ class EventManager:
         for candidate in events:
             if candidate.id == event.id:
                 return self._face_recognition_fields(candidate)
+        return {}
+
+    async def _lookup_event_plate_recognition_fields(self, event: Event) -> dict[str, Any]:
+        """Fetch the same LPR event from the list/search path when the detail
+        endpoint drops the plate group metadata (it keeps the plate text and
+        confidence but not the stable group id). Mirrors
+        :meth:`_lookup_event_recognition_fields` for license plates."""
+        if "licensePlate" not in set(_enum_values(_get(event, "smart_detect_types"))):
+            return {}
+
+        kwargs: dict[str, Any] = {
+            "limit": 100,
+            "sorting": "desc",
+            "types": [EventType.SMART_DETECT, EventType.SMART_DETECT_LINE],
+            "smart_detect_types": [SmartDetectObjectType.LICENSE_PLATE],
+        }
+        if event.start:
+            kwargs["start"] = event.start - timedelta(seconds=5)
+            end = event.end or event.start
+            kwargs["end"] = end + timedelta(minutes=1)
+
+        try:
+            events: list[Event] = await self._cm.client.get_events(**kwargs)
+        except Exception:
+            logger.debug("[event-mgr] Unable to backfill plate metadata for event %s", event.id, exc_info=True)
+            return {}
+
+        for candidate in events:
+            if candidate.id == event.id:
+                return self._license_plate_recognition_fields(candidate)
         return {}
 
     async def _known_face_names_by_id(self) -> dict[str, str]:
@@ -437,6 +529,7 @@ class EventManager:
             "smart_detect_types": _enum_values(event.smart_detect_types),
         }
         result.update(self._face_recognition_fields(event))
+        result.update(self._license_plate_recognition_fields(event))
         if not compact:
             result["thumbnail_id"] = event.thumbnail_id
             result["category"] = event.category
@@ -489,12 +582,10 @@ class EventManager:
             "score": _get(raw, "score"),
             "smart_detect_types": sdt,
         }
-        # Existing face convenience extractor (relies on _get/_get_any which
-        # handle both Event objects and dicts) keeps working untouched.
-        # Note: PR-4 introduces _license_plate_recognition_fields on a separate
-        # branch. This PR does not depend on PR-4; when both merge an integration
-        # commit will add the parallel call here.
+        # Face + license-plate convenience extractors (rely on _get/_get_any,
+        # which read both parsed Event objects and raw camelCase dicts).
         result.update(self._face_recognition_fields(raw))
+        result.update(self._license_plate_recognition_fields(raw))
 
         if not compact:
             result["thumbnail_id"] = _get(raw, "thumbnail") or _get(raw, "thumbnail_id")
@@ -659,6 +750,8 @@ class EventManager:
         result = self._event_to_dict(event)
         if not result.get("recognized_person_id") and not result.get("recognized_person_name"):
             result.update(await self._lookup_event_recognition_fields(event))
+        if not result.get("recognized_plate_group_id"):
+            result.update(await self._lookup_event_plate_recognition_fields(event))
         await self._apply_known_face_names([result])
         return result
 

--- a/packages/unifi-core/src/unifi_core/protect/models/events.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/events.py
@@ -49,6 +49,21 @@ class Event(BaseModel):
     recognized_person_confidence: Optional[int] = Field(
         default=None, description="Known Face match confidence when present", json_schema_extra={"mutable": False}
     )
+    recognized_plate_text: Optional[str] = Field(
+        default=None,
+        description="Recognized license-plate text (e.g. 'ABC123') when LPR fires on a vehicle event",
+        json_schema_extra={"mutable": False},
+    )
+    recognized_plate_group_id: Optional[str] = Field(
+        default=None,
+        description="Recognized license-plate group UUID (a stable ID per recognized plate) when present",
+        json_schema_extra={"mutable": False},
+    )
+    recognized_plate_confidence: Optional[int] = Field(
+        default=None,
+        description="License-plate match confidence (0-100) when LPR fires",
+        json_schema_extra={"mutable": False},
+    )
     metadata: Optional[dict[str, Any]] = Field(
         default=None,
         description=(
@@ -101,6 +116,21 @@ class SmartDetection(BaseModel):
     )
     recognized_person_confidence: Optional[int] = Field(
         default=None, description="Known Face match confidence when present", json_schema_extra={"mutable": False}
+    )
+    recognized_plate_text: Optional[str] = Field(
+        default=None,
+        description="Recognized license-plate text (e.g. 'ABC123') when LPR fires on a vehicle event",
+        json_schema_extra={"mutable": False},
+    )
+    recognized_plate_group_id: Optional[str] = Field(
+        default=None,
+        description="Recognized license-plate group UUID (a stable ID per recognized plate) when present",
+        json_schema_extra={"mutable": False},
+    )
+    recognized_plate_confidence: Optional[int] = Field(
+        default=None,
+        description="License-plate match confidence (0-100) when LPR fires",
+        json_schema_extra={"mutable": False},
     )
     metadata: Optional[dict[str, Any]] = Field(
         default=None,
@@ -214,6 +244,9 @@ def from_controller(raw: Any) -> Event:
         recognized_person_id=_get(raw, "recognized_person_id"),
         recognized_person_name=_get(raw, "recognized_person_name"),
         recognized_person_confidence=_get(raw, "recognized_person_confidence"),
+        recognized_plate_text=_get(raw, "recognized_plate_text"),
+        recognized_plate_group_id=_get(raw, "recognized_plate_group_id"),
+        recognized_plate_confidence=_get(raw, "recognized_plate_confidence"),
         metadata=_get(raw, "metadata"),
         detected_thumbnail_id=_get_any(raw, "detected_thumbnail_id", "detectedThumbnailId"),
     )
@@ -240,6 +273,9 @@ def smart_detection_from_controller(raw: Any) -> SmartDetection:
         recognized_person_id=_get(raw, "recognized_person_id"),
         recognized_person_name=_get(raw, "recognized_person_name"),
         recognized_person_confidence=_get(raw, "recognized_person_confidence"),
+        recognized_plate_text=_get(raw, "recognized_plate_text"),
+        recognized_plate_group_id=_get(raw, "recognized_plate_group_id"),
+        recognized_plate_confidence=_get(raw, "recognized_plate_confidence"),
         metadata=_get(raw, "metadata"),
         detected_thumbnail_id=_get_any(raw, "detected_thumbnail_id", "detectedThumbnailId"),
     )

--- a/packages/unifi-core/tests/protect/managers/test_event_manager_recognition.py
+++ b/packages/unifi-core/tests/protect/managers/test_event_manager_recognition.py
@@ -1,0 +1,186 @@
+"""Tests for EventManager._license_plate_recognition_fields.
+
+The new method mirrors the face-recognition extractor but targets LPR
+events. The carrying thumbnail's ``type`` is ``"vehicle"`` (per live UNVR
+data); the plate string lives at ``thumbnail.name`` and is mirrored at
+``thumbnail.group.matched_name``; the plate's stable group UUID and the
+recognition confidence sit on the same ``group`` sub-object.
+"""
+
+from unittest.mock import MagicMock
+
+from unifi_core.protect.managers.event_manager import EventManager
+
+
+def _make_manager() -> EventManager:
+    return EventManager(MagicMock())
+
+
+def _lpr_event(thumbnails: list[dict], smart_detect_types: list[str] | None = None) -> dict:
+    """Build a minimal event dict resembling a uiprotect Event payload.
+
+    The recognition extractor reads via the polymorphic ``_get`` / ``_get_any``
+    helpers, so a plain dict suffices — no need for the full pydantic shape.
+    """
+    return {
+        "id": "evt_test",
+        "smart_detect_types": smart_detect_types if smart_detect_types is not None else ["licensePlate", "vehicle"],
+        "metadata": {"detected_thumbnails": thumbnails},
+    }
+
+
+def test_plate_fields_populated_when_lpr_thumbnail_present() -> None:
+    """Vehicle thumbnail with a plate string yields all three plate fields."""
+    mgr = _make_manager()
+    event = _lpr_event(
+        thumbnails=[
+            {
+                "type": "vehicle",
+                "name": "ABC123",
+                "cropped_id": "thumb-1",
+                "group": {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "name": None,
+                    "matched_name": "ABC123",
+                    "confidence": 86,
+                },
+            }
+        ]
+    )
+
+    fields = mgr._license_plate_recognition_fields(event)
+
+    assert fields["recognized_plate_text"] == "ABC123"
+    assert fields["recognized_plate_group_id"] == "11111111-1111-1111-1111-111111111111"
+    assert fields["recognized_plate_confidence"] == 86
+
+
+def test_returns_empty_when_smart_detect_types_lacks_license_plate() -> None:
+    """Vehicle-only events (no LPR) must not surface plate fields even if a thumbnail name looks plate-like."""
+    mgr = _make_manager()
+    event = _lpr_event(
+        thumbnails=[
+            {
+                "type": "vehicle",
+                "name": "SOMETHING",
+                "group": {"id": "g1", "matched_name": "SOMETHING", "confidence": 70},
+            }
+        ],
+        smart_detect_types=["vehicle"],  # NOT licensePlate
+    )
+
+    assert mgr._license_plate_recognition_fields(event) == {}
+
+
+def test_returns_empty_when_no_thumbnail_carries_plate_text() -> None:
+    """LPR was signaled but no thumbnail actually carries a plate string (rare but possible)."""
+    mgr = _make_manager()
+    event = _lpr_event(
+        thumbnails=[
+            {
+                "type": "vehicle",
+                "name": None,
+                "group": {"id": None, "matched_name": None, "confidence": None},
+            }
+        ]
+    )
+
+    assert mgr._license_plate_recognition_fields(event) == {}
+
+
+def test_picks_candidate_with_group_id_over_one_without() -> None:
+    """When multiple plate-bearing thumbnails exist, prefer the one with a group_id."""
+    mgr = _make_manager()
+    event = _lpr_event(
+        thumbnails=[
+            {
+                "type": "vehicle",
+                "name": "AAA111",
+                "group": {"id": None, "matched_name": "AAA111", "confidence": 99},  # higher conf but no id
+            },
+            {
+                "type": "vehicle",
+                "name": "BBB222",
+                "group": {"id": "g_winner", "matched_name": "BBB222", "confidence": 70},  # lower conf but has id
+            },
+        ]
+    )
+
+    fields = mgr._license_plate_recognition_fields(event)
+
+    assert fields["recognized_plate_text"] == "BBB222"
+    assert fields["recognized_plate_group_id"] == "g_winner"
+    assert fields["recognized_plate_confidence"] == 70
+
+
+def _lpr_event_raw(thumbnails: list[dict], smart_detect_types: list[str] | None = None) -> dict:
+    """Build a RAW UniFi event dict as ``api_request_list`` returns it.
+
+    Unlike :func:`_lpr_event`, raw rows use camelCase keys (``smartDetectTypes``,
+    ``detectedThumbnails``) — the shape the ``_raw_event_to_dict`` path consumes.
+    The recognition extractor must read both casings or plate identity silently
+    vanishes on the primary list/search/query tools.
+    """
+    return {
+        "id": "evt_raw",
+        "type": "smartDetectZone",
+        "start": 1717612345000,
+        "end": 1717612350000,
+        "smartDetectTypes": smart_detect_types if smart_detect_types is not None else ["licensePlate", "vehicle"],
+        "metadata": {
+            "detectedThumbnails": thumbnails,
+        },
+    }
+
+
+def test_plate_fields_populated_on_raw_camelcase_event() -> None:
+    """The extractor must honor camelCase ``smartDetectTypes`` from raw rows."""
+    mgr = _make_manager()
+    event = _lpr_event_raw(
+        thumbnails=[
+            {
+                "type": "vehicle",
+                "name": "XYZ789",
+                "croppedId": "thumb-raw-1",
+                "group": {
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "matchedName": "XYZ789",
+                    "matchedGroupConfidence": 91,
+                },
+            }
+        ]
+    )
+
+    fields = mgr._license_plate_recognition_fields(event)
+
+    assert fields["recognized_plate_text"] == "XYZ789"
+    assert fields["recognized_plate_group_id"] == "33333333-3333-3333-3333-333333333333"
+    assert fields["recognized_plate_confidence"] == 91
+
+
+def test_raw_event_to_dict_surfaces_plate_fields() -> None:
+    """Plate identity must flow through the primary ``_raw_event_to_dict`` path.
+
+    ``_raw_event_to_dict`` backs protect_list_events / protect_get_event /
+    protect_list_smart_detections — the tools an LPR consumer actually calls.
+    """
+    mgr = _make_manager()
+    raw = _lpr_event_raw(
+        thumbnails=[
+            {
+                "type": "vehicle",
+                "name": "PLT456",
+                "group": {
+                    "id": "44444444-4444-4444-4444-444444444444",
+                    "matchedName": "PLT456",
+                    "matchedGroupConfidence": 88,
+                },
+            }
+        ]
+    )
+
+    result = mgr._raw_event_to_dict(raw)
+
+    assert result["recognized_plate_text"] == "PLT456"
+    assert result["recognized_plate_group_id"] == "44444444-4444-4444-4444-444444444444"
+    assert result["recognized_plate_confidence"] == 88


### PR DESCRIPTION
## Summary

UniFi Protect surfaces recognized **face** identity (`recognized_person_id` / `_name` / `_confidence`) on event records, but there is no parallel for **License Plate Recognition**. This adds the equivalent plate identity, mirroring the face feature, so consumers can correlate a vehicle event to a recognized plate.

Three new optional fields on the `Event` and `SmartDetection` shapes (and their controller parsers):

- `recognized_plate_text` — the recognized plate string (e.g. `ABC123`)
- `recognized_plate_group_id` — the stable per-plate group UUID (survives OCR drift across captures of the same vehicle)
- `recognized_plate_confidence` — match confidence (0–100)

## How it works

`EventManager._license_plate_recognition_fields()` mirrors `_face_recognition_fields()`. On live payloads the carrying detected-thumbnail's `type` is `vehicle` (not `licensePlate`) while the event-level `smart_detect_types` contains `licensePlate`, so the method gates on the event-level enum and accepts thumbnail type `vehicle`/`licensePlate`. It is wired into **both** event projection paths — `_event_to_dict` (parsed) and `_raw_event_to_dict` (the raw `api_request_list` path that backs `protect_list_events` / `protect_get_event` / `protect_list_smart_detections`) — and reads `smart_detect_types` in either snake_case or camelCase so plate identity also surfaces on the raw list path.

Like faces, the `events/<id>` detail endpoint returns the plate text and confidence but drops the stable group id; `_lookup_event_plate_recognition_fields()` (mirroring the face backfill) recovers it from the list/search path when it is missing.

The `apps/api` GraphQL `Event`/`SmartDetection` types and REST projections expose the three fields; the GraphQL schema, OpenAPI spec, reference docs, and the protect tool manifest are regenerated.

## Testing

- **Unit:** raw camelCase extraction, end-to-end `_raw_event_to_dict`, candidate scoring, and the `get_event` group-id backfill (mirroring the face backfill test); GraphQL (event detail + smart detections) and REST (`get_event`) fixtures.
- **Live:** exercised `protect_list_smart_detections`, `protect_list_events`, and `protect_get_event` against a live controller — plate identity surfaces on the list/search paths, the `get_event` backfill recovers the group id, and existing face identity continues to surface alongside plate identity on mixed events.

## Notes

- `detected_thumbnail_id` is populated by the face extractor (from the matched face thumbnail); a pure-LPR event with no face thumbnail will not carry it. Left as-is for parity with the existing face path rather than guessing at a vehicle-thumbnail id.
- The plate `smart_detect_types` gate reads both snake_case and camelCase (`smartDetectTypes`); the existing face extractor reads snake_case only, which is fine for it because it also matches `type == "face"` thumbnails directly.
