### PR TITLE
Fix Windows setup and auth error diagnostics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Launch `codex`, run `/plugins`, open the UniFi MCP marketplace, and install `uni
 
 The setup skill registers the MCP server with `codex mcp add`, stores the selected environment values in Codex's MCP configuration, and keeps the same preview-before-confirm safety model as Claude Code.
 
+### UniFi account requirements
+
+The MCP servers authenticate to the local UniFi controller APIs with a local admin/service account. Do not use a Ubiquiti SSO cloud account for MCP setup. For Network MCP today, accounts that require SSO MFA or local 2FA are not supported through configuration; use a dedicated local admin account without MFA for the service account, scoped to the permissions you are comfortable giving the MCP server.
+
 ### OpenClaw
 
 OpenClaw can install the same UniFi plugin bundles from the marketplace and map their skills plus MCP server definitions into embedded Pi sessions:
@@ -190,8 +194,8 @@ Set these environment variables (or use a `.env` file):
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `UNIFI_HOST` | Yes | Controller IP or hostname |
-| `UNIFI_USERNAME` | Yes | Local admin username |
-| `UNIFI_PASSWORD` | Yes | Admin password |
+| `UNIFI_USERNAME` | Yes | Local admin/service account username; do not use a Ubiquiti SSO account |
+| `UNIFI_PASSWORD` | Yes | Password for the local account |
 | `UNIFI_API_KEY` | No | UniFi API key (experimental — limited to read-only, subset of tools) |
 
 ### Multi-controller setups

--- a/apps/network/docs/troubleshooting.md
+++ b/apps/network/docs/troubleshooting.md
@@ -22,6 +22,10 @@
 3. Try logging into the controller web UI with the same credentials
 4. If using an API key: note that API key auth is experimental and limited to read-only operations — username/password are still required for full functionality
 
+### SSO/MFA auth fails but tools say "Not connected"
+
+If logs show `SSO MFA required but no totp_secret configured`, the controller is reachable but the configured account requires an MFA flow that Network MCP does not currently expose in configuration. Configure a dedicated local UniFi admin/service account without SSO MFA or local 2FA, then restart the MCP client so the updated environment is loaded.
+
 ### 404 errors on API calls
 
 **Symptoms:** Tools return 404 Not Found or "endpoint not found" errors.

--- a/apps/network/tests/unit/test_path_detection.py
+++ b/apps/network/tests/unit/test_path_detection.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 from aioresponses import CallbackResult, aioresponses
+from aiounifi.errors import RequestError
+from aiounifi.models.api import ApiRequest
 from yarl import URL
 
 from unifi_core.network.managers.connection_manager import (
@@ -45,6 +47,26 @@ def _mock_get(mock: aioresponses, base_url: str, path: str = "", **kwargs) -> No
 def _mock_post(mock: aioresponses, base_url: str, path: str = "", **kwargs) -> None:
     kwargs.setdefault("response_class", _Aiohttp314CompatibleResponse)
     mock.post(_mock_url(base_url, path), **kwargs)
+
+
+class _FailingLoginController:
+    def __init__(self, config):
+        self.connectivity = MagicMock()
+        self.connectivity.is_unifi_os = False
+        self.connectivity.config = config
+
+    async def login(self):
+        raise RequestError("SSO MFA required but no totp_secret configured")
+
+
+class _PasswordLeakingLoginController:
+    def __init__(self, config):
+        self.connectivity = MagicMock()
+        self.connectivity.is_unifi_os = False
+        self.connectivity.config = config
+
+    async def login(self):
+        raise RequestError(f"login failed for {self.connectivity.config.password}")
 
 
 class TestPathDetection:
@@ -418,4 +440,37 @@ class TestPathDetection:
                     assert manager._unifi_os_override is True, "Cached result should be preserved"
 
         # Cleanup
+        await manager.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_request_includes_last_initialize_error_after_auth_failure(self):
+        manager = ConnectionManager("192.168.1.1", "admin", "secret", max_retries=1)
+
+        with patch("unifi_core.network.managers.connection_manager.Controller", _FailingLoginController):
+            with patch("unifi_core.network.controller_type.resolve_controller_type", return_value="direct"):
+                initialized = await manager.initialize()
+                assert initialized is False
+
+                with pytest.raises(ConnectionError) as exc_info:
+                    await manager.request(ApiRequest(method="get", path="/stat/sysinfo"))
+
+        assert "Not connected to controller" in str(exc_info.value)
+        assert "SSO MFA required but no totp_secret configured" in str(exc_info.value)
+        await manager.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_last_initialize_error_redacts_configured_secret(self):
+        manager = ConnectionManager("192.168.1.1", "admin", "super-secret-password", max_retries=1)
+
+        with patch("unifi_core.network.managers.connection_manager.Controller", _PasswordLeakingLoginController):
+            with patch("unifi_core.network.controller_type.resolve_controller_type", return_value="direct"):
+                initialized = await manager.initialize()
+                assert initialized is False
+
+                with pytest.raises(ConnectionError) as exc_info:
+                    await manager.request(ApiRequest(method="get", path="/stat/sysinfo"))
+
+        message = str(exc_info.value)
+        assert "super-secret-password" not in message
+        assert "<redacted>" in message
         await manager.cleanup()

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 import time
 import time as _time
 from typing import Any, Dict, Optional
@@ -240,6 +241,7 @@ class ConnectionManager:
         self._connect_lock = asyncio.Lock()
         self._cache: Dict[str, Any] = {}
         self._last_cache_update: Dict[str, float] = {}
+        self._last_connection_error: Optional[str] = None
 
         # Path detection state
         self._unifi_os_override: Optional[bool] = None
@@ -254,6 +256,26 @@ class ConnectionManager:
     def url_base(self) -> str:
         proto = "https"
         return f"{proto}://{self.host}:{self.port}"
+
+    def _sanitize_connection_error(self, error: BaseException) -> str:
+        """Return a user-facing connection error without configured secrets."""
+        message = str(error) or type(error).__name__
+        for secret in (self.password, self.username):
+            if secret:
+                pattern = rf"(?<![A-Za-z0-9_-]){re.escape(secret)}(?![A-Za-z0-9_-])"
+                message = re.sub(pattern, "<redacted>", message)
+        return message
+
+    def _record_connection_error(self, error: BaseException) -> str:
+        self._last_connection_error = self._sanitize_connection_error(error)
+        return self._last_connection_error
+
+    def _not_connected_error(self) -> ConnectionError:
+        if self._last_connection_error:
+            return ConnectionError(
+                f"Not connected to controller: last connection attempt failed: {self._last_connection_error}"
+            )
+        return ConnectionError("Not connected to controller")
 
     async def initialize(self) -> bool:
         """Initialize the controller connection (correct for attached aiounifi version)."""
@@ -363,6 +385,7 @@ class ConnectionManager:
                             logger.debug("Post-login detection confirmed pre-login result")
 
                     self._initialized = True
+                    self._last_connection_error = None
                     logger.info("Successfully connected to Unifi controller at %s for site '%s'", self.host, self.site)
                     self._invalidate_cache()
                     return True
@@ -374,7 +397,8 @@ class ConnectionManager:
                     asyncio.TimeoutError,
                     aiohttp.ClientError,
                 ) as e:
-                    logger.warning("Connection attempt %s failed: %s", attempt + 1, e)
+                    connection_error = self._record_connection_error(e)
+                    logger.warning("Connection attempt %s failed: %s", attempt + 1, connection_error)
                     if session_created and self._aiohttp_session and not self._aiohttp_session.closed:
                         await self._aiohttp_session.close()
                         self._aiohttp_session = None
@@ -383,14 +407,17 @@ class ConnectionManager:
                         await asyncio.sleep(self._retry_delay)
                     else:
                         logger.error(
-                            "Failed to initialize Unifi controller after %s attempts: %s", self._max_retries, e
+                            "Failed to initialize Unifi controller after %s attempts: %s",
+                            self._max_retries,
+                            connection_error,
                         )
                         self._initialized = False
                         return False
                 except Exception as e:
+                    connection_error = self._record_connection_error(e)
                     logger.error(
                         "Unexpected error during controller initialization: %s",
-                        e,
+                        connection_error,
                         exc_info=True,
                     )
                     if session_created and self._aiohttp_session and not self._aiohttp_session.closed:
@@ -435,7 +462,7 @@ class ConnectionManager:
     async def request(self, api_request: ApiRequest | ApiRequestV2, return_raw: bool = False) -> Any:
         """Make a request to the controller API, handling raw responses."""
         if not await self.ensure_connected() or not self.controller:
-            raise ConnectionError("Not connected to controller")
+            raise self._not_connected_error()
 
         # Apply override if we have better detection (FR-003: use cached detection)
         original_is_unifi_os = None

--- a/plugins/unifi-access/scripts/check-prereqs.ps1
+++ b/plugins/unifi-access/scripts/check-prereqs.ps1
@@ -1,0 +1,89 @@
+param(
+    [ValidateSet("claude", "codex", "openclaw")]
+    [string]$Target = "claude",
+
+    [string]$PluginName = "unifi plugin"
+)
+
+$ErrorActionPreference = "Stop"
+$errors = 0
+$warnings = 0
+
+function Test-CommandExists {
+    param([string]$Name)
+    return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Write-Ok { param([string]$Message) Write-Host "  [OK]   $Message" }
+function Write-Warn { param([string]$Message) Write-Host "  [WARN] $Message"; $script:warnings++ }
+function Write-Fail { param([string]$Message) Write-Host "  [FAIL] $Message"; $script:errors++ }
+
+Write-Host "Checking prerequisites for $PluginName ($Target)..."
+Write-Host ""
+
+if (Test-CommandExists "uvx") {
+    $uvxVersion = (& uvx --version 2>&1 | Select-Object -First 1)
+    Write-Ok "uvx found: $uvxVersion"
+} else {
+    Write-Fail "uvx not found on PATH"
+    Write-Host ""
+    Write-Host "         Install uv from https://docs.astral.sh/uv/getting-started/installation/"
+    Write-Host "         Then restart PowerShell or Codex so PATH refreshes."
+}
+
+if ($Target -eq "codex") {
+    if (Test-CommandExists "codex") {
+        $codexVersion = (& codex --version 2>&1 | Select-Object -First 1)
+        Write-Ok "codex found: $codexVersion"
+        try {
+            & codex mcp list *> $null
+            Write-Ok "codex mcp list succeeded"
+        } catch {
+            Write-Warn "codex is installed, but 'codex mcp list' failed. Setup may still work after Codex authentication is refreshed."
+        }
+    } else {
+        Write-Fail "codex CLI not found on PATH"
+        Write-Host "         Codex setup registers the MCP server with 'codex mcp add'."
+    }
+} elseif ($Target -eq "openclaw") {
+    if (Test-CommandExists "openclaw") {
+        $openclawVersion = (& openclaw --version 2>&1 | Select-Object -First 1)
+        Write-Ok "openclaw found: $openclawVersion"
+    } else {
+        Write-Fail "openclaw CLI not found on PATH"
+    }
+} else {
+    $settingsFile = ".claude/settings.local.json"
+    if (Test-Path $settingsFile) {
+        try {
+            Get-Content $settingsFile -Raw | ConvertFrom-Json | Out-Null
+            Write-Ok "$settingsFile is valid JSON"
+        } catch {
+            Write-Fail "$settingsFile exists but is not valid JSON"
+            Write-Host "         Fix or move it aside before continuing; setup will not clobber a malformed settings file."
+        }
+    } else {
+        Write-Ok "$settingsFile does not exist yet (will be created)"
+    }
+}
+
+if ($Target -eq "codex") {
+    Write-Host "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+} elseif ($Target -eq "openclaw") {
+    Write-Host "  [INFO] After setup, restart the OpenClaw Gateway so MCP server changes are loaded."
+} else {
+    Write-Host "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
+    Write-Host "         After setup, run /plugin and confirm the plugin shows enabled."
+}
+
+Write-Host ""
+if ($errors -gt 0) {
+    Write-Host "Prerequisite check FAILED with $errors error(s). Resolve the issues above and re-run."
+    exit 1
+}
+
+if ($warnings -gt 0) {
+    Write-Host "Prerequisite check passed with $warnings warning(s)."
+} else {
+    Write-Host "Prerequisite check passed."
+}

--- a/plugins/unifi-access/skills/unifi-access-setup/SKILL.md
+++ b/plugins/unifi-access/skills/unifi-access-setup/SKILL.md
@@ -23,14 +23,22 @@ On macOS and Linux, resolve setup scripts relative to this skill file:
 
 When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
 
-On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable.
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, prefer the native PowerShell prereq script and call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable. Do not run the Bash prereq script on Windows unless the user explicitly asks to use a Bash environment.
 
 ## Step 0: Check Prerequisites
 
-Before asking for credentials, run:
+Before asking for credentials, run the prereq checker for the current OS.
+
+On macOS/Linux:
 
 ```bash
 bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex|openclaw> "unifi-access"
+```
+
+On Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File <path-to-plugin>/scripts/check-prereqs.ps1 -Target <claude|codex|openclaw> -PluginName "unifi-access"
 ```
 
 If the script exits non-zero, stop and report the error. Do not proceed to credentials.

--- a/plugins/unifi-network/scripts/check-prereqs.ps1
+++ b/plugins/unifi-network/scripts/check-prereqs.ps1
@@ -1,0 +1,89 @@
+param(
+    [ValidateSet("claude", "codex", "openclaw")]
+    [string]$Target = "claude",
+
+    [string]$PluginName = "unifi plugin"
+)
+
+$ErrorActionPreference = "Stop"
+$errors = 0
+$warnings = 0
+
+function Test-CommandExists {
+    param([string]$Name)
+    return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Write-Ok { param([string]$Message) Write-Host "  [OK]   $Message" }
+function Write-Warn { param([string]$Message) Write-Host "  [WARN] $Message"; $script:warnings++ }
+function Write-Fail { param([string]$Message) Write-Host "  [FAIL] $Message"; $script:errors++ }
+
+Write-Host "Checking prerequisites for $PluginName ($Target)..."
+Write-Host ""
+
+if (Test-CommandExists "uvx") {
+    $uvxVersion = (& uvx --version 2>&1 | Select-Object -First 1)
+    Write-Ok "uvx found: $uvxVersion"
+} else {
+    Write-Fail "uvx not found on PATH"
+    Write-Host ""
+    Write-Host "         Install uv from https://docs.astral.sh/uv/getting-started/installation/"
+    Write-Host "         Then restart PowerShell or Codex so PATH refreshes."
+}
+
+if ($Target -eq "codex") {
+    if (Test-CommandExists "codex") {
+        $codexVersion = (& codex --version 2>&1 | Select-Object -First 1)
+        Write-Ok "codex found: $codexVersion"
+        try {
+            & codex mcp list *> $null
+            Write-Ok "codex mcp list succeeded"
+        } catch {
+            Write-Warn "codex is installed, but 'codex mcp list' failed. Setup may still work after Codex authentication is refreshed."
+        }
+    } else {
+        Write-Fail "codex CLI not found on PATH"
+        Write-Host "         Codex setup registers the MCP server with 'codex mcp add'."
+    }
+} elseif ($Target -eq "openclaw") {
+    if (Test-CommandExists "openclaw") {
+        $openclawVersion = (& openclaw --version 2>&1 | Select-Object -First 1)
+        Write-Ok "openclaw found: $openclawVersion"
+    } else {
+        Write-Fail "openclaw CLI not found on PATH"
+    }
+} else {
+    $settingsFile = ".claude/settings.local.json"
+    if (Test-Path $settingsFile) {
+        try {
+            Get-Content $settingsFile -Raw | ConvertFrom-Json | Out-Null
+            Write-Ok "$settingsFile is valid JSON"
+        } catch {
+            Write-Fail "$settingsFile exists but is not valid JSON"
+            Write-Host "         Fix or move it aside before continuing; setup will not clobber a malformed settings file."
+        }
+    } else {
+        Write-Ok "$settingsFile does not exist yet (will be created)"
+    }
+}
+
+if ($Target -eq "codex") {
+    Write-Host "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+} elseif ($Target -eq "openclaw") {
+    Write-Host "  [INFO] After setup, restart the OpenClaw Gateway so MCP server changes are loaded."
+} else {
+    Write-Host "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
+    Write-Host "         After setup, run /plugin and confirm the plugin shows enabled."
+}
+
+Write-Host ""
+if ($errors -gt 0) {
+    Write-Host "Prerequisite check FAILED with $errors error(s). Resolve the issues above and re-run."
+    exit 1
+}
+
+if ($warnings -gt 0) {
+    Write-Host "Prerequisite check passed with $warnings warning(s)."
+} else {
+    Write-Host "Prerequisite check passed."
+}

--- a/plugins/unifi-network/skills/unifi-network-setup/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network-setup/SKILL.md
@@ -23,14 +23,22 @@ On macOS and Linux, resolve setup scripts relative to this skill file:
 
 When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
 
-On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable.
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, prefer the native PowerShell prereq script and call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable. Do not run the Bash prereq script on Windows unless the user explicitly asks to use a Bash environment.
 
 ## Step 0: Check Prerequisites
 
-Before asking for credentials, run:
+Before asking for credentials, run the prereq checker for the current OS.
+
+On macOS/Linux:
 
 ```bash
 bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex|openclaw> "unifi-network"
+```
+
+On Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File <path-to-plugin>/scripts/check-prereqs.ps1 -Target <claude|codex|openclaw> -PluginName "unifi-network"
 ```
 
 If the script exits non-zero, stop and report the error. Do not proceed to credentials.

--- a/plugins/unifi-protect/scripts/check-prereqs.ps1
+++ b/plugins/unifi-protect/scripts/check-prereqs.ps1
@@ -1,0 +1,89 @@
+param(
+    [ValidateSet("claude", "codex", "openclaw")]
+    [string]$Target = "claude",
+
+    [string]$PluginName = "unifi plugin"
+)
+
+$ErrorActionPreference = "Stop"
+$errors = 0
+$warnings = 0
+
+function Test-CommandExists {
+    param([string]$Name)
+    return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Write-Ok { param([string]$Message) Write-Host "  [OK]   $Message" }
+function Write-Warn { param([string]$Message) Write-Host "  [WARN] $Message"; $script:warnings++ }
+function Write-Fail { param([string]$Message) Write-Host "  [FAIL] $Message"; $script:errors++ }
+
+Write-Host "Checking prerequisites for $PluginName ($Target)..."
+Write-Host ""
+
+if (Test-CommandExists "uvx") {
+    $uvxVersion = (& uvx --version 2>&1 | Select-Object -First 1)
+    Write-Ok "uvx found: $uvxVersion"
+} else {
+    Write-Fail "uvx not found on PATH"
+    Write-Host ""
+    Write-Host "         Install uv from https://docs.astral.sh/uv/getting-started/installation/"
+    Write-Host "         Then restart PowerShell or Codex so PATH refreshes."
+}
+
+if ($Target -eq "codex") {
+    if (Test-CommandExists "codex") {
+        $codexVersion = (& codex --version 2>&1 | Select-Object -First 1)
+        Write-Ok "codex found: $codexVersion"
+        try {
+            & codex mcp list *> $null
+            Write-Ok "codex mcp list succeeded"
+        } catch {
+            Write-Warn "codex is installed, but 'codex mcp list' failed. Setup may still work after Codex authentication is refreshed."
+        }
+    } else {
+        Write-Fail "codex CLI not found on PATH"
+        Write-Host "         Codex setup registers the MCP server with 'codex mcp add'."
+    }
+} elseif ($Target -eq "openclaw") {
+    if (Test-CommandExists "openclaw") {
+        $openclawVersion = (& openclaw --version 2>&1 | Select-Object -First 1)
+        Write-Ok "openclaw found: $openclawVersion"
+    } else {
+        Write-Fail "openclaw CLI not found on PATH"
+    }
+} else {
+    $settingsFile = ".claude/settings.local.json"
+    if (Test-Path $settingsFile) {
+        try {
+            Get-Content $settingsFile -Raw | ConvertFrom-Json | Out-Null
+            Write-Ok "$settingsFile is valid JSON"
+        } catch {
+            Write-Fail "$settingsFile exists but is not valid JSON"
+            Write-Host "         Fix or move it aside before continuing; setup will not clobber a malformed settings file."
+        }
+    } else {
+        Write-Ok "$settingsFile does not exist yet (will be created)"
+    }
+}
+
+if ($Target -eq "codex") {
+    Write-Host "  [INFO] After setup, restart Codex so MCP server changes are loaded."
+} elseif ($Target -eq "openclaw") {
+    Write-Host "  [INFO] After setup, restart the OpenClaw Gateway so MCP server changes are loaded."
+} else {
+    Write-Host "  [INFO] Reminder: 'installed' is not the same as 'enabled'."
+    Write-Host "         After setup, run /plugin and confirm the plugin shows enabled."
+}
+
+Write-Host ""
+if ($errors -gt 0) {
+    Write-Host "Prerequisite check FAILED with $errors error(s). Resolve the issues above and re-run."
+    exit 1
+}
+
+if ($warnings -gt 0) {
+    Write-Host "Prerequisite check passed with $warnings warning(s)."
+} else {
+    Write-Host "Prerequisite check passed."
+}

--- a/plugins/unifi-protect/skills/unifi-protect-setup/SKILL.md
+++ b/plugins/unifi-protect/skills/unifi-protect-setup/SKILL.md
@@ -23,14 +23,22 @@ On macOS and Linux, resolve setup scripts relative to this skill file:
 
 When the host exposes a plugin-root variable such as `CLAUDE_PLUGIN_ROOT`, using `$CLAUDE_PLUGIN_ROOT/scripts/...` is also valid. Do not assume the current shell directory is the plugin root.
 
-On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable.
+On Windows with Claude Code, use `../../scripts/set-env.ps1` for the final Claude settings write. On Windows with Codex, prefer the native PowerShell prereq script and call `codex mcp add` directly with the same env variables if Bash is unavailable. On Windows with OpenClaw, call `openclaw mcp set` directly with a JSON object containing `command`, `args`, and `env` if Bash is unavailable. Do not run the Bash prereq script on Windows unless the user explicitly asks to use a Bash environment.
 
 ## Step 0: Check Prerequisites
 
-Before asking for credentials, run:
+Before asking for credentials, run the prereq checker for the current OS.
+
+On macOS/Linux:
 
 ```bash
 bash <path-to-plugin>/scripts/check-prereqs.sh --target <claude|codex|openclaw> "unifi-protect"
+```
+
+On Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File <path-to-plugin>/scripts/check-prereqs.ps1 -Target <claude|codex|openclaw> -PluginName "unifi-protect"
 ```
 
 If the script exits non-zero, stop and report the error. Do not proceed to credentials.

--- a/scripts/smoke-plugin-setup.sh
+++ b/scripts/smoke-plugin-setup.sh
@@ -74,10 +74,23 @@ assert_not_contains() {
   fi
 }
 
+assert_no_crlf() {
+  local desc="$1"
+  local file="$2"
+  if LC_ALL=C grep -q $'\r' "$file"; then
+    echo "  [FAIL] $desc (CRLF byte found in $file)"
+    fails=$((fails + 1))
+    fail_messages="$fail_messages\n  - $desc"
+  else
+    echo "  [OK]   $desc"
+    passes=$((passes + 1))
+  fi
+}
+
 # --- 1. Scripts are byte-identical across all three plugins (drift guard) ---
 echo ""
 echo "== 1. Cross-plugin script parity =="
-for script in check-prereqs.sh set-env.sh; do
+for script in check-prereqs.sh set-env.sh check-prereqs.ps1; do
   reference="$REPO_ROOT/plugins/${PLUGINS[0]}/scripts/$script"
   for plugin in "${PLUGINS[@]:1}"; do
     other="$REPO_ROOT/plugins/$plugin/scripts/$script"
@@ -90,6 +103,13 @@ for script in check-prereqs.sh set-env.sh; do
       fail_messages="$fail_messages\n  - $script drift: ${PLUGINS[0]} vs $plugin"
     fi
   done
+done
+
+echo ""
+echo "== 1b. Script line endings =="
+for plugin in "${PLUGINS[@]}"; do
+  assert_no_crlf "$plugin check-prereqs.sh uses LF" "$REPO_ROOT/plugins/$plugin/scripts/check-prereqs.sh"
+  assert_no_crlf "$plugin set-env.sh uses LF" "$REPO_ROOT/plugins/$plugin/scripts/set-env.sh"
 done
 
 # --- 2. check-prereqs.sh behavior ---


### PR DESCRIPTION
## Summary

- Preserve and surface the last sanitized Network controller connection error so tools report actionable auth/connectivity failures instead of only `Not connected to controller`.
- Add Windows-native `check-prereqs.ps1` scripts for Network, Protect, and Access plugin setup, and update setup skills to route Windows users to PowerShell.
- Document local UniFi service-account requirements, SSO/MFA limitations, and guard shell scripts against CRLF line endings.

## Root Cause

Issue #346 combined two separate setup/debugging failures: the Windows setup path pointed users at Bash-oriented prereq checks, and Network auth initialization failures were logged during startup but then hidden from later tool calls behind a generic disconnected error.

Fixes #346.

## Validation

- `uv run --package unifi-network-mcp pytest apps/network/tests/unit/test_path_detection.py -q`
- `/bin/bash scripts/smoke-plugin-setup.sh`
- `make pre-commit`
- PowerShell prereq matrix for all plugins and targets: `unifi-network`, `unifi-protect`, `unifi-access` x `claude`, `codex`, `openclaw`
- Codex/OpenClaw setup dry-runs for all three plugins with masked dummy credentials
- Real MCP stdio client probe against a forced closed-port controller; confirmed the tool response includes `last connection attempt failed` and does not include the dummy password
- `git diff --check`