### PR TITLE
fix(access): handle structured location object on AccessDevice

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -16,7 +16,7 @@ type AccessDevice {
   type: String
   isOnline: Boolean
   firmwareVersion: String
-  location: String
+  location: AccessLocation
 }
 
 """Paginated page of UniFi Access devices."""
@@ -54,6 +54,18 @@ type AccessHealth {
   numDoors: Int
   numDevices: Int
   numOfflineDevices: Int
+}
+
+"""
+Structured location reference (door / floor / building) for an Access device.
+"""
+type AccessLocation {
+  uniqueId: ID
+  name: String
+  upId: ID
+  locationType: String
+  fullName: String
+  level: Int
 }
 
 """Read-only access to UniFi Access resources."""

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -5,7 +5,7 @@ type AccessDevice {
   type: String
   isOnline: Boolean
   firmwareVersion: String
-  location: String
+  location: AccessLocation
 }
 
 """Paginated page of UniFi Access devices."""
@@ -43,6 +43,18 @@ type AccessHealth {
   numDoors: Int
   numDevices: Int
   numOfflineDevices: Int
+}
+
+"""
+Structured location reference (door / floor / building) for an Access device.
+"""
+type AccessLocation {
+  uniqueId: ID
+  name: String
+  upId: ID
+  locationType: String
+  fullName: String
+  level: Int
 }
 
 """Read-only access to UniFi Access resources."""

--- a/apps/api/src/unifi_api/graphql/types/access/devices.py
+++ b/apps/api/src/unifi_api/graphql/types/access/devices.py
@@ -41,6 +41,45 @@ def _is_online(obj: Any) -> Any:
     return None
 
 
+@strawberry.type(description="Structured location reference (door / floor / building) for an Access device.")
+class AccessLocation:
+    """Mirrors the ``unifi_core`` ``AccessLocation`` model. UNVR's Access API
+    returns ``location`` as this object, not a bare string; a bare string (the
+    pre-fix / proxy ``_door_name`` shape) maps to ``name``."""
+
+    unique_id: strawberry.ID | None
+    name: str | None
+    up_id: strawberry.ID | None
+    location_type: str | None
+    full_name: str | None
+    level: int | None
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "AccessLocation | None":
+        if obj is None:
+            return None
+        if isinstance(obj, str):
+            stripped = obj.strip()
+            if not stripped:
+                return None
+            return cls(
+                unique_id=None,
+                name=stripped,
+                up_id=None,
+                location_type=None,
+                full_name=None,
+                level=None,
+            )
+        return cls(
+            unique_id=_get(obj, "unique_id"),
+            name=_get(obj, "name"),
+            up_id=_get(obj, "up_id"),
+            location_type=_get(obj, "location_type"),
+            full_name=_get(obj, "full_name"),
+            level=_get(obj, "level"),
+        )
+
+
 @strawberry.type(description="A UniFi Access device (reader / hub / lock).")
 class AccessDevice:
     """Mirrors ``AccessDeviceSerializer.serialize`` projection byte-for-byte."""
@@ -50,7 +89,7 @@ class AccessDevice:
     type: str | None
     is_online: bool | None
     firmware_version: str | None
-    location: str | None
+    location: AccessLocation | None
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
@@ -68,7 +107,7 @@ class AccessDevice:
             type=_get(obj, "type") or _get(obj, "device_type"),
             is_online=_is_online(obj),
             firmware_version=_get(obj, "firmware_version") or _get(obj, "firmware"),
-            location=_get(obj, "location") or _get(obj, "_door_name"),
+            location=AccessLocation.from_manager_output(_get(obj, "location") or _get(obj, "_door_name")),
         )
 
     def to_dict(self) -> dict:

--- a/apps/api/tests/graphql/fixtures/access/test_devices.py
+++ b/apps/api/tests/graphql/fixtures/access/test_devices.py
@@ -63,3 +63,46 @@ async def test_access_device_detail(tmp_path, monkeypatch):
     assert body.get("errors") is None, body
     assert body["data"]["access"]["device"]["id"] == "dev1"
     assert body["data"]["access"]["device"]["name"] == "Reader A"
+
+
+@pytest.mark.asyncio
+async def test_access_device_surfaces_structured_location(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    stub_managers(
+        monkeypatch,
+        {
+            ("access", "device_manager", "list_devices"): [
+                {
+                    "id": "dev1",
+                    "name": "Hub B",
+                    "type": "UA-Hub",
+                    "location": {
+                        "unique_id": "loc-1",
+                        "name": "Front Door",
+                        "up_id": "loc-parent",
+                        "location_type": "door",
+                        "full_name": "Site - Floor 1 - Front Door",
+                        "level": 3,
+                    },
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ devices(controller: "{cid}", limit: 10) {{
+            items {{ id location {{ uniqueId name upId locationType fullName level }} }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    loc = body["data"]["access"]["devices"]["items"][0]["location"]
+    assert loc["uniqueId"] == "loc-1"
+    assert loc["name"] == "Front Door"
+    assert loc["upId"] == "loc-parent"
+    assert loc["locationType"] == "door"
+    assert loc["fullName"] == "Site - Floor 1 - Front Door"
+    assert loc["level"] == 3

--- a/apps/api/tests/serializers/test_access_doors_policies_system.py
+++ b/apps/api/tests/serializers/test_access_doors_policies_system.py
@@ -110,7 +110,61 @@ def test_access_device_serializer_shape() -> None:
     assert out["type"] == "UA-G2"
     assert out["is_online"] is True
     assert out["firmware_version"] == "2.10.0"
-    assert out["location"] == "Front Door"
+    # location is now a structured AccessLocation object; the proxy-path
+    # ``_door_name`` string maps to its ``name`` field.
+    assert out["location"] == {
+        "unique_id": None,
+        "name": "Front Door",
+        "up_id": None,
+        "location_type": None,
+        "full_name": None,
+        "level": None,
+    }
+
+
+def test_access_device_serializer_from_typed_core_model() -> None:
+    """The device_manager may return a typed unifi-core AccessDevice whose
+    ``location`` is an AccessLocation pydantic object (not a dict). The
+    Strawberry projection must read that object path, not just dicts."""
+    from unifi_api.graphql.types.access.devices import AccessDevice
+    from unifi_core.access.models.devices import from_controller
+
+    core = from_controller(
+        {
+            "id": "dev1",
+            "name": "Hub B",
+            "type": "UA-Hub",
+            "is_online": True,
+            "location": {
+                "unique_id": "loc-1",
+                "name": "Front Door",
+                "up_id": "loc-parent",
+                "location_type": "door",
+                "full_name": "Site - Floor 1 - Front Door",
+                "level": 3,
+            },
+        }
+    )
+    # core.location is a unifi_core AccessLocation pydantic object, not a dict.
+    out = AccessDevice.from_manager_output(core).to_dict()
+    assert out["id"] == "dev1"
+    assert out["location"] == {
+        "unique_id": "loc-1",
+        "name": "Front Door",
+        "up_id": "loc-parent",
+        "location_type": "door",
+        "full_name": "Site - Floor 1 - Front Door",
+        "level": 3,
+    }
+
+
+def test_access_device_serializer_location_none() -> None:
+    """No location and no proxy ``_door_name`` -> to_dict surfaces None (the
+    value the REST route returns to callers)."""
+    from unifi_api.graphql.types.access.devices import AccessDevice
+
+    out = AccessDevice.from_manager_output({"id": "dev1", "name": "Reader A"}).to_dict()
+    assert out["location"] is None
 
 
 def test_access_system_info_and_health() -> None:

--- a/packages/unifi-core/src/unifi_core/access/models/devices.py
+++ b/packages/unifi-core/src/unifi_core/access/models/devices.py
@@ -12,6 +12,31 @@ from typing import Any, Optional
 from pydantic import BaseModel, Field
 
 
+class AccessLocation(BaseModel):
+    """The location object UniFi Access associates with a device.
+
+    UNVR's Access API returns ``location`` as a structured object (door / floor /
+    building reference), not a bare string. Fields are read-only.
+    """
+
+    unique_id: Optional[str] = Field(default=None, description="Location UUID", json_schema_extra={"mutable": False})
+    name: Optional[str] = Field(default=None, description="Location display name", json_schema_extra={"mutable": False})
+    up_id: Optional[str] = Field(default=None, description="Parent location UUID", json_schema_extra={"mutable": False})
+    location_type: Optional[str] = Field(
+        default=None,
+        description="Location category (door, floor, building, site)",
+        json_schema_extra={"mutable": False},
+    )
+    full_name: Optional[str] = Field(
+        default=None,
+        description="Fully-qualified location path (e.g. 'Site - Floor - Door')",
+        json_schema_extra={"mutable": False},
+    )
+    level: Optional[int] = Field(
+        default=None, description="Depth in the location hierarchy", json_schema_extra={"mutable": False}
+    )
+
+
 class AccessDevice(BaseModel):
     """Canonical Access device model (read-only)."""
 
@@ -26,8 +51,10 @@ class AccessDevice(BaseModel):
     firmware_version: Optional[str] = Field(
         default=None, description="Installed firmware version string", json_schema_extra={"mutable": False}
     )
-    location: Optional[str] = Field(
-        default=None, description="Physical location or associated door name", json_schema_extra={"mutable": False}
+    location: Optional[AccessLocation] = Field(
+        default=None,
+        description="Location reference (door/floor/building) this device is mounted at",
+        json_schema_extra={"mutable": False},
     )
 
 
@@ -41,6 +68,33 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
     return getattr(obj, key, default)
 
 
+def _coerce_location(raw: Any) -> Optional[AccessLocation]:
+    """Build an AccessLocation from a dict, an existing AccessLocation, or a
+    bare string. Returns None for None or empty values.
+
+    Bare strings (the pre-fix shape some mocks still emit) are mapped to
+    ``AccessLocation(name=<string>)`` so callers continue to surface a
+    human-readable label.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, AccessLocation):
+        return raw
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        return AccessLocation(name=stripped) if stripped else None
+    if isinstance(raw, dict):
+        return AccessLocation(
+            unique_id=raw.get("unique_id"),
+            name=raw.get("name"),
+            up_id=raw.get("up_id"),
+            location_type=raw.get("location_type"),
+            full_name=raw.get("full_name"),
+            level=raw.get("level"),
+        )
+    return None
+
+
 def from_controller(raw: Any) -> AccessDevice:
     """Build an AccessDevice from a manager dict or object."""
     return AccessDevice(
@@ -49,5 +103,5 @@ def from_controller(raw: Any) -> AccessDevice:
         type=_get(raw, "type"),
         is_online=_get(raw, "is_online"),
         firmware_version=_get(raw, "firmware_version"),
-        location=_get(raw, "location"),
+        location=_coerce_location(_get(raw, "location")),
     )

--- a/packages/unifi-core/tests/access/models/test_devices.py
+++ b/packages/unifi-core/tests/access/models/test_devices.py
@@ -6,6 +6,7 @@ from unifi_core.access.models.devices import (
     MUTABLE_FIELDS,
     READ_ONLY_FIELDS,
     AccessDevice,
+    AccessLocation,
     from_controller,
 )
 
@@ -32,14 +33,22 @@ class TestFieldSets:
 
 
 class TestFromController:
-    def test_full_dict(self) -> None:
+    def test_full_dict_with_structured_location(self) -> None:
+        """Real UNVR shape: location is a structured dict."""
         raw = {
             "id": "dev-1",
             "name": "Front Door Reader",
             "type": "UA-Reader-Pro",
             "is_online": True,
             "firmware_version": "3.2.7",
-            "location": "Main Entrance",
+            "location": {
+                "unique_id": "loc-uuid-1",
+                "name": "Front Door",
+                "up_id": "parent-uuid",
+                "location_type": "door",
+                "full_name": "Site - 1F - Front Door",
+                "level": 0,
+            },
         }
         d = from_controller(raw)
         assert d.id == "dev-1"
@@ -47,7 +56,25 @@ class TestFromController:
         assert d.type == "UA-Reader-Pro"
         assert d.is_online is True
         assert d.firmware_version == "3.2.7"
-        assert d.location == "Main Entrance"
+        assert isinstance(d.location, AccessLocation)
+        assert d.location.unique_id == "loc-uuid-1"
+        assert d.location.name == "Front Door"
+        assert d.location.up_id == "parent-uuid"
+        assert d.location.location_type == "door"
+        assert d.location.full_name == "Site - 1F - Front Door"
+        assert d.location.level == 0
+
+    def test_bare_string_location_wrapped_into_name(self) -> None:
+        """Legacy/string location is mapped to AccessLocation(name=...)."""
+        d = from_controller({"id": "dev-1", "location": "Main Entrance"})
+        assert isinstance(d.location, AccessLocation)
+        assert d.location.name == "Main Entrance"
+        assert d.location.unique_id is None
+        assert d.location.location_type is None
+
+    def test_empty_string_location_is_none(self) -> None:
+        d = from_controller({"id": "dev-1", "location": "   "})
+        assert d.location is None
 
     def test_missing_fields_are_none(self) -> None:
         d = from_controller({})
@@ -71,7 +98,7 @@ class TestFromController:
         assert d.firmware_version is None
         assert d.location is None
 
-    def test_from_object(self) -> None:
+    def test_from_object_with_string_location(self) -> None:
         """from_controller works with an attribute-bearing object."""
 
         class Obj:
@@ -88,7 +115,23 @@ class TestFromController:
         assert d.type == "UA-Lock"
         assert d.is_online is True
         assert d.firmware_version == "2.1.0"
-        assert d.location == "Side Door"
+        assert d.location is not None
+        assert d.location.name == "Side Door"
+
+    def test_partial_location_dict_only_some_fields(self) -> None:
+        """Location dict with only some fields populates available subset, leaves rest None."""
+        d = from_controller({"id": "dev-5", "location": {"name": "Lobby", "location_type": "floor"}})
+        assert d.location is not None
+        assert d.location.name == "Lobby"
+        assert d.location.location_type == "floor"
+        assert d.location.unique_id is None
+        assert d.location.full_name is None
+        assert d.location.level is None
+
+    def test_unknown_location_value_type_yields_none(self) -> None:
+        """Defensive: an unexpected location shape (e.g. a list) yields None rather than crashing."""
+        d = from_controller({"id": "dev-6", "location": ["not", "a", "valid", "shape"]})
+        assert d.location is None
 
     def test_model_dump_exclude_none_omits_missing(self) -> None:
         d = from_controller({"id": "dev-5", "name": "Hub A"})
@@ -99,3 +142,18 @@ class TestFromController:
         assert "is_online" not in dumped
         assert "firmware_version" not in dumped
         assert "location" not in dumped
+
+    def test_model_dump_serializes_nested_location(self) -> None:
+        """model_dump produces a nested dict for the location field, not a string."""
+        d = from_controller(
+            {
+                "id": "dev-7",
+                "location": {"unique_id": "loc-7", "name": "Roof", "location_type": "floor"},
+            }
+        )
+        dumped = d.model_dump(exclude_none=True)
+        assert dumped["location"] == {
+            "unique_id": "loc-7",
+            "name": "Roof",
+            "location_type": "floor",
+        }


### PR DESCRIPTION
## Summary

`AccessDevice.location` is typed `Optional[str]`, but UNVR's Access API returns `location` as a **structured object** (door / floor / building reference). As a result, `access_list_devices` fails with a Pydantic `ValidationError` on every call against a real controller (`Input should be a valid string ... input_type=dict`) — the device-listing tool is unusable.

## Fix

- **unifi-core**: add an `AccessLocation` model (`unique_id` / `name` / `up_id` / `location_type` / `full_name` / `level`) and retype `AccessDevice.location` to `Optional[AccessLocation]`. A `_coerce_location` helper accepts the structured dict, an existing `AccessLocation`, or a bare string (mapped to `AccessLocation(name=...)`), returning `None` for empty values — so both the API-path object and the proxy-path door-name string parse.
- **apps/api**: mirror `AccessLocation` as a Strawberry type and retype the GraphQL/REST `AccessDevice.location`; `from_manager_output` coerces the typed model object, a nested dict, or the proxy `_door_name` string. Regenerated `schema.graphql` and `graphql-reference.md`.

This is an intentional contract change for the device projection (`location` string → object). `AccessDoor.location` is left `Optional[str]` — the controller returns door locations as plain strings.

## Testing

- **Unit**: `_coerce_location` across dict / string / typed object / empty; the apps/api projection from a typed unifi-core model object and from raw dicts; a GraphQL fixture asserting the nested location surfaces; serializer-shape and `location=None` contracts.
- **Live**: verified against a real UNVR — `access_list_devices` now succeeds and returns the structured location with all fields populated, where previously it raised a hard `ValidationError` on every call.
