### PR TITLE
chore(release): require unifi-core >=0.4.2 across downstream packages

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.
-    "unifi-core[access]>=0.4.0,<0.5",
+    "unifi-core[access]>=0.4.2,<0.5",
     "mcp[cli]>=1.27.2,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.1,<0.5",
+    "unifi-core[network,protect,access]>=0.4.2,<0.5",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.49.0",
     "sqlalchemy[asyncio]>=2.0.50",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.1,<0.5",
+    "unifi-core[network]>=0.4.2,<0.5",
     "mcp[cli]>=1.27.2,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "unifi-mcp-shared>=0.6.0,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.0,<0.5",
+    "unifi-core[protect]>=0.4.2,<0.5",
     "mcp[cli]>=1.27.2,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",

--- a/packages/unifi-mcp-shared/pyproject.toml
+++ b/packages/unifi-mcp-shared/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "Shared MCP server patterns: permissions, confirmation, lazy loading, config"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-core>=0.4.0,<0.5",
+    "unifi-core>=0.4.2,<0.5",
     "mcp[cli]>=1.27.2,<2",
     "omegaconf>=2.3.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
Raises the `unifi-core` lower bound to the VPN-redaction security fix (#351, `core/v0.4.2`) in every downstream package, so no install path can resolve the vulnerable 0.4.1.

Wheel-metadata verified (Procedure D) — all emit `Requires-Dist: unifi-core … >=0.4.2`:
- unifi-network-mcp
- unifi-protect-mcp
- unifi-access-mcp
- unifi-api-server
- unifi-mcp-shared

`uv.lock` unchanged (workspace sources). Precedes cascade release tags: shared → network → protect → access → api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)