### PR TITLE
feat(network,api): add traffic-flow statistics tool (Insights > Flows summary)

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1182,6 +1182,11 @@ type NetworkQuery {
   """Query historical traffic flows (Insights > Flows), paginated."""
   trafficFlows(controller: ID!, site: String! = "default", withinHours: Int! = 24, timeFrom: Int = null, timeTo: Int = null, searchText: String = null, pageSize: Int! = 100, cursor: String = null): TrafficFlowPage!
 
+  """
+  Aggregated Insights > Flows summary (risk/region counts + Top-Talkers).
+  """
+  trafficFlowStatistics(controller: ID!, site: String! = "default", period: String! = "DAY", top: Int! = 10): TrafficFlowStatistics!
+
   """List switch port profiles on the given controller/site (paginated)."""
   portProfiles(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortProfilePage!
 
@@ -1772,6 +1777,51 @@ type TrafficFlowPage {
   nextCursor: String
 }
 
+"""Aggregated Insights > Flows summary (latest-statistics)."""
+type TrafficFlowStatistics {
+  allowedCountByRisk: JSON!
+  blockedCountByRisk: JSON!
+  allowedCountByRegionByRisk: JSON!
+  allCountByRegion: JSON!
+  blockedCountByRegion: JSON!
+  topClients: [TrafficFlowTopClient!]!
+  topBlockedClients: [TrafficFlowTopClient!]!
+  topDestinations: [TrafficFlowTopDestination!]!
+  topApplications: [TrafficFlowTopApplication!]!
+  topBlockedPolicies: [TrafficFlowTopPolicy!]!
+}
+
+"""An application in a traffic-flow Top-Talkers ranking (by bytes)."""
+type TrafficFlowTopApplication {
+  applicationId: Int
+  categoryId: Int
+  bytes: Int
+  applicationName: String
+  categoryName: String
+}
+
+"""A client in a traffic-flow Top-Talkers ranking."""
+type TrafficFlowTopClient {
+  count: Int
+  clientMac: String
+  clientName: String
+}
+
+"""A destination in a traffic-flow Top-Talkers ranking."""
+type TrafficFlowTopDestination {
+  count: Int
+  destination: String
+  mostFrequentRegion: String
+}
+
+"""A policy in a traffic-flow blocked-flow ranking."""
+type TrafficFlowTopPolicy {
+  count: Int
+  policyId: String
+  policyName: String
+  policyType: String
+}
+
 """A traffic-route policy (V2 /trafficroutes entry)."""
 type TrafficRoute {
   id: ID
@@ -2069,6 +2119,7 @@ Read-only access to UniFi Network resources.
 - `switchPorts: SwitchPorts`  — Get the port-override wrapper for a switch (name/model + per-port overrides).
 - `systemInfo: SystemInfo`  — Get controller system info (build, uptime, hardware).
 - `topClients: [TopClient!]!`  — List top-traffic clients within a window.
+- `trafficFlowStatistics: TrafficFlowStatistics!`  — Aggregated Insights > Flows summary (risk/region counts + Top-Talkers).
 - `trafficFlows: TrafficFlowPage!`  — Query historical traffic flows (Insights > Flows), paginated.
 - `trafficRoute: TrafficRoute`  — Look up a single traffic-route policy by id.
 - `trafficRoutes: TrafficRoutePage!`  — List traffic-route policies (V2 /trafficroutes) (paginated).

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1269,6 +1269,19 @@ LIST kind per Phase 4A — manager returns multi-element list of subsystems.
 
 ## network/traffic-flows
 
+### `GET /v1/sites/{site_id}/traffic-flow-statistics` — Get Traffic Flow Statistics
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `period` (query)
+- `top` (query)
+- `controller` (query)
+
+
+**Returns:** `object`
+
 ### `GET /v1/sites/{site_id}/traffic-flows` — Get Traffic Flows
 
 

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1280,7 +1280,7 @@ LIST kind per Phase 4A — manager returns multi-element list of subsystems.
 - `controller` (query)
 
 
-**Returns:** `object`
+**Returns:** `Detail_TrafficFlowStatisticsModel_`
 
 ### `GET /v1/sites/{site_id}/traffic-flows` — Get Traffic Flows
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -17341,6 +17341,90 @@
         ]
       }
     },
+    "/v1/sites/{site_id}/traffic-flow-statistics": {
+      "get": {
+        "operationId": "get_traffic_flow_statistics_v1_sites__site_id__traffic_flow_statistics_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "period",
+            "required": false,
+            "schema": {
+              "default": "DAY",
+              "title": "Period",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Top",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Traffic Flow Statistics V1 Sites  Site Id  Traffic Flow Statistics Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Traffic Flow Statistics",
+        "tags": [
+          "network/traffic-flows"
+        ]
+      }
+    },
     "/v1/sites/{site_id}/traffic-flows": {
       "get": {
         "operationId": "get_traffic_flows_v1_sites__site_id__traffic_flows_get",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1558,6 +1558,31 @@
         "title": "Detail[RouteModel]",
         "type": "object"
       },
+      "Detail_TrafficFlowStatisticsModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TrafficFlowStatisticsModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[TrafficFlowStatisticsModel]",
+        "type": "object"
+      },
       "Detail_TrafficRouteModel_": {
         "additionalProperties": true,
         "properties": {
@@ -5922,6 +5947,256 @@
           }
         },
         "title": "TrafficFlowModel",
+        "type": "object"
+      },
+      "TrafficFlowStatisticsModel": {
+        "additionalProperties": true,
+        "properties": {
+          "all_count_by_region": {
+            "title": "All Count By Region"
+          },
+          "allowed_count_by_region_by_risk": {
+            "title": "Allowed Count By Region By Risk"
+          },
+          "allowed_count_by_risk": {
+            "title": "Allowed Count By Risk"
+          },
+          "blocked_count_by_region": {
+            "title": "Blocked Count By Region"
+          },
+          "blocked_count_by_risk": {
+            "title": "Blocked Count By Risk"
+          },
+          "top_applications": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficFlowTopApplicationModel"
+            },
+            "title": "Top Applications",
+            "type": "array"
+          },
+          "top_blocked_clients": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficFlowTopClientModel"
+            },
+            "title": "Top Blocked Clients",
+            "type": "array"
+          },
+          "top_blocked_policies": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficFlowTopPolicyModel"
+            },
+            "title": "Top Blocked Policies",
+            "type": "array"
+          },
+          "top_clients": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficFlowTopClientModel"
+            },
+            "title": "Top Clients",
+            "type": "array"
+          },
+          "top_destinations": {
+            "items": {
+              "$ref": "#/components/schemas/TrafficFlowTopDestinationModel"
+            },
+            "title": "Top Destinations",
+            "type": "array"
+          }
+        },
+        "title": "TrafficFlowStatisticsModel",
+        "type": "object"
+      },
+      "TrafficFlowTopApplicationModel": {
+        "additionalProperties": true,
+        "properties": {
+          "application_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Application Id"
+          },
+          "application_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Application Name"
+          },
+          "bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bytes"
+          },
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "category_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Name"
+          }
+        },
+        "title": "TrafficFlowTopApplicationModel",
+        "type": "object"
+      },
+      "TrafficFlowTopClientModel": {
+        "additionalProperties": true,
+        "properties": {
+          "client_mac": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Mac"
+          },
+          "client_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Name"
+          },
+          "count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Count"
+          }
+        },
+        "title": "TrafficFlowTopClientModel",
+        "type": "object"
+      },
+      "TrafficFlowTopDestinationModel": {
+        "additionalProperties": true,
+        "properties": {
+          "count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Count"
+          },
+          "destination": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination"
+          },
+          "most_frequent_region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Most Frequent Region"
+          }
+        },
+        "title": "TrafficFlowTopDestinationModel",
+        "type": "object"
+      },
+      "TrafficFlowTopPolicyModel": {
+        "additionalProperties": true,
+        "properties": {
+          "count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Count"
+          },
+          "policy_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Policy Id"
+          },
+          "policy_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Policy Name"
+          },
+          "policy_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Policy Type"
+          }
+        },
+        "title": "TrafficFlowTopPolicyModel",
         "type": "object"
       },
       "TrafficRouteModel": {
@@ -17400,9 +17675,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Traffic Flow Statistics V1 Sites  Site Id  Traffic Flow Statistics Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/Detail_TrafficFlowStatisticsModel_"
                 }
               }
             },

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -87,7 +87,11 @@ from unifi_api.graphql.types.network.system import (
     SystemInfo,
     TopClient,
 )
-from unifi_api.graphql.types.network.traffic_flow import TrafficFlow, TrafficFlowPage
+from unifi_api.graphql.types.network.traffic_flow import (
+    TrafficFlow,
+    TrafficFlowPage,
+    TrafficFlowStatistics,
+)
 from unifi_api.graphql.types.network.voucher import Voucher
 from unifi_api.graphql.types.network.vpn import VpnClient, VpnServer
 from unifi_api.graphql.types.network.wlan import Wlan
@@ -652,6 +656,30 @@ async def _fetch_traffic_flows(
         if cm.site != site:
             await cm.set_site(site)
         return await mgr.get_traffic_flows(query)
+
+
+async def _fetch_traffic_flow_statistics(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+    period: str,
+    top: int,
+) -> dict:
+    async with ctx.sessionmaker() as session:
+        mgr = await ctx.manager_factory.get_domain_manager(
+            session,
+            controller,
+            "network",
+            "traffic_flow_manager",
+        )
+        cm = await ctx.manager_factory.get_connection_manager(
+            session,
+            controller,
+            "network",
+        )
+        if cm.site != site:
+            await cm.set_site(site)
+        return await mgr.get_traffic_flow_statistics(period=period, top=top)
 
 
 # ---- Cluster C fetch helpers (firewall / qos / dpi / cf / acl / oon / pf) -
@@ -3823,6 +3851,22 @@ class NetworkQuery:
         items = [TrafficFlow.from_manager_output(f) for f in result.get("flows", [])]
         next_cursor = _encode_flow_cursor(page + 1) if result.get("has_next") else None
         return TrafficFlowPage(items=items, next_cursor=next_cursor)
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Aggregated Insights > Flows summary (risk/region counts + Top-Talkers).",
+    )
+    async def traffic_flow_statistics(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        period: str = "DAY",
+        top: int = 10,
+    ) -> TrafficFlowStatistics:
+        ctx: GraphQLContext = info.context
+        result = await _fetch_traffic_flow_statistics(ctx, controller, site, period, top)
+        return TrafficFlowStatistics.from_manager_output(result)
 
     # ---- Switch domain ---------------------------------------------------
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1171,6 +1171,11 @@ type NetworkQuery {
   """Query historical traffic flows (Insights > Flows), paginated."""
   trafficFlows(controller: ID!, site: String! = "default", withinHours: Int! = 24, timeFrom: Int = null, timeTo: Int = null, searchText: String = null, pageSize: Int! = 100, cursor: String = null): TrafficFlowPage!
 
+  """
+  Aggregated Insights > Flows summary (risk/region counts + Top-Talkers).
+  """
+  trafficFlowStatistics(controller: ID!, site: String! = "default", period: String! = "DAY", top: Int! = 10): TrafficFlowStatistics!
+
   """List switch port profiles on the given controller/site (paginated)."""
   portProfiles(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): PortProfilePage!
 
@@ -1759,6 +1764,51 @@ type TrafficFlowEndpoint {
 type TrafficFlowPage {
   items: [TrafficFlow!]!
   nextCursor: String
+}
+
+"""Aggregated Insights > Flows summary (latest-statistics)."""
+type TrafficFlowStatistics {
+  allowedCountByRisk: JSON!
+  blockedCountByRisk: JSON!
+  allowedCountByRegionByRisk: JSON!
+  allCountByRegion: JSON!
+  blockedCountByRegion: JSON!
+  topClients: [TrafficFlowTopClient!]!
+  topBlockedClients: [TrafficFlowTopClient!]!
+  topDestinations: [TrafficFlowTopDestination!]!
+  topApplications: [TrafficFlowTopApplication!]!
+  topBlockedPolicies: [TrafficFlowTopPolicy!]!
+}
+
+"""An application in a traffic-flow Top-Talkers ranking (by bytes)."""
+type TrafficFlowTopApplication {
+  applicationId: Int
+  categoryId: Int
+  bytes: Int
+  applicationName: String
+  categoryName: String
+}
+
+"""A client in a traffic-flow Top-Talkers ranking."""
+type TrafficFlowTopClient {
+  count: Int
+  clientMac: String
+  clientName: String
+}
+
+"""A destination in a traffic-flow Top-Talkers ranking."""
+type TrafficFlowTopDestination {
+  count: Int
+  destination: String
+  mostFrequentRegion: String
+}
+
+"""A policy in a traffic-flow blocked-flow ranking."""
+type TrafficFlowTopPolicy {
+  count: Int
+  policyId: String
+  policyName: String
+  policyType: String
 }
 
 """A traffic-route policy (V2 /trafficroutes entry)."""

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -198,6 +198,9 @@ from unifi_api.graphql.types.network.system import (
 from unifi_api.graphql.types.network.traffic_flow import (
     TrafficFlow as NetworkTrafficFlowType,
 )
+from unifi_api.graphql.types.network.traffic_flow import (
+    TrafficFlowStatistics as NetworkTrafficFlowStatisticsType,
+)
 from unifi_api.graphql.types.network.voucher import (
     Voucher as NetworkVoucherType,
 )
@@ -309,6 +312,7 @@ def build_type_registry() -> TypeRegistry:
 
     # network/traffic-flows
     reg.register_tool_type("unifi_get_traffic_flows", NetworkTrafficFlowType, "list")
+    reg.register_tool_type("unifi_get_traffic_flow_statistics", NetworkTrafficFlowStatisticsType, "detail")
 
     # network/devices
     reg.register_type("network", "devices", NetworkDeviceType)

--- a/apps/api/src/unifi_api/graphql/types/network/traffic_flow.py
+++ b/apps/api/src/unifi_api/graphql/types/network/traffic_flow.py
@@ -125,3 +125,119 @@ class TrafficFlow:
 class TrafficFlowPage:
     items: list[TrafficFlow]
     next_cursor: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Traffic-flow statistics (Insights > Flows "Flow Summary")
+#
+# Mirrors ``TrafficFlowManager.get_traffic_flow_statistics()``. Count-by-risk /
+# region maps are exposed as ``JSON`` scalars (dynamic key sets); the Top-Talker
+# rankings are enumerated sub-types.
+# ---------------------------------------------------------------------------
+
+
+@strawberry.type(description="A client in a traffic-flow Top-Talkers ranking.")
+class TrafficFlowTopClient:
+    count: int | None
+    client_mac: str | None
+    client_name: str | None
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "TrafficFlowTopClient":
+        return cls(
+            count=_get(obj, "count"),
+            client_mac=_get(obj, "client_mac"),
+            client_name=_get(obj, "client_name"),
+        )
+
+
+@strawberry.type(description="A destination in a traffic-flow Top-Talkers ranking.")
+class TrafficFlowTopDestination:
+    count: int | None
+    destination: str | None
+    most_frequent_region: str | None
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "TrafficFlowTopDestination":
+        return cls(
+            count=_get(obj, "count"),
+            destination=_get(obj, "destination"),
+            most_frequent_region=_get(obj, "most_frequent_region"),
+        )
+
+
+@strawberry.type(description="An application in a traffic-flow Top-Talkers ranking (by bytes).")
+class TrafficFlowTopApplication:
+    application_id: int | None
+    category_id: int | None
+    bytes: int | None
+    application_name: str | None
+    category_name: str | None
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "TrafficFlowTopApplication":
+        return cls(
+            application_id=_get(obj, "application_id"),
+            category_id=_get(obj, "category_id"),
+            bytes=_get(obj, "bytes"),
+            application_name=_get(obj, "application_name"),
+            category_name=_get(obj, "category_name"),
+        )
+
+
+@strawberry.type(description="A policy in a traffic-flow blocked-flow ranking.")
+class TrafficFlowTopPolicy:
+    count: int | None
+    policy_id: str | None
+    policy_name: str | None
+    policy_type: str | None
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "TrafficFlowTopPolicy":
+        return cls(
+            count=_get(obj, "count"),
+            policy_id=_get(obj, "policy_id"),
+            policy_name=_get(obj, "policy_name"),
+            policy_type=_get(obj, "policy_type"),
+        )
+
+
+@strawberry.type(description="Aggregated Insights > Flows summary (latest-statistics).")
+class TrafficFlowStatistics:
+    # Count maps keyed by risk band (low/medium/high) or region (country code);
+    # dynamic key sets, so exposed as JSON scalars.
+    allowed_count_by_risk: strawberry.scalars.JSON  # type: ignore[name-defined]
+    blocked_count_by_risk: strawberry.scalars.JSON  # type: ignore[name-defined]
+    allowed_count_by_region_by_risk: strawberry.scalars.JSON  # type: ignore[name-defined]
+    all_count_by_region: strawberry.scalars.JSON  # type: ignore[name-defined]
+    blocked_count_by_region: strawberry.scalars.JSON  # type: ignore[name-defined]
+    top_clients: list[TrafficFlowTopClient]
+    top_blocked_clients: list[TrafficFlowTopClient]
+    top_destinations: list[TrafficFlowTopDestination]
+    top_applications: list[TrafficFlowTopApplication]
+    top_blocked_policies: list[TrafficFlowTopPolicy]
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {"kind": kind}
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "TrafficFlowStatistics":
+        def _list(key: str, sub: Any) -> list:
+            return [sub.from_manager_output(i) for i in (_get(obj, key, default=[]) or [])]
+
+        return cls(
+            allowed_count_by_risk=_get(obj, "allowed_count_by_risk", default={}),
+            blocked_count_by_risk=_get(obj, "blocked_count_by_risk", default={}),
+            allowed_count_by_region_by_risk=_get(obj, "allowed_count_by_region_by_risk", default={}),
+            all_count_by_region=_get(obj, "all_count_by_region", default={}),
+            blocked_count_by_region=_get(obj, "blocked_count_by_region", default={}),
+            top_clients=_list("top_clients", TrafficFlowTopClient),
+            top_blocked_clients=_list("top_blocked_clients", TrafficFlowTopClient),
+            top_destinations=_list("top_destinations", TrafficFlowTopDestination),
+            top_applications=_list("top_applications", TrafficFlowTopApplication),
+            top_blocked_policies=_list("top_blocked_policies", TrafficFlowTopPolicy),
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
+++ b/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
@@ -104,3 +104,44 @@ async def get_traffic_flows(
         "next_cursor": next_cursor,
         "render_hint": hint,
     }
+
+
+@router.get(
+    "/sites/{site_id}/traffic-flow-statistics",
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/traffic-flows"],
+)
+async def get_traffic_flow_statistics(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    period: str = Query("DAY"),
+    top: int = Query(10, ge=1, le=100),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "network",
+            "traffic_flow_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        try:
+            result = await mgr.get_traffic_flow_statistics(period=period, top=top)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    type_registry = request.app.state.type_registry
+    tool_type = type_registry.lookup_tool("unifi_get_traffic_flow_statistics")
+    if tool_type is None:
+        raise HTTPException(status_code=500, detail="traffic-flow-statistics projection not registered")
+    type_class, kind = tool_type
+    return {
+        "data": type_class.from_manager_output(result).to_dict(),
+        "render_hint": type_class.render_hint(kind),
+    }

--- a/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
+++ b/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
@@ -15,12 +15,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
 from unifi_api.graphql.pydantic_export import to_pydantic_model
-from unifi_api.graphql.types.network.traffic_flow import TrafficFlow
+from unifi_api.graphql.types.network.traffic_flow import (
+    TrafficFlow,
+    TrafficFlowStatistics,
+)
 from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
-from unifi_api.services.pydantic_models import Page
+from unifi_api.services.pydantic_models import Detail, Page
 
 router = APIRouter()
 
@@ -108,6 +111,7 @@ async def get_traffic_flows(
 
 @router.get(
     "/sites/{site_id}/traffic-flow-statistics",
+    response_model=Detail[to_pydantic_model(TrafficFlowStatistics)],
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["network/traffic-flows"],
 )

--- a/apps/api/tests/graphql/fixtures/network/test_traffic_flows.py
+++ b/apps/api/tests/graphql/fixtures/network/test_traffic_flows.py
@@ -1,6 +1,7 @@
 """Fixture e2e tests for network/traffic-flows resolver.
 
 # tool: unifi_get_traffic_flows
+# tool: unifi_get_traffic_flow_statistics
 """
 
 from __future__ import annotations
@@ -131,3 +132,78 @@ async def test_traffic_flows_partial_time_window_errors(tmp_path, monkeypatch):
     )
     # time_from set without time_to -> resolver raises ValueError -> GraphQL errors.
     assert body.get("errors"), body
+
+
+@pytest.mark.asyncio
+async def test_traffic_flow_statistics(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "traffic_flow_manager", "get_traffic_flow_statistics"): {
+                "allowed_count_by_risk": {"low": 103, "medium": 2},
+                "blocked_count_by_risk": {"low": 7},
+                "allowed_count_by_region_by_risk": {"US": {"low": 98}},
+                "all_count_by_region": {"US": 100},
+                "blocked_count_by_region": {"US": 7},
+                "top_clients": [{"count": 500, "client_mac": "aa:bb:cc:00:00:01", "client_name": "Lab"}],
+                "top_blocked_clients": [],
+                "top_destinations": [{"count": 200, "destination": "example.test", "most_frequent_region": "US"}],
+                "top_applications": [
+                    {
+                        "application_id": 470,
+                        "category_id": 4,
+                        "bytes": 999,
+                        "application_name": None,
+                        "category_name": None,
+                    }
+                ],
+                "top_blocked_policies": [
+                    {"count": 7, "policy_id": "p1", "policy_name": "Region Blocking", "policy_type": "PROTECTION"}
+                ],
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f"""{{
+        network {{ trafficFlowStatistics(controller: "{cid}", period: "DAY", top: 10) {{
+            allowedCountByRisk
+            topClients {{ count clientName clientMac }}
+            topBlockedClients {{ count clientName }}
+            topDestinations {{ destination mostFrequentRegion }}
+            topApplications {{ applicationId categoryId bytes applicationName }}
+            topBlockedPolicies {{ policyName policyType }}
+        }} }}
+    }}""",
+    )
+    assert body.get("errors") is None, body
+    stats = body["data"]["network"]["trafficFlowStatistics"]
+    assert stats["allowedCountByRisk"] == {"low": 103, "medium": 2}
+    assert stats["topClients"][0]["clientName"] == "Lab"
+    assert stats["topBlockedClients"] == []
+    assert stats["topDestinations"][0]["mostFrequentRegion"] == "US"
+    assert stats["topApplications"][0]["applicationId"] == 470
+    assert stats["topApplications"][0]["applicationName"] is None
+    assert stats["topBlockedPolicies"][0]["policyName"] == "Region Blocking"
+
+
+@pytest.mark.asyncio
+async def test_traffic_flow_statistics_invalid_period_errors(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    # Real manager validates period before any controller call, so no stub needed.
+    body = await graphql_query(
+        app,
+        key,
+        f"""{{
+        network {{ trafficFlowStatistics(controller: "{cid}", period: "YEAR") {{
+            allowedCountByRisk
+        }} }}
+    }}""",
+    )
+    # Invalid period -> manager raises ValueError -> GraphQL error.
+    assert body.get("errors"), body
+    assert "period must be one of" in str(body["errors"])

--- a/apps/api/tests/serializers/test_network_traffic_flows.py
+++ b/apps/api/tests/serializers/test_network_traffic_flows.py
@@ -88,3 +88,63 @@ def test_traffic_flow_page() -> None:
     page = TrafficFlowPage(items=[TrafficFlow.from_manager_output(raw)])
     assert page.next_cursor is None
     assert page.items[0].id == "f3"
+
+
+# ---------------------------------------------------------------------------
+# TrafficFlowStatistics
+# ---------------------------------------------------------------------------
+
+_STATS_MANAGER_OUTPUT = {
+    "allowed_count_by_risk": {"low": 103, "medium": 2},
+    "blocked_count_by_risk": {"low": 7},
+    "allowed_count_by_region_by_risk": {"US": {"low": 98, "medium": 2}},
+    "all_count_by_region": {"US": 100},
+    "blocked_count_by_region": {"US": 7},
+    "top_clients": [{"count": 500, "client_mac": "aa:bb:cc:00:00:01", "client_name": "Lab-Laptop"}],
+    "top_blocked_clients": [{"count": 7, "client_mac": "aa:bb:cc:00:00:02", "client_name": "Blocked-Host"}],
+    "top_destinations": [{"count": 200, "destination": "example.test", "most_frequent_region": "US"}],
+    "top_applications": [
+        {"application_id": 470, "category_id": 4, "bytes": 999, "application_name": None, "category_name": None}
+    ],
+    "top_blocked_policies": [
+        {"count": 7, "policy_id": "p1", "policy_name": "Region Blocking", "policy_type": "PROTECTION"}
+    ],
+}
+
+
+def test_statistics_from_manager_output_maps_fields() -> None:
+    from unifi_api.graphql.types.network.traffic_flow import TrafficFlowStatistics
+
+    stats = TrafficFlowStatistics.from_manager_output(_STATS_MANAGER_OUTPUT)
+    d = stats.to_dict()
+    assert d["allowed_count_by_risk"] == {"low": 103, "medium": 2}
+    assert d["allowed_count_by_region_by_risk"]["US"] == {"low": 98, "medium": 2}
+    assert d["top_clients"][0] == {"count": 500, "client_mac": "aa:bb:cc:00:00:01", "client_name": "Lab-Laptop"}
+    assert d["top_destinations"][0]["most_frequent_region"] == "US"
+    assert d["top_blocked_policies"][0]["policy_name"] == "Region Blocking"
+
+
+def test_statistics_top_application_name_nullable() -> None:
+    from unifi_api.graphql.types.network.traffic_flow import TrafficFlowStatistics
+
+    app = TrafficFlowStatistics.from_manager_output(_STATS_MANAGER_OUTPUT).to_dict()["top_applications"][0]
+    assert app["application_id"] == 470
+    assert app["category_id"] == 4
+    assert app["bytes"] == 999
+    assert app["application_name"] is None
+    assert app["category_name"] is None
+
+
+def test_statistics_render_hint() -> None:
+    from unifi_api.graphql.types.network.traffic_flow import TrafficFlowStatistics
+
+    assert TrafficFlowStatistics.render_hint("detail") == {"kind": "detail"}
+
+
+def test_statistics_handles_empty() -> None:
+    from unifi_api.graphql.types.network.traffic_flow import TrafficFlowStatistics
+
+    d = TrafficFlowStatistics.from_manager_output({}).to_dict()
+    assert d["allowed_count_by_risk"] == {}
+    assert d["top_clients"] == []
+    assert d["top_applications"] == []

--- a/apps/network/src/unifi_network_mcp/tools/traffic_flows.py
+++ b/apps/network/src/unifi_network_mcp/tools/traffic_flows.py
@@ -90,3 +90,30 @@ async def get_traffic_flows(
     except Exception as e:
         logger.error("Error getting traffic flows: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to get traffic flows: {e}"}
+
+
+@server.tool(
+    name="unifi_get_traffic_flow_statistics",
+    description=(
+        "Aggregated UniFi Traffic Flows summary (Insights > Flows 'Flow Summary'). Returns risk and "
+        "region count breakdowns plus Top-Talker rankings for a preset period: top clients, top "
+        "destinations, top applications (by bytes), top blocked clients, and top blocking policies. "
+        "Risk bands are low/medium/high (the UI labels these Low/Suspicious/Concerning). Application "
+        "entries carry DPI application_id/category_id and bytes; application_name/category_name are "
+        "null (DPI-catalog name resolution is not yet wired). Read-only."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_traffic_flow_statistics(
+    period: Annotated[str, Field(description="Time window: HOUR, DAY, WEEK, or MONTH")] = "DAY",
+    top: Annotated[int, Field(description="Entries per ranking (1-100)")] = 10,
+) -> Dict[str, Any]:
+    """Query aggregated traffic-flow statistics."""
+    try:
+        result = await traffic_flow_manager.get_traffic_flow_statistics(period=period, top=top)
+        return {"success": True, "site": traffic_flow_manager._connection.site, **result}
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error getting traffic flow statistics: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to get traffic flow statistics: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 177,
+  "count": 178,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -86,6 +86,7 @@
     "unifi_get_switch_ports": "unifi_network_mcp.tools.switch",
     "unifi_get_system_info": "unifi_network_mcp.tools.system",
     "unifi_get_top_clients": "unifi_network_mcp.tools.stats",
+    "unifi_get_traffic_flow_statistics": "unifi_network_mcp.tools.traffic_flows",
     "unifi_get_traffic_flows": "unifi_network_mcp.tools.traffic_flows",
     "unifi_get_traffic_route_details": "unifi_network_mcp.tools.traffic_routes",
     "unifi_get_usergroup_details": "unifi_network_mcp.tools.usergroups",
@@ -8550,6 +8551,99 @@
         }
       },
       "title": "Get Top Clients"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Aggregated UniFi Traffic Flows summary (Insights > Flows 'Flow Summary'). Returns risk and region count breakdowns plus Top-Talker rankings for a preset period: top clients, top destinations, top applications (by bytes), top blocked clients, and top blocking policies. Risk bands are low/medium/high (the UI labels these Low/Suspicious/Concerning). Application entries carry DPI application_id/category_id and bytes; application_name/category_name are null (DPI-catalog name resolution is not yet wired). Read-only.",
+      "name": "unifi_get_traffic_flow_statistics",
+      "schema": {
+        "input": {
+          "properties": {
+            "period": {
+              "description": "Time window: HOUR, DAY, WEEK, or MONTH",
+              "type": "string"
+            },
+            "top": {
+              "description": "Entries per ranking (1-100)",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Get Traffic Flow Statistics"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_traffic_flows_tool.py
+++ b/apps/network/tests/unit/test_traffic_flows_tool.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from unifi_network_mcp.runtime import traffic_flow_manager
-from unifi_network_mcp.tools.traffic_flows import get_traffic_flows
+from unifi_network_mcp.tools.traffic_flows import (
+    get_traffic_flow_statistics,
+    get_traffic_flows,
+)
 
 # Patch the manager METHOD on the class so interception is robust regardless of
 # which TrafficFlowManager instance the tool resolves (real singleton vs mock)
@@ -105,3 +108,48 @@ async def test_tool_manager_failure_returns_error_envelope():
         out = await get_traffic_flows(time_from=1, time_to=2)
     assert out["success"] is False
     assert "Failed to get traffic flows" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# unifi_get_traffic_flow_statistics
+# ---------------------------------------------------------------------------
+
+_STATS_METHOD = "unifi_core.network.managers.traffic_flow_manager.TrafficFlowManager.get_traffic_flow_statistics"
+
+_STATS_ENVELOPE = {
+    "allowed_count_by_risk": {"low": 9},
+    "blocked_count_by_risk": {"low": 1},
+    "top_clients": [{"count": 5, "client_mac": "aa:bb:cc:00:00:01", "client_name": "Lab"}],
+    "top_applications": [{"application_id": 470, "category_id": 4, "bytes": 9, "application_name": None}],
+}
+
+
+@pytest.mark.asyncio
+async def test_stats_tool_maps_params_and_returns_success():
+    with patch(_STATS_METHOD, new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = dict(_STATS_ENVELOPE)
+        out = await get_traffic_flow_statistics(period="WEEK", top=5)
+
+    assert out["success"] is True
+    assert out["site"] == traffic_flow_manager._connection.site
+    for key, value in _STATS_ENVELOPE.items():
+        assert out[key] == value
+    # period/top forwarded as kwargs.
+    assert mock_get.call_args.kwargs == {"period": "WEEK", "top": 5}
+
+
+@pytest.mark.asyncio
+async def test_stats_tool_invalid_period_returns_error_envelope():
+    # The real manager validates period before any controller call, so no patch.
+    out = await get_traffic_flow_statistics(period="YEAR")
+    assert out["success"] is False
+    assert "period must be one of" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_stats_tool_manager_failure_returns_error_envelope():
+    with patch(_STATS_METHOD, new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = RuntimeError("boom")
+        out = await get_traffic_flow_statistics(period="DAY")
+    assert out["success"] is False
+    assert "Failed to get traffic flow statistics" in out["error"]

--- a/packages/unifi-core/src/unifi_core/network/managers/traffic_flow_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/traffic_flow_manager.py
@@ -12,9 +12,16 @@ from typing import Any, Dict
 from aiounifi.models.api import ApiRequestV2
 
 from unifi_core.network.managers.connection_manager import ConnectionManager
-from unifi_core.network.models.traffic_flows import TrafficFlowQuery, traffic_flow_from_controller
+from unifi_core.network.models.traffic_flows import (
+    TrafficFlowQuery,
+    traffic_flow_from_controller,
+    traffic_flow_statistics_from_controller,
+)
 
 _FLOWS_CACHE_TTL = 45  # seconds; short-lived, matching the 60s alerts-cache precedent
+
+# Periods accepted by /traffic-flow-latest-statistics (the UI's 1h/1D/1W/1M).
+_STATISTICS_PERIODS = ("HOUR", "DAY", "WEEK", "MONTH")
 
 # User-facing filter arrays (populated from TrafficFlowQuery).
 _FILTER_FIELDS = (
@@ -108,5 +115,37 @@ class TrafficFlowManager:
             "has_next": response.get("has_next", False),
             "or_more": response.get("or_more", False),
         }
+        self._connection._update_cache(cache_key, result, timeout=_FLOWS_CACHE_TTL)
+        return result
+
+    async def get_traffic_flow_statistics(self, period: str = "DAY", top: int = 10) -> Dict[str, Any]:
+        """Fetch aggregated Insights > Flows statistics (latest-statistics).
+
+        ``period`` is one of HOUR/DAY/WEEK/MONTH (the UI's 1h/1D/1W/1M); ``top``
+        bounds each Top-Talker ranking (clamped 1-100). Validated client-side so
+        an unknown period fails clearly instead of as an opaque controller 400.
+        Cached ~45s keyed on period+top+site.
+        """
+        period = (period or "").upper()
+        if period not in _STATISTICS_PERIODS:
+            raise ValueError(f"period must be one of {', '.join(_STATISTICS_PERIODS)}")
+        top = max(1, min(int(top), 100))
+
+        cache_key = f"traffic_flow_statistics_{period}_{top}_{self._connection.site}"
+        cached = self._connection.get_cached(cache_key, timeout=_FLOWS_CACHE_TTL)
+        if cached is not None:
+            return cached
+
+        api_request = ApiRequestV2(method="get", path=f"/traffic-flow-latest-statistics?period={period}&top={top}")
+        response = await self._connection.request(api_request)
+
+        # aiounifi's ApiRequestV2.decode list-wraps the response object (data=[obj]),
+        # mirroring the /traffic-flows path; unwrap to the single statistics object.
+        if isinstance(response, list):
+            response = response[0] if response else {}
+        if not isinstance(response, dict):
+            response = {}
+
+        result = traffic_flow_statistics_from_controller(response).model_dump()
         self._connection._update_cache(cache_key, result, timeout=_FLOWS_CACHE_TTL)
         return result

--- a/packages/unifi-core/src/unifi_core/network/models/traffic_flows.py
+++ b/packages/unifi-core/src/unifi_core/network/models/traffic_flows.py
@@ -152,3 +152,188 @@ TRAFFICFLOW_MUTABLE_FIELDS: frozenset[str] = frozenset()
 TRAFFICFLOW_READ_ONLY_FIELDS: frozenset[str] = frozenset(TrafficFlow.model_fields.keys())
 # Alias required by the model-symmetry test harness — pattern used by all read-only models
 MUTABLE_FIELDS = TRAFFICFLOW_MUTABLE_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Traffic-flow statistics (Insights > Flows "Flow Summary")
+#
+# Read shape of the private v2 /traffic-flow-latest-statistics endpoint: risk
+# and region count breakdowns plus Top-Talker rankings (clients, destinations,
+# applications, blocked clients, blocked policies). Read-only.
+# ---------------------------------------------------------------------------
+
+
+class TrafficFlowTopClient(BaseModel):
+    """A client in a Top-Talkers ranking (by flow count)."""
+
+    count: Optional[int] = Field(default=None, description="Flow count", json_schema_extra={"mutable": False})
+    client_mac: Optional[str] = Field(
+        default=None, description="Client MAC address", json_schema_extra={"mutable": False}
+    )
+    client_name: Optional[str] = Field(
+        default=None, description="Client display name", json_schema_extra={"mutable": False}
+    )
+
+
+class TrafficFlowTopDestination(BaseModel):
+    """A destination in a Top-Talkers ranking (by flow count)."""
+
+    count: Optional[int] = Field(default=None, description="Flow count", json_schema_extra={"mutable": False})
+    destination: Optional[str] = Field(
+        default=None, description="Destination domain or IP", json_schema_extra={"mutable": False}
+    )
+    most_frequent_region: Optional[str] = Field(
+        default=None,
+        description="Most frequent destination region (country code)",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class TrafficFlowTopApplication(BaseModel):
+    """An application in a Top-Talkers ranking (by bytes).
+
+    ``application_id``/``category_id`` are DPI catalog ids; ``application_name``/
+    ``category_name`` are resolved via the DPI catalog and are null when the
+    catalog does not cover the application.
+    """
+
+    application_id: Optional[int] = Field(
+        default=None, description="DPI application id", json_schema_extra={"mutable": False}
+    )
+    category_id: Optional[int] = Field(
+        default=None, description="DPI category id", json_schema_extra={"mutable": False}
+    )
+    bytes: Optional[int] = Field(default=None, description="Total bytes", json_schema_extra={"mutable": False})
+    application_name: Optional[str] = Field(
+        default=None,
+        description="Resolved DPI application name (null when unresolved)",
+        json_schema_extra={"mutable": False},
+    )
+    category_name: Optional[str] = Field(
+        default=None,
+        description="Resolved DPI category name (null when unresolved)",
+        json_schema_extra={"mutable": False},
+    )
+
+
+class TrafficFlowTopPolicy(BaseModel):
+    """A firewall/protection policy in a blocked-flow ranking (by flow count)."""
+
+    count: Optional[int] = Field(default=None, description="Blocked-flow count", json_schema_extra={"mutable": False})
+    policy_id: Optional[str] = Field(default=None, description="Policy id", json_schema_extra={"mutable": False})
+    policy_name: Optional[str] = Field(default=None, description="Policy name", json_schema_extra={"mutable": False})
+    policy_type: Optional[str] = Field(default=None, description="Policy type", json_schema_extra={"mutable": False})
+
+
+class TrafficFlowStatistics(BaseModel):
+    """Aggregated Insights > Flows summary (v2 /traffic-flow-latest-statistics).
+
+    Risk keys are ``low``/``medium``/``high`` (the UI surfaces these as Low /
+    Suspicious / Concerning). Region keys are ISO country codes.
+    """
+
+    allowed_count_by_risk: dict[str, int] = Field(
+        default_factory=dict, description="Allowed flow counts by risk band", json_schema_extra={"mutable": False}
+    )
+    blocked_count_by_risk: dict[str, int] = Field(
+        default_factory=dict, description="Blocked flow counts by risk band", json_schema_extra={"mutable": False}
+    )
+    allowed_count_by_region_by_risk: dict[str, dict[str, int]] = Field(
+        default_factory=dict,
+        description="Allowed flow counts by region then risk band",
+        json_schema_extra={"mutable": False},
+    )
+    all_count_by_region: dict[str, int] = Field(
+        default_factory=dict, description="All flow counts by region", json_schema_extra={"mutable": False}
+    )
+    blocked_count_by_region: dict[str, int] = Field(
+        default_factory=dict, description="Blocked flow counts by region", json_schema_extra={"mutable": False}
+    )
+    top_clients: list[TrafficFlowTopClient] = Field(
+        default_factory=list, description="Top clients by flow count", json_schema_extra={"mutable": False}
+    )
+    top_blocked_clients: list[TrafficFlowTopClient] = Field(
+        default_factory=list, description="Top blocked clients by flow count", json_schema_extra={"mutable": False}
+    )
+    top_destinations: list[TrafficFlowTopDestination] = Field(
+        default_factory=list, description="Top destinations by flow count", json_schema_extra={"mutable": False}
+    )
+    top_applications: list[TrafficFlowTopApplication] = Field(
+        default_factory=list, description="Top applications by bytes", json_schema_extra={"mutable": False}
+    )
+    top_blocked_policies: list[TrafficFlowTopPolicy] = Field(
+        default_factory=list,
+        description="Top blocking policies by blocked-flow count",
+        json_schema_extra={"mutable": False},
+    )
+
+
+def _top_client_from_controller(raw: Any) -> TrafficFlowTopClient:
+    return TrafficFlowTopClient(
+        count=_get(raw, "count"),
+        client_mac=_get(raw, "client_mac"),
+        client_name=_get(raw, "client_name"),
+    )
+
+
+def _top_destination_from_controller(raw: Any) -> TrafficFlowTopDestination:
+    region = _get(raw, "mostFrequentRegion")
+    if region is None:
+        region = _get(raw, "most_frequent_region")
+    return TrafficFlowTopDestination(
+        count=_get(raw, "count"),
+        destination=_get(raw, "destination"),
+        most_frequent_region=region,
+    )
+
+
+def _top_application_from_controller(raw: Any) -> TrafficFlowTopApplication:
+    # Name fields are intentionally left None here; DPI-catalog resolution of
+    # application_id/category_id is a separate concern layered on top.
+    return TrafficFlowTopApplication(
+        application_id=_get(raw, "application_id"),
+        category_id=_get(raw, "category_id"),
+        bytes=_get(raw, "bytes"),
+    )
+
+
+def _top_policy_from_controller(raw: Any) -> TrafficFlowTopPolicy:
+    return TrafficFlowTopPolicy(
+        count=_get(raw, "count"),
+        policy_id=_get(raw, "policy_id"),
+        policy_name=_get(raw, "policy_name"),
+        policy_type=_get(raw, "policy_type"),
+    )
+
+
+def traffic_flow_statistics_from_controller(obj: Any) -> TrafficFlowStatistics:
+    """Normalise a raw /traffic-flow-latest-statistics response into the model."""
+
+    def _region_by_risk(raw: Any) -> dict[str, dict[str, int]]:
+        # Guard each sub-entry: a firmware edge case can send {"US": null}.
+        return {
+            k: dict(v)
+            for k, v in (_get(raw, "allowed_count_by_region_by_risk", {}) or {}).items()
+            if isinstance(v, dict)
+        }
+
+    return TrafficFlowStatistics(
+        allowed_count_by_risk=dict(_get(obj, "allowed_count_by_risk", {}) or {}),
+        blocked_count_by_risk=dict(_get(obj, "blocked_count_by_risk", {}) or {}),
+        allowed_count_by_region_by_risk=_region_by_risk(obj),
+        all_count_by_region=dict(_get(obj, "all_count_by_region", {}) or {}),
+        blocked_count_by_region=dict(_get(obj, "blocked_count_by_region", {}) or {}),
+        top_clients=[_top_client_from_controller(c) for c in (_get(obj, "top_all_count_by_client", []) or [])],
+        top_blocked_clients=[
+            _top_client_from_controller(c) for c in (_get(obj, "top_blocked_count_by_client", []) or [])
+        ],
+        top_destinations=[
+            _top_destination_from_controller(d) for d in (_get(obj, "top_all_count_by_destination", []) or [])
+        ],
+        top_applications=[
+            _top_application_from_controller(a) for a in (_get(obj, "top_all_traffic_by_application", []) or [])
+        ],
+        top_blocked_policies=[
+            _top_policy_from_controller(p) for p in (_get(obj, "top_blocked_count_by_policy", []) or [])
+        ],
+    )

--- a/packages/unifi-core/tests/network/managers/test_traffic_flow_manager.py
+++ b/packages/unifi-core/tests/network/managers/test_traffic_flow_manager.py
@@ -74,3 +74,72 @@ async def test_handles_empty_and_nondict_response():
         result = await mgr.get_traffic_flows(TrafficFlowQuery(time_from=1, time_to=2, page_number=0, page_size=100))
         assert result["flows"] == [], f"Expected empty flows for response {raw!r}"
         assert result["total_element_count"] == 0, f"Expected 0 for response {raw!r}"
+
+
+# ---------------------------------------------------------------------------
+# D. get_traffic_flow_statistics (latest-statistics)
+# ---------------------------------------------------------------------------
+
+_STATS_RESPONSE = {
+    "allowed_count_by_risk": {"low": 103, "medium": 2},
+    "blocked_count_by_risk": {"low": 7},
+    "all_count_by_region": {"US": 100},
+    "top_all_count_by_client": [{"count": 500, "client_mac": "aa:bb:cc:00:00:01", "client_name": "Lab-Laptop"}],
+    "top_all_count_by_destination": [{"count": 200, "destination": "example.test", "mostFrequentRegion": "US"}],
+    "top_all_traffic_by_application": [{"application_id": 470, "bytes": 999, "category_id": 4}],
+    "top_blocked_count_by_policy": [
+        {"count": 7, "policy_id": "p1", "policy_name": "Region Blocking", "policy_type": "PROTECTION"}
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_statistics_rejects_invalid_period():
+    conn = _make_connection(response=_STATS_RESPONSE)
+    mgr = TrafficFlowManager(conn)
+    with pytest.raises(ValueError, match="period must be one of"):
+        await mgr.get_traffic_flow_statistics(period="YEAR")
+    # The controller must not have been called for an invalid period.
+    assert conn.request.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_statistics_builds_period_and_top_query():
+    conn = _make_connection(response=_STATS_RESPONSE)
+    mgr = TrafficFlowManager(conn)
+    await mgr.get_traffic_flow_statistics(period="day", top=5)
+    api_request = conn.request.await_args.args[0]
+    assert api_request.method == "get"
+    assert api_request.path == "/traffic-flow-latest-statistics?period=DAY&top=5"
+
+
+@pytest.mark.asyncio
+async def test_statistics_shapes_response():
+    conn = _make_connection(response=_STATS_RESPONSE)
+    mgr = TrafficFlowManager(conn)
+    result = await mgr.get_traffic_flow_statistics(period="DAY", top=30)
+    assert result["allowed_count_by_risk"] == {"low": 103, "medium": 2}
+    assert result["top_clients"][0]["client_name"] == "Lab-Laptop"
+    assert result["top_destinations"][0]["most_frequent_region"] == "US"
+    assert result["top_applications"][0]["application_id"] == 470
+    assert result["top_applications"][0]["application_name"] is None
+    assert result["top_blocked_policies"][0]["policy_name"] == "Region Blocking"
+
+
+@pytest.mark.asyncio
+async def test_statistics_is_cached_within_ttl():
+    conn = _make_connection(response=_STATS_RESPONSE)
+    mgr = TrafficFlowManager(conn)
+    await mgr.get_traffic_flow_statistics(period="DAY", top=10)
+    await mgr.get_traffic_flow_statistics(period="DAY", top=10)
+    assert conn.request.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_statistics_handles_list_wrapped_and_empty():
+    for raw in ([_STATS_RESPONSE], [{}], {}):
+        conn = _make_connection(response=raw)
+        mgr = TrafficFlowManager(conn)
+        result = await mgr.get_traffic_flow_statistics(period="HOUR", top=10)
+        assert isinstance(result["top_clients"], list)
+        assert isinstance(result["allowed_count_by_risk"], dict)

--- a/packages/unifi-core/tests/network/models/test_traffic_flows.py
+++ b/packages/unifi-core/tests/network/models/test_traffic_flows.py
@@ -61,3 +61,114 @@ def test_trafficflow_fields_marked_immutable():
         for name, field in model.model_fields.items():
             extra = field.json_schema_extra or {}
             assert extra.get("mutable") is False, f"{model.__name__}.{name} missing mutable:False"
+
+
+# ---------------------------------------------------------------------------
+# TrafficFlowStatistics (Insights > Flows "Flow Summary" — latest-statistics)
+# ---------------------------------------------------------------------------
+
+# Mirrors the live v2 /traffic-flow-latest-statistics response shape with
+# synthetic data (no real identifiers). Risk keys are low/medium/high; the
+# top_* arrays drop the UI-only client_fingerprint/icon_* noise.
+_RAW_STATS = {
+    "all_count_by_region": {"US": 100, "DE": 5},
+    "allowed_count_by_region_by_risk": {"US": {"low": 98, "medium": 2}, "DE": {"low": 5}},
+    "allowed_count_by_risk": {"low": 103, "medium": 2},
+    "blocked_count_by_region": {"US": 7},
+    "blocked_count_by_risk": {"low": 7},
+    "top_all_count_by_client": [
+        {
+            "count": 500,
+            "client_mac": "aa:bb:cc:00:00:01",
+            "client_name": "Lab-Laptop",
+            "client_fingerprint": {"dev_id": 1, "dev_vendor": 7},
+            "icon_filename": None,
+            "icon_resolutions": None,
+        }
+    ],
+    "top_all_count_by_destination": [{"count": 200, "destination": "example.test", "mostFrequentRegion": "US"}],
+    "top_all_traffic_by_application": [{"application_id": 470, "bytes": 123456789, "category_id": 4}],
+    "top_blocked_count_by_client": [{"count": 7, "client_mac": "aa:bb:cc:00:00:02", "client_name": "Blocked-Host"}],
+    "top_blocked_count_by_policy": [
+        {"count": 7, "policy_id": "pol-1", "policy_name": "Region Blocking", "policy_type": "PROTECTION"}
+    ],
+}
+
+
+def test_statistics_maps_count_breakdowns():
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller(_RAW_STATS)
+    assert stats.allowed_count_by_risk == {"low": 103, "medium": 2}
+    assert stats.blocked_count_by_risk == {"low": 7}
+    assert stats.all_count_by_region == {"US": 100, "DE": 5}
+    assert stats.blocked_count_by_region == {"US": 7}
+    assert stats.allowed_count_by_region_by_risk["US"] == {"low": 98, "medium": 2}
+
+
+def test_statistics_maps_top_clients_dropping_fingerprint_and_icon():
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller(_RAW_STATS)
+    assert len(stats.top_clients) == 1
+    client = stats.top_clients[0]
+    assert client.count == 500
+    assert client.client_mac == "aa:bb:cc:00:00:01"
+    assert client.client_name == "Lab-Laptop"
+    # The UI-only fingerprint/icon fields are not projected.
+    dumped = client.model_dump()
+    assert "client_fingerprint" not in dumped
+    assert "icon_filename" not in dumped
+    assert set(dumped) == {"count", "client_mac", "client_name"}
+
+
+def test_statistics_maps_top_destinations_camel_to_snake():
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller(_RAW_STATS)
+    dest = stats.top_destinations[0]
+    assert dest.count == 200
+    assert dest.destination == "example.test"
+    assert dest.most_frequent_region == "US"
+
+
+def test_statistics_top_applications_carry_ids_and_nullable_names():
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller(_RAW_STATS)
+    app = stats.top_applications[0]
+    assert app.application_id == 470
+    assert app.category_id == 4
+    assert app.bytes == 123456789
+    # Name resolution is deferred (PR-B / DPI catalog) — fields exist but default None.
+    assert app.application_name is None
+    assert app.category_name is None
+
+
+def test_statistics_maps_blocked_clients_and_policies():
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller(_RAW_STATS)
+    assert stats.top_blocked_clients[0].client_name == "Blocked-Host"
+    policy = stats.top_blocked_policies[0]
+    assert policy.policy_id == "pol-1"
+    assert policy.policy_name == "Region Blocking"
+    assert policy.policy_type == "PROTECTION"
+
+
+def test_statistics_handles_empty_response():
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller({})
+    assert stats.allowed_count_by_risk == {}
+    assert stats.top_clients == []
+    assert stats.top_applications == []
+    assert stats.top_blocked_policies == []
+
+
+def test_statistics_skips_null_region_subentry():
+    # A firmware edge case can send a null per-region sub-entry; it must not crash.
+    from unifi_core.network.models.traffic_flows import traffic_flow_statistics_from_controller
+
+    stats = traffic_flow_statistics_from_controller({"allowed_count_by_region_by_risk": {"US": {"low": 5}, "DE": None}})
+    assert stats.allowed_count_by_region_by_risk == {"US": {"low": 5}}

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (177 tools)
+# Network Server Tool Reference (178 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -219,10 +219,11 @@ Manage static DNS A/AAAA/CNAME/MX/TXT/NS/SRV records on the controller's local D
 ## Traffic Flows
 
 <!-- AUTO:tools:traffic_flows -->
-1 tools.
+2 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
+| `unifi_get_traffic_flow_statistics` | Read | Aggregated UniFi Traffic Flows summary (Insights > Flows 'Flow Summary'). |
 | `unifi_get_traffic_flows` | Read | Query historical UniFi Traffic Flows (Insights > Flows). |
 <!-- /AUTO:tools:traffic_flows -->
 


### PR DESCRIPTION
## Summary

Adds a read-only `unifi_get_traffic_flow_statistics` tool that wraps the controller's private v2 `GET /traffic-flow-latest-statistics` endpoint — the data behind the Insights › Flows **"Flow Summary"** panel. It's a companion to the existing `unifi_get_traffic_flows` per-flow reader: where that returns individual flow records, this returns the aggregated summary for a preset period.

Returns:
- **Risk + region count breakdowns** — `allowed`/`blocked` counts by risk band (`low`/`medium`/`high`; the UI labels these Low/Suspicious/Concerning) and by region.
- **Top-Talker rankings** — top clients, top destinations, top applications (by bytes), top blocked clients, and top blocking policies.

## Parameters

- `period` — `HOUR` | `DAY` | `WEEK` | `MONTH` (the UI's 1h/1D/1W/1M). Validated client-side, so an unknown value returns a clear error instead of an opaque controller 400.
- `top` — entries per ranking (1–100).

## Implementation

Mirrors the existing traffic-flows pattern across all layers:
- **unifi-core** — `TrafficFlowStatistics` model + Top-Talker sub-models + factory; `TrafficFlowManager.get_traffic_flow_statistics(period, top)` (GET via `ApiRequestV2`, ~45s cache).
- **apps/network** — the MCP tool + regenerated manifest.
- **apps/api** — Strawberry `TrafficFlowStatistics` type (count maps as `JSON` scalars, rankings as enumerated sub-types), `trafficFlowStatistics` query field, REST detail route, and regenerated `schema.graphql` / `openapi.json` / docs.

Top-client entries are projected lean (`count` / `client_mac` / `client_name`), dropping the UI-only fingerprint/icon payload — consistent with how `TrafficFlowEndpoint` projects identity. Application entries carry the DPI `application_id` / `category_id` and `bytes`; `application_name` / `category_name` are present but null — DPI-catalog name resolution is intentionally left as a follow-on (the official integration API only covers DPI categories 0–1, ref #20).

## Testing

- Unit tests at every layer (core model + manager, MCP tool, apps/api serializer, GraphQL e2e fixture): period validation, caching, null-field handling, and a null-region-sub-entry edge case.
- Verified live against a real UniFi controller — the tool returns the full shaped summary (risk/region maps + all five rankings), and an invalid `period` returns the client-side validation error.
- `make check-generated`, `ruff format --check`/`ruff check`, and all affected suites pass.
