### PR TITLE
Harden live smoke and app precommit workflows

### DIFF
--- a/apps/access/Makefile
+++ b/apps/access/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo "  make lint           Run linters"
 	@echo "  make format         Format code"
 	@echo "  make format-fix     Auto-fix lint issues"
-	@echo "  make pre-commit     Format + lint + test"
+	@echo "  make pre-commit     Format + manifests + lint + test"
 	@echo ""
 	@echo "Build & Release:"
 	@echo "  make version        Show current version (from git tags)"
@@ -115,7 +115,7 @@ version:
 build: manifest server-manifest
 	cd ../.. && uv build --package unifi-access-mcp
 
-build-check: clean manifest
+build-check: clean manifest server-manifest
 	@echo "Building and verifying version..."
 	cd ../.. && uv build --package unifi-access-mcp
 	@WHEEL=$$(ls ../../dist/unifi_access_mcp-*.whl | head -1); \
@@ -159,9 +159,9 @@ clean:
 	find . -type f -name "*.pyc" -delete
 
 # Pre-commit / Pre-release
-pre-commit: format lint test
+pre-commit: format manifest server-manifest lint test
 
-pre-release: clean manifest format lint test build-check
+pre-release: clean manifest server-manifest format lint test build-check
 	@echo ""
 	@echo "Release preparation complete!"
 	@echo ""

--- a/apps/api/tests/test_live_api_smoke_harness.py
+++ b/apps/api/tests/test_live_api_smoke_harness.py
@@ -96,3 +96,21 @@ def test_live_smoke_known_visitor_endpoint_404_requires_full_signature():
             '"error":"you entered no-man zone"}'
         ),
     )
+
+
+def test_live_smoke_known_firewall_policy_rejection_requires_controller_code():
+    import live_smoke
+
+    runner = live_smoke.LiveSmokeRunner.__new__(live_smoke.LiveSmokeRunner)
+
+    assert runner.expected_known_controller_issue(
+        "unifi_create_firewall_policy",
+        (
+            "Failed to create firewall policy: api.err.FirewallPolicyCreateRespondTrafficPolicyNotAllowed "
+            "Firewall policy create respond traffic not allowed"
+        ),
+    )
+    assert not runner.expected_known_controller_issue(
+        "unifi_create_firewall_policy",
+        "Failed to create firewall policy: Firewall policy create respond traffic not allowed",
+    )

--- a/apps/network/Makefile
+++ b/apps/network/Makefile
@@ -30,7 +30,7 @@ help:
 	@echo "  make lint           Run linters"
 	@echo "  make format         Format code"
 	@echo "  make format-fix     Auto-fix lint issues"
-	@echo "  make pre-commit     Format + lint + test"
+	@echo "  make pre-commit     Format + manifests + lint + test"
 	@echo ""
 	@echo "Build & Release:"
 	@echo "  make version        Show current version (from git tags)"
@@ -118,7 +118,7 @@ version:
 build: manifest server-manifest
 	cd ../.. && uv build --package unifi-network-mcp
 
-build-check: clean manifest
+build-check: clean manifest server-manifest
 	@echo "Building and verifying version..."
 	cd ../.. && uv build --package unifi-network-mcp
 	@WHEEL=$$(ls ../../dist/unifi_network_mcp-*.whl | head -1); \
@@ -175,9 +175,9 @@ console-direct:
 	cd ../.. && UNIFI_CONTROLLER_TYPE=direct UNIFI_MCP_LOG_LEVEL=DEBUG UNIFI_TOOL_REGISTRATION_MODE=eager uv run --package unifi-network-mcp python apps/network/devtools/dev_console.py
 
 # Pre-commit / Pre-release
-pre-commit: format lint test
+pre-commit: format manifest server-manifest lint test
 
-pre-release: clean manifest format lint test build-check
+pre-release: clean manifest server-manifest format lint test build-check
 	@echo ""
 	@echo "Release preparation complete!"
 	@echo ""

--- a/apps/protect/Makefile
+++ b/apps/protect/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo "  make lint           Run linters"
 	@echo "  make format         Format code"
 	@echo "  make format-fix     Auto-fix lint issues"
-	@echo "  make pre-commit     Format + lint + test"
+	@echo "  make pre-commit     Format + manifests + lint + test"
 	@echo ""
 	@echo "Build & Release:"
 	@echo "  make version        Show current version (from git tags)"
@@ -115,7 +115,7 @@ version:
 build: manifest server-manifest
 	cd ../.. && uv build --package unifi-protect-mcp
 
-build-check: clean manifest
+build-check: clean manifest server-manifest
 	@echo "Building and verifying version..."
 	cd ../.. && uv build --package unifi-protect-mcp
 	@WHEEL=$$(ls ../../dist/unifi_protect_mcp-*.whl | head -1); \
@@ -159,9 +159,9 @@ clean:
 	find . -type f -name "*.pyc" -delete
 
 # Pre-commit / Pre-release
-pre-commit: format lint test
+pre-commit: format manifest server-manifest lint test
 
-pre-release: clean manifest format lint test build-check
+pre-release: clean manifest server-manifest format lint test build-check
 	@echo ""
 	@echo "Release preparation complete!"
 	@echo ""

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -99,6 +99,10 @@ KNOWN_CONTROLLER_ISSUE_MARKERS = {
         r"/proxy/access/api/v2/visitors\b",
         "you entered no-man zone",
     ),
+    "unifi_create_firewall_policy": (
+        "FirewallPolicyCreateRespondTrafficPolicyNotAllowed",
+        "Firewall policy create respond traffic not allowed",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- classify the exact UniFi controller firewall-policy create rejection as a known live-smoke skip instead of failing the approved network run
- make app-local `make pre-commit` regenerate both tool manifests and `server.json` before lint/test for Network, Protect, and Access
- align app `build-check`/`pre-release` targets with the same manifest generation expectations

## Validation
- `uv run pytest apps/api/tests/test_live_api_smoke_harness.py -q`
- `uv run ruff check scripts/live_smoke.py apps/api/tests/test_live_api_smoke_harness.py`
- `git diff --check`
- `make -n -C apps/network pre-commit`
- `make -n -C apps/protect pre-commit`
- `make -n -C apps/access pre-commit`
- `uv run --package unifi-network-mcp python scripts/live_smoke.py --server network --phase approved`
  - report: `live-smoke-results/network-2026-06-27T145232.275028Z.json`
  - result: `67 ok`, `2 skipped`, `0 failed`; firewall-policy create skipped only for `api.err.FirewallPolicyCreateRespondTrafficPolicyNotAllowed`
