### PR TITLE
chore(release): require unifi-core 0.4.5 (protect, api)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.4,<0.5",
+    "unifi-core[network,protect,access]>=0.4.5,<0.5",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.49.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "unifi-mcp-shared>=0.6.0,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.2,<0.5",
+    "unifi-core[protect]>=0.4.5,<0.5",
     "mcp[cli]>=1.27.2,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
Bumps the **protect** and **api** pins to `unifi-core>=0.4.5,<0.5`, propagating the legacy Protect alarm write-routing fix (`core/v0.4.5`, merged in #366) to the downstream apps.

Both apps route alarm CRUD through the shared `AlarmRulesFacade`, so this guarantees a fresh PyPI install / rebuilt Docker image carries the fix rather than resolving an older core within the previous range.

- Mechanical pin bump only — no source changes; `uv lock` shows no churn (workspace source).
- `unifi-core 0.4.5` is already published to PyPI, so the pin-alignment gate resolves cleanly.

Refs #355. Tag `protect/v0.5.2` + `api/v0.5.5` follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
