### PR TITLE
fix(redaction): catch underscore-split pre_shared_key fields

### DIFF
--- a/packages/unifi-core/src/unifi_core/redaction.py
+++ b/packages/unifi-core/src/unifi_core/redaction.py
@@ -118,6 +118,11 @@ def is_sensitive_key(key: Any) -> bool:
     for left, right in zip(parts, parts[1:]):
         if right == "key" and left in _SENSITIVE_KEY_QUALIFIERS:
             return True
+    # "preshared" sometimes arrives underscore-split as "pre_shared" (e.g. the
+    # controller's x_ipsec_pre_shared_key field) — match that 3-gram too.
+    for first, second, third in zip(parts, parts[1:], parts[2:]):
+        if (first, second, third) == ("pre", "shared", "key"):
+            return True
     return False
 
 

--- a/packages/unifi-core/tests/test_redaction.py
+++ b/packages/unifi-core/tests/test_redaction.py
@@ -128,6 +128,15 @@ def test_redacts_role_infixed_private_and_preshared_keys() -> None:
     assert is_sensitive_key("wireguard_client_public_key") is False
 
 
+def test_redacts_underscore_split_preshared_key_fields() -> None:
+    # Real UniFi networkconf field for L2TP/IPsec VPNs: "pre" and "shared" are
+    # split into separate underscore-delimited segments, so the bare
+    # "preshared" qualifier match misses it and the PSK leaks in cleartext.
+    assert is_sensitive_key("x_ipsec_pre_shared_key") is True
+    assert is_sensitive_key("ipsec_pre_shared_key") is True
+    assert is_sensitive_key("remote_pre_shared_key") is True
+
+
 def test_redacts_vpn_config_blob_fields() -> None:
     # The secret rides inside a config-blob string under an innocuous key
     # (issue #351): the whole blob field is treated as a secret (suppression).


### PR DESCRIPTION
## Problem

`x_ipsec_pre_shared_key` (L2TP/IPsec VPN networkconf field) leaked in cleartext through `unifi_get_network_details` and other read paths, despite the redaction policy intending to hide VPN preshared keys.

## Root cause

The field name splits into segments `["x", "ipsec", "pre", "shared", "key"]` because `pre` and `shared` are separated by an underscore in the real controller API field name. The existing qualifier check in `is_sensitive_key` only matched a single `preshared` segment immediately before `key`, so this 3-way split never matched.

## Fix

Added a 3-gram check in `packages/unifi-core/src/unifi_core/redaction.py` that recognizes the ("pre", "shared", "key") sequence alongside the existing single-token qualifier match. This generically covers any future field following the same `_pre_shared_key` naming pattern, not just this one field.

## Testing

TDD: added a failing test (`test_redacts_underscore_split_preshared_key_fields`) reproducing the gap, confirmed RED, applied the minimal fix, confirmed GREEN. Full unifi-core suite passes (873 tests; unrelated pre-existing collection errors for protect/aiounifi-dependent modules due to missing optional dependencies in this environment, not caused by this change).

Found while doing a live firewall and security audit on my own controller via the unifi-network MCP plugin -- the PSK appeared in cleartext in a unifi_get_network_details response.