### PR TITLE
feat(network): allow unifi_update_traffic_route to edit route-match fields

### DIFF
--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -78,6 +78,10 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     "unifi_toggle_qos_rule_enabled": ("qos_manager", "update_qos_rule"),
     "unifi_toggle_oon_policy": ("oon_manager", "toggle_oon_policy"),
     "unifi_toggle_traffic_route": ("traffic_route_manager", "toggle_traffic_route"),
+    # update_traffic_route now pre-fetches the route via get_traffic_route_details
+    # to render a current-vs-proposed preview, so the AST walker captures the read
+    # method first. Pin dispatch to the mutation method.
+    "unifi_update_traffic_route": ("traffic_route_manager", "update_traffic_route"),
     # update_device_radio: tool needs current radio_table to identify target band.
     "unifi_update_device_radio": ("device_manager", "update_device_radio"),
     # Stats: tool combines existence check on client/device with stats fetch.

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -292,6 +292,10 @@ def test_dispatch_overrides_specific_targets() -> None:
     # Toggle that needs current state
     assert table["unifi_toggle_firewall_policy"].method == "toggle_firewall_policy"
     assert table["unifi_reorder_firewall_policies"].method == "reorder_firewall_policies"
+    # update_traffic_route pre-fetches the route for its preview, so the AST captures
+    # get_traffic_route_details; the override must pin it to the mutation method.
+    assert table["unifi_update_traffic_route"].manager_attr == "traffic_route_manager"
+    assert table["unifi_update_traffic_route"].method == "update_traffic_route"
     # Stats: list-returning method (was AST-captured as get_X_details, a dict)
     assert table["unifi_get_device_stats"].manager_attr == "stats_manager"
     assert table["unifi_get_device_stats"].method == "get_device_stats"
@@ -318,6 +322,65 @@ def test_dispatch_overrides_specific_targets() -> None:
     assert table["access_lock_door"].method == "apply_lock_door"
     assert table["access_create_credential"].method == "apply_create_credential"
     assert table["access_update_policy"].method == "apply_update_policy"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_update_traffic_route_routes_to_mutation_with_widened_field() -> None:
+    """Regression: unifi_update_traffic_route pre-fetches the route via
+    get_traffic_route_details to render a current-vs-proposed preview, so the AST
+    dispatcher captures the READ method first. The DISPATCH_OVERRIDES entry must
+    redirect dispatch to the mutation method, and a widened match field
+    (target_devices) must reach the manager.
+
+    Uses the REAL build_dispatch_table() so this exercises the override wiring, not
+    just dispatch_action's arg forwarding.
+    """
+    entry = ToolEntry(
+        name="unifi_update_traffic_route",
+        product="network",
+        category="traffic_routes",
+        manager="",
+        method="",
+    )
+    registry = _registry_with(entry)
+
+    domain_manager = MagicMock()
+    domain_manager.update_traffic_route = AsyncMock(return_value=True)
+
+    conn_manager = MagicMock()
+    conn_manager.site = "default"
+    conn_manager.set_site = AsyncMock()
+
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    session = MagicMock()
+    target_devices = [{"type": "CLIENT", "client_mac": "aa:bb:cc:dd:ee:ff"}]
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=session,
+        tool_name="unifi_update_traffic_route",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"route_id": "tr1", "target_devices": target_devices},
+        confirm=True,
+        dispatch_table=build_dispatch_table(),
+    )
+
+    # Override resolved to the traffic_route_manager mutation, NOT the read method
+    # get_traffic_route_details the AST would otherwise capture.
+    factory.get_domain_manager.assert_awaited_once_with(
+        session=session,
+        controller_id="cid",
+        product="network",
+        attr_name="traffic_route_manager",
+    )
+    # The widened match field is forwarded to update_traffic_route as a kwarg
+    # (no arg translator — the manager takes **kwargs; confirm is a separate arg).
+    domain_manager.update_traffic_route.assert_awaited_once_with(route_id="tr1", target_devices=target_devices)
 
 
 @pytest.mark.asyncio

--- a/apps/network/src/unifi_network_mcp/tools/traffic_routes.py
+++ b/apps/network/src/unifi_network_mcp/tools/traffic_routes.py
@@ -6,7 +6,7 @@ on a UniFi Network Controller using the V2 API.
 """
 
 import logging
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -92,11 +92,22 @@ async def get_traffic_route_details(
     name="unifi_update_traffic_route",
     description="""Update a traffic route's settings.
 
-Can update:
+Toggle fields:
 - enabled: Enable or disable the traffic route
 - kill_switch_enabled: Enable/disable the kill switch (blocks traffic if VPN is down)
 
-At least one parameter must be provided.""",
+Routing-match fields (each REPLACES the whole existing list/value — read the route
+first with unifi_get_traffic_route_details, then send the full desired value):
+- target_devices: Which clients/networks the route applies to. List of objects, e.g.
+  [{"type": "CLIENT", "client_mac": "aa:bb:cc:dd:ee:ff"}],
+  [{"type": "NETWORK", "network_id": "<id>"}], or [{"type": "ALL_CLIENTS"}].
+- domains: List of domain objects, e.g. [{"domain": "example.com", "ports": [], "port_ranges": []}].
+- ip_addresses: List of IP/subnet objects (for matching_target=IP routes).
+- ip_ranges: List of IP-range objects.
+- regions: List of ISO country/region codes, e.g. ["US", "CA"].
+- next_hop: Next-hop IP address (string) for static next-hop routes.
+
+At least one field must be provided.""",
     permission_category="traffic_routes",
     permission_action="update",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
@@ -113,44 +124,102 @@ async def update_traffic_route(
             description="Enable (true) or disable (false) the kill switch, which blocks traffic if the VPN goes down"
         ),
     ] = None,
+    target_devices: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(
+            description=(
+                "Replace the route's target devices. List of objects, e.g. "
+                '[{"type": "CLIENT", "client_mac": "aa:bb:cc:dd:ee:ff"}], '
+                '[{"type": "NETWORK", "network_id": "<id>"}], or [{"type": "ALL_CLIENTS"}].'
+            )
+        ),
+    ] = None,
+    domains: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(
+            description=(
+                "Replace the route's domains. List of objects, e.g. "
+                '[{"domain": "example.com", "ports": [], "port_ranges": []}].'
+            )
+        ),
+    ] = None,
+    ip_addresses: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(description="Replace the route's IP addresses/subnets (for matching_target=IP routes)."),
+    ] = None,
+    ip_ranges: Annotated[
+        Optional[List[Dict[str, Any]]],
+        Field(description="Replace the route's IP ranges."),
+    ] = None,
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description='Replace the route\'s regions. List of ISO country/region codes, e.g. ["US", "CA"].'),
+    ] = None,
+    next_hop: Annotated[
+        Optional[str],
+        Field(description="Next-hop IP address (string) for static next-hop routes."),
+    ] = None,
     confirm: Annotated[
         bool,
         Field(description="When true, applies the update. When false (default), returns a preview of the changes"),
     ] = False,
 ) -> Dict[str, Any]:
     """Update a traffic route's settings."""
-    if enabled is None and kill_switch_enabled is None:
+    field_values: Dict[str, Any] = {
+        "enabled": enabled,
+        "kill_switch_enabled": kill_switch_enabled,
+        "target_devices": target_devices,
+        "domains": domains,
+        "ip_addresses": ip_addresses,
+        "ip_ranges": ip_ranges,
+        "regions": regions,
+        "next_hop": next_hop,
+    }
+    updates: Dict[str, Any] = {k: v for k, v in field_values.items() if v is not None}
+
+    if not updates:
         return {
             "success": False,
-            "error": "At least one of 'enabled' or 'kill_switch_enabled' must be provided.",
+            "error": (
+                "At least one updatable field must be provided: enabled, kill_switch_enabled, "
+                "target_devices, domains, ip_addresses, ip_ranges, regions, next_hop."
+            ),
         }
 
-    updates: Dict[str, Any] = {}
-    if enabled is not None:
-        updates["enabled"] = enabled
-    if kill_switch_enabled is not None:
-        updates["kill_switch_enabled"] = kill_switch_enabled
-
-    if not confirm:
-        return update_preview(
-            resource_type="traffic_route",
-            resource_id=route_id,
-            resource_name=route_id,
-            current_state={},
-            updates=updates,
-        )
+    # Validate list-shaped fields client-side before touching the controller.
+    for field in ("target_devices", "domains", "ip_addresses", "ip_ranges", "regions"):
+        if field in updates and not isinstance(updates[field], list):
+            return {"success": False, "error": f"'{field}' must be a list."}
+    for entry in updates.get("target_devices", []):
+        if not isinstance(entry, dict) or "type" not in entry:
+            return {
+                "success": False,
+                "error": (
+                    "Each target_devices entry must be an object with a 'type', e.g. "
+                    '{"type": "CLIENT", "client_mac": "aa:bb:cc:dd:ee:ff"}, '
+                    '{"type": "NETWORK", "network_id": "<id>"}, or {"type": "ALL_CLIENTS"}.'
+                ),
+            }
 
     try:
+        # Fetch current route so the preview can show what is being replaced.
+        current = await traffic_route_manager.get_traffic_route_details(route_id)
+        route_name = current.get("description", route_id)
+
+        if not confirm:
+            return update_preview(
+                resource_type="traffic_route",
+                resource_id=route_id,
+                resource_name=route_name,
+                current_state=current,
+                updates=updates,
+            )
+
         success = await traffic_route_manager.update_traffic_route(route_id, **updates)
         if success:
-            changes = []
-            if enabled is not None:
-                changes.append(f"enabled={'on' if enabled else 'off'}")
-            if kill_switch_enabled is not None:
-                changes.append(f"kill_switch={'on' if kill_switch_enabled else 'off'}")
             return {
                 "success": True,
-                "message": f"Traffic route '{route_id}' updated: {', '.join(changes)}.",
+                "message": f"Traffic route '{route_name}' updated: {', '.join(sorted(updates.keys()))}.",
             }
         return {
             "success": False,

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -16808,7 +16808,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Update a traffic route's settings.\n\nCan update:\n- enabled: Enable or disable the traffic route\n- kill_switch_enabled: Enable/disable the kill switch (blocks traffic if VPN is down)\n\nAt least one parameter must be provided.",
+      "description": "Update a traffic route's settings.\n\nToggle fields:\n- enabled: Enable or disable the traffic route\n- kill_switch_enabled: Enable/disable the kill switch (blocks traffic if VPN is down)\n\nRouting-match fields (each REPLACES the whole existing list/value \u2014 read the route\nfirst with unifi_get_traffic_route_details, then send the full desired value):\n- target_devices: Which clients/networks the route applies to. List of objects, e.g.\n  [{\"type\": \"CLIENT\", \"client_mac\": \"aa:bb:cc:dd:ee:ff\"}],\n  [{\"type\": \"NETWORK\", \"network_id\": \"<id>\"}], or [{\"type\": \"ALL_CLIENTS\"}].\n- domains: List of domain objects, e.g. [{\"domain\": \"example.com\", \"ports\": [], \"port_ranges\": []}].\n- ip_addresses: List of IP/subnet objects (for matching_target=IP routes).\n- ip_ranges: List of IP-range objects.\n- regions: List of ISO country/region codes, e.g. [\"US\", \"CA\"].\n- next_hop: Next-hop IP address (string) for static next-hop routes.\n\nAt least one field must be provided.",
       "name": "unifi_update_traffic_route",
       "permission_action": "update",
       "permission_category": "traffic_routes",
@@ -16819,17 +16819,41 @@
               "description": "When true, applies the update. When false (default), returns a preview of the changes",
               "type": "boolean"
             },
+            "domains": {
+              "description": "Replace the route's domains. List of objects, e.g. [{\"domain\": \"example.com\", \"ports\": [], \"port_ranges\": []}].",
+              "type": "array"
+            },
             "enabled": {
               "description": "Enable (true) or disable (false) the traffic route",
               "type": "boolean"
+            },
+            "ip_addresses": {
+              "description": "Replace the route's IP addresses/subnets (for matching_target=IP routes).",
+              "type": "array"
+            },
+            "ip_ranges": {
+              "description": "Replace the route's IP ranges.",
+              "type": "array"
             },
             "kill_switch_enabled": {
               "description": "Enable (true) or disable (false) the kill switch, which blocks traffic if the VPN goes down",
               "type": "boolean"
             },
+            "next_hop": {
+              "description": "Next-hop IP address (string) for static next-hop routes.",
+              "type": "string"
+            },
+            "regions": {
+              "description": "Replace the route's regions. List of ISO country/region codes, e.g. [\"US\", \"CA\"].",
+              "type": "array"
+            },
             "route_id": {
               "description": "Unique identifier (_id) of the traffic route to update (from unifi_list_traffic_routes)",
               "type": "string"
+            },
+            "target_devices": {
+              "description": "Replace the route's target devices. List of objects, e.g. [{\"type\": \"CLIENT\", \"client_mac\": \"aa:bb:cc:dd:ee:ff\"}], [{\"type\": \"NETWORK\", \"network_id\": \"<id>\"}], or [{\"type\": \"ALL_CLIENTS\"}].",
+              "type": "array"
             }
           },
           "required": [

--- a/apps/network/tests/unit/test_traffic_route_tools.py
+++ b/apps/network/tests/unit/test_traffic_route_tools.py
@@ -1,0 +1,150 @@
+"""Tests for unifi_update_traffic_route editing route-match fields (target_devices, domains, etc.)."""
+
+import copy
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_ROUTE = {
+    "_id": "route-001",
+    "description": "secondlife-staging.com",
+    "enabled": True,
+    "kill_switch_enabled": False,
+    "network_id": "net-vpn",
+    "matching_target": "DOMAIN",
+    "domains": [{"domain": "secondlife-staging.com", "ports": [], "port_ranges": []}],
+    "ip_addresses": [],
+    "ip_ranges": [],
+    "regions": [],
+    "target_devices": [{"type": "CLIENT", "client_mac": "dc:cc:e6:66:86:2b"}],
+    "next_hop": "",
+}
+
+NEW_TARGETS = [{"type": "CLIENT", "client_mac": "fe:38:bd:88:e9:c5"}]
+
+
+def _mock_manager():
+    """Return a mock TrafficRouteManager with async get/update methods."""
+    mgr = MagicMock()
+    mgr.get_traffic_route_details = AsyncMock(return_value=copy.deepcopy(SAMPLE_ROUTE))
+    mgr.update_traffic_route = AsyncMock(return_value=True)
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Preview / apply for target_devices (the headline use case: swapping a device)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTrafficRouteTargets:
+    @pytest.mark.asyncio
+    async def test_target_devices_preview_shows_current_and_proposed(self):
+        mgr = _mock_manager()
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route("route-001", target_devices=NEW_TARGETS, confirm=False)
+
+        assert result["success"] is True
+        assert result["requires_confirmation"] is True
+        assert result["preview"]["current"]["target_devices"] == SAMPLE_ROUTE["target_devices"]
+        assert result["preview"]["proposed"]["target_devices"] == NEW_TARGETS
+        mgr.update_traffic_route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_target_devices_apply_forwards_to_manager(self):
+        mgr = _mock_manager()
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route("route-001", target_devices=NEW_TARGETS, confirm=True)
+
+        assert result["success"] is True
+        mgr.update_traffic_route.assert_awaited_once_with("route-001", target_devices=NEW_TARGETS)
+
+    @pytest.mark.asyncio
+    async def test_multiple_route_match_fields_forwarded(self):
+        mgr = _mock_manager()
+        new_domains = [{"domain": "dev.secondlife.io", "ports": [], "port_ranges": []}]
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route(
+                "route-001",
+                domains=new_domains,
+                regions=["US"],
+                next_hop="10.0.0.1",
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        mgr.update_traffic_route.assert_awaited_once_with(
+            "route-001", domains=new_domains, regions=["US"], next_hop="10.0.0.1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enabled_only_still_works(self):
+        mgr = _mock_manager()
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route("route-001", enabled=False, confirm=True)
+
+        assert result["success"] is True
+        mgr.update_traffic_route.assert_awaited_once_with("route-001", enabled=False)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTrafficRouteValidation:
+    @pytest.mark.asyncio
+    async def test_no_fields_provided_errors(self):
+        mgr = _mock_manager()
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route("route-001", confirm=True)
+
+        assert result["success"] is False
+        assert "At least one updatable field" in result["error"]
+        # Should fail fast without touching the controller.
+        mgr.get_traffic_route_details.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_target_devices_must_be_list(self):
+        mgr = _mock_manager()
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route("route-001", target_devices={"type": "ALL_CLIENTS"}, confirm=True)
+
+        assert result["success"] is False
+        assert "must be a list" in result["error"]
+        mgr.update_traffic_route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_target_devices_entry_requires_type(self):
+        mgr = _mock_manager()
+        with patch("unifi_network_mcp.tools.traffic_routes.traffic_route_manager", mgr):
+            from unifi_network_mcp.tools.traffic_routes import update_traffic_route
+
+            result = await update_traffic_route(
+                "route-001", target_devices=[{"client_mac": "aa:bb:cc:dd:ee:ff"}], confirm=True
+            )
+
+        assert result["success"] is False
+        assert "must be an object with a 'type'" in result["error"]
+        mgr.update_traffic_route.assert_not_awaited()

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -633,6 +633,7 @@ class LiveSmokeRunner:
             await self.lifecycle_network_firewall_policy()
             await self.lifecycle_network_oon_policy()
             await self.lifecycle_network_voucher()
+            await self.lifecycle_network_traffic_route()
         elif self.server_key == "protect":
             await self.approved_protect_physical()
         elif self.server_key == "access":
@@ -778,7 +779,10 @@ class LiveSmokeRunner:
             route_id = self.value_for_param(name, "route_id")
             if not route_id:
                 return None, "could not discover required argument route_id"
-            return {"route_id": route_id, "enabled": True}, ""
+            # Exercise a widened match field (target_devices) in preview. run_previews
+            # forces confirm=False, so this only renders a current-vs-proposed diff and
+            # runs the tool's client-side target_devices validation — nothing is written.
+            return {"route_id": route_id, "target_devices": [{"type": "ALL_CLIENTS"}]}, ""
         if name == "unifi_update_usergroup":
             group_id = self.value_for_param(name, "group_id")
             if not group_id:
@@ -893,6 +897,30 @@ class LiveSmokeRunner:
             if value:
                 return str(value)
         return None
+
+    def traffic_route_detail(self) -> dict[str, Any]:
+        """Full route dict from the most recent unifi_get_traffic_route_details call."""
+        payload = self.cache.by_tool.get("unifi_get_traffic_route_details", {})
+        detail = payload.get("details") if isinstance(payload, dict) else None
+        return detail if isinstance(detail, dict) else {}
+
+    def record_check(self, tool: str, phase: str, ok: bool, detail: str) -> None:
+        """Append a pass/fail verification record (a re-read content assertion).
+
+        Unlike WLAN/AP-group updates, the traffic-route manager does not verify-
+        after-write, so the lifecycle re-reads the route and records whether the
+        change actually persisted/reverted. A failed record fails the run.
+        """
+        self.report.records.append(
+            SmokeRecord(
+                tool=tool,
+                phase=phase,
+                status="ok" if ok else "failed",
+                success=ok,
+                summary={"check": detail},
+            )
+        )
+        print(f"{self.server_key} {phase} {'ok' if ok else 'failed'}: {tool} - {detail}", flush=True)
 
     async def lifecycle_network_dns(self) -> None:
         stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
@@ -1203,6 +1231,94 @@ class LiveSmokeRunner:
         )
         if revoke.success:
             self.report.cleaned_resources.append({"type": "voucher", "id": voucher_id, "name": note})
+
+    async def lifecycle_network_traffic_route(self) -> None:
+        # Traffic routes can't be created via MCP (they require a VPN policy), so the
+        # widened-update path (PR #377: target_devices/domains/ip_addresses/ip_ranges/
+        # regions/next_hop) is exercised against an EXISTING route in a fully
+        # reversible way: read current domains, append a throwaway non-resolving
+        # domain, apply, re-read to prove it persisted, then revert to the original
+        # list and re-read to prove it reverted. An operator can pin the target route
+        # via UNIFI_SMOKE_TRAFFIC_ROUTE_ID; otherwise the first DOMAIN route is used.
+        await self.call("unifi_list_traffic_routes", {}, "approved:seed")
+        routes = self.cache.items_from_tool("unifi_list_traffic_routes", "traffic_routes") or self.cache.items(
+            "traffic_routes"
+        )
+        pinned = os.environ.get("UNIFI_SMOKE_TRAFFIC_ROUTE_ID")
+        route_id: Any = None
+        if pinned:
+            if not any(first_value(r, ("_id", "id")) == pinned for r in routes):
+                self.skip("unifi_update_traffic_route", "approved", f"pinned route {pinned} not found")
+                return
+            route_id = pinned
+        else:
+            for r in routes:
+                if str(r.get("matching_target", "")).upper() == "DOMAIN":
+                    route_id = first_value(r, ("_id", "id"))
+                    break
+        if not route_id:
+            self.skip("unifi_update_traffic_route", "approved", "no DOMAIN traffic route to exercise")
+            return
+
+        await self.call("unifi_get_traffic_route_details", {"route_id": route_id}, "approved:get")
+        detail = self.traffic_route_detail()
+        original_domains = detail.get("domains")
+        if not isinstance(original_domains, list) or not original_domains:
+            self.skip("unifi_update_traffic_route", "approved", "route has no domains list to exercise")
+            return
+        route_name = detail.get("description", route_id)
+
+        stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+        # Use the IANA documentation domain (example.com) so the controller accepts it
+        # as a valid domain — a reserved TLD like .invalid is rejected (api.err.InvalidDomain).
+        probe_domain = f"{RUN_PREFIX}-{stamp}.example.com"
+        new_domains = [*original_domains, {"domain": probe_domain, "ports": [], "port_ranges": []}]
+
+        # Preview the widened-field change (confirm=False → no mutation).
+        await self.call(
+            "unifi_update_traffic_route",
+            {"route_id": route_id, "domains": new_domains, "confirm": False},
+            "approved:preview",
+        )
+
+        # Apply the reversible change.
+        self.report.created_resources.append(
+            {"type": "traffic_route_domain_probe", "id": route_id, "name": probe_domain}
+        )
+        await self.call(
+            "unifi_update_traffic_route",
+            {"route_id": route_id, "domains": new_domains, "confirm": True},
+            "approved:update",
+        )
+        # Re-read and prove the probe domain persisted.
+        await self.call("unifi_get_traffic_route_details", {"route_id": route_id}, "approved:verify")
+        persisted = any(d.get("domain") == probe_domain for d in self.traffic_route_detail().get("domains", []))
+        self.record_check(
+            "unifi_update_traffic_route",
+            "approved:verify",
+            persisted,
+            f"probe domain {probe_domain} present on '{route_name}' after update",
+        )
+
+        # Revert to the original domains list.
+        await self.call(
+            "unifi_update_traffic_route",
+            {"route_id": route_id, "domains": original_domains, "confirm": True},
+            "approved:revert",
+        )
+        await self.call("unifi_get_traffic_route_details", {"route_id": route_id}, "approved:verify-revert")
+        reverted_domains = self.traffic_route_detail().get("domains", [])
+        reverted = all(d.get("domain") != probe_domain for d in reverted_domains)
+        self.record_check(
+            "unifi_update_traffic_route",
+            "approved:verify-revert",
+            reverted,
+            f"probe domain removed; '{route_name}' domains restored to {len(original_domains)} entries",
+        )
+        if reverted:
+            self.report.cleaned_resources.append(
+                {"type": "traffic_route_domain_probe", "id": route_id, "name": probe_domain}
+            )
 
     async def lifecycle_protect_alarm_rule(self) -> None:
         if not self.cache.items_from_tool("protect_list_cameras", "cameras"):


### PR DESCRIPTION
Closes #376.

### What

Widens `unifi_update_traffic_route` so it can edit a route's match/targeting, not just toggle it. New optional params:

- `target_devices` — replace which clients/networks the route applies to (`[{"type": "CLIENT", "client_mac": "…"}]`, `[{"type": "NETWORK", "network_id": "…"}]`, `[{"type": "ALL_CLIENTS"}]`)
- `domains`, `ip_addresses`, `ip_ranges` — list-of-object match fields
- `regions` — list of ISO country/region codes
- `next_hop` — static next-hop IP

`enabled` / `kill_switch_enabled` behave exactly as before.

### Why

There was no MCP path to change which device a policy-based (VPN) route targets — that required the UniFi UI. See #376 for the motivating device-swap scenario.

### How

This is a **tool-layer change only**. `TrafficRouteManager.update_traffic_route(route_id, enabled=None, **kwargs)` already fetches the full route, merges non-`None` kwargs, and `PUT`s the whole object to `/trafficroutes/{id}` (V2). The tool just never forwarded anything beyond the two toggles. The diff:

- forwards any provided field into the existing manager call;
- requires **at least one** updatable field (instead of specifically `enabled`/`kill_switch_enabled`);
- fetches the current route so the confirm-preview shows current-vs-proposed for the changed fields;
- validates list-shaped fields (and that each `target_devices` entry is an object with a `type`) client-side;
- updates the tool description and regenerates `tools_manifest.json`.

No manager or controller-API change.

### Testing

- New `apps/network/tests/unit/test_traffic_route_tools.py` covering target-device preview/apply, multi-field forwarding, the enabled-only path, and validation errors.
- `make manifest` regenerated (178 tools).
- `make format` / `make lint` clean; full `make test` → **797 passed** (incl. manifest-sync and tool-map-sync).

### Backward compatibility

Additive — all new params are optional and default `None`; existing toggle behavior is unchanged.