### PR TITLE
fix(acl): surface, set, and clear MAC ACL netmask across MCP + API

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -148,6 +148,10 @@ type AclRule {
   destinationType: String
   sourceMacs: [String!]!
   destinationMacs: [String!]!
+  sourceNetmask: Int
+  destinationNetmask: Int
+  sourceMacMask: String
+  destinationMacMask: String
 }
 
 """Paginated page of ACL rules."""

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -26,12 +26,34 @@
             ],
             "title": "Action"
           },
+          "destination_mac_mask": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination Mac Mask"
+          },
           "destination_macs": {
             "items": {
               "type": "string"
             },
             "title": "Destination Macs",
             "type": "array"
+          },
+          "destination_netmask": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination Netmask"
           },
           "destination_type": {
             "anyOf": [
@@ -81,12 +103,34 @@
             ],
             "title": "Network Id"
           },
+          "source_mac_mask": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Mac Mask"
+          },
           "source_macs": {
             "items": {
               "type": "string"
             },
             "title": "Source Macs",
             "type": "array"
+          },
+          "source_netmask": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Netmask"
           },
           "source_type": {
             "anyOf": [

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -137,6 +137,10 @@ type AclRule {
   destinationType: String
   sourceMacs: [String!]!
   destinationMacs: [String!]!
+  sourceNetmask: Int
+  destinationNetmask: Int
+  sourceMacMask: String
+  destinationMacMask: String
 }
 
 """Paginated page of ACL rules."""

--- a/apps/api/src/unifi_api/graphql/types/network/acl.py
+++ b/apps/api/src/unifi_api/graphql/types/network/acl.py
@@ -19,6 +19,7 @@ from dataclasses import asdict
 from typing import Any
 
 import strawberry
+from unifi_core.network.models.acl import read_mask_fields
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -42,6 +43,10 @@ class AclRule:
     destination_type: str | None
     source_macs: list[str]
     destination_macs: list[str]
+    source_netmask: int | None
+    destination_netmask: int | None
+    source_mac_mask: str | None
+    destination_mac_mask: str | None
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
@@ -66,6 +71,8 @@ class AclRule:
             src_macs = []
         if not isinstance(dst_macs, list):
             dst_macs = []
+        src_mask, src_netmask = read_mask_fields(source)
+        dst_mask, dst_netmask = read_mask_fields(destination)
         return cls(
             id=_get(obj, "_id") or _get(obj, "id"),
             name=_get(obj, "name"),
@@ -77,6 +84,10 @@ class AclRule:
             destination_type=destination.get("type"),
             source_macs=list(src_macs),
             destination_macs=list(dst_macs),
+            source_netmask=src_netmask,
+            destination_netmask=dst_netmask,
+            source_mac_mask=src_mask,
+            destination_mac_mask=dst_mask,
         )
 
     def to_dict(self) -> dict:

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -177,10 +177,15 @@ def _translate_acl_update(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[s
     # The mutable fields are nested in the rule_data dict (the tool's signature is
     # update_acl_rule(rule_id, rule_data: dict, clear_*, confirm)) — NOT top-level args.
     rule_data = args.get("rule_data") or {}
-    fields = {k: v for k, v in rule_data.items() if k in MUTABLE_FIELDS and v is not None}
-    ok, err = validate_update_fields(fields)
+    unknown_fields = set(rule_data) - MUTABLE_FIELDS
+    if unknown_fields:
+        raise ValueError(
+            f"Unknown or read-only fields: {sorted(unknown_fields)}. Allowed fields: {sorted(MUTABLE_FIELDS)}"
+        )
+    ok, err = validate_update_fields(rule_data)
     if not ok:
         raise ValueError(err)
+    fields = dict(rule_data)
     # The clear-netmask sentinels are TOP-LEVEL args (siblings of rule_data), not members
     # of rule_data / MUTABLE_FIELDS.
     has_clear = False

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -147,17 +147,15 @@ def _translate_acl_create(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[s
     Mirrors the translation in
     ``apps/network/src/unifi_network_mcp/tools/acl.py:create_acl_rule``.
     """
-    from unifi_core.network.models.acl import AclRule, to_controller_create
+    from pydantic import ValidationError
+    from unifi_core.network.models.acl import build_acl_rule, to_controller_create
 
-    rule = AclRule(
-        name=args["name"],
-        acl_index=args["acl_index"],
-        action=str(args["action"]).upper(),
-        enabled=args.get("enabled", True),
-        network_id=args["network_id"],
-        source_macs=args.get("source_macs") or [],
-        destination_macs=args.get("destination_macs") or [],
-    )
+    try:
+        rule = build_acl_rule(args)
+    except ValidationError as e:
+        # Surface the same clean message the MCP tool returns, not a raw pydantic dump.
+        msg = e.errors()[0].get("msg", str(e)) if e.errors() else str(e)
+        raise ValueError(f"Invalid ACL rule: {msg}") from e
     return (to_controller_create(rule),), {}
 
 
@@ -168,10 +166,31 @@ def _translate_acl_update(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[s
     ``apps/network/src/unifi_network_mcp/tools/acl.py:update_acl_rule``.
     Only fields the caller actually supplied are passed through.
     """
-    from unifi_core.network.models.acl import MUTABLE_FIELDS, to_controller_update
+    from unifi_core.network.models.acl import (
+        CLEAR_NETMASK_FIELDS,
+        MUTABLE_FIELDS,
+        to_controller_update,
+        validate_update_fields,
+    )
 
     rule_id = args["rule_id"]
-    fields = {k: v for k, v in args.items() if k != "rule_id" and k in MUTABLE_FIELDS and v is not None}
+    # The mutable fields are nested in the rule_data dict (the tool's signature is
+    # update_acl_rule(rule_id, rule_data: dict, clear_*, confirm)) — NOT top-level args.
+    rule_data = args.get("rule_data") or {}
+    fields = {k: v for k, v in rule_data.items() if k in MUTABLE_FIELDS and v is not None}
+    ok, err = validate_update_fields(fields)
+    if not ok:
+        raise ValueError(err)
+    # The clear-netmask sentinels are TOP-LEVEL args (siblings of rule_data), not members
+    # of rule_data / MUTABLE_FIELDS.
+    has_clear = False
+    for clear_key in CLEAR_NETMASK_FIELDS:
+        if args.get(clear_key):
+            fields[clear_key] = True
+            has_clear = True
+    # Parity with the MCP tool: reject a no-op update (no fields and no clear).
+    if not fields and not has_clear:
+        raise ValueError("No fields to update")
     return (rule_id, to_controller_update(fields)), {}
 
 

--- a/apps/api/tests/serializers/test_network_filtering.py
+++ b/apps/api/tests/serializers/test_network_filtering.py
@@ -281,6 +281,37 @@ def test_acl_rule_detail_serializer_shape() -> None:
     assert AclRule.render_hint("detail")["kind"] == "detail"
 
 
+def test_acl_rule_netmask_projection() -> None:
+    """The GraphQL type derives source/destination netmask + raw mask from the
+    controller's mac_mask, on the correct side, and degrades non-contiguous to null."""
+    from unifi_api.graphql.types.network.acl import AclRule
+
+    sample = {
+        "_id": "acl3",
+        "name": "multicast",
+        "enabled": True,
+        "action": "ALLOW",
+        "traffic_source": {"type": "CLIENT_MAC", "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"]},
+        "traffic_destination": {
+            "type": "CLIENT_MAC",
+            "specific_mac_addresses": ["01:00:5e:00:00:00"],
+            "mac_mask": "ff:ff:ff:00:00:00",
+        },
+    }
+    out = AclRule.from_manager_output(sample).to_dict()
+    # mask is on the destination side only — must not bleed onto source
+    assert out["destination_netmask"] == 24
+    assert out["destination_mac_mask"] == "ff:ff:ff:00:00:00"
+    assert out["source_netmask"] is None
+    assert out["source_mac_mask"] is None
+
+    # non-contiguous mask: netmask null but the raw mask stays visible
+    sample["traffic_destination"]["mac_mask"] = "ff:00:ff:00:00:00"
+    out = AclRule.from_manager_output(sample).to_dict()
+    assert out["destination_netmask"] is None
+    assert out["destination_mac_mask"] == "ff:00:ff:00:00:00"
+
+
 def test_acl_mutation_ack_dispatches_for_all_mutations() -> None:
     reg = _registry()
     for tool in (

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -436,7 +436,8 @@ async def test_dispatch_translates_acl_create_kwargs_to_controller_payload() -> 
             "action": "block",  # lowercase — tool layer uppercases
             "network_id": "net001",
             "source_macs": ["aa:bb:cc:dd:ee:ff"],
-            "destination_macs": [],
+            "destination_macs": ["01:00:5e:00:00:00"],
+            "destination_netmask": 24,  # must survive the API translation boundary
             "enabled": True,
         },
         confirm=True,
@@ -458,7 +459,9 @@ async def test_dispatch_translates_acl_create_kwargs_to_controller_payload() -> 
     assert payload["mac_acl_network_id"] == "net001"
     assert payload["traffic_source"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
     assert payload["traffic_source"]["type"] == "CLIENT_MAC"
-    assert payload["traffic_destination"]["specific_mac_addresses"] == []
+    assert payload["traffic_destination"]["specific_mac_addresses"] == ["01:00:5e:00:00:00"]
+    # netmask passed through the API dispatch translator and converted to a bitmask
+    assert payload["traffic_destination"]["mac_mask"] == "ff:ff:ff:00:00:00"
 
 
 @pytest.mark.asyncio
@@ -494,10 +497,10 @@ async def test_dispatch_translates_acl_update_kwargs_to_rule_id_plus_payload() -
         controller_id="cid",
         controller_products=["network"],
         site="default",
+        # fields are nested in rule_data (the real tool/manifest schema), NOT top-level
         args={
             "rule_id": "r1",
-            "name": "New",
-            "source_macs": ["11:22:33:44:55:66"],
+            "rule_data": {"name": "New", "source_macs": ["11:22:33:44:55:66"]},
         },
         confirm=True,
         dispatch_table={
@@ -515,6 +518,104 @@ async def test_dispatch_translates_acl_update_kwargs_to_rule_id_plus_payload() -
     # Field not provided in args is absent from the controller update payload
     assert "traffic_destination" not in update_payload
     assert "acl_index" not in update_payload
+
+
+@pytest.mark.asyncio
+async def test_dispatch_acl_update_clears_netmask() -> None:
+    """clear_destination_netmask flows through the API translator to a None mac_mask sentinel."""
+    entry = ToolEntry(name="unifi_update_acl_rule", product="network", category="acl_rules", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    domain_manager.update_acl_rule = AsyncMock(return_value={"_id": "r1"})
+    conn_manager = MagicMock()
+    conn_manager.site = "default"
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_update_acl_rule",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        # clear (top-level) alongside a sibling field change (nested in rule_data) — both must come through
+        args={"rule_id": "r1", "rule_data": {"name": "renamed"}, "clear_destination_netmask": True},
+        confirm=True,
+        dispatch_table={"unifi_update_acl_rule": DispatchEntry(manager_attr="acl_manager", method="update_acl_rule")},
+    )
+    (positional, _) = domain_manager.update_acl_rule.await_args
+    payload = positional[1]
+    assert payload["traffic_destination"]["mac_mask"] is None  # clear sentinel
+    assert payload["name"] == "renamed"  # sibling field preserved alongside the clear
+
+
+@pytest.mark.asyncio
+async def test_dispatch_acl_update_rejects_empty() -> None:
+    """A no-field, no-clear update is rejected (parity with the MCP tool), not a silent no-op."""
+    entry = ToolEntry(name="unifi_update_acl_rule", product="network", category="acl_rules", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    domain_manager.update_acl_rule = AsyncMock(return_value={"_id": "r1"})
+    conn_manager = MagicMock()
+    conn_manager.site = "default"
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    with pytest.raises(ValueError, match="No fields"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_update_acl_rule",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"rule_id": "r1"},
+            confirm=True,
+            dispatch_table={
+                "unifi_update_acl_rule": DispatchEntry(manager_attr="acl_manager", method="update_acl_rule")
+            },
+        )
+    domain_manager.update_acl_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_acl_update_rejects_bad_netmask() -> None:
+    """An out-of-range netmask via the API update path raises a clean ValueError (the route layer
+    converts it to an error envelope) rather than reaching netmask_to_mac_mask unvalidated."""
+    entry = ToolEntry(name="unifi_update_acl_rule", product="network", category="acl_rules", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    domain_manager.update_acl_rule = AsyncMock(return_value={"_id": "r1"})
+    conn_manager = MagicMock()
+    conn_manager.site = "default"
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    with pytest.raises(ValueError, match="netmask"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_update_acl_rule",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"rule_id": "r1", "rule_data": {"destination_netmask": 99}},
+            confirm=True,
+            dispatch_table={
+                "unifi_update_acl_rule": DispatchEntry(manager_attr="acl_manager", method="update_acl_rule")
+            },
+        )
+    domain_manager.update_acl_rule.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -619,6 +619,97 @@ async def test_dispatch_acl_update_rejects_bad_netmask() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_acl_update_rejects_read_only_nested_field() -> None:
+    """The API translator must reject read-only fields nested in rule_data, matching the MCP tool."""
+    entry = ToolEntry(name="unifi_update_acl_rule", product="network", category="acl_rules", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    domain_manager.update_acl_rule = AsyncMock(return_value={"_id": "r1"})
+    conn_manager = MagicMock(site="default")
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    with pytest.raises(ValueError, match="Unknown or read-only fields"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_update_acl_rule",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"rule_id": "r1", "rule_data": {"source_mac_mask": "ff:ff:ff:00:00:00"}},
+            confirm=True,
+            dispatch_table={
+                "unifi_update_acl_rule": DispatchEntry(manager_attr="acl_manager", method="update_acl_rule")
+            },
+        )
+    domain_manager.update_acl_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_acl_update_rejects_unknown_nested_field() -> None:
+    """Unknown fields nested in rule_data must fail instead of being silently dropped."""
+    entry = ToolEntry(name="unifi_update_acl_rule", product="network", category="acl_rules", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    domain_manager.update_acl_rule = AsyncMock(return_value={"_id": "r1"})
+    conn_manager = MagicMock(site="default")
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    with pytest.raises(ValueError, match="Unknown or read-only fields"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_update_acl_rule",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"rule_id": "r1", "rule_data": {"bogus": "ignored-before"}},
+            confirm=True,
+            dispatch_table={
+                "unifi_update_acl_rule": DispatchEntry(manager_attr="acl_manager", method="update_acl_rule")
+            },
+        )
+    domain_manager.update_acl_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_acl_update_netmask_none_is_noop_field() -> None:
+    """source_netmask=None remains a safe no-op update field, matching the MCP tool's round-trip behavior."""
+    entry = ToolEntry(name="unifi_update_acl_rule", product="network", category="acl_rules", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    domain_manager.update_acl_rule = AsyncMock(return_value={"_id": "r1"})
+    conn_manager = MagicMock(site="default")
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_update_acl_rule",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"rule_id": "r1", "rule_data": {"source_netmask": None}},
+        confirm=True,
+        dispatch_table={"unifi_update_acl_rule": DispatchEntry(manager_attr="acl_manager", method="update_acl_rule")},
+    )
+    (positional, _) = domain_manager.update_acl_rule.await_args
+    assert positional == ("r1", {})
+
+
+@pytest.mark.asyncio
 async def test_dispatch_delete_acl_passes_rule_id_unchanged() -> None:
     """unifi_delete_acl_rule already aligns: manager takes rule_id as the only
     kwarg, so the default **args dispatch works. No translator needed."""

--- a/apps/network/src/unifi_network_mcp/tools/acl.py
+++ b/apps/network/src/unifi_network_mcp/tools/acl.py
@@ -15,13 +15,13 @@ import logging
 from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from unifi_core.confirmation import create_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.acl import (
     MUTABLE_FIELDS,
-    AclRule,
+    build_acl_rule,
     from_controller,
     to_controller_create,
     to_controller_update,
@@ -108,7 +108,9 @@ async def get_acl_rule_details(
     name="unifi_create_acl_rule",
     description="Create a new MAC ACL rule for Layer 2 access control within a VLAN. "
     "Uses the same field names as unifi_list_acl_rules output — source_macs, destination_macs, "
-    "network_id, action, etc. Empty MAC list = match any device. Requires confirmation.",
+    "network_id, action, etc. Empty MAC list = match any device. Optionally apply a netmask "
+    "(source_netmask/destination_netmask) to match a leading-bit prefix instead of exact MACs. "
+    "Requires confirmation.",
     permission_category="acl_rules",
     permission_action="create",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
@@ -133,6 +135,22 @@ async def create_acl_rule(
         Optional[List[str]],
         Field(description="List of destination MAC addresses to match (empty list = any destination)"),
     ] = None,
+    source_netmask: Annotated[
+        Optional[int],
+        Field(
+            description="Optional netmask for source_macs — number of leading bits that must match "
+            "(e.g. 24 matches the vendor OUI, 48 matches the complete MAC). Omit for an exact match; "
+            "do NOT pass 0 to mean 'no mask' — 0 matches ANY MAC."
+        ),
+    ] = None,
+    destination_netmask: Annotated[
+        Optional[int],
+        Field(
+            description="Optional netmask for destination_macs — number of leading bits that must match "
+            "(e.g. 24 matches the vendor OUI, 48 matches the complete MAC). Omit for an exact match; "
+            "do NOT pass 0 to mean 'no mask' — 0 matches ANY MAC."
+        ),
+    ] = None,
     confirm: Annotated[
         bool,
         Field(description="When true, creates the rule. When false (default), returns a preview of the changes"),
@@ -149,6 +167,8 @@ async def create_acl_rule(
         enabled (bool): Whether the rule is active. Defaults to True.
         source_macs (list): List of source MAC addresses. Empty list or None = any.
         destination_macs (list): List of destination MAC addresses. Empty list or None = any.
+        source_netmask (int): Optional leading-bit match count for source_macs (e.g. 24=OUI, 48=full MAC). None = exact.
+        destination_netmask (int): Optional leading-bit match count for destination_macs. None = exact.
         confirm (bool): Must be True to execute. False returns a preview.
 
     Returns:
@@ -156,15 +176,23 @@ async def create_acl_rule(
     """
     logger.info("unifi_create_acl_rule called (name=%s, action=%s, confirm=%s)", name, action, confirm)
 
-    rule = AclRule(
-        name=name,
-        acl_index=acl_index,
-        action=action.upper(),
-        enabled=enabled,
-        network_id=network_id,
-        source_macs=source_macs if source_macs is not None else [],
-        destination_macs=destination_macs if destination_macs is not None else [],
-    )
+    try:
+        rule = build_acl_rule(
+            {
+                "name": name,
+                "acl_index": acl_index,
+                "action": action,
+                "enabled": enabled,
+                "network_id": network_id,
+                "source_macs": source_macs,
+                "destination_macs": destination_macs,
+                "source_netmask": source_netmask,
+                "destination_netmask": destination_netmask,
+            }
+        )
+    except ValidationError as e:
+        msg = e.errors()[0].get("msg", str(e)) if e.errors() else str(e)
+        return {"success": False, "error": f"Invalid ACL rule: {msg}"}
     controller_payload = to_controller_create(rule)
 
     if not confirm:
@@ -195,7 +223,10 @@ async def create_acl_rule(
     description="Update an existing MAC ACL rule. Pass only the fields you want to change — "
     "current values are automatically preserved. "
     "Uses the same field names as unifi_list_acl_rules output: name, acl_index, action, enabled, "
-    "network_id, source_macs, destination_macs. Requires confirmation.",
+    "network_id, source_macs, destination_macs, source_netmask, destination_netmask. "
+    "To remove a netmask (widen a prefix rule back to an exact match), set clear_source_netmask / "
+    "clear_destination_netmask = true (passing source_netmask=null is a no-op, not a clear). "
+    "Requires confirmation.",
     permission_category="acl_rules",
     permission_action="update",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
@@ -210,9 +241,20 @@ async def update_acl_rule(
             description="Dictionary of fields to update. Pass only the fields you want to change — "
             "current values are automatically preserved. "
             "Allowed keys: name, acl_index, action ('ALLOW'/'BLOCK'), enabled (bool), "
-            "network_id, source_macs (list of MACs), destination_macs (list of MACs)"
+            "network_id, source_macs (list of MACs), destination_macs (list of MACs), "
+            "source_netmask (int, e.g. 24=OUI/48=full MAC), destination_netmask (int)"
         ),
     ],
+    clear_source_netmask: Annotated[
+        bool,
+        Field(
+            description="When true, removes the source netmask (revert to exact-MAC match). Overrides source_netmask."
+        ),
+    ] = False,
+    clear_destination_netmask: Annotated[
+        bool,
+        Field(description="When true, removes the destination netmask (revert to exact-MAC match)."),
+    ] = False,
     confirm: Annotated[
         bool,
         Field(description="When true, applies the update. When false (default), returns a preview of the changes"),
@@ -222,7 +264,7 @@ async def update_acl_rule(
     logger.info("unifi_update_acl_rule called (rule_id=%s, confirm=%s)", rule_id, confirm)
     if not rule_id:
         return {"success": False, "error": "rule_id is required"}
-    if not rule_data:
+    if not rule_data and not (clear_source_netmask or clear_destination_netmask):
         return {"success": False, "error": "rule_data cannot be empty"}
 
     # Validate field names against the model's mutable fields
@@ -238,8 +280,16 @@ async def update_acl_rule(
     if not is_valid:
         return {"success": False, "error": type_error}
 
+    # Add the clear-netmask sentinels (handled by to_controller_update / the manager),
+    # separate from rule_data so they bypass the MUTABLE_FIELDS check above.
+    update_fields = dict(rule_data)
+    if clear_source_netmask:
+        update_fields["clear_source_netmask"] = True
+    if clear_destination_netmask:
+        update_fields["clear_destination_netmask"] = True
+
     # Translate model field names to controller API shape
-    controller_update = to_controller_update(rule_data)
+    controller_update = to_controller_update(update_fields)
 
     if not confirm:
         return update_preview(
@@ -247,7 +297,7 @@ async def update_acl_rule(
             resource_id=rule_id,
             resource_name=rule_id,
             current_state={},
-            updates=rule_data,
+            updates=update_fields,
         )
 
     try:

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1030,7 +1030,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Uses the same field names as unifi_list_acl_rules output \u2014 source_macs, destination_macs, network_id, action, etc. Empty MAC list = match any device. Requires confirmation.",
+      "description": "Create a new MAC ACL rule for Layer 2 access control within a VLAN. Uses the same field names as unifi_list_acl_rules output \u2014 source_macs, destination_macs, network_id, action, etc. Empty MAC list = match any device. Optionally apply a netmask (source_netmask/destination_netmask) to match a leading-bit prefix instead of exact MACs. Requires confirmation.",
       "name": "unifi_create_acl_rule",
       "permission_action": "create",
       "permission_category": "acl_rules",
@@ -1053,6 +1053,10 @@
               "description": "List of destination MAC addresses to match (empty list = any destination)",
               "type": "array"
             },
+            "destination_netmask": {
+              "description": "Optional netmask for destination_macs \u2014 number of leading bits that must match (e.g. 24 matches the vendor OUI, 48 matches the complete MAC). Omit for an exact match; do NOT pass 0 to mean 'no mask' \u2014 0 matches ANY MAC.",
+              "type": "integer"
+            },
             "enabled": {
               "description": "Whether the rule is active (default: true)",
               "type": "boolean"
@@ -1068,6 +1072,10 @@
             "source_macs": {
               "description": "List of source MAC addresses to match (empty list = any source)",
               "type": "array"
+            },
+            "source_netmask": {
+              "description": "Optional netmask for source_macs \u2014 number of leading bits that must match (e.g. 24 matches the vendor OUI, 48 matches the complete MAC). Omit for an exact match; do NOT pass 0 to mean 'no mask' \u2014 0 matches ANY MAC.",
+              "type": "integer"
             }
           },
           "required": [
@@ -15010,19 +15018,27 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Update an existing MAC ACL rule. Pass only the fields you want to change \u2014 current values are automatically preserved. Uses the same field names as unifi_list_acl_rules output: name, acl_index, action, enabled, network_id, source_macs, destination_macs. Requires confirmation.",
+      "description": "Update an existing MAC ACL rule. Pass only the fields you want to change \u2014 current values are automatically preserved. Uses the same field names as unifi_list_acl_rules output: name, acl_index, action, enabled, network_id, source_macs, destination_macs, source_netmask, destination_netmask. To remove a netmask (widen a prefix rule back to an exact match), set clear_source_netmask / clear_destination_netmask = true (passing source_netmask=null is a no-op, not a clear). Requires confirmation.",
       "name": "unifi_update_acl_rule",
       "permission_action": "update",
       "permission_category": "acl_rules",
       "schema": {
         "input": {
           "properties": {
+            "clear_destination_netmask": {
+              "description": "When true, removes the destination netmask (revert to exact-MAC match).",
+              "type": "boolean"
+            },
+            "clear_source_netmask": {
+              "description": "When true, removes the source netmask (revert to exact-MAC match). Overrides source_netmask.",
+              "type": "boolean"
+            },
             "confirm": {
               "description": "When true, applies the update. When false (default), returns a preview of the changes",
               "type": "boolean"
             },
             "rule_data": {
-              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, acl_index, action ('ALLOW'/'BLOCK'), enabled (bool), network_id, source_macs (list of MACs), destination_macs (list of MACs)",
+              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, acl_index, action ('ALLOW'/'BLOCK'), enabled (bool), network_id, source_macs (list of MACs), destination_macs (list of MACs), source_netmask (int, e.g. 24=OUI/48=full MAC), destination_netmask (int)",
               "type": "object"
             },
             "rule_id": {

--- a/apps/network/tests/unit/test_acl_manager.py
+++ b/apps/network/tests/unit/test_acl_manager.py
@@ -408,3 +408,86 @@ class TestAclManager:
         api_request = call_args[0][0]
         assert api_request.path == "/acl-rules/r1"
         assert api_request.method == "delete"
+
+    # ---- update_acl_rule: mask-clear sentinel handling (real pop path) ----
+
+    @pytest.mark.asyncio
+    async def test_update_clears_mask_via_none_sentinel(self, acl_manager, mock_connection):
+        """A None mac_mask in the update is popped (cleared) before the PUT; MACs survive."""
+        existing = {
+            "_id": "r1",
+            "name": "R",
+            "traffic_source": {"specific_mac_addresses": [], "type": "CLIENT_MAC"},
+            "traffic_destination": {
+                "mac_mask": "ff:ff:ff:00:00:00",
+                "specific_mac_addresses": ["01:00:5e:00:00:00"],
+                "type": "CLIENT_MAC",
+            },
+        }
+        mock_connection.request.side_effect = [[existing], {}]
+        result = await acl_manager.update_acl_rule(
+            "r1", {"traffic_destination": {"mac_mask": None, "type": "CLIENT_MAC"}}
+        )
+        assert "mac_mask" not in result["traffic_destination"]  # cleared
+        assert result["traffic_destination"]["specific_mac_addresses"] == ["01:00:5e:00:00:00"]  # preserved
+
+    @pytest.mark.asyncio
+    async def test_update_clear_idempotent_no_existing_mask(self, acl_manager, mock_connection):
+        """Clearing a side that has no mask is a harmless no-op (no error, MACs intact)."""
+        existing = {
+            "_id": "r1",
+            "name": "R",
+            "traffic_source": {"specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"], "type": "CLIENT_MAC"},
+            "traffic_destination": {"specific_mac_addresses": [], "type": "CLIENT_MAC"},
+        }
+        mock_connection.request.side_effect = [[existing], {}]
+        result = await acl_manager.update_acl_rule("r1", {"traffic_source": {"mac_mask": None, "type": "CLIENT_MAC"}})
+        assert "mac_mask" not in result["traffic_source"]
+        assert result["traffic_source"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+
+    @pytest.mark.asyncio
+    async def test_update_clear_both_sides(self, acl_manager, mock_connection):
+        """Clearing both sides in one update pops both masks."""
+        existing = {
+            "_id": "r1",
+            "name": "R",
+            "traffic_source": {
+                "mac_mask": "ff:ff:00:00:00:00",
+                "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                "type": "CLIENT_MAC",
+            },
+            "traffic_destination": {
+                "mac_mask": "ff:ff:ff:00:00:00",
+                "specific_mac_addresses": ["01:00:5e:00:00:00"],
+                "type": "CLIENT_MAC",
+            },
+        }
+        mock_connection.request.side_effect = [[existing], {}]
+        result = await acl_manager.update_acl_rule(
+            "r1",
+            {
+                "traffic_source": {"mac_mask": None, "type": "CLIENT_MAC"},
+                "traffic_destination": {"mac_mask": None, "type": "CLIENT_MAC"},
+            },
+        )
+        assert "mac_mask" not in result["traffic_source"]
+        assert "mac_mask" not in result["traffic_destination"]
+
+    @pytest.mark.asyncio
+    async def test_update_clear_does_not_mutate_aliased_untouched_side(self, acl_manager, mock_connection):
+        """Regression: a destination-only update must not pop the source side, even if the (aliased,
+        cached) source dict happens to hold mac_mask=None — popping there would corrupt the cache."""
+        existing = {
+            "_id": "r1",
+            "name": "R",
+            "traffic_source": {"mac_mask": None, "specific_mac_addresses": [], "type": "CLIENT_MAC"},
+            "traffic_destination": {
+                "mac_mask": "ff:ff:ff:00:00:00",
+                "specific_mac_addresses": ["01:00:5e:00:00:00"],
+                "type": "CLIENT_MAC",
+            },
+        }
+        mock_connection.request.side_effect = [[existing], {}]
+        await acl_manager.update_acl_rule("r1", {"traffic_destination": {"mac_mask": None, "type": "CLIENT_MAC"}})
+        # source was absent from the update → its aliased cached dict is left intact (key not popped)
+        assert "mac_mask" in existing["traffic_source"]

--- a/apps/network/tests/unit/test_acl_tools.py
+++ b/apps/network/tests/unit/test_acl_tools.py
@@ -116,6 +116,14 @@ class TestAclRuleModel:
         assert result["mac_acl_network_id"] == "net999"
         assert "network_id" not in result
 
+    def test_update_action_case_insensitive(self):
+        """Lowercase action is accepted on update (parity with create) and emitted uppercase."""
+        from unifi_core.network.models.acl import to_controller_update, validate_update_fields
+
+        ok, _ = validate_update_fields({"action": "allow"})
+        assert ok is True
+        assert to_controller_update({"action": "block"})["action"] == "BLOCK"
+
     def test_mutable_fields_excludes_read_only(self):
         """MUTABLE_FIELDS does not contain read-only fields."""
         from unifi_core.network.models.acl import MUTABLE_FIELDS, READ_ONLY_FIELDS
@@ -128,6 +136,324 @@ class TestAclRuleModel:
 
         assert "id" in READ_ONLY_FIELDS
         assert "source_macs" not in READ_ONLY_FIELDS
+
+
+class TestAclNetmask:
+    """Netmask handling: the UI's 'Netmask' dropdown number <-> controller bitmask."""
+
+    def test_netmask_bitmask_converters_round_trip(self):
+        from unifi_core.network.models.acl import mac_mask_to_netmask, netmask_to_mac_mask
+
+        assert netmask_to_mac_mask(24) == "ff:ff:ff:00:00:00"
+        assert netmask_to_mac_mask(48) == "ff:ff:ff:ff:ff:ff"
+        assert netmask_to_mac_mask(0) == "00:00:00:00:00:00"
+        assert mac_mask_to_netmask("ff:ff:ff:00:00:00") == 24
+        assert mac_mask_to_netmask("ff:ff:ff:ff:ff:ff") == 48
+        # non-contiguous and malformed masks have no prefix length
+        assert mac_mask_to_netmask("ff:00:ff:00:00:00") is None
+        assert mac_mask_to_netmask("not-a-mask") is None
+
+    def test_from_controller_reads_netmask_and_raw_mask(self):
+        """A masked rule surfaces both the friendly number and the raw bitmask."""
+        from unifi_core.network.models.acl import from_controller
+
+        raw = {
+            "_id": "r1",
+            "name": "multicast",
+            "acl_index": 1,
+            "action": "ALLOW",
+            "enabled": True,
+            "mac_acl_network_id": "net1",
+            "traffic_source": {"specific_mac_addresses": [], "type": "CLIENT_MAC"},
+            "traffic_destination": {
+                "specific_mac_addresses": ["01:00:5e:00:00:00"],
+                "mac_mask": "ff:ff:ff:00:00:00",
+                "type": "CLIENT_MAC",
+            },
+        }
+        rule = from_controller(raw)
+        assert rule.destination_netmask == 24
+        assert rule.destination_mac_mask == "ff:ff:ff:00:00:00"
+        assert rule.source_netmask is None
+        assert rule.source_mac_mask is None
+
+    def test_non_contiguous_mask_stays_visible(self):
+        """A mask the number can't express still round-trips via the read-only raw field."""
+        from unifi_core.network.models.acl import from_controller
+
+        raw = {
+            "_id": "r2",
+            "name": "weird",
+            "acl_index": 1,
+            "action": "ALLOW",
+            "enabled": True,
+            "mac_acl_network_id": "net1",
+            "traffic_source": {"specific_mac_addresses": [], "type": "CLIENT_MAC"},
+            "traffic_destination": {
+                "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                "mac_mask": "ff:00:ff:00:00:00",
+                "type": "CLIENT_MAC",
+            },
+        }
+        rule = from_controller(raw)
+        assert rule.destination_netmask is None
+        assert rule.destination_mac_mask == "ff:00:ff:00:00:00"
+
+    def test_create_converts_netmask_to_bitmask(self):
+        from unifi_core.network.models.acl import AclRule, to_controller_create
+
+        rule = AclRule(
+            name="oui",
+            acl_index=1,
+            action="ALLOW",
+            network_id="net1",
+            destination_macs=["01:00:5e:00:00:00"],
+            destination_netmask=24,
+        )
+        payload = to_controller_create(rule)
+        assert payload["traffic_destination"]["mac_mask"] == "ff:ff:ff:00:00:00"
+        # unset side carries no mask key (exact match)
+        assert "mac_mask" not in payload["traffic_source"]
+
+    def test_update_netmask_only_is_partial(self):
+        """Updating just the netmask must not clobber the existing MACs (deep-merge preserves them)."""
+        from unifi_core.network.models.acl import to_controller_update
+
+        result = to_controller_update({"destination_netmask": 16})
+        assert result["traffic_destination"]["mac_mask"] == "ff:ff:00:00:00:00"
+        assert "specific_mac_addresses" not in result["traffic_destination"]
+
+    def test_update_netmask_none_is_no_op(self):
+        """netmask=None means 'leave unchanged', NOT clear-to-'' (the controller 400s on '')."""
+        from unifi_core.network.models.acl import to_controller_update
+
+        # netmask=None alone produces no traffic_destination block at all (pure no-op).
+        result = to_controller_update({"destination_netmask": None})
+        assert "traffic_destination" not in result
+        # netmask=None alongside a MAC change updates the MACs but never touches the mask.
+        result = to_controller_update({"destination_macs": ["aa:bb:cc:dd:ee:ff"], "destination_netmask": None})
+        assert result["traffic_destination"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+        assert "mac_mask" not in result["traffic_destination"]
+
+    def test_update_source_and_dest_netmask(self):
+        """Both sides translate independently; source path is exercised too (not just dest)."""
+        from unifi_core.network.models.acl import to_controller_update
+
+        result = to_controller_update({"source_netmask": 24, "destination_netmask": 16})
+        assert result["traffic_source"]["mac_mask"] == "ff:ff:ff:00:00:00"
+        assert result["traffic_destination"]["mac_mask"] == "ff:ff:00:00:00:00"
+
+    def test_update_macs_and_netmask_together(self):
+        """A single update setting both MACs and netmask populates both sub-keys."""
+        from unifi_core.network.models.acl import to_controller_update
+
+        result = to_controller_update({"source_macs": ["01:00:5e:00:00:00"], "source_netmask": 24})
+        assert result["traffic_source"]["specific_mac_addresses"] == ["01:00:5e:00:00:00"]
+        assert result["traffic_source"]["mac_mask"] == "ff:ff:ff:00:00:00"
+
+    def test_create_source_netmask(self):
+        """The source-side create path (separate from destination) converts correctly."""
+        from unifi_core.network.models.acl import AclRule, to_controller_create
+
+        rule = AclRule(
+            name="oui",
+            acl_index=1,
+            action="ALLOW",
+            network_id="net1",
+            source_macs=["01:00:5e:00:00:00"],
+            source_netmask=24,
+        )
+        payload = to_controller_create(rule)
+        assert payload["traffic_source"]["mac_mask"] == "ff:ff:ff:00:00:00"
+        assert "mac_mask" not in payload["traffic_destination"]
+
+    def test_non_contiguous_mask_preserved_on_recreate(self):
+        """from_controller -> to_controller_create must NOT drop a non-contiguous mask
+        (netmask is None for it, so the raw mac_mask fallback carries it)."""
+        from unifi_core.network.models.acl import from_controller, to_controller_create
+
+        raw = {
+            "_id": "r",
+            "name": "weird",
+            "acl_index": 1,
+            "action": "ALLOW",
+            "enabled": True,
+            "mac_acl_network_id": "net1",
+            "traffic_source": {"specific_mac_addresses": [], "type": "CLIENT_MAC"},
+            "traffic_destination": {
+                "specific_mac_addresses": ["aa:bb:cc:dd:ee:ff"],
+                "mac_mask": "ff:00:ff:00:00:00",
+                "type": "CLIENT_MAC",
+            },
+        }
+        payload = to_controller_create(from_controller(raw))
+        assert payload["traffic_destination"]["mac_mask"] == "ff:00:ff:00:00:00"
+
+    def test_netmask_to_mac_mask_rejects_out_of_range(self):
+        """The converter raises rather than silently producing a match-everything/garbage mask."""
+        import pytest as _pytest
+
+        from unifi_core.network.models.acl import netmask_to_mac_mask
+
+        with _pytest.raises(ValueError):
+            netmask_to_mac_mask(-1)
+        with _pytest.raises(ValueError):
+            netmask_to_mac_mask(49)
+
+    def test_mac_mask_to_netmask_rejects_malformed(self):
+        """Non-string, wrong octet count, and lenient int forms (0x/whitespace) return None, not a bogus number."""
+        from unifi_core.network.models.acl import mac_mask_to_netmask
+
+        assert mac_mask_to_netmask(["ff", "ff"]) is None  # non-string -> no AttributeError
+        assert mac_mask_to_netmask(None) is None
+        assert mac_mask_to_netmask("ff:ff:ff") is None  # wrong octet count
+        assert mac_mask_to_netmask("0xff:00:00:00:00:00") is None  # 0x-prefixed token
+        assert mac_mask_to_netmask(" ff:ff:ff:ff:ff:ff ") is None  # surrounding whitespace
+        assert mac_mask_to_netmask("ff:ff:f:00:00:00") is None  # single-digit octet rejected (strict 2-digit)
+        assert mac_mask_to_netmask("FF:FF:FF:00:00:00") == 24  # uppercase still accepted
+        assert mac_mask_to_netmask("ff:ff:ff:00:00:00") == 24  # the valid form still works
+
+    def test_converter_partial_octet_boundaries(self):
+        """Off-by-one in the intra-octet shift/mask math would only show at non-byte-aligned widths."""
+        from unifi_core.network.models.acl import mac_mask_to_netmask, netmask_to_mac_mask
+
+        for bits, mask in [(1, "80:00:00:00:00:00"), (9, "ff:80:00:00:00:00"), (47, "ff:ff:ff:ff:ff:fe")]:
+            assert netmask_to_mac_mask(bits) == mask, bits
+            assert mac_mask_to_netmask(mask) == bits, bits
+
+    def test_field_validator_rejects_on_construction(self):
+        """The model's own field_validator (the create/from_controller path) rejects out-of-range,
+        independently of validate_update_fields (the update path)."""
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        from unifi_core.network.models.acl import AclRule
+
+        with _pytest.raises(ValidationError):
+            AclRule(name="x", acl_index=1, action="ALLOW", network_id="n", source_netmask=99)
+
+    def test_netmask_zero_round_trips_as_match_any(self):
+        """netmask=0 is accepted and means match-any (all bits wildcarded), distinct from omit/None."""
+        from unifi_core.network.models.acl import AclRule, mac_mask_to_netmask, to_controller_create
+
+        rule = AclRule(name="z", acl_index=1, action="ALLOW", network_id="n", destination_netmask=0)
+        payload = to_controller_create(rule)
+        assert payload["traffic_destination"]["mac_mask"] == "00:00:00:00:00:00"
+        assert mac_mask_to_netmask("00:00:00:00:00:00") == 0
+
+    def test_update_macs_only_preserves_existing_mask(self):
+        """Updating only MACs emits no mac_mask, so the manager's deep_merge keeps the existing one."""
+        from unifi_core.merge import deep_merge
+        from unifi_core.network.models.acl import to_controller_update
+
+        existing = {
+            "traffic_destination": {
+                "mac_mask": "ff:ff:ff:00:00:00",
+                "specific_mac_addresses": ["01:00:5e:00:00:00"],
+                "type": "CLIENT_MAC",
+            }
+        }
+        partial = to_controller_update({"destination_macs": ["aa:bb:cc:dd:ee:ff"]})
+        assert "mac_mask" not in partial["traffic_destination"]
+        merged = deep_merge(existing, partial)
+        assert merged["traffic_destination"]["mac_mask"] == "ff:ff:ff:00:00:00"  # preserved
+        assert merged["traffic_destination"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]  # updated
+
+    def test_clear_netmask_sentinel_and_manager_pop(self):
+        """clear_<side>_netmask emits a None sentinel that the manager turns into key removal,
+        clearing the mask while preserving the MACs."""
+        from unifi_core.merge import deep_merge
+        from unifi_core.network.models.acl import to_controller_update
+
+        partial = to_controller_update({"clear_destination_netmask": True})
+        assert partial["traffic_destination"]["mac_mask"] is None  # sentinel
+        existing = {
+            "traffic_destination": {
+                "mac_mask": "ff:ff:ff:00:00:00",
+                "specific_mac_addresses": ["01:00:5e:00:00:00"],
+                "type": "CLIENT_MAC",
+            }
+        }
+        merged = deep_merge(existing, partial)
+        # replicate the manager's pop-None-mask step
+        for sk in ("traffic_source", "traffic_destination"):
+            s = merged.get(sk)
+            if isinstance(s, dict) and s.get("mac_mask", "keep") is None:
+                s.pop("mac_mask", None)
+        assert "mac_mask" not in merged["traffic_destination"]  # cleared
+        assert merged["traffic_destination"]["specific_mac_addresses"] == ["01:00:5e:00:00:00"]  # MACs kept
+
+    def test_update_clear_and_set_macs_same_side(self):
+        """Clearing the mask AND changing MACs on the same side in one update: both apply
+        (clear wins over any netmask, MACs still written)."""
+        from unifi_core.network.models.acl import to_controller_update
+
+        r = to_controller_update({"destination_macs": ["aa:bb:cc:dd:ee:ff"], "clear_destination_netmask": True})
+        assert r["traffic_destination"]["specific_mac_addresses"] == ["aa:bb:cc:dd:ee:ff"]
+        assert r["traffic_destination"]["mac_mask"] is None  # clear sentinel emitted
+
+    @pytest.mark.asyncio
+    async def test_update_tool_clear_netmask(self):
+        """The update tool's clear flag reaches the manager as a None mac_mask sentinel."""
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.update_acl_rule = AsyncMock(return_value={"name": "r"})
+
+            from unifi_network_mcp.tools.acl import update_acl_rule
+
+            result = await update_acl_rule(rule_id="r1", rule_data={}, clear_destination_netmask=True, confirm=True)
+        assert result["success"] is True
+        rule_id_arg, payload = mock_mgr.update_acl_rule.call_args[0]
+        assert payload["traffic_destination"]["mac_mask"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_tool_rejects_bad_netmask_gracefully(self):
+        """An out-of-range netmask returns a {'success': False} dict, not an unhandled exception."""
+        from unifi_network_mcp.tools.acl import create_acl_rule
+
+        result = await create_acl_rule(
+            name="bad",
+            acl_index=1,
+            action="ALLOW",
+            network_id="net001",
+            destination_netmask=99,
+            confirm=True,
+        )
+        assert result["success"] is False
+        assert "netmask" in result["error"].lower()
+
+    def test_netmask_mutable_mask_read_only(self):
+        from unifi_core.network.models.acl import MUTABLE_FIELDS, READ_ONLY_FIELDS
+
+        assert {"source_netmask", "destination_netmask"} <= MUTABLE_FIELDS
+        assert {"source_mac_mask", "destination_mac_mask"} <= READ_ONLY_FIELDS
+
+    def test_netmask_out_of_range_rejected(self):
+        from unifi_core.network.models.acl import validate_update_fields
+
+        ok, _ = validate_update_fields({"destination_netmask": 24})
+        assert ok is True
+        bad, msg = validate_update_fields({"destination_netmask": 99})
+        assert bad is False and "netmask" in msg
+
+    @pytest.mark.asyncio
+    async def test_create_tool_passes_netmask(self):
+        with patch("unifi_network_mcp.tools.acl.acl_manager") as mock_mgr:
+            mock_mgr.create_acl_rule = AsyncMock(return_value=SAMPLE_CONTROLLER_RULE)
+
+            from unifi_network_mcp.tools.acl import create_acl_rule
+
+            result = await create_acl_rule(
+                name="oui",
+                acl_index=5,
+                action="ALLOW",
+                network_id="net001",
+                destination_macs=["01:00:5e:00:00:00"],
+                destination_netmask=24,
+                confirm=True,
+            )
+        assert result["success"] is True
+        payload = mock_mgr.create_acl_rule.call_args[0][0]
+        assert payload["traffic_destination"]["mac_mask"] == "ff:ff:ff:00:00:00"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/src/unifi_core/network/managers/acl_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/acl_manager.py
@@ -150,6 +150,18 @@ class AclManager:
             return existing
 
         merged_data = deep_merge(existing, update_data)
+        # Honor the mask-clear sentinel: to_controller_update emits mac_mask=None to
+        # mean "remove the mask" (the controller 400s on an empty string, and deep_merge
+        # cannot delete a key). Drop any None-valued mac_mask so the PUT omits it entirely.
+        # Only touch sides present in update_data — those are fresh dicts from deep_merge's
+        # recursion; an untouched side still aliases the cached rule (shallow base.copy()),
+        # so popping there could corrupt the in-process cache.
+        for side_key in ("traffic_source", "traffic_destination"):
+            if side_key not in update_data:
+                continue
+            side = merged_data.get(side_key)
+            if isinstance(side, dict) and side.get("mac_mask", "keep") is None:
+                side.pop("mac_mask", None)
         api_request = ApiRequestV2(method="put", path=f"/acl-rules/{rule_id}", data=merged_data)
         await self._connection.request(api_request)
         self._invalidate_cache()

--- a/packages/unifi-core/src/unifi_core/network/models/acl.py
+++ b/packages/unifi-core/src/unifi_core/network/models/acl.py
@@ -11,7 +11,80 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
-from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, field_validator
+
+# A MAC netmask is the number of leading bits that must match (the UI's
+# optional "Netmask" dropdown — e.g. 24 = vendor OUI, 48 = the complete MAC).
+# The controller stores it as a 6-octet MAC-format bitmask. The UI offers
+# 9..48, but the controller accepts the full 0..48 range (verified against a
+# live UDM-Pro-Max, Network 10.x), so we allow that range.
+_NETMASK_BITS = 48
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _check_netmask_range(bits: Optional[int]) -> Optional[str]:
+    """Return an error message if ``bits`` is out of the accepted range, else None.
+
+    None (no netmask) is allowed. Single source of truth for the range rule,
+    shared by the model field_validator, validate_update_fields, and the
+    converter below so they can never disagree.
+    """
+    if bits is None:
+        return None
+    if not 0 <= bits <= _NETMASK_BITS:
+        return f"netmask must be between 0 and {_NETMASK_BITS} (bits of a MAC address), got {bits!r}"
+    return None
+
+
+def netmask_to_mac_mask(bits: int) -> str:
+    """Convert a netmask bit-count (0-48) to a 6-octet MAC-format bitmask string.
+
+    Raises ValueError on an out-of-range bit-count rather than silently
+    producing a wrong mask, so any caller that reaches here without validating
+    fails loudly instead of writing a match-everything/garbage ACL.
+    """
+    err = _check_netmask_range(bits)
+    if err is not None:
+        raise ValueError(err)
+    mask_int = ((1 << bits) - 1) << (_NETMASK_BITS - bits)
+    return ":".join(f"{(mask_int >> (40 - 8 * i)) & 0xFF:02x}" for i in range(6))
+
+
+def mac_mask_to_netmask(mask: Any) -> Optional[int]:
+    """Convert a MAC-format bitmask string to a netmask bit-count.
+
+    Returns None for anything that is not a strictly-formatted 6-octet hex mask
+    (non-string, wrong octet count, any token that is not exactly two hex digits —
+    so ``0x``-prefixed, single-digit, or whitespace-padded tokens are rejected),
+    or for a well-formed but non-contiguous mask (a value the controller accepts
+    via the API but the UI's prefix dropdown cannot represent). The raw bitmask
+    remains available on the read-only ``*_mac_mask`` field.
+    """
+    if not isinstance(mask, str):
+        return None
+    tokens = mask.split(":")
+    if len(tokens) != 6:
+        return None
+    if not all(len(t) == 2 and all(c in _HEX_DIGITS for c in t) for t in tokens):
+        return None
+    bits = "".join(f"{int(t, 16):08b}" for t in tokens)
+    stripped = bits.rstrip("0")
+    if "0" in stripped:  # a zero before the final set bit → non-contiguous
+        return None
+    return len(stripped)
+
+
+def read_mask_fields(traffic: Dict[str, Any]) -> Tuple[Optional[str], Optional[int]]:
+    """Derive (raw_mac_mask, netmask) from a controller traffic_source/destination dict.
+
+    Single source of truth for the read-side mask derivation, shared by the
+    pydantic ``from_controller`` and the GraphQL ``AclRule.from_manager_output``
+    so the two layers can never report a different netmask for the same rule.
+    """
+    mask = traffic.get("mac_mask")
+    if not isinstance(mask, str) or not mask:
+        return None, None
+    return mask, mac_mask_to_netmask(mask)
 
 
 class AclRule(BaseModel):
@@ -52,6 +125,52 @@ class AclRule(BaseModel):
         default_factory=list,
         description="Destination MAC addresses (empty list = any destination)",
     )
+    source_netmask: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional netmask for source_macs — the number of leading bits that must match, as chosen "
+            "by the 'Netmask' dropdown in the UI (e.g. 24 matches the vendor OUI, 48 matches the "
+            "complete MAC). Omit (null) for an exact match. The UI offers 9-48; 0-48 is accepted, but "
+            "do NOT pass 0 to mean 'no mask' — 0 matches ANY MAC (every bit is wildcarded)."
+        ),
+    )
+    destination_netmask: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional netmask for destination_macs — the number of leading bits that must match, as "
+            "chosen by the 'Netmask' dropdown in the UI (e.g. 24 matches the vendor OUI, 48 matches the "
+            "complete MAC). Omit (null) for an exact match. The UI offers 9-48; 0-48 is accepted, but "
+            "do NOT pass 0 to mean 'no mask' — 0 matches ANY MAC (every bit is wildcarded)."
+        ),
+    )
+    # Raw bitmask exactly as stored on the controller. Read-only and set via
+    # *_netmask; surfaced so the true stored value is always visible — including
+    # a non-contiguous mask the API permits but the UI cannot express, where the
+    # corresponding *_netmask is null.
+    source_mac_mask: Optional[str] = Field(
+        default=None,
+        description=(
+            "Raw MAC-format bitmask stored for source_macs (e.g. 'ff:ff:ff:00:00:00'). "
+            "Read-only; set via source_netmask."
+        ),
+        json_schema_extra={"mutable": False},
+    )
+    destination_mac_mask: Optional[str] = Field(
+        default=None,
+        description=(
+            "Raw MAC-format bitmask stored for destination_macs (e.g. 'ff:ff:ff:00:00:00'). "
+            "Read-only; set via destination_netmask."
+        ),
+        json_schema_extra={"mutable": False},
+    )
+
+    @field_validator("source_netmask", "destination_netmask")
+    @classmethod
+    def _validate_netmask(cls, v: Optional[int]) -> Optional[int]:
+        err = _check_netmask_range(v)
+        if err is not None:
+            raise ValueError(err)
+        return v
 
 
 MUTABLE_FIELDS = frozenset(
@@ -69,8 +188,16 @@ def from_controller(raw: Dict[str, Any]) -> AclRule:
     The controller returns nested traffic_source/traffic_destination
     objects; this flattens them to the model's canonical field names.
     """
-    source = raw.get("traffic_source", {})
-    destination = raw.get("traffic_destination", {})
+    # Guard against a null/non-dict traffic block (matches the defensive coercion in the
+    # GraphQL AclRule.from_manager_output): a controller returning "traffic_source": null
+    # must not crash list/get with an AttributeError, and a null specific_mac_addresses
+    # must not reach the List[str] field as None.
+    source = raw.get("traffic_source")
+    destination = raw.get("traffic_destination")
+    source = source if isinstance(source, dict) else {}
+    destination = destination if isinstance(destination, dict) else {}
+    source_mask, source_netmask = read_mask_fields(source)
+    destination_mask, destination_netmask = read_mask_fields(destination)
 
     return AclRule(
         id=raw.get("_id"),
@@ -80,10 +207,60 @@ def from_controller(raw: Dict[str, Any]) -> AclRule:
         enabled=raw.get("enabled", True),
         network_id=raw.get("mac_acl_network_id", ""),
         source_type=source.get("type"),
-        source_macs=source.get("specific_mac_addresses", []),
+        source_macs=source.get("specific_mac_addresses") or [],
+        source_mac_mask=source_mask,
+        source_netmask=source_netmask,
         destination_type=destination.get("type"),
-        destination_macs=destination.get("specific_mac_addresses", []),
+        destination_macs=destination.get("specific_mac_addresses") or [],
+        destination_mac_mask=destination_mask,
+        destination_netmask=destination_netmask,
     )
+
+
+def build_acl_rule(args: Dict[str, Any]) -> "AclRule":
+    """Construct an AclRule from flat user-facing create args.
+
+    Single source of truth for create-arg → model mapping, shared by the MCP
+    tool (``tools/acl.py:create_acl_rule``) and the API dispatch translator
+    (``dispatch_overrides.py:_translate_acl_create``) so the two surfaces can
+    never drift (e.g. one accepting a field the other silently drops). Raises
+    pydantic ``ValidationError`` on invalid input; callers translate that into
+    their surface's error contract.
+    """
+    return AclRule(
+        name=args["name"],
+        acl_index=args["acl_index"],
+        action=str(args["action"]).upper(),
+        enabled=args.get("enabled", True),
+        network_id=args["network_id"],
+        source_macs=args.get("source_macs") or [],
+        destination_macs=args.get("destination_macs") or [],
+        source_netmask=args.get("source_netmask"),
+        destination_netmask=args.get("destination_netmask"),
+    )
+
+
+def _create_side(macs: List[str], netmask: Optional[int], raw_mask: Optional[str]) -> Dict[str, Any]:
+    """Build a full traffic_source/destination block for a create payload.
+
+    Mask precedence: the mutable ``netmask`` wins; otherwise fall back to the
+    read-only ``raw_mask`` (set by ``from_controller``) so a recreate of a rule
+    whose mask is non-contiguous — and therefore has ``netmask=None`` — does not
+    silently drop the mask. Omit the key entirely when neither is present
+    (exact match), matching how the controller stores an unmasked rule.
+    """
+    side: Dict[str, Any] = {
+        "ips_or_subnets": [],
+        "network_ids": [],
+        "ports": [],
+        "specific_mac_addresses": macs,
+        "type": "CLIENT_MAC",
+    }
+    if netmask is not None:
+        side["mac_mask"] = netmask_to_mac_mask(netmask)
+    elif raw_mask:
+        side["mac_mask"] = raw_mask
+    return side
 
 
 def to_controller_create(rule: AclRule) -> Dict[str, Any]:
@@ -95,20 +272,8 @@ def to_controller_create(rule: AclRule) -> Dict[str, Any]:
         "enabled": rule.enabled,
         "mac_acl_network_id": rule.network_id,
         "specific_enforcers": [],
-        "traffic_source": {
-            "ips_or_subnets": [],
-            "network_ids": [],
-            "ports": [],
-            "specific_mac_addresses": rule.source_macs,
-            "type": "CLIENT_MAC",
-        },
-        "traffic_destination": {
-            "ips_or_subnets": [],
-            "network_ids": [],
-            "ports": [],
-            "specific_mac_addresses": rule.destination_macs,
-            "type": "CLIENT_MAC",
-        },
+        "traffic_source": _create_side(rule.source_macs, rule.source_netmask, rule.source_mac_mask),
+        "traffic_destination": _create_side(rule.destination_macs, rule.destination_netmask, rule.destination_mac_mask),
         "type": "MAC",
     }
 
@@ -123,12 +288,54 @@ def validate_update_fields(fields: Dict[str, Any]) -> Tuple[bool, Optional[str]]
         field_info = AclRule.model_fields.get(field_name)
         if field_info is None:
             continue
+        # action is a case-insensitive Literal — normalize before the strict check so the
+        # update path accepts lowercase like the create path (build_acl_rule does .upper()).
+        check_value = value.upper() if field_name == "action" and isinstance(value, str) else value
         try:
-            TypeAdapter(field_info.annotation).validate_python(value, strict=True)
+            TypeAdapter(field_info.annotation).validate_python(check_value, strict=True)
         except ValidationError as e:
             err = e.errors()[0]
             return False, f"Invalid value for '{field_name}': {err['msg']}"
+        if field_name in ("source_netmask", "destination_netmask"):
+            range_err = _check_netmask_range(value)
+            if range_err is not None:
+                return False, f"Invalid value for '{field_name}': {range_err}"
     return True, None
+
+
+CLEAR_NETMASK_FIELDS = frozenset({"clear_source_netmask", "clear_destination_netmask"})
+
+
+def _update_side(fields: Dict[str, Any], prefix: str) -> Dict[str, Any]:
+    """Build a PARTIAL traffic_source/destination block for an update payload.
+
+    The manager deep-merges this into the fetched rule, so omitted sub-keys
+    (type, the existing mask when only MACs change, or the existing MACs when
+    only the mask changes) are preserved.
+
+    Mask handling:
+    - ``<prefix>_netmask`` set to a value writes the corresponding bitmask.
+    - ``<prefix>_netmask`` of None / absent is "leave unchanged" (a safe no-op,
+      so round-tripping a listed rule whose netmask is null is non-destructive).
+    - ``clear_<prefix>_netmask`` True emits ``mac_mask: None`` — a sentinel the
+      manager turns into key REMOVAL after the deep-merge (the controller rejects
+      an empty mac_mask with HTTP 400, and deep-merge cannot itself delete a key,
+      so the manager pops it). This is the explicit, unambiguous way to widen a
+      prefix rule back to an exact match without delete+recreate.
+    """
+    side: Dict[str, Any] = {}
+    macs_key = f"{prefix}_macs"
+    netmask_key = f"{prefix}_netmask"
+    clear_key = f"clear_{prefix}_netmask"
+    if macs_key in fields:
+        side["specific_mac_addresses"] = fields[macs_key]
+    if fields.get(clear_key):
+        side["mac_mask"] = None  # sentinel → manager removes the key, clearing the mask
+    elif fields.get(netmask_key) is not None:
+        side["mac_mask"] = netmask_to_mac_mask(fields[netmask_key])
+    if side:
+        side["type"] = "CLIENT_MAC"
+    return side
 
 
 def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
@@ -138,27 +345,19 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     """
     result: Dict[str, Any] = {}
 
-    if "source_macs" in fields:
-        result["traffic_source"] = {
-            "ips_or_subnets": [],
-            "network_ids": [],
-            "ports": [],
-            "specific_mac_addresses": fields["source_macs"],
-            "type": "CLIENT_MAC",
-        }
-
-    if "destination_macs" in fields:
-        result["traffic_destination"] = {
-            "ips_or_subnets": [],
-            "network_ids": [],
-            "ports": [],
-            "specific_mac_addresses": fields["destination_macs"],
-            "type": "CLIENT_MAC",
-        }
+    source = _update_side(fields, "source")
+    if source:
+        result["traffic_source"] = source
+    destination = _update_side(fields, "destination")
+    if destination:
+        result["traffic_destination"] = destination
 
     for model_key, controller_key in UPDATE_FIELD_MAP.items():
         if model_key in fields:
-            result[controller_key] = fields[model_key]
+            value = fields[model_key]
+            if model_key == "action" and isinstance(value, str):
+                value = value.upper()  # canonical form, matching the create path
+            result[controller_key] = value
 
     return result
 
@@ -171,4 +370,4 @@ UPDATE_FIELD_MAP: Dict[str, str] = {
     "network_id": "mac_acl_network_id",
 }
 
-MAC_TRANSLATED_FIELDS = frozenset({"source_macs", "destination_macs"})
+MAC_TRANSLATED_FIELDS = frozenset({"source_macs", "destination_macs", "source_netmask", "destination_netmask"})


### PR DESCRIPTION
## Summary

MAC ACL rules can match a leading-bit MAC **prefix** — the UI's optional
"Netmask" dropdown (9–48; 24 = vendor OUI, 48 = full MAC) — but the MCP/API
layer silently dropped it. `from_controller` never read the controller's
`mac_mask` field, so a masked rule looked like a bare-MAC match and the mask
could be **neither seen, set, nor changed**.

This surfaces the netmask end-to-end across both the MCP tools and the API
(GraphQL/REST) server, adds the ability to set and clear it, and hardens the
shared model so the two surfaces can't drift.

**Root cause:** the read translator (`from_controller`) extracted only
`type` + `specific_mac_addresses` from each `traffic_source`/`traffic_destination`
block and discarded the sibling `mac_mask`. Verified against a live controller:
the IGMP/SSDP/mDNS rules carry `mac_mask: ff:ff:ff:00:00:00` (a /24) that the
tools rendered as a bare `01:00:5e:00:00:00`.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server
- [x] API server
- [x] Shared packages
- [x] Documentation

## What changed

- **Model** (`unifi-core/network/models/acl.py`): `AclRule` gains mutable
  `source_netmask`/`destination_netmask` (int 0–48) plus read-only
  `source_mac_mask`/`destination_mac_mask` (the raw 6-octet bitmask, so a
  non-contiguous mask the int can't express stays visible). Bidirectional
  int↔bitmask converters; read-side derivation shared by `from_controller`
  and the GraphQL type (`read_mask_fields`). Clearing emits a `None` sentinel
  the manager pops after fetch-merge-PUT (the controller 400s on an empty
  `mac_mask` and deep-merge can't delete a key). One shared `build_acl_rule`
  used by both surfaces. Hardened: range-guarded converters, strict 6-octet
  mask parsing, null/non-dict traffic blocks, case-insensitive action on update.
- **MCP tools**: `unifi_create_acl_rule` / `unifi_update_acl_rule` gain
  netmask params + `clear_*_netmask` flags; descriptions warn that `0` matches
  ANY MAC.
- **API dispatch** (`_translate_acl_update`): now reads the nested `rule_data`
  dict (it was reading top-level args and dropping **every** field update).
- GraphQL `AclRule` type + cross-layer symmetry; regenerated manifest, OpenAPI
  spec, and GraphQL reference.

## Files changed

| File | Change |
|---|---|
| `packages/unifi-core/.../models/acl.py` | netmask fields, converters, clear sentinel, shared builder, hardening |
| `packages/unifi-core/.../managers/acl_manager.py` | pop the `None` mask sentinel after merge (clears the mask) |
| `apps/network/.../tools/acl.py` | netmask + clear params on create/update; `0`-matches-any warning |
| `apps/api/.../services/dispatch_overrides.py` | read nested `rule_data`; clean error envelope; clear-flag passthrough |
| `apps/api/.../graphql/types/network/acl.py` | expose netmask fields via shared `read_mask_fields` |
| `tests/` (acl_tools, acl_manager, dispatcher, filtering) | model/manager/tool/API + clear + cross-surface coverage |
| `tools_manifest.json`, `openapi.json`, `schema.graphql`, `graphql-reference.md` | regenerated |

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests/checks for the files I changed.
- [ ] I ran `make pre-commit` — `make` isn't installed on this Windows dev host, so I ran the equivalents individually: `ruff check` / `ruff format`, per-package `pytest`, and regenerated every generated artifact (`tools_manifest.json`, `openapi.json`, `schema.graphql`, and the OpenAPI/GraphQL reference docs). The full gate — all three app packages, the Node worker typecheck, and the generated-artifact drift checks — runs in CI.
- [x] I regenerated generated manifests (`tools_manifest.json`, `openapi.json`, `graphql-reference.md`).
- [x] I added/updated tests for the behavior changes.
- [x] I updated documentation (regenerated API reference) for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

| Environment | Details |
|---|---|
| **Device** | UniFi Dream Machine Pro Max (UDMPROMAX) |
| **UniFi OS** | 5.0.16 |
| **Network Application** | 10.1.89 |
| **MCP Client** | Claude Code (stdio) |
| **Host OS** | Windows 10 Pro 10.0.19045 |

| Live test | Result |
|---|---|
| Existing IGMP/SSDP/mDNS /24 rules now surface `destination_netmask=24` + raw `mac_mask` | ✅ |
| `unifi_create_acl_rule` with `destination_netmask=24` → reads back 24 (MCP tool path) | ✅ |
| Update 24→16 via the MCP tool **and** the API dispatch translator (nested `rule_data`) | ✅ |
| `clear_destination_netmask` → mask removed, MACs preserved (MCP + API paths) | ✅ |
| Out-of-range netmask (99) → graceful `{"success": false}` error, not an exception | ✅ |
| All disposable test rules created `enabled: false` and deleted after verification | ✅ |

Unit tests (focused, per-package):

```
apps/network  test_acl_tools.py + test_acl_manager.py — 82 passed
apps/api      test_actions_dispatcher / test_network_filtering / test_cross_layer_symmetry / test_openapi_drift — 123 passed
ruff check + format — clean
```

(One local-only failure, `test_build_dispatch_table_finds_real_tools`, is an
environment artifact — the Access app isn't installed in this machine's
api-server venv — unrelated to this change; it passes in CI where all apps
are present.)

## Notes for reviewers

- The **API dispatch fix** (`_translate_acl_update` reading `rule_data`) is the
  highest-impact change — the API update path previously dropped all field
  updates; the dispatcher tests had encoded a flat arg shape that masked it.
- **Clearing** a netmask uses a `None`-mask sentinel popped by the manager
  (the controller rejects an empty `mac_mask`, and deep-merge can't delete a
  key). `netmask=None` on update remains a safe no-op (round-trip friendly);
  removal is explicit via `clear_*_netmask`.
- **Non-contiguous masks** (API-legal, UI can't express) round-trip via the
  read-only raw `*_mac_mask` field; the int `*_netmask` is `null` for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

