### PR TITLE
fix(network): persist manual min-rate by coupling preference + enable

### DIFF
--- a/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
@@ -49,6 +49,35 @@ def _unpersisted_fields(before: Dict[str, Any], after: Dict[str, Any], requested
     return stuck
 
 
+# Manual min-rate data-rate fields are honored only when the controller's rate
+# mode is "manual" and the band's min-rate is enabled. Setting a *_data_rate_kbps
+# while minrate_setting_preference is "auto" is answered rc:ok but silently
+# recomputed away — which the verify step above would (correctly) flag as a
+# non-persisted write. Map each rate field to the enable flag it requires.
+_MINRATE_RATE_FIELDS = {
+    "minrate_ng_data_rate_kbps": "minrate_ng_enabled",
+    "minrate_na_data_rate_kbps": "minrate_na_enabled",
+}
+
+
+def _apply_minrate_dependencies(update_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return update_data with the dependencies a manual min-rate write needs.
+
+    When a caller sets ``minrate_{ng,na}_data_rate_kbps``, also force
+    ``minrate_setting_preference="manual"`` and the band's ``minrate_*_enabled``
+    so the controller persists the requested rate instead of recomputing it
+    under auto mode. Values the caller set explicitly are left untouched.
+    """
+    rate_fields = [field for field in _MINRATE_RATE_FIELDS if field in update_data]
+    if not rate_fields:
+        return update_data
+    patched = dict(update_data)
+    patched.setdefault("minrate_setting_preference", "manual")
+    for rate_field in rate_fields:
+        patched.setdefault(_MINRATE_RATE_FIELDS[rate_field], True)
+    return patched
+
+
 class NetworkManager:
     """Manages network (LAN/VLAN) and WLAN operations on the Unifi Controller."""
 
@@ -329,7 +358,12 @@ class NetworkManager:
             # 1. Existence check; raises UniFiNotFoundError on miss.
             existing_wlan = await self.get_wlan_details(wlan_id)
 
-            # 2. Merge updates (deep merge preserves nested sub-objects)
+            # 2. A manual min-rate request is silently recomputed away unless the
+            #    rate mode is "manual" and the band is enabled; inject those
+            #    dependencies so a rate-only update actually persists.
+            update_data = _apply_minrate_dependencies(update_data)
+
+            # 3. Merge updates (deep merge preserves nested sub-objects)
             merged_data = deep_merge(existing_wlan, update_data)
 
             # 3. Send the full merged data

--- a/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
@@ -366,7 +366,7 @@ class NetworkManager:
             # 3. Merge updates (deep merge preserves nested sub-objects)
             merged_data = deep_merge(existing_wlan, update_data)
 
-            # 3. Send the full merged data
+            # 4. Send the full merged data
             api_request = ApiRequest(
                 method="put",
                 path=f"/rest/wlanconf/{wlan_id}",

--- a/packages/unifi-core/tests/network/managers/test_network_manager_update_verification.py
+++ b/packages/unifi-core/tests/network/managers/test_network_manager_update_verification.py
@@ -8,7 +8,11 @@ unconditionally; they now re-read and confirm the change actually landed.
 
 from unittest.mock import AsyncMock, MagicMock
 
-from unifi_core.network.managers.network_manager import NetworkManager, _unpersisted_fields
+from unifi_core.network.managers.network_manager import (
+    NetworkManager,
+    _apply_minrate_dependencies,
+    _unpersisted_fields,
+)
 
 WLAN_ID = "60c7d8e9f0a1b2c3d4e5f6a7"
 NETWORK_ID = "70d8e9f0a1b2c3d4e5f6a7b8"
@@ -123,3 +127,67 @@ async def test_update_network_fails_when_not_persisted():
 
     assert ok is False
     assert err is not None and "igmp_snooping" in err
+
+
+# ---------------------------------------------------------------------------
+# _apply_minrate_dependencies helper
+# ---------------------------------------------------------------------------
+
+
+def test_minrate_deps_adds_manual_preference_and_enable_for_ng():
+    out = _apply_minrate_dependencies({"minrate_ng_data_rate_kbps": 6000})
+    assert out["minrate_setting_preference"] == "manual"
+    assert out["minrate_ng_enabled"] is True
+    assert out["minrate_ng_data_rate_kbps"] == 6000
+
+
+def test_minrate_deps_adds_enable_for_na_band():
+    out = _apply_minrate_dependencies({"minrate_na_data_rate_kbps": 12000})
+    assert out["minrate_setting_preference"] == "manual"
+    assert out["minrate_na_enabled"] is True
+
+
+def test_minrate_deps_preserves_explicit_caller_values():
+    # A caller who deliberately sets auto/disabled is not overridden.
+    out = _apply_minrate_dependencies(
+        {
+            "minrate_ng_data_rate_kbps": 6000,
+            "minrate_setting_preference": "auto",
+            "minrate_ng_enabled": False,
+        }
+    )
+    assert out["minrate_setting_preference"] == "auto"
+    assert out["minrate_ng_enabled"] is False
+
+
+def test_minrate_deps_noop_without_rate_field():
+    assert _apply_minrate_dependencies({"proxy_arp": True}) == {"proxy_arp": True}
+
+
+def test_minrate_deps_does_not_mutate_input():
+    src = {"minrate_ng_data_rate_kbps": 6000}
+    _apply_minrate_dependencies(src)
+    assert src == {"minrate_ng_data_rate_kbps": 6000}
+
+
+# ---------------------------------------------------------------------------
+# update_wlan applies the min-rate dependencies on the wire
+# ---------------------------------------------------------------------------
+
+
+async def test_update_wlan_injects_manual_minrate_dependencies_into_put():
+    conn = _make_connection()
+    mgr = NetworkManager(conn)
+    before = _wlan(minrate_ng_data_rate_kbps=1000, minrate_setting_preference="auto", minrate_ng_enabled=True)
+    after = _wlan(minrate_ng_data_rate_kbps=6000, minrate_setting_preference="manual", minrate_ng_enabled=True)
+    # get(pre) -> put -> get(post, rate now persisted because mode is manual)
+    conn.request.side_effect = [[before], {}, [after]]
+
+    ok, err = await mgr.update_wlan(WLAN_ID, {"minrate_ng_data_rate_kbps": 6000})
+
+    assert ok is True
+    assert err is None
+    put_request = conn.request.call_args_list[1].args[0]
+    assert put_request.data["minrate_ng_data_rate_kbps"] == 6000
+    assert put_request.data["minrate_setting_preference"] == "manual"
+    assert put_request.data["minrate_ng_enabled"] is True

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1177,6 +1177,15 @@ class LiveSmokeRunner:
             {"wlan_id": wlan_id, "update_data": {"hide_ssid": False}, "confirm": True},
             "approved:update",
         )
+        # Exercise the manual min-rate coupling: a freshly created WLAN is in auto
+        # rate mode, so a rate-only update persists only if the manager also flips
+        # minrate_setting_preference=manual and enables the band. verify-after-write
+        # turns a silent recompute into a failed record here.
+        await self.call(
+            "unifi_update_wlan",
+            {"wlan_id": wlan_id, "update_data": {"minrate_ng_data_rate_kbps": 6000}, "confirm": True},
+            "approved:update",
+        )
         delete = await self.call("unifi_delete_wlan", {"wlan_id": wlan_id, "confirm": True}, "approved:delete")
         if delete.success:
             self.report.cleaned_resources.append({"type": "wlan", "id": wlan_id, "name": name})


### PR DESCRIPTION
## Summary

`unifi_update_wlan` could not persist a manual 2.4/5 GHz minimum data rate. It sent `minrate_{ng,na}_data_rate_kbps` without `minrate_setting_preference`, so a controller in `auto` rate mode answered `rc: ok` and silently recomputed the rate away. The #372 verify-after-write surfaced this as a "did not persist" error (mis-attributed to the legacy write path).

Closes #396.

## Root cause (live-verified on a UDM Pro)

The min-rate data-rate fields are only honored in **manual** mode with the band enabled. Holding everything else constant and varying only the preference / payload shape:

- rate-only write while `minrate_setting_preference: auto` → not persisted
- set preference to `manual`, then the rate → persists
- with `manual`, **both** the full-object PUT and a minimal `{rate}` payload persist

So this is field coupling, not a write-path / payload-shape bug.

## Change

- New pure helper `_apply_minrate_dependencies(update_data)` in `network_manager.py`: when a `*_data_rate_kbps` is requested, inject `minrate_setting_preference="manual"` and the band's `minrate_*_enabled`, **preserving any value the caller set explicitly**.
- `update_wlan` applies it before the merge/PUT. No tool signature or manifest change.

## Tests

- 6 new cases in `test_network_manager_update_verification.py` (helper unit tests + an `update_wlan` test asserting the coupling reaches the PUT payload).
- The `live_smoke` WLAN lifecycle now issues a rate-only update on its throwaway SSID, so the silent-recompute path is covered by verify-after-write.
- `make core-test` → **1285 passed**; `ruff check` / `ruff format --check` clean.

## Live verification (UDM Pro, through the patched manager)

Reproduced the broken `auto` baseline, ran the patched `update_wlan` with a rate-only payload, then restored:

```
baseline:        {'rate': 6000,  'preference': 'manual', 'ng_enabled': True}
set auto:        {'rate': 1000,  'preference': 'auto',   'ng_enabled': True}   # broken precondition
update_wlan({minrate_ng_data_rate_kbps: 12000}) -> (True, None)
                 {'rate': 12000, 'preference': 'manual', 'ng_enabled': True}   # fix flips to manual + enables, rate persists
restore:         {'rate': 6000,  'preference': 'manual', 'ng_enabled': True}
```

From the `auto` state the rate-only update now persists; pre-fix the same call left `auto` and the rate was recomputed away.

## Note

`create_wlan` has the same latent coupling (a WLAN created with a manual rate but `auto` preference). Left as a follow-up to keep this PR focused on the reported `update_wlan` path.
