### PR TITLE
fix(api): unwrap (ok, error) mutation-ack tuple on the /v1/actions path

### DIFF
--- a/apps/api/src/unifi_api/serializers/_base.py
+++ b/apps/api/src/unifi_api/serializers/_base.py
@@ -22,6 +22,20 @@ class SerializerContractError(Exception):
     """Raised when manager-method return type doesn't match declared kind."""
 
 
+def _is_ack_tuple(result: Any) -> bool:
+    """True for a mutation ``(ok: bool, error: Optional[str])`` ack tuple.
+
+    Fetch-merge-put update managers (e.g. update_network / update_wlan /
+    update_gateway_settings) return this shape instead of the resource dict.
+    """
+    return (
+        isinstance(result, tuple)
+        and len(result) == 2
+        and isinstance(result[0], bool)
+        and (result[1] is None or isinstance(result[1], str))
+    )
+
+
 class Serializer:
     """Subclass + override serialize() and declare kind. Optional richer
     metadata (primary_key, display_columns, sort_default) is per-serializer
@@ -60,6 +74,18 @@ class Serializer:
         return redact_sensitive_fields(data, redact_sensitive=redact_sensitive)
 
     def serialize_action(self, result, *, tool_name: str, redact_sensitive: bool = True) -> dict:
+        # Mutation managers that follow the fetch-merge-put golden path return a
+        # (ok: bool, error: Optional[str]) ack tuple rather than the resource. Surface
+        # it as a structured envelope so the action path reports failures correctly.
+        # Without this the tuple falls through to serialize()'s str() fallback, which
+        # stringifies it into data.result and always reports top-level success=True.
+        if _is_ack_tuple(result):
+            ok, error = result
+            envelope: dict[str, Any] = {"success": ok}
+            if error:
+                envelope["error"] = error
+            return envelope
+
         kind = self._kind_for_tool(tool_name)
         hint = self._render_hint(kind)
         if kind == RenderKind.LIST:

--- a/apps/api/tests/serializers/test_mutation_ack_tuple.py
+++ b/apps/api/tests/serializers/test_mutation_ack_tuple.py
@@ -1,0 +1,62 @@
+"""Mutation-ack (ok, error) tuple unwrapping in Serializer.serialize_action.
+
+Fetch-merge-put update managers (update_network / update_wlan /
+update_gateway_settings) return a ``(bool, Optional[str])`` ack tuple. The action
+path must surface it as a structured ``{"success", "error"}`` envelope rather than
+stringify it (which previously reported every result as success).
+"""
+
+import pytest
+from unifi_api.serializers._base import RenderKind, Serializer, _is_ack_tuple
+
+
+class _AckSerializer(Serializer):
+    kind = RenderKind.DETAIL
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        # Mirrors the real mutation-ack serializers' fallback for non-tuple input.
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        return {"result": str(obj)}
+
+
+def test_is_ack_tuple_true_cases():
+    assert _is_ack_tuple((True, None))
+    assert _is_ack_tuple((False, "boom"))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        False,
+        {"_id": "x"},
+        ("a", "b"),  # first element not a bool
+        (True, 5),  # second element not str/None
+        (True, None, "extra"),  # wrong arity
+        [True, None],  # list, not tuple
+    ],
+)
+def test_is_ack_tuple_false_cases(value):
+    assert not _is_ack_tuple(value)
+
+
+def test_serialize_action_unwraps_success_tuple():
+    out = _AckSerializer().serialize_action((True, None), tool_name="unifi_update_network")
+    assert out == {"success": True}
+
+
+def test_serialize_action_unwraps_failure_tuple():
+    out = _AckSerializer().serialize_action((False, "did not persist: x"), tool_name="unifi_update_network")
+    assert out == {"success": False, "error": "did not persist: x"}
+
+
+def test_serialize_action_bool_result_unchanged():
+    # Non-tuple results still flow through the kind-based path (regression guard).
+    out = _AckSerializer().serialize_action(True, tool_name="unifi_update_network")
+    assert out["success"] is True
+    assert out["data"] == {"success": True}
+    assert out["render_hint"]["kind"] == "detail"

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -156,6 +156,71 @@ async def test_action_endpoint_serializer_contract_error(tmp_path, monkeypatch) 
         assert action_rows[0].error_kind == "serializer_contract"
 
 
+@pytest.mark.asyncio
+async def test_action_endpoint_update_ack_tuple_success(tmp_path, monkeypatch) -> None:
+    """Fetch-merge-put update managers return a (ok, error) ack tuple. A success
+    tuple must surface as a clean {"success": true} envelope (not a stringified
+    tuple) and audit as success."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    from unifi_api.services import actions as actions_svc
+
+    monkeypatch.setattr(actions_svc, "dispatch_action", AsyncMock(return_value=(True, None)))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post(
+            "/v1/actions/unifi_update_network",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {"network_id": "n1"}, "confirm": True},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"success": True}
+
+    sm = app.state.sessionmaker
+    async with sm() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+        action_rows = [row for row in rows if row.target == "unifi_update_network"]
+        assert len(action_rows) == 1
+        assert action_rows[0].outcome == "success"
+
+
+@pytest.mark.asyncio
+async def test_action_endpoint_update_ack_tuple_failure(tmp_path, monkeypatch) -> None:
+    """Regression: a FAILED update ack tuple must report success=false with the
+    error message — not top-level success=true with the failure stringified into
+    data.result — and must audit as error."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    from unifi_api.services import actions as actions_svc
+
+    err = "Controller accepted the request but did not persist field(s): upnp_enabled."
+    monkeypatch.setattr(actions_svc, "dispatch_action", AsyncMock(return_value=(False, err)))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post(
+            "/v1/actions/unifi_update_network",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {"network_id": "n1"}, "confirm": True},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is False
+    assert body["error"] == err
+    assert "result" not in body.get("data", {})
+
+    sm = app.state.sessionmaker
+    async with sm() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+        action_rows = [row for row in rows if row.target == "unifi_update_network"]
+        assert len(action_rows) == 1
+        assert action_rows[0].outcome == "error"
+
+
 @pytest.mark.parametrize(
     ("tool_name", "items_key", "item"),
     [


### PR DESCRIPTION
## Summary

Fixes #400. On `POST /v1/actions/{tool}`, the three update tools whose manager
methods return a `(ok: bool, error: Optional[str])` ack tuple were serialized
incorrectly — a **failed** update reported top-level `success: true` with the
failure stringified into `data.result`, and the audit log recorded `success`.

Affected tools: `unifi_update_network`, `unifi_update_wlan`,
`unifi_update_gateway_settings` (the latter via #391; gateway inherits this fix).

## Root cause

`dispatch_action` returns the manager's raw `(ok, error)` tuple; the route calls
`serialize_action`, which (DETAIL kind) hardcodes top-level `success: true` and
passes the tuple to `serialize()`, whose fallback turns the unrecognized tuple
into `{"result": str(obj)}`. The failure boolean and message never reached a
structured field.

## Fix

Detect the `(ok, error)` ack tuple at the `serialize_action` boundary (the single
action-result chokepoint) and surface it as a structured envelope:

- success → `{"success": true}`
- failure → `{"success": false, "error": "<message>"}`

Centralized, so any future tuple-returning mutation manager is covered. Non-tuple
results (bool, dict, lists, typed resources) are unchanged.

### Before / after (failure case)

```
before: {"success": true,  "data": {"result": "(False, 'did not persist: upnp_enabled')"}, "render_hint": {...}}
after:  {"success": false, "error": "did not persist: upnp_enabled"}
```

## Tests

- Unit: `_is_ack_tuple` guard (true/false matrix) + `serialize_action` unwrap for
  success/failure, with a regression guard that bool/dict results are untouched.
- End-to-end `/v1/actions`: success tuple → `{"success": true}` audited `success`;
  failure tuple → `{"success": false, "error": ...}` audited `error`.

Full `apps/api` suite + SDL/OpenAPI/docs drift gates pass.

## Scope / release

Fast-follow alongside the gateway-settings work; targeted for the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
