### PR TITLE
docs(protect): alarm rule_id is an id, not a UUID

### DIFF
--- a/packages/unifi-core/src/unifi_core/protect/models/_actions.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/_actions.py
@@ -86,7 +86,7 @@ class AlarmGetRuleInput(BaseModel):
 
     __action_input__: ClassVar[bool] = True
 
-    rule_id: str = Field(description="Alarm rule (automation) UUID")
+    rule_id: str = Field(description="Alarm rule (automation) id")
 
 
 class AlarmUpdateRuleInput(BaseModel):
@@ -99,7 +99,7 @@ class AlarmUpdateRuleInput(BaseModel):
 
     __action_input__: ClassVar[bool] = True
 
-    rule_id: str = Field(description="Alarm rule (automation) UUID")
+    rule_id: str = Field(description="Alarm rule (automation) id")
     body: dict = Field(
         description=(
             "Full rule payload (Protect rejects partial bodies). "
@@ -137,7 +137,7 @@ class AlarmDeleteRuleInput(BaseModel):
 
     __action_input__: ClassVar[bool] = True
 
-    rule_id: str = Field(description="Alarm rule (automation) UUID to delete")
+    rule_id: str = Field(description="Alarm rule (automation) id to delete")
 
 
 class TriggerChimeInput(BaseModel):


### PR DESCRIPTION
Cosmetic doc-only follow-up to the alarm legacy-routing fix (#366).

After that fix, an alarm `rule_id` can be a v2 UUID **or** a legacy automation ObjectID (sometimes `_new`-suffixed), so the `get`/`update`/`delete` input-model field descriptions calling it a "UUID" were inaccurate — and could nudge a caller into reformatting a valid legacy id. Changed to "id". Arm-profile ids are genuinely UUIDs and are left unchanged.

No behavior change; rides the next release (not worth a dedicated release cut). Refs #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
