### PR TITLE
fix: support superHdr and fix boolean handling in protect hdr_mode

### DIFF
--- a/apps/protect/src/unifi_protect_mcp/tools/cameras.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/cameras.py
@@ -215,7 +215,9 @@ async def protect_update_camera_settings(
         Field(
             description=(
                 "Dictionary of settings to update. Supported keys: "
-                "ir_led_mode (auto, on, autoFilterOnly), hdr_mode (true/false), "
+                "ir_led_mode (auto, on, autoFilterOnly), "
+                "hdr_mode (off, auto, or always; always = superHdr highest quality. "
+                "Booleans accepted: true=auto, false=off), "
                 "mic_enabled (true/false), mic_volume (0-100), "
                 "status_light_on (true/false), speaker_volume (0-100), "
                 "name (string), motion_detection (true/false)."

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -4998,7 +4998,7 @@
               "type": "boolean"
             },
             "settings": {
-              "description": "Dictionary of settings to update. Supported keys: ir_led_mode (auto, on, autoFilterOnly), hdr_mode (true/false), mic_enabled (true/false), mic_volume (0-100), status_light_on (true/false), speaker_volume (0-100), name (string), motion_detection (true/false).",
+              "description": "Dictionary of settings to update. Supported keys: ir_led_mode (auto, on, autoFilterOnly), hdr_mode (off, auto, or always; always = superHdr highest quality. Booleans accepted: true=auto, false=off), mic_enabled (true/false), mic_volume (0-100), status_light_on (true/false), speaker_volume (0-100), name (string), motion_detection (true/false).",
               "type": "object"
             }
           },

--- a/apps/protect/tests/unit/test_cameras.py
+++ b/apps/protect/tests/unit/test_cameras.py
@@ -472,6 +472,77 @@ class TestCameraManagerApplyCameraSettings:
         assert "errors" in result
         assert any("API error" in e for e in result["errors"])
 
+    @pytest.mark.asyncio
+    async def test_apply_hdr_superhdr(self, mock_cm):
+        from unifi_core.protect.managers.camera_manager import CameraManager
+
+        mgr = CameraManager(mock_cm)
+        cam = mock_cm.client.bootstrap.cameras["cam-001"]
+        result = await mgr.apply_camera_settings("cam-001", {"hdr_mode": "superHdr"})
+        assert "hdr_mode=always" in result["applied"]
+        cam.set_hdr_mode.assert_awaited_once_with("always")
+
+    @pytest.mark.asyncio
+    async def test_apply_hdr_bool_false_turns_off(self, mock_cm):
+        # Regression: set_hdr_mode(False) does NOT turn HDR off because
+        # ``False == "off"`` is false; we must normalize to the "off" literal.
+        from unifi_core.protect.managers.camera_manager import CameraManager
+
+        mgr = CameraManager(mock_cm)
+        cam = mock_cm.client.bootstrap.cameras["cam-001"]
+        result = await mgr.apply_camera_settings("cam-001", {"hdr_mode": False})
+        assert "hdr_mode=off" in result["applied"]
+        cam.set_hdr_mode.assert_awaited_once_with("off")
+
+    @pytest.mark.asyncio
+    async def test_apply_hdr_bool_true_is_auto(self, mock_cm):
+        from unifi_core.protect.managers.camera_manager import CameraManager
+
+        mgr = CameraManager(mock_cm)
+        cam = mock_cm.client.bootstrap.cameras["cam-001"]
+        await mgr.apply_camera_settings("cam-001", {"hdr_mode": True})
+        cam.set_hdr_mode.assert_awaited_once_with("auto")
+
+    @pytest.mark.asyncio
+    async def test_apply_hdr_invalid_value(self, mock_cm):
+        from unifi_core.protect.managers.camera_manager import CameraManager
+
+        mgr = CameraManager(mock_cm)
+        result = await mgr.apply_camera_settings("cam-001", {"hdr_mode": "ultra"})
+        assert "errors" in result
+        assert any("Invalid hdr_mode" in e for e in result["errors"])
+
+
+class TestNormalizeHdrMode:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (True, "auto"),
+            (False, "off"),
+            ("off", "off"),
+            ("none", "off"),
+            ("auto", "auto"),
+            ("normal", "auto"),
+            ("on", "auto"),
+            ("always", "always"),
+            ("super", "always"),
+            ("superHdr", "always"),
+            ("super_hdr", "always"),
+            ("  SuperHDR  ", "always"),
+        ],
+    )
+    def test_aliases(self, value, expected):
+        from unifi_core.protect.managers.camera_manager import normalize_hdr_mode
+
+        assert normalize_hdr_mode(value) == expected
+
+    @pytest.mark.parametrize("value", ["ultra", "", 3, None])
+    def test_invalid(self, value):
+        from unifi_core.protect.managers.camera_manager import normalize_hdr_mode
+
+        with pytest.raises(ValueError):
+            normalize_hdr_mode(value)
+
 
 class TestCameraManagerToggleRecording:
     @pytest.mark.asyncio

--- a/packages/unifi-core/src/unifi_core/protect/managers/camera_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/camera_manager.py
@@ -21,6 +21,49 @@ PTZ_MIN_SPEED = -1000
 PTZ_MAX_SPEED = 1000
 PTZ_MAX_DURATION_MS = 5000
 
+# uiprotect's Camera.set_hdr_mode accepts the literals "off", "auto" and
+# "always". "always" maps to ISP HDRMode.ALWAYS_ON ("superHdr"), the highest
+# quality HDR. We accept booleans and the controller-facing value names as
+# aliases so callers can request superHdr explicitly and so that passing
+# ``false`` reliably turns HDR off (``set_hdr_mode(False)`` does NOT, because
+# ``False == "off"`` is false in Python).
+_HDR_MODE_ALIASES = {
+    # off
+    "off": "off",
+    "false": "off",
+    "none": "off",
+    "disabled": "off",
+    # auto: HDR on, normal dynamic range (ISP hdr_mode == "normal")
+    "auto": "auto",
+    "on": "auto",
+    "true": "auto",
+    "normal": "auto",
+    # always-on / super HDR: highest quality (ISP hdr_mode == "superHdr")
+    "always": "always",
+    "super": "always",
+    "superhdr": "always",
+    "super_hdr": "always",
+}
+
+
+def normalize_hdr_mode(value: Any) -> str:
+    """Map a user-supplied hdr_mode value to a uiprotect literal.
+
+    Returns one of "off", "auto", or "always". Raises ``ValueError`` for
+    unrecognised values so the error surfaces during preview, before any
+    mutation is applied.
+    """
+    if isinstance(value, bool):
+        return "auto" if value else "off"
+    if isinstance(value, str):
+        normalized = _HDR_MODE_ALIASES.get(value.strip().lower())
+        if normalized is not None:
+            return normalized
+    raise ValueError(
+        f"Invalid hdr_mode {value!r}. Use one of: off, auto, always "
+        "(aliases: true=auto, false=off, on, normal, super/superHdr=always)."
+    )
+
 
 class CameraManager:
     """Reads and mutates camera data from the Protect NVR bootstrap."""
@@ -349,7 +392,9 @@ class CameraManager:
             elif key == "hdr_mode":
                 current_isp_hdr = camera.isp_settings.hdr_mode
                 current_state["hdr_mode"] = str(current_isp_hdr.value) if current_isp_hdr else None
-                proposed_changes["hdr_mode"] = value
+                # Normalize so the preview shows what will actually be applied
+                # (and rejects invalid values before confirmation).
+                proposed_changes["hdr_mode"] = normalize_hdr_mode(value)
             elif key == "mic_enabled":
                 current_state["mic_enabled"] = camera.is_mic_enabled
                 proposed_changes["mic_enabled"] = value
@@ -395,8 +440,9 @@ class CameraManager:
                     await camera.set_ir_led_model(mode)
                     applied.append(f"ir_led_mode={value}")
                 elif key == "hdr_mode":
-                    await camera.set_hdr_mode(value)
-                    applied.append(f"hdr_mode={value}")
+                    mode = normalize_hdr_mode(value)
+                    await camera.set_hdr_mode(mode)
+                    applied.append(f"hdr_mode={mode}")
                 elif key == "mic_enabled":
                     # There's no direct set_mic_enabled; adjust mic volume to 0 for disable
                     # or use set_privacy for full mic control. Use save_device pattern.


### PR DESCRIPTION
## Problem

`protect_update_camera_settings` advertised `hdr_mode` as a boolean and passed the raw value straight to uiprotect's `Camera.set_hdr_mode(mode: Literal["auto", "off", "always"])`. Two bugs resulted:

1. **No way to request the highest-quality HDR (`superHdr`)**, even though the controller and uiprotect support it via the `"always"` mode (which sets ISP `HDRMode.ALWAYS_ON` / `"superHdr"`).
2. **Passing `false` did not turn HDR off.** `set_hdr_mode(False)` falls through to the `else` branch because `False == "off"` is `False` in Python, so it enables superHdr. In effect *both* `true` and `false` enabled HDR.

## Fix

- Add `normalize_hdr_mode()` in `camera_manager.py`, mapping booleans and friendly aliases to uiprotect's literals:
  - `off` ← `False`, `"off"`, `"none"`, `"disabled"`
  - `auto` ← `True`, `"auto"`, `"on"`, `"normal"`
  - `always` ← `"always"`, `"super"`, `"superHdr"`, `"super_hdr"`
- Use it in **both** the preview and apply paths, so the preview reflects what will actually be applied and invalid values raise before any mutation.
- Update the `protect_update_camera_settings` schema description and regenerate `tools_manifest.json`.
- Add unit tests (alias table, bool handling regression, superHdr apply, invalid value).

## Testing

- `uv run --package unifi-protect-mcp pytest apps/protect/tests/unit/test_cameras.py` → **84 passed**
- `ruff check` clean on changed files
- `tools_manifest.json` regenerated via `generate_tool_manifest.py` (only the hdr_mode description line changes)

Verified against a live NVR (UDM, Protect) across AI Pro, AI Turret, G6 Dome, and G6 Instant cameras: `{"ispSettings":{"hdrMode":"superHdr"}}` is accepted and persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)