### PR TITLE
chore(deps): consolidate Dependabot updates incl. uiprotect 14→15

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.
     "unifi-core[access]>=0.4.9,<0.5",
-    "mcp[cli]>=1.28.0,<2",
+    "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
@@ -56,7 +56,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-xdist>=3.6.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
     "pytest-cov>=4.0.0",
     "ruff>=0.15.15",
 ]
@@ -66,7 +66,7 @@ managed = true
 dev-dependencies = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
     "pytest-cov>=4.0.0",
     "ruff>=0.15.15",
 ]

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
     "unifi-core[network,protect,access]>=0.4.12,<0.5",
-    "fastapi>=0.138.0",
+    "fastapi>=0.138.2",
     "uvicorn[standard]>=0.49.0",
     "sqlalchemy[asyncio]>=2.0.51",
     "alembic>=1.14.0",
@@ -19,7 +19,7 @@ dependencies = [
     "typer>=0.26.7",
     "pydantic>=2.10.0",
     "jinja2>=3.1.0",
-    "strawberry-graphql[fastapi]>=0.319.0,<0.320.0",
+    "strawberry-graphql[fastapi]>=0.320.0,<0.321.0",
     "pyyaml>=6.0",
     "omegaconf>=2.3.0",
     "python-dotenv>=1.2.2",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
     "unifi-core[network]>=0.4.12,<0.5",
-    "mcp[cli]>=1.28.0,<2",
+    "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
@@ -56,7 +56,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-xdist>=3.6.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
     "pytest-cov>=4.0.0",
     "ruff>=0.15.15",
 ]
@@ -66,7 +66,7 @@ managed = true
 dev-dependencies = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
     "pytest-cov>=4.0.0",
     "ruff>=0.15.15",
 ]

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
     "unifi-core[protect]>=0.4.11,<0.5",
-    "mcp[cli]>=1.28.0,<2",
+    "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
@@ -55,7 +55,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-xdist>=3.6.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
     "pytest-cov>=4.0.0",
     "ruff>=0.15.15",
 ]
@@ -65,7 +65,7 @@ managed = true
 dev-dependencies = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
     "pytest-cov>=4.0.0",
     "ruff>=0.15.15",
 ]

--- a/apps/worker/worker/package-lock.json
+++ b/apps/worker/worker/package-lock.json
@@ -8,11 +8,11 @@
       "name": "unifi-mcp-worker-source",
       "version": "1.0.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260621.1",
+        "@cloudflare/workers-types": "^4.20260629.1",
         "@types/node": "^22.20.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.9",
-        "wrangler": "^4.103.0"
+        "wrangler": "^4.105.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
-      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
+      "integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
       "cpu": [
         "x64"
       ],
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
-      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
       "cpu": [
         "arm64"
       ],
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
-      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
+      "integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
-      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
       "cpu": [
         "arm64"
       ],
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
-      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
+      "integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260621.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260621.1.tgz",
-      "integrity": "sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA==",
+      "version": "4.20260629.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260629.1.tgz",
+      "integrity": "sha512-5vq2ErIFVRSQ8Dcw5YOeEoBdZBudqBjHFKTWD3SBGiJR5hD1+/86aRUV/DTpEK9sXXCGOTGgpWBGlPSlW7djVg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -2148,16 +2148,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260617.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
-      "integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
+      "version": "4.20260625.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
+      "integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260617.1",
+        "workerd": "1.20260625.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -2676,9 +2676,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260617.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
-      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
+      "integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2689,17 +2689,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260617.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
-        "@cloudflare/workerd-linux-64": "1.20260617.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
-        "@cloudflare/workerd-windows-64": "1.20260617.1"
+        "@cloudflare/workerd-darwin-64": "1.20260625.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260625.1",
+        "@cloudflare/workerd-linux-64": "1.20260625.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260625.1",
+        "@cloudflare/workerd-windows-64": "1.20260625.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.103.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.103.0.tgz",
-      "integrity": "sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==",
+      "version": "4.105.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
+      "integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -2707,10 +2707,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260617.1",
+        "miniflare": "4.20260625.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260617.1"
+        "workerd": "1.20260625.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -2724,7 +2724,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260617.1"
+        "@cloudflare/workers-types": "^4.20260625.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/apps/worker/worker/package.json
+++ b/apps/worker/worker/package.json
@@ -10,10 +10,10 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260621.1",
+    "@cloudflare/workers-types": "^4.20260629.1",
     "@types/node": "^22.20.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.9",
-    "wrangler": "^4.103.0"
+    "wrangler": "^4.105.0"
   }
 }

--- a/packages/unifi-core/pyproject.toml
+++ b/packages/unifi-core/pyproject.toml
@@ -16,14 +16,14 @@ dependencies = [
 # mode hit prod historically. Versions floor at the lowest tested.
 [project.optional-dependencies]
 network = ["aiounifi>=88"]
-protect = ["uiprotect>=14.1.0"]
+protect = ["uiprotect>=15.3.0"]
 access = ["py-unifi-access>=1.1.1"]
 
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
 ]
 
 [build-system]

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP relay: bridges local MCP servers to a Cloudflare Worker gatew
 requires-python = ">=3.13"
 dependencies = [
     "websockets>=13.0",
-    "mcp[cli]>=1.28.0,<2",
+    "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "python-dotenv>=1.2.2",
     "unifi-mcp-shared>=0.6.3,<0.7",
@@ -19,7 +19,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-xdist>=3.6.0",
-    "aioresponses>=0.7.0",
+    "aioresponses>=0.7.9",
 ]
 
 [build-system]

--- a/packages/unifi-mcp-shared/pyproject.toml
+++ b/packages/unifi-mcp-shared/pyproject.toml
@@ -5,7 +5,7 @@ description = "Shared MCP server patterns: permissions, confirmation, lazy loadi
 requires-python = ">=3.13"
 dependencies = [
     "unifi-core>=0.4.9,<0.5",
-    "mcp[cli]>=1.28.0,<2",
+    "mcp[cli]>=1.28.1,<2",
     "omegaconf>=2.3.0",
     "pyyaml>=6.0",
     "jsonschema>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -119,15 +119,15 @@ wheels = [
 
 [[package]]
 name = "aioresponses"
-version = "0.7.8"
+version = "0.7.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/fb/e3f08af812b3e66fca511ea1babb9dfddeca5965dea2a4d13b6926e0b1c2/aioresponses-0.7.9.tar.gz", hash = "sha256:1dcfa28938fc006f046a98383a7c07ac180be7a492c1ed557f5cd7b0805357d3", size = 34072, upload-time = "2026-06-23T21:23:23.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
+    { url = "https://files.pythonhosted.org/packages/71/55/4c77cda7e69c1ac81a32e6895a361e0da9350eb7835a2ddb161a37ef1ce9/aioresponses-0.7.9-py2.py3-none-any.whl", hash = "sha256:94f9617f841c5bd7ee088ed783284f2cf4e6acc85d3933d92fc2fc7bd572a1b0", size = 12832, upload-time = "2026-06-23T21:23:22.426Z" },
 ]
 
 [[package]]
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.138.0"
+version = "0.138.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -561,9 +561,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a9/9f8f7e00195c29836e9bf58bbbaf579e29878b8a67851efff93d9b6d4eb7/fastapi-0.138.2.tar.gz", hash = "sha256:6432359d067a432134620e7c5e4c6e5063e7f37815bbbbf20acef14b0d2e3fc8", size = 420423, upload-time = "2026-06-29T12:44:12.556Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b3/38be2c074bdd0c986340db1d72d7b2321b805b1c5a68069aa00b5d31fd02/fastapi-0.138.2-py3-none-any.whl", hash = "sha256:db90c1ffb5517fba5d4a9f80e866daa008747e646310c9ce155c8c535f9d1615", size = 129271, upload-time = "2026-06-29T12:44:13.905Z" },
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -913,9 +913,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -1664,7 +1664,7 @@ wheels = [
 
 [[package]]
 name = "strawberry-graphql"
-version = "0.319.0"
+version = "0.320.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cross-web" },
@@ -1673,9 +1673,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/c4/5d7cf2f2459d9a553993217212acc911bfc63f3957a45980230105e1c92e/strawberry_graphql-0.319.0.tar.gz", hash = "sha256:e9afdfe2ca745b5337d3c4909ffd612e405105af6ffc21b1766a2b9848fcfd4f", size = 227709, upload-time = "2026-06-21T14:57:38.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/38/95a72342ba94570a35b8cc7db6a6789378f10b69be1d77e0fb022f5079e0/strawberry_graphql-0.320.0.tar.gz", hash = "sha256:c5ee8abf7f4db00d3515e537578a5c094a4a9f3b732a959d9020c8788d3ac7c7", size = 229231, upload-time = "2026-06-27T23:11:43.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/b4/5005afc8369dbb3f5c03dd681ac8a13a5c0b9a8c6ae13f1c0643bb815cfa/strawberry_graphql-0.319.0-py3-none-any.whl", hash = "sha256:fcd5cbe43a5d7274d91bda2261f272f57c84d39532ff58b95fadd0749d225835", size = 330534, upload-time = "2026-06-21T14:57:36.36Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/f8e8919a73ae466f9740e63115f010a02fac3f2b69c02ea60c9c85d42c1a/strawberry_graphql-0.320.0-py3-none-any.whl", hash = "sha256:8ea27f43f73a1accbfd1599b37234086d26504cf60213ebb521528319ccf2309", size = 332321, upload-time = "2026-06-27T23:11:41.045Z" },
 ]
 
 [package.optional-dependencies]
@@ -1731,7 +1731,7 @@ wheels = [
 
 [[package]]
 name = "uiprotect"
-version = "14.1.0"
+version = "15.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1748,9 +1748,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/15/9ef700df2980300e8aa0f72c366e5851fbeb215358a64e53ee63dfcc350b/uiprotect-14.1.0.tar.gz", hash = "sha256:3bebf5b6812c50343763a3d3537d5517b85f045437b04a7a92d7002a95025a66", size = 192677, upload-time = "2026-06-21T09:43:58.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/8d/1fb5338414be442cb5065f63c6c8d699982e403e1ea8902f5a5a67a67ca8/uiprotect-15.3.0.tar.gz", hash = "sha256:522e6473ce9a89244acf58c77aaaca86a4d329896e0f7d2907421aa3524eb5ae", size = 198335, upload-time = "2026-06-26T21:34:40.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/7c/6099130441863d5c4a96033383a878e23ddaaf3376a4adb0e71b5c940cb6/uiprotect-14.1.0-py3-none-any.whl", hash = "sha256:d0f0a76fa81576b3ebddea91d185f7f431b0e91cb74e8423b9ac3bafb709376a", size = 213283, upload-time = "2026-06-21T09:43:57.373Z" },
+    { url = "https://files.pythonhosted.org/packages/29/22/2428b94fa0ed1fd2d8d37eaea3b3c36d336fcd6b9ff37eb2ed68a605cc13/uiprotect-15.3.0-py3-none-any.whl", hash = "sha256:dbfe7cc8ad9aa12d1f8d96d9d300b6d67072dd2280a467cf3c66504b893c139e", size = 218947, upload-time = "2026-06-26T21:34:38.889Z" },
 ]
 
 [[package]]
@@ -1782,7 +1782,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "jsonschema", specifier = ">=4.17.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1793,7 +1793,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses", specifier = ">=0.7.0" },
+    { name = "aioresponses", specifier = ">=0.7.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
@@ -1836,14 +1836,14 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
-    { name = "fastapi", specifier = ">=0.138.0" },
+    { name = "fastapi", specifier = ">=0.138.2" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
-    { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.319.0,<0.320.0" },
+    { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.320.0,<0.321.0" },
     { name = "typer", specifier = ">=0.26.7" },
     { name = "unifi-core", extras = ["access", "network", "protect"], editable = "packages/unifi-core" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
@@ -1891,13 +1891,13 @@ requires-dist = [
     { name = "py-unifi-access", marker = "extra == 'access'", specifier = ">=1.1.1" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=14.1.0" },
+    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=15.3.0" },
 ]
 provides-extras = ["access", "network", "protect"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses", specifier = ">=0.7.0" },
+    { name = "aioresponses", specifier = ">=0.7.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
 ]
@@ -1929,7 +1929,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "unifi-mcp-shared", editable = "packages/unifi-mcp-shared" },
     { name = "websockets", specifier = ">=13.0" },
@@ -1937,7 +1937,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses", specifier = ">=0.7.0" },
+    { name = "aioresponses", specifier = ">=0.7.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-xdist", specifier = ">=3.6.0" },
@@ -1964,7 +1964,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", specifier = ">=4.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -2006,7 +2006,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "jsonschema", specifier = ">=4.17.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -2017,7 +2017,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses", specifier = ">=0.7.0" },
+    { name = "aioresponses", specifier = ">=0.7.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
@@ -2054,7 +2054,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "jsonschema", specifier = ">=4.17.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -2065,7 +2065,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses", specifier = ">=0.7.0" },
+    { name = "aioresponses", specifier = ">=0.7.9" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

Consolidates the five open Dependabot PRs into one verified change. All Python bumps are resolved **together** into a single coherent `uv.lock`; the worker bump updates its own npm lockfile. Supersedes #402, #403, #404, #405, #406.

| Dependency | From → To | Source |
|---|---|---|
| uiprotect | 14.1.0 → 15.3.0 (**major**) | #406 |
| strawberry-graphql[fastapi] | 0.319.0 → 0.320.0 | #405 |
| mcp[cli] | 1.28.0 → 1.28.1 | #404 |
| aioresponses | 0.7.8 → 0.7.9 | #403 |
| fastapi | 0.138.0 → 0.138.2 | #403 |
| @cloudflare/workers-types | 4.20260621.1 → 4.20260629.1 | #402 |
| wrangler | 4.103.0 → 4.105.0 | #402 |

## uiprotect 14 → 15 — the high-risk bump

The 15.0.0 major bump's **only** breaking change is `feat(data)!: expose LinkStation.last_event as datetime` — `LinkStation.last_event` went from `int` (epoch-ms) to `datetime`. **We never reference `LinkStation`**, so it does not touch our surface. Our uiprotect imports are narrow and unchanged across 15.x:

- `ProtectApiClient`, `WSSubscriptionMessage`
- exceptions: `BadRequest`, `NotAuthorized`, `NvrError`
- `IRLEDMode`, `RecordingMode`
- event types: `Event`, `EventType`, `ModelType`, `SmartDetectObjectType`, `WSAction`

Everything else in 14.1 → 15.3 is **additive**, all on the **Public Integration API** surface we don't currently consume:

- PublicCamera smart-audio / detection-state booleans (WebSocket-derived)
- public-API setters for **sensors** (`update_sensor_public`, armed / glass-break fields), **chimes** (per-camera repeat-times), and **viewers** (`set_liveview_public`, `set_name_public`)

These are candidate future enhancements (they'd live in the Integration-API tool family), not adopted in this PR.

## Verification (local)

- ✅ `make check` — 903 tests, lint, format, SDL/openapi/docs drift gates, worker typecheck + tests
- ✅ Protect suites — 373 (unifi-core) + 466 (protect app) pass against uiprotect 15.3.0
- ✅ `scripts/check_pin_alignment.py` — all five downstream wheels install and import cleanly with declared pins
- ✅ `uv lock --check` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
