### PR TITLE
fix: verify WLAN/network/AP-group updates persisted before reporting success

### DIFF
--- a/apps/network/tests/unit/test_wifi_tools.py
+++ b/apps/network/tests/unit/test_wifi_tools.py
@@ -376,8 +376,16 @@ class TestNetworkManagerApGroups:
                 "attr_hidden_id": "default",
             }
         ]
-        # First call: list_ap_groups (GET list), second call: PUT merged data
-        mock_connection.request.side_effect = [existing_groups, {}]
+        updated_groups = [
+            {
+                "_id": "grp1",
+                "name": "Renamed Group",
+                "device_macs": ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"],
+                "attr_hidden_id": "default",
+            }
+        ]
+        # GET list (existence) -> PUT merged data -> GET list (persistence re-check)
+        mock_connection.request.side_effect = [existing_groups, {}, updated_groups]
 
         result = await network_manager.update_ap_group(
             "grp1",
@@ -385,8 +393,8 @@ class TestNetworkManagerApGroups:
         )
 
         assert result is True
-        # Verify two requests were made: GET list then PUT
-        assert mock_connection.request.call_count == 2
+        # GET (existence) + PUT + GET (persistence verification)
+        assert mock_connection.request.call_count == 3
         # Second call should be the PUT with merged data
         put_call = mock_connection.request.call_args_list[1]
         put_req = put_call[0][0]

--- a/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
@@ -14,6 +14,40 @@ CACHE_PREFIX_NETWORKS = "networks"
 CACHE_PREFIX_WLANS = "wlans"
 CACHE_PREFIX_AP_GROUPS = "ap_groups"
 
+# Fields the controller never echoes back verbatim (write-only / redacted), so a
+# re-read cannot confirm them. Excluded from post-write persistence verification.
+_UNVERIFIABLE_UPDATE_KEYS = frozenset(
+    {
+        "x_passphrase",
+        "x_password",
+        "sae_psk",
+        "private_preshared_keys",
+        "x_iapp_key",
+        "password",
+    }
+)
+
+
+def _unpersisted_fields(before: Dict[str, Any], after: Dict[str, Any], requested: Dict[str, Any]) -> List[str]:
+    """Return requested keys that were meant to change but did not move.
+
+    A field counts as *not persisted* only when it was actually being changed
+    (requested value differs from the pre-write value) yet the re-read value is
+    still identical to the pre-write value. Fields the controller normalizes to a
+    different-but-non-original value are treated as persisted (avoids false
+    positives), and write-only/redacted fields are skipped entirely.
+    """
+    stuck: List[str] = []
+    for key, want in requested.items():
+        if key in _UNVERIFIABLE_UPDATE_KEYS:
+            continue
+        prev = before.get(key)
+        if prev == want:
+            continue  # no real change requested for this field
+        if after.get(key) == prev:
+            stuck.append(key)
+    return stuck
+
 
 class NetworkManager:
     """Manages network (LAN/VLAN) and WLAN operations on the Unifi Controller."""
@@ -157,6 +191,19 @@ class NetworkManager:
             await self._connection.request(api_request)
             logger.info("Update command sent for network %s with merged data.", network_id)
             self._connection._invalidate_cache(f"{CACHE_PREFIX_NETWORKS}_{self._connection.site}")
+
+            # Verify the controller actually persisted the change. Some controller
+            # versions answer the legacy /rest/networkconf PUT with rc:ok but
+            # silently ignore the write, so a non-raising request() is not
+            # sufficient evidence of success.
+            refetched = await self.get_network_details(network_id)
+            stuck = _unpersisted_fields(existing_network, refetched, update_data)
+            if stuck:
+                return False, (
+                    "Controller accepted the request but did not persist field(s): "
+                    f"{', '.join(sorted(stuck))}. The legacy /rest/networkconf write "
+                    "path may be ignored for these fields on this controller version."
+                )
             return True, None
         except Exception as e:
             logger.error("Error updating network %s: %s", network_id, e, exc_info=True)
@@ -294,6 +341,19 @@ class NetworkManager:
             await self._connection.request(api_request)
             logger.info("Update command sent for WLAN %s with merged data.", wlan_id)
             self._connection._invalidate_cache(f"{CACHE_PREFIX_WLANS}_{self._connection.site}")
+
+            # Verify the controller actually persisted the change. Some controller
+            # / UniFi OS versions answer the legacy /rest/wlanconf PUT with rc:ok
+            # but silently ignore the write, so a non-raising request() is not
+            # sufficient evidence of success.
+            refetched = await self.get_wlan_details(wlan_id)
+            stuck = _unpersisted_fields(existing_wlan, refetched, update_data)
+            if stuck:
+                return False, (
+                    "Controller accepted the request but did not persist field(s): "
+                    f"{', '.join(sorted(stuck))}. The legacy /rest/wlanconf write path "
+                    "may be ignored for these fields on this controller version."
+                )
             return True, None
         except Exception as e:
             logger.error("Error updating WLAN %s: %s", wlan_id, e, exc_info=True)
@@ -445,6 +505,18 @@ class NetworkManager:
             await self._connection.request(api_request)
 
             self._connection._invalidate_cache(CACHE_PREFIX_AP_GROUPS)
+
+            # Verify the controller actually persisted the change; a non-raising
+            # request() is not sufficient evidence the write was applied.
+            refetched = await self.get_ap_group_details(group_id)
+            stuck = _unpersisted_fields(existing, refetched, update_data)
+            if stuck:
+                logger.error(
+                    "AP group %s update not persisted by controller; fields unchanged: %s",
+                    group_id,
+                    ", ".join(sorted(stuck)),
+                )
+                return False
             return True
         except Exception as e:
             logger.error("Error updating AP group %s: %s", group_id, e, exc_info=True)

--- a/packages/unifi-core/tests/network/managers/test_network_manager_update_verification.py
+++ b/packages/unifi-core/tests/network/managers/test_network_manager_update_verification.py
@@ -1,0 +1,125 @@
+"""Post-write persistence verification for fetch-merge-put manager updates.
+
+Regression coverage for the silent-no-op write: the controller can answer a
+legacy /rest/wlanconf (or /rest/networkconf) PUT with rc:ok yet silently not
+persist the requested fields. The managers used to return success
+unconditionally; they now re-read and confirm the change actually landed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from unifi_core.network.managers.network_manager import NetworkManager, _unpersisted_fields
+
+WLAN_ID = "60c7d8e9f0a1b2c3d4e5f6a7"
+NETWORK_ID = "70d8e9f0a1b2c3d4e5f6a7b8"
+
+
+def _make_connection():
+    """Connection mock whose cache always misses, so each fetch hits request()."""
+    conn = MagicMock()
+    conn.site = "default"
+    conn.request = AsyncMock()
+    conn.get_cached = MagicMock(return_value=None)
+    conn._update_cache = MagicMock()
+    conn._invalidate_cache = MagicMock()
+    conn.ensure_connected = AsyncMock(return_value=True)
+    return conn
+
+
+def _wlan(**overrides):
+    base = {"_id": WLAN_ID, "name": "IoT", "proxy_arp": False, "minrate_ng_data_rate_kbps": 1000}
+    base.update(overrides)
+    return base
+
+
+def _network(**overrides):
+    base = {"_id": NETWORK_ID, "name": "Default", "igmp_snooping": False}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _unpersisted_fields helper
+# ---------------------------------------------------------------------------
+
+
+def test_unpersisted_flags_field_that_did_not_move():
+    before = {"proxy_arp": False}
+    after = {"proxy_arp": False}  # unchanged after the write
+    assert _unpersisted_fields(before, after, {"proxy_arp": True}) == ["proxy_arp"]
+
+
+def test_unpersisted_accepts_field_that_changed():
+    before = {"proxy_arp": False}
+    after = {"proxy_arp": True}
+    assert _unpersisted_fields(before, after, {"proxy_arp": True}) == []
+
+
+def test_unpersisted_ignores_noop_request():
+    # Requested value already equals current state -> nothing to verify.
+    before = {"proxy_arp": True}
+    after = {"proxy_arp": True}
+    assert _unpersisted_fields(before, after, {"proxy_arp": True}) == []
+
+
+def test_unpersisted_skips_write_only_fields():
+    before = {"x_passphrase": "old"}
+    after = {}  # controller never echoes the passphrase back
+    assert _unpersisted_fields(before, after, {"x_passphrase": "new"}) == []
+
+
+# ---------------------------------------------------------------------------
+# update_wlan
+# ---------------------------------------------------------------------------
+
+
+async def test_update_wlan_fails_when_not_persisted():
+    conn = _make_connection()
+    mgr = NetworkManager(conn)
+    before = _wlan()
+    # get(pre) -> put(ignored) -> get(post == pre)
+    conn.request.side_effect = [[before], {}, [_wlan()]]
+
+    ok, err = await mgr.update_wlan(WLAN_ID, {"proxy_arp": True})
+
+    assert ok is False
+    assert err is not None and "proxy_arp" in err
+
+
+async def test_update_wlan_succeeds_when_persisted():
+    conn = _make_connection()
+    mgr = NetworkManager(conn)
+    conn.request.side_effect = [[_wlan()], {}, [_wlan(proxy_arp=True)]]
+
+    ok, err = await mgr.update_wlan(WLAN_ID, {"proxy_arp": True})
+
+    assert ok is True
+    assert err is None
+
+
+async def test_update_wlan_succeeds_for_write_only_field():
+    conn = _make_connection()
+    mgr = NetworkManager(conn)
+    # passphrase never round-trips; must not be reported as unpersisted
+    conn.request.side_effect = [[_wlan()], {}, [_wlan()]]
+
+    ok, err = await mgr.update_wlan(WLAN_ID, {"x_passphrase": "newsecret"})
+
+    assert ok is True
+    assert err is None
+
+
+# ---------------------------------------------------------------------------
+# update_network (shares the same verification path)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_network_fails_when_not_persisted():
+    conn = _make_connection()
+    mgr = NetworkManager(conn)
+    conn.request.side_effect = [[_network()], {}, [_network()]]
+
+    ok, err = await mgr.update_network(NETWORK_ID, {"igmp_snooping": True})
+
+    assert ok is False
+    assert err is not None and "igmp_snooping" in err

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1029,6 +1029,13 @@ class LiveSmokeRunner:
             self.skip("unifi_delete_ap_group", "approved", "AP group create did not return an id")
             return
         self.report.created_resources.append({"type": "ap_group", "id": group_id, "name": name})
+        # Exercise update_ap_group: with verify-after-write, a silently dropped
+        # change surfaces as a failed record instead of a phantom success.
+        await self.call(
+            "unifi_update_ap_group",
+            {"group_id": group_id, "update_data": {"name": f"{name}-upd"}, "confirm": True},
+            "approved:update",
+        )
         delete = await self.call("unifi_delete_ap_group", {"group_id": group_id, "confirm": True}, "approved:delete")
         if delete.success:
             self.report.cleaned_resources.append({"type": "ap_group", "id": group_id, "name": name})
@@ -1062,6 +1069,14 @@ class LiveSmokeRunner:
             self.skip("unifi_delete_wlan", "approved", "WLAN create did not return an id")
             return
         self.report.created_resources.append({"type": "wlan", "id": wlan_id, "name": name})
+        # Exercise update_wlan: the WLAN is created hidden, so flipping hide_ssid
+        # is a real change. With verify-after-write a controller that silently
+        # ignores the legacy /rest/wlanconf PUT now yields a failed record here.
+        await self.call(
+            "unifi_update_wlan",
+            {"wlan_id": wlan_id, "update_data": {"hide_ssid": False}, "confirm": True},
+            "approved:update",
+        )
         delete = await self.call("unifi_delete_wlan", {"wlan_id": wlan_id, "confirm": True}, "approved:delete")
         if delete.success:
             self.report.cleaned_resources.append({"type": "wlan", "id": wlan_id, "name": name})


### PR DESCRIPTION
## Summary

The fetch-merge-put manager methods (`update_wlan`, `update_network`, `update_ap_group`) PUT the full merged object to the controller and then returned success **without inspecting the result**. On some controllers / UniFi OS versions the legacy `/rest/wlanconf` and `/rest/networkconf` endpoints answer `rc: ok` but silently do **not** persist the requested fields. Because `aiounifi` only raises on `rc: error`, the manager returned `True` while nothing changed — and the tool layer reported `success: true` with an `updated_fields` list derived from the request, not a read-back.

Refs #371 (full root-cause trace in the issue thread).

## Change

- Add a shared `_unpersisted_fields(before, after, requested)` helper to `network_manager.py`.
- After each write, re-read the object and diff it: if a field was meant to change (requested value differs from the pre-write value) but did **not** move, return a real failure naming the stuck field(s).
- Applied to `update_wlan`, `update_network`, and `update_ap_group`.

Design choices to avoid false positives:
- **Write-only / redacted keys** (`x_passphrase`, `sae_psk`, `private_preshared_keys`, `x_iapp_key`, …) are skipped — they never round-trip.
- A field whose re-read value is *different but non-original* (controller normalization) is treated as **persisted**; only "did not move at all" is flagged.
- No-op requests (requested value already equals current) are ignored.

This converts the silent false-success into an actionable error. It does **not** change the write path itself — if a controller is ignoring the legacy full-object PUT, callers now get a clear error instead of a phantom success. Fixing the underlying write path (minimal payload / V2 endpoint) can be a follow-up.

## Testing

- New `packages/unifi-core/tests/network/managers/test_network_manager_update_verification.py` (8 cases): helper unit tests + `update_wlan` persisted/not-persisted/write-only + `update_network` not-persisted.
- Updated `test_update_ap_group` to supply the post-write re-read (now 3 controller calls: GET existence → PUT → GET verify).
- `make`-equivalent runs: `unifi-core` network suite **618 passed**; network-app `test_wifi_tools` + `test_network_tools` **45 passed**; `ruff check` + `ruff format --check` clean.
