### PR TITLE
chore(deps): raise unifi-core floor to 0.4.11 in protect and api

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.9,<0.5",
+    "unifi-core[network,protect,access]>=0.4.11,<0.5",
     "fastapi>=0.138.0",
     "uvicorn[standard]>=0.49.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "unifi-mcp-shared>=0.6.3,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.9,<0.5",
+    "unifi-core[protect]>=0.4.11,<0.5",
     "mcp[cli]>=1.28.0,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Why

Release coordination for `core/v0.4.11` (now live on PyPI). `apps/protect` now imports `ToggleRtspInput` from `unifi-core` and the HDR-mode fix lives in `unifi-core`'s camera manager; `apps/api` dispatches to the new `apply_toggle_rtsp` manager method. The previous floor (`>=0.4.9`) would let a fresh PyPI install resolve 0.4.9/0.4.10 — which lack these — so raise it to `>=0.4.11`.

## Change

- `apps/protect/pyproject.toml`: `unifi-core[protect]>=0.4.9,<0.5` → `>=0.4.11,<0.5`
- `apps/api/pyproject.toml`: `unifi-core[network,protect,access]>=0.4.9,<0.5` → `>=0.4.11,<0.5`

Must merge before tagging `protect/v0.6.0` and `api/v0.5.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)