### PR TITLE
fix(wlan): accept networkconf_id alias in create_wlan and update_wlan

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -1193,7 +1193,9 @@ async def create_wlan(
     from unifi_core.network.models.wlans import Wlan as WlanModel
 
     try:
-        wlan_model = WlanModel(**{k: v for k, v in wlan_data.items() if k in WLAN_MUTABLE_FIELDS})
+        # Accept networkconf_id as an alias for network_id (controller name vs model name)
+        normalized = {("network_id" if k == "networkconf_id" else k): v for k, v in wlan_data.items()}
+        wlan_model = WlanModel(**{k: v for k, v in normalized.items() if k in WLAN_MUTABLE_FIELDS})
     except Exception as exc:
         return {"success": False, "error": f"Invalid WLAN data: {exc}"}
     validated_data = wlan_to_create(wlan_model)

--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -1193,9 +1193,12 @@ async def create_wlan(
     from unifi_core.network.models.wlans import Wlan as WlanModel
 
     try:
-        # Accept networkconf_id as an alias for network_id (controller name vs model name)
-        normalized = {("network_id" if k == "networkconf_id" else k): v for k, v in wlan_data.items()}
-        wlan_model = WlanModel(**{k: v for k, v in normalized.items() if k in WLAN_MUTABLE_FIELDS})
+        # Accept networkconf_id as an alias for network_id (controller name vs model name).
+        # Only remap when network_id is not already present — mirrors to_controller_update behaviour.
+        if "networkconf_id" in wlan_data and "network_id" not in wlan_data:
+            wlan_data = {**wlan_data, "network_id": wlan_data["networkconf_id"]}
+            wlan_data = {k: v for k, v in wlan_data.items() if k != "networkconf_id"}
+        wlan_model = WlanModel(**{k: v for k, v in wlan_data.items() if k in WLAN_MUTABLE_FIELDS})
     except Exception as exc:
         return {"success": False, "error": f"Invalid WLAN data: {exc}"}
     validated_data = wlan_to_create(wlan_model)

--- a/apps/network/tests/unit/test_network_tools.py
+++ b/apps/network/tests/unit/test_network_tools.py
@@ -582,10 +582,11 @@ class TestUpdateWlanNetworkconfId:
 
             result = await update_wlan("w1", {"networkconf_id": "new-net"}, confirm=True)
 
-        assert result.get("error") != "Update data is effectively empty or invalid."
         assert result["success"] is True
+        assert "networkconf_id" in result["updated_fields"]
         payload = mock_mgr.update_wlan.call_args[0][1]
         assert payload.get("networkconf_id") == "new-net"
+        assert "network_id" not in payload
 
     @pytest.mark.asyncio
     async def test_networkconf_id_preview_is_not_rejected(self):
@@ -598,6 +599,6 @@ class TestUpdateWlanNetworkconfId:
 
             result = await update_wlan("w1", {"networkconf_id": "new-net"}, confirm=False)
 
-        assert result.get("error") != "Update data is effectively empty or invalid."
         assert "preview" in result
+        assert result["preview"]["proposed"]["networkconf_id"] == "new-net"
         mock_mgr.update_wlan.assert_not_called()

--- a/apps/network/tests/unit/test_network_tools.py
+++ b/apps/network/tests/unit/test_network_tools.py
@@ -510,3 +510,94 @@ class TestWlanToolRedaction:
         )
 
         assert result["preview"]["will_create"]["x_passphrase"] == REDACTED
+
+
+class TestCreateWlanNetworkconfId:
+    """create_wlan must forward networkconf_id to the manager regardless of whether
+    the caller uses the controller field name (networkconf_id) or the model field name (network_id)."""
+
+    @pytest.mark.asyncio
+    async def test_networkconf_id_alias_reaches_manager(self):
+        created = {"_id": "w99", "name": "HomeSSID", "networkconf_id": "net-abc"}
+        with patch("unifi_network_mcp.tools.network.network_manager") as mock_mgr:
+            mock_mgr.create_wlan = AsyncMock(return_value=created)
+            mock_mgr._connection.site = "default"
+
+            from unifi_network_mcp.tools.network import create_wlan
+
+            result = await create_wlan(
+                {
+                    "name": "HomeSSID",
+                    "security": "wpapsk",
+                    "x_passphrase": "password1",
+                    "networkconf_id": "net-abc",
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        payload = mock_mgr.create_wlan.call_args[0][0]
+        assert payload.get("networkconf_id") == "net-abc", (
+            "networkconf_id was silently dropped before reaching the manager"
+        )
+        assert "network_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_network_id_model_name_also_works(self):
+        created = {"_id": "w99", "name": "HomeSSID", "networkconf_id": "net-abc"}
+        with patch("unifi_network_mcp.tools.network.network_manager") as mock_mgr:
+            mock_mgr.create_wlan = AsyncMock(return_value=created)
+            mock_mgr._connection.site = "default"
+
+            from unifi_network_mcp.tools.network import create_wlan
+
+            result = await create_wlan(
+                {
+                    "name": "HomeSSID",
+                    "security": "wpapsk",
+                    "x_passphrase": "password1",
+                    "network_id": "net-abc",
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        payload = mock_mgr.create_wlan.call_args[0][0]
+        assert payload.get("networkconf_id") == "net-abc"
+
+
+class TestUpdateWlanNetworkconfId:
+    """update_wlan must accept networkconf_id (controller field name) and not return
+    'Update data is effectively empty or invalid' when it is the only field passed."""
+
+    @pytest.mark.asyncio
+    async def test_networkconf_id_alias_is_not_rejected(self):
+        current_wlan = {"_id": "w1", "name": "SSID", "networkconf_id": "old-net"}
+        updated_wlan = {"_id": "w1", "name": "SSID", "networkconf_id": "new-net"}
+        with patch("unifi_network_mcp.tools.network.network_manager") as mock_mgr:
+            mock_mgr.get_wlan_details = AsyncMock(side_effect=[current_wlan, updated_wlan])
+            mock_mgr.update_wlan = AsyncMock(return_value=(True, None))
+
+            from unifi_network_mcp.tools.network import update_wlan
+
+            result = await update_wlan("w1", {"networkconf_id": "new-net"}, confirm=True)
+
+        assert result.get("error") != "Update data is effectively empty or invalid."
+        assert result["success"] is True
+        payload = mock_mgr.update_wlan.call_args[0][1]
+        assert payload.get("networkconf_id") == "new-net"
+
+    @pytest.mark.asyncio
+    async def test_networkconf_id_preview_is_not_rejected(self):
+        current_wlan = {"_id": "w1", "name": "SSID", "networkconf_id": "old-net"}
+        with patch("unifi_network_mcp.tools.network.network_manager") as mock_mgr:
+            mock_mgr.get_wlan_details = AsyncMock(return_value=current_wlan)
+            mock_mgr.update_wlan = AsyncMock()
+
+            from unifi_network_mcp.tools.network import update_wlan
+
+            result = await update_wlan("w1", {"networkconf_id": "new-net"}, confirm=False)
+
+        assert result.get("error") != "Update data is effectively empty or invalid."
+        assert "preview" in result
+        mock_mgr.update_wlan.assert_not_called()

--- a/packages/unifi-core/src/unifi_core/network/models/wlans.py
+++ b/packages/unifi-core/src/unifi_core/network/models/wlans.py
@@ -281,7 +281,12 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     Read-only fields and unrecognised keys are dropped.
     ``None`` values are dropped; boolean ``False`` is preserved.
     Maps model field names to controller API field names.
+    Accepts ``networkconf_id`` as an alias for ``network_id`` so callers can
+    pass either the controller field name or the model field name.
     """
+    if "networkconf_id" in fields and "network_id" not in fields:
+        fields = {**fields, "network_id": fields["networkconf_id"]}
+        fields = {k: v for k, v in fields.items() if k != "networkconf_id"}
     result = {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
     # Map network_id → networkconf_id
     if "network_id" in result:

--- a/packages/unifi-core/tests/network/models/test_wlans.py
+++ b/packages/unifi-core/tests/network/models/test_wlans.py
@@ -178,3 +178,9 @@ class TestToControllerUpdate:
         result = to_controller_update({"networkconf_id": "net-3", "enabled": True})
         assert result.get("networkconf_id") == "net-3"
         assert result.get("enabled") is True
+
+    def test_network_id_takes_precedence_when_both_passed(self) -> None:
+        """Explicit model field name wins over the controller alias regardless of insertion order."""
+        result = to_controller_update({"networkconf_id": "alias", "network_id": "explicit"})
+        assert result.get("networkconf_id") == "explicit"
+        assert "network_id" not in result

--- a/packages/unifi-core/tests/network/models/test_wlans.py
+++ b/packages/unifi-core/tests/network/models/test_wlans.py
@@ -167,3 +167,14 @@ class TestToControllerUpdate:
     def test_toggle_payload(self) -> None:
         result = to_controller_update({"enabled": False})
         assert result == {"enabled": False}
+
+    def test_networkconf_id_alias_maps_to_networkconf_id(self) -> None:
+        """Callers may pass the controller field name networkconf_id directly."""
+        result = to_controller_update({"networkconf_id": "net-3"})
+        assert result.get("networkconf_id") == "net-3"
+        assert "network_id" not in result
+
+    def test_networkconf_id_alias_combined_with_other_fields(self) -> None:
+        result = to_controller_update({"networkconf_id": "net-3", "enabled": True})
+        assert result.get("networkconf_id") == "net-3"
+        assert result.get("enabled") is True


### PR DESCRIPTION
## Summary

Both `unifi_create_wlan` and `unifi_update_wlan` accept a `networkconf_id` parameter in their documentation and descriptions, but the value was silently dropped before reaching the controller — causing all SSIDs to land on the Default network regardless of the parameter passed.

**Root cause:** The shared `Wlan` pydantic model normalises the controller field `networkconf_id` to the model field `network_id` on ingest. Both tool input filters check model field names only, so a caller passing `networkconf_id` (as the docs say to) had it discarded before the model was built.

- `create_wlan`: input was filtered against `WLAN_MUTABLE_FIELDS` (which contains `network_id`, not `networkconf_id`) before the pydantic model was constructed
- `update_wlan`: `to_controller_update` filtered to `MUTABLE_FIELDS` keys only — `networkconf_id` was not one of them, producing an empty dict and the error `"Update data is effectively empty or invalid."`

Closes #386.

## Changes

- **`packages/unifi-core/src/unifi_core/network/models/wlans.py`** — `to_controller_update` normalises `networkconf_id` → `network_id` before filtering, when `network_id` is not already present. Fixes `update_wlan`.
- **`apps/network/src/unifi_network_mcp/tools/network.py`** — `create_wlan` applies the same explicit guard before the `WLAN_MUTABLE_FIELDS` filter. Uses an explicit condition (not a dict comprehension) so `network_id` always wins when both names are passed, regardless of insertion order.
- **`packages/unifi-core/tests/network/models/test_wlans.py`** — model-layer tests for the alias and both-names-passed precedence case
- **`apps/network/tests/unit/test_network_tools.py`** — tool-layer tests covering alias and model-name paths for both `create_wlan` and `update_wlan` (confirm + preview)

Both caller-side names now work; the controller payload always uses `networkconf_id`.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server
- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

```
cd apps/network && make pre-commit
# 801 passed
```

## Notes for reviewers

The fix is intentionally minimal — two explicit alias-normalisation guards, one in `to_controller_update` (shared model layer) and one in `create_wlan` (tool layer). No schema changes, no manifest regeneration needed (tool signatures are unchanged).

The same aliasing pattern exists for `vlan`/`vlan_id` but is out of scope for this PR.

Reproduced on UCG Ultra running UniFi OS 5.1.19 with `unifi-network-mcp` via `uvx`.