### PR TITLE
feat(network): add Dynamic DNS management tools

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -669,6 +669,26 @@ type DpiStats {
   categories: JSON!
 }
 
+"""A Dynamic DNS provider entry configured on the controller."""
+type DynamicDns {
+  id: ID
+  siteId: String
+  hostName: String
+  service: String
+  server: String
+  login: String
+  xPassword: String
+  interface: String
+  customService: String
+  options: [String!]
+}
+
+"""Paginated page of Dynamic DNS entries."""
+type DynamicDnsPage {
+  items: [DynamicDns!]!
+  nextCursor: String
+}
+
 """A UniFi Protect event row (list + detail share this shape)."""
 type Event {
   id: ID
@@ -1123,6 +1143,14 @@ type NetworkQuery {
 
   """Look up a single DNS record by id."""
   dnsRecord(controller: ID!, id: ID!, site: String! = "default"): DnsRecord
+
+  """
+  List Dynamic DNS provider entries on the given controller/site (paginated).
+  """
+  dynamicDns(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DynamicDnsPage!
+
+  """Look up a single Dynamic DNS entry by id."""
+  dynamicDnsEntry(controller: ID!, id: ID!, site: String! = "default"): DynamicDns
 
   """List configured static routes (paginated)."""
   routes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): RoutePage!
@@ -2176,6 +2204,8 @@ Read-only access to UniFi Network resources.
 - `dpiApplications: DpiApplicationPage!`  — List DPI applications (paginated).
 - `dpiCategories: DpiCategoryPage!`  — List DPI categories (paginated).
 - `dpiStats: DpiStats`  — DPI stats catalog (applications + categories).
+- `dynamicDns: DynamicDnsPage!`  — List Dynamic DNS provider entries on the given controller/site (paginated).
+- `dynamicDnsEntry: DynamicDns`  — Look up a single Dynamic DNS entry by id.
 - `eventLog: EventLogPage!`  — List recent controller events (paginated).
 - `eventTypes: EventTypes`  — Get the controller's event-type prefix catalog.
 - `firewallGroup: FirewallGroup`  — Look up a single firewall group by id.

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -469,6 +469,34 @@ Fetch a user by listing then filtering — no native get_user method.
 **Returns:** `Detail_DnsRecordModel_`
 
 
+## network/dynamic_dns
+
+### `GET /v1/sites/{site_id}/dynamic-dns` — List Dynamic Dns
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_DynamicDnsModel_`
+
+### `GET /v1/sites/{site_id}/dynamic-dns/{entry_id}` — Get Dynamic Dns Entry Details
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `entry_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `Detail_DynamicDnsModel_`
+
+
 ## network/firewall
 
 ### `GET /v1/sites/{site_id}/acl-rules` — List Acl Rules

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1377,6 +1377,31 @@
         "title": "Detail[DoorModel]",
         "type": "object"
       },
+      "Detail_DynamicDnsModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DynamicDnsModel"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "Detail[DynamicDnsModel]",
+        "type": "object"
+      },
       "Detail_FirewallGroupModel_": {
         "additionalProperties": true,
         "properties": {
@@ -2282,6 +2307,126 @@
           }
         },
         "title": "DpiCategoryModel",
+        "type": "object"
+      },
+      "DynamicDnsModel": {
+        "additionalProperties": true,
+        "properties": {
+          "custom_service": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Service"
+          },
+          "host_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Name"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "interface": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interface"
+          },
+          "login": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Login"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
+          "server": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server"
+          },
+          "service": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service"
+          },
+          "site_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Site Id"
+          },
+          "x_password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Password"
+          }
+        },
+        "title": "DynamicDnsModel",
         "type": "object"
       },
       "EventModel": {
@@ -4912,6 +5057,46 @@
           "items"
         ],
         "title": "Page[DpiCategoryModel]",
+        "type": "object"
+      },
+      "Page_DynamicDnsModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/DynamicDnsModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[DynamicDnsModel]",
         "type": "object"
       },
       "Page_EventModel_": {
@@ -12882,6 +13067,163 @@
         "summary": "List Dpi Categories",
         "tags": [
           "network/policy"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/dynamic-dns": {
+      "get": {
+        "operationId": "list_dynamic_dns_v1_sites__site_id__dynamic_dns_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_DynamicDnsModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Dynamic Dns",
+        "tags": [
+          "network/dynamic_dns"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/dynamic-dns/{entry_id}": {
+      "get": {
+        "operationId": "get_dynamic_dns_entry_details_v1_sites__site_id__dynamic_dns__entry_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "entry_id",
+            "required": true,
+            "schema": {
+              "title": "Entry Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Detail_DynamicDnsModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Dynamic Dns Entry Details",
+        "tags": [
+          "network/dynamic_dns"
         ]
       }
     },

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -48,6 +48,7 @@ from unifi_api.graphql.types.network.device import (
 )
 from unifi_api.graphql.types.network.dns import DnsRecord
 from unifi_api.graphql.types.network.dpi import DpiApplication, DpiCategory
+from unifi_api.graphql.types.network.dynamic_dns import DynamicDns
 from unifi_api.graphql.types.network.event import EventLog
 from unifi_api.graphql.types.network.firewall import (
     FirewallGroup,
@@ -552,6 +553,33 @@ async def _fetch_dns_records(
             if cm.site != site:
                 await cm.set_site(site)
             return list(await mgr.list_dns_records())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_dynamic_dns(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+) -> list:
+    key = f"network/dynamic-dns/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "network",
+                "dynamic_dns_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.list_dynamic_dns())
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -1792,6 +1820,12 @@ class DnsRecordPage:
     next_cursor: str | None
 
 
+@strawberry.type(description="Paginated page of Dynamic DNS entries.")
+class DynamicDnsPage:
+    items: list[DynamicDns]
+    next_cursor: str | None
+
+
 @strawberry.type(description="Paginated page of static routes.")
 class RoutePage:
     items: list[Route]
@@ -2693,6 +2727,60 @@ class NetworkQuery:
                 did = getattr(r, "_id", None) or getattr(r, "id", None)
             if did == id:
                 return DnsRecord.from_manager_output(d)
+        return None
+
+    # ---- Dynamic DNS domain ----------------------------------------------
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List Dynamic DNS provider entries on the given controller/site (paginated).",
+    )
+    async def dynamic_dns(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> DynamicDnsPage:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dynamic_dns(ctx, controller, site)
+
+        from unifi_api.services.pagination import paginate
+
+        cursor_obj = _decode_cursor(cursor)
+        page, next_cursor = paginate(
+            list(raw),
+            limit=limit,
+            cursor=cursor_obj,
+            key_fn=_id_key,
+        )
+        return DynamicDnsPage(
+            items=[DynamicDns.from_manager_output(d) for d in page],
+            next_cursor=next_cursor.encode() if next_cursor else None,
+        )
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="Look up a single Dynamic DNS entry by id.",
+    )
+    async def dynamic_dns_entry(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        id: strawberry.ID,
+        site: str = "default",
+    ) -> DynamicDns | None:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_dynamic_dns(ctx, controller, site)
+        for d in raw:
+            r = _raw(d)
+            if isinstance(r, dict):
+                did = r.get("_id") or r.get("id")
+            else:
+                did = getattr(r, "_id", None) or getattr(r, "id", None)
+            if did == id:
+                return DynamicDns.from_manager_output(d)
         return None
 
     # ---- Routes domain ---------------------------------------------------

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -2756,7 +2756,7 @@ class NetworkQuery:
             key_fn=_id_key,
         )
         return DynamicDnsPage(
-            items=[DynamicDns.from_manager_output(d) for d in page],
+            items=[DynamicDns.from_manager_output(d, redact_sensitive=ctx.redact_sensitive_fields) for d in page],
             next_cursor=next_cursor.encode() if next_cursor else None,
         )
 
@@ -2780,7 +2780,7 @@ class NetworkQuery:
             else:
                 did = getattr(r, "_id", None) or getattr(r, "id", None)
             if did == id:
-                return DynamicDns.from_manager_output(d)
+                return DynamicDns.from_manager_output(d, redact_sensitive=ctx.redact_sensitive_fields)
         return None
 
     # ---- Routes domain ---------------------------------------------------

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -658,6 +658,26 @@ type DpiStats {
   categories: JSON!
 }
 
+"""A Dynamic DNS provider entry configured on the controller."""
+type DynamicDns {
+  id: ID
+  siteId: String
+  hostName: String
+  service: String
+  server: String
+  login: String
+  xPassword: String
+  interface: String
+  customService: String
+  options: [String!]
+}
+
+"""Paginated page of Dynamic DNS entries."""
+type DynamicDnsPage {
+  items: [DynamicDns!]!
+  nextCursor: String
+}
+
 """A UniFi Protect event row (list + detail share this shape)."""
 type Event {
   id: ID
@@ -1112,6 +1132,14 @@ type NetworkQuery {
 
   """Look up a single DNS record by id."""
   dnsRecord(controller: ID!, id: ID!, site: String! = "default"): DnsRecord
+
+  """
+  List Dynamic DNS provider entries on the given controller/site (paginated).
+  """
+  dynamicDns(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): DynamicDnsPage!
+
+  """Look up a single Dynamic DNS entry by id."""
+  dynamicDnsEntry(controller: ID!, id: ID!, site: String! = "default"): DynamicDns
 
   """List configured static routes (paginated)."""
   routes(controller: ID!, site: String! = "default", limit: Int! = 50, cursor: String = null): RoutePage!

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -108,6 +108,9 @@ from unifi_api.graphql.types.network.dpi import (
 from unifi_api.graphql.types.network.dpi import (
     DpiCategory as NetworkDpiCategoryType,
 )
+from unifi_api.graphql.types.network.dynamic_dns import (
+    DynamicDns as NetworkDynamicDnsType,
+)
 from unifi_api.graphql.types.network.event import (
     EventLog as NetworkEventLogType,
 )
@@ -379,6 +382,14 @@ def build_type_registry() -> TypeRegistry:
     reg.register_tool_type(
         "unifi_get_dns_record_details",
         NetworkDnsRecordType,
+        "detail",
+    )
+
+    # network/dynamic_dns (tool-keyed only)
+    reg.register_tool_type("unifi_list_dynamic_dns", NetworkDynamicDnsType, "list")
+    reg.register_tool_type(
+        "unifi_get_dynamic_dns_entry_details",
+        NetworkDynamicDnsType,
         "detail",
     )
 

--- a/apps/api/src/unifi_api/graphql/types/network/dynamic_dns.py
+++ b/apps/api/src/unifi_api/graphql/types/network/dynamic_dns.py
@@ -1,0 +1,71 @@
+"""Strawberry types for network/dynamic_dns (Dynamic DNS provider entries).
+
+One type per read serializer, mirroring the pydantic domain model in
+``unifi_core.network.models.dynamic_dns``:
+
+- ``DynamicDns`` — list_dynamic_dns + get_dynamic_dns_entry_details
+
+Field names map 1:1 to the controller keys. The provider secret
+``x_password`` is redacted at this surface via ``redact_value`` (per the
+response redaction policy); ``from_manager_output`` carries every other
+field through unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+import strawberry
+from unifi_core.redaction import redact_value
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@strawberry.type(description="A Dynamic DNS provider entry configured on the controller.")
+class DynamicDns:
+    id: strawberry.ID | None
+    site_id: str | None
+    host_name: str | None
+    service: str | None
+    server: str | None
+    login: str | None
+    x_password: str | None
+    interface: str | None
+    custom_service: str | None
+    options: list[str] | None
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "primary_key": "id",
+            "display_columns": ["host_name", "service", "interface", "login"],
+            "sort_default": "host_name:asc",
+        }
+
+    @classmethod
+    def from_manager_output(cls, obj: Any, *, redact_sensitive: bool = True) -> "DynamicDns":
+        options = _get(obj, "options")
+        return cls(
+            id=_get(obj, "_id") or _get(obj, "id"),
+            site_id=_get(obj, "site_id"),
+            host_name=_get(obj, "host_name"),
+            service=_get(obj, "service"),
+            server=_get(obj, "server"),
+            login=_get(obj, "login"),
+            x_password=redact_value("x_password", _get(obj, "x_password"), redact_sensitive=redact_sensitive),
+            interface=_get(obj, "interface"),
+            custom_service=_get(obj, "custom_service"),
+            options=list(options) if isinstance(options, list) else None,
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/apps/api/src/unifi_api/routes/resources/network/dynamic_dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dynamic_dns.py
@@ -19,6 +19,10 @@ from unifi_api.services.pydantic_models import Detail, Page
 router = APIRouter()
 
 
+def _redact_sensitive(request: Request) -> bool:
+    return request.app.state.config.policy.response.redact_sensitive_fields
+
+
 def _id_key(obj) -> tuple:
     raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
     return (0, raw.get("_id") or raw.get("id") or "")
@@ -72,7 +76,8 @@ async def list_dynamic_dns(
     tool_type = type_registry.lookup_tool("unifi_list_dynamic_dns")
     if tool_type is not None:
         type_class, kind = tool_type
-        rows = [type_class.from_manager_output(i).to_dict() for i in page]
+        redact_sensitive = _redact_sensitive(request)
+        rows = [type_class.from_manager_output(i, redact_sensitive=redact_sensitive).to_dict() for i in page]
         hint = type_class.render_hint(kind)
     else:
         registry = request.app.state.serializer_registry
@@ -124,7 +129,7 @@ async def get_dynamic_dns_entry_details(
     tool_type = type_registry.lookup_tool("unifi_get_dynamic_dns_entry_details")
     if tool_type is not None:
         type_class, kind = tool_type
-        data = type_class.from_manager_output(item).to_dict()
+        data = type_class.from_manager_output(item, redact_sensitive=_redact_sensitive(request)).to_dict()
         hint = type_class.render_hint(kind)
     else:
         registry = request.app.state.serializer_registry

--- a/apps/api/src/unifi_api/routes/resources/network/dynamic_dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dynamic_dns.py
@@ -1,0 +1,134 @@
+"""GET /v1/sites/{site_id}/dynamic-dns[/{entry_id}] — V1 Dynamic DNS entries."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from unifi_core.exceptions import UniFiNotFoundError
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.dynamic_dns import DynamicDns
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+from unifi_api.services.pydantic_models import Detail, Page
+
+router = APIRouter()
+
+
+def _id_key(obj) -> tuple:
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    return (0, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/dynamic-dns",
+    response_model=Page[to_pydantic_model(DynamicDns)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/dynamic_dns"],
+)
+async def list_dynamic_dns(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "network",
+            "dynamic_dns_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.list_dynamic_dns()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items),
+        limit=limit,
+        cursor=cursor_obj,
+        key_fn=_id_key,
+    )
+    type_registry = request.app.state.type_registry
+    tool_type = type_registry.lookup_tool("unifi_list_dynamic_dns")
+    if tool_type is not None:
+        type_class, kind = tool_type
+        rows = [type_class.from_manager_output(i).to_dict() for i in page]
+        hint = type_class.render_hint(kind)
+    else:
+        registry = request.app.state.serializer_registry
+        serializer = registry.serializer_for_tool("unifi_list_dynamic_dns")
+        rows = [serializer.serialize(i) for i in page]
+        hint = registry.render_hint_for_tool("unifi_list_dynamic_dns")
+    return {
+        "items": rows,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }
+
+
+@router.get(
+    "/sites/{site_id}/dynamic-dns/{entry_id}",
+    response_model=Detail[to_pydantic_model(DynamicDns)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/dynamic_dns"],
+)
+async def get_dynamic_dns_entry_details(
+    request: Request,
+    site_id: str,
+    entry_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session,
+                controller.id,
+                "network",
+                "dynamic_dns_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "network")
+            if cm.site != site_id:
+                await cm.set_site(site_id)
+            item = await mgr.get_dynamic_dns(entry_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    if item is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"dynamic dns entry {entry_id} not found",
+        )
+    type_registry = request.app.state.type_registry
+    tool_type = type_registry.lookup_tool("unifi_get_dynamic_dns_entry_details")
+    if tool_type is not None:
+        type_class, kind = tool_type
+        data = type_class.from_manager_output(item).to_dict()
+        hint = type_class.render_hint(kind)
+    else:
+        registry = request.app.state.serializer_registry
+        serializer = registry.serializer_for_tool("unifi_get_dynamic_dns_entry_details")
+        data = serializer.serialize(item)
+        hint = registry.render_hint_for_tool("unifi_get_dynamic_dns_entry_details")
+    return {"data": data, "render_hint": hint}

--- a/apps/api/src/unifi_api/serializers/network/dynamic_dns.py
+++ b/apps/api/src/unifi_api/serializers/network/dynamic_dns.py
@@ -1,0 +1,35 @@
+"""Dynamic DNS serializers.
+
+The read shape (list/detail) lives in the Strawberry type at
+``unifi_api.graphql.types.network.dynamic_dns.DynamicDns``. Only the
+mutation ack is served here, for the create/update/delete tools.
+"""
+
+from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
+
+
+@register_serializer(
+    tools={
+        "unifi_create_dynamic_dns": {"kind": RenderKind.DETAIL},
+        "unifi_update_dynamic_dns": {"kind": RenderKind.DETAIL},
+        "unifi_delete_dynamic_dns": {"kind": RenderKind.DETAIL},
+    },
+)
+class DynamicDnsMutationAckSerializer(Serializer):
+    """DETAIL ack for Dynamic DNS create/update/delete operations.
+
+    ``create_dynamic_dns`` returns the created dict; ``update_*`` / ``delete_*``
+    return ``bool``. Coerce both to a DETAIL-shaped payload."""
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        if isinstance(obj, bool):
+            return {"success": obj}
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "raw", None)
+        if isinstance(raw, dict):
+            return raw
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump()
+        return {"result": str(obj)}

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -96,6 +96,9 @@ from unifi_api.routes.resources.network import (
     dpi as net_dpi_routes,
 )
 from unifi_api.routes.resources.network import (
+    dynamic_dns as net_dynamic_dns_routes,
+)
+from unifi_api.routes.resources.network import (
     events as net_events_routes,
 )
 from unifi_api.routes.resources.network import (
@@ -504,6 +507,7 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_routes_routes,
         net_traffic_flows_routes,
         net_dns_routes,
+        net_dynamic_dns_routes,
         net_vpn_routes,
         net_ap_groups_routes,
         net_firewall_groups_routes,

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -84,6 +84,10 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     # to render a current-vs-proposed preview, so the AST walker captures the read
     # method first. Pin dispatch to the mutation method.
     "unifi_update_traffic_route": ("traffic_route_manager", "update_traffic_route"),
+    # update_dynamic_dns pre-fetches the entry via get_dynamic_dns to render a
+    # current-vs-proposed preview, so the AST walker captures the read method
+    # first. Pin dispatch to the mutation method.
+    "unifi_update_dynamic_dns": ("dynamic_dns_manager", "update_dynamic_dns"),
     # update_device_radio: tool needs current radio_table to identify target band.
     "unifi_update_device_radio": ("device_manager", "update_device_radio"),
     # Stats: tool combines existence check on client/device with stats fetch.
@@ -226,6 +230,51 @@ def _translate_gateway_settings_update(args: dict[str, Any]) -> tuple[tuple[Any,
 
     update_data = args.get("update_data") or {}
     return (to_controller_update(update_data),), {}
+
+
+def _translate_create_dynamic_dns(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Validate + translate ``entry_data`` → controller create payload for
+    ``DynamicDnsManager.create_dynamic_dns(entry_data)``.
+
+    Mirrors ``apps/network/src/unifi_network_mcp/tools/dynamic_dns.py:create_dynamic_dns``:
+    reject unknown / read-only keys (so they are not forwarded raw to the
+    controller) and require ``host_name`` + ``service``.
+    """
+    from unifi_core.network.models.dynamic_dns import (
+        MUTABLE_FIELDS,
+        DynamicDns,
+        reject_unknown_fields,
+        to_controller_create,
+    )
+
+    entry_data = args.get("entry_data") or {}
+    reject_unknown_fields(entry_data)
+    model = DynamicDns(**{k: v for k, v in entry_data.items() if k in MUTABLE_FIELDS})
+    if not model.host_name or not model.service:
+        raise ValueError("'host_name' and 'service' are required")
+    return (to_controller_create(model),), {}
+
+
+def _translate_update_dynamic_dns(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Reshape ``(entry_id, update_data)`` → positional ``(entry_id, payload)`` for
+    ``DynamicDnsManager.update_dynamic_dns(entry_id, entry_data)``.
+
+    The tool exposes ``update_data`` but the manager parameter is ``entry_data``,
+    so the default ``method(**args)`` would pass an unexpected ``update_data=``
+    kwarg. Mirrors the MCP tool: reject unknown / read-only keys, then filter to
+    mutable fields.
+    """
+    from unifi_core.network.models.dynamic_dns import reject_unknown_fields, to_controller_update
+
+    entry_id = args["entry_id"]
+    update_data = args.get("update_data") or {}
+    if not update_data:
+        raise ValueError("No fields provided to update.")
+    reject_unknown_fields(update_data)
+    validated = to_controller_update(update_data)
+    if not validated:
+        raise ValueError("No valid fields to update after validation.")
+    return (entry_id, validated), {}
 
 
 def _parse_iso_datetime(value: Any) -> Any:
@@ -442,6 +491,10 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslator] = {
     "unifi_create_acl_rule": _translate_acl_create,
     "unifi_update_acl_rule": _translate_acl_update,
     "unifi_update_gateway_settings": _translate_gateway_settings_update,
+    # Network — dynamic DNS: create validates+translates entry_data; update reshapes
+    # (entry_id, update_data) → (entry_id, entry_data) and rejects unknown/read-only keys.
+    "unifi_create_dynamic_dns": _translate_create_dynamic_dns,
+    "unifi_update_dynamic_dns": _translate_update_dynamic_dns,
     "protect_export_clip": _translate_export_clip,
     "protect_delete_recording": _translate_delete_recording,
     "protect_update_chime": _translate_chime_update,

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -51,6 +51,7 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
     from unifi_core.network.managers.device_manager import DeviceManager
     from unifi_core.network.managers.dns_manager import DnsManager
     from unifi_core.network.managers.dpi_manager import DpiManager
+    from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
     from unifi_core.network.managers.event_manager import EventManager
     from unifi_core.network.managers.firewall_manager import FirewallManager
     from unifi_core.network.managers.gateway_settings_manager import GatewaySettingsManager
@@ -79,6 +80,7 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
         # API token is configured for the controller, the auth is unset
         # internally and DpiManager returns None with a clear log line.
         "dpi_manager": lambda cm: DpiManager(cm, getattr(cm, "unifi_auth", None)),
+        "dynamic_dns_manager": lambda cm: DynamicDnsManager(cm),
         "event_manager": lambda cm: EventManager(cm),
         "firewall_manager": lambda cm: FirewallManager(cm),
         "gateway_settings_manager": lambda cm: GatewaySettingsManager(cm),

--- a/apps/api/tests/graphql/fixtures/network/test_dynamic_dns.py
+++ b/apps/api/tests/graphql/fixtures/network/test_dynamic_dns.py
@@ -116,3 +116,55 @@ async def test_dynamic_dns_entry_redacts_secret(tmp_path, monkeypatch):
     )
     assert body.get("errors") is None, body
     assert body["data"]["network"]["dynamicDnsEntry"]["xPassword"] == "***REDACTED***"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dns_shows_secret_when_policy_off(tmp_path, monkeypatch):
+    """With the redaction policy disabled, the resolver must honor it and return
+    the raw secret (the policy flag has to be threaded into from_manager_output)."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network", redact_sensitive_fields=False)
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "dynamic_dns_manager", "list_dynamic_dns"): [
+                {"_id": "ddns-1", "host_name": "home.example.com", "x_password": "super-secret"},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ dynamicDns(controller: "{cid}", limit: 10) {{
+            items {{ xPassword }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    assert body["data"]["network"]["dynamicDns"]["items"][0]["xPassword"] == "super-secret"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dns_entry_shows_secret_when_policy_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network", redact_sensitive_fields=False)
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "dynamic_dns_manager", "list_dynamic_dns"): [
+                {"_id": "ddns-1", "host_name": "home.example.com", "x_password": "super-secret"},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ dynamicDnsEntry(controller: "{cid}", id: "ddns-1") {{
+            xPassword
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    assert body["data"]["network"]["dynamicDnsEntry"]["xPassword"] == "super-secret"

--- a/apps/api/tests/graphql/fixtures/network/test_dynamic_dns.py
+++ b/apps/api/tests/graphql/fixtures/network/test_dynamic_dns.py
@@ -1,0 +1,118 @@
+"""Fixture e2e tests for network/dynamic_dns resolvers.
+
+# tool: unifi_list_dynamic_dns
+# tool: unifi_get_dynamic_dns_entry_details
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.graphql.fixtures._helpers import (
+    bootstrap,
+    graphql_query,
+    stub_managers,
+)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dns_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "dynamic_dns_manager", "list_dynamic_dns"): [
+                {"_id": "ddns-1", "host_name": "home.example.com", "service": "dyndns"},
+                {"_id": "ddns-2", "host_name": "alt.example.com", "service": "noip"},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ dynamicDns(controller: "{cid}", limit: 10) {{
+            items {{ id hostName service }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    items = body["data"]["network"]["dynamicDns"]["items"]
+    assert len(items) == 2
+    assert {i["hostName"] for i in items} == {"home.example.com", "alt.example.com"}
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dns_detail(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "dynamic_dns_manager", "list_dynamic_dns"): [
+                {"_id": "ddns-1", "host_name": "home.example.com", "service": "dyndns"},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ dynamicDnsEntry(controller: "{cid}", id: "ddns-1") {{
+            id
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    assert body["data"]["network"]["dynamicDnsEntry"]["id"] == "ddns-1"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dns_redacts_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "dynamic_dns_manager", "list_dynamic_dns"): [
+                {"_id": "ddns-1", "host_name": "home.example.com", "x_password": "super-secret"},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ dynamicDns(controller: "{cid}", limit: 10) {{
+            items {{ xPassword }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    assert body["data"]["network"]["dynamicDns"]["items"][0]["xPassword"] == "***REDACTED***"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_dns_entry_redacts_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "dynamic_dns_manager", "list_dynamic_dns"): [
+                {"_id": "ddns-1", "host_name": "home.example.com", "x_password": "super-secret"},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ dynamicDnsEntry(controller: "{cid}", id: "ddns-1") {{
+            xPassword
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    assert body["data"]["network"]["dynamicDnsEntry"]["xPassword"] == "***REDACTED***"

--- a/apps/api/tests/routes/resources/test_network_resources.py
+++ b/apps/api/tests/routes/resources/test_network_resources.py
@@ -357,6 +357,52 @@ async def test_list_dynamic_dns_policy_disabled_returns_raw_secret(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_get_dynamic_dns_detail_redacts_secret(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, entry_id, *a, **kw):
+        assert entry_id == "ddns-1"
+        return {"_id": "ddns-1", "host_name": "home.example.com", "service": "dyndns", "x_password": "ddns-secret"}
+
+    from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
+
+    monkeypatch.setattr(DynamicDnsManager, "get_dynamic_dns", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dynamic-dns/ddns-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["x_password"] == REDACTED
+
+
+@pytest.mark.asyncio
+async def test_get_dynamic_dns_detail_policy_disabled_returns_raw_secret(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, redact_sensitive_fields=False)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, entry_id, *a, **kw):
+        assert entry_id == "ddns-1"
+        return {"_id": "ddns-1", "host_name": "home.example.com", "service": "dyndns", "x_password": "ddns-secret"}
+
+    from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
+
+    monkeypatch.setattr(DynamicDnsManager, "get_dynamic_dns", fake_get)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dynamic-dns/ddns-1?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["data"]["x_password"] == "ddns-secret"
+
+
+@pytest.mark.asyncio
 async def test_list_firewall_rules_happy_path(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)

--- a/apps/api/tests/routes/resources/test_network_resources.py
+++ b/apps/api/tests/routes/resources/test_network_resources.py
@@ -313,6 +313,50 @@ async def test_list_wlans_policy_disabled_returns_raw_passphrases(tmp_path, monk
 
 
 @pytest.mark.asyncio
+async def test_list_dynamic_dns_redacts_secret(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_list(self, *a, **kw):
+        return [{"_id": "ddns-1", "host_name": "home.example.com", "service": "dyndns", "x_password": "ddns-secret"}]
+
+    from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
+
+    monkeypatch.setattr(DynamicDnsManager, "list_dynamic_dns", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dynamic-dns?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["items"][0]["x_password"] == REDACTED
+
+
+@pytest.mark.asyncio
+async def test_list_dynamic_dns_policy_disabled_returns_raw_secret(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, redact_sensitive_fields=False)
+    _stub_connection(app, cid)
+
+    async def fake_list(self, *a, **kw):
+        return [{"_id": "ddns-1", "host_name": "home.example.com", "service": "dyndns", "x_password": "ddns-secret"}]
+
+    from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
+
+    monkeypatch.setattr(DynamicDnsManager, "list_dynamic_dns", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/dynamic-dns?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["items"][0]["x_password"] == "ddns-secret"
+
+
+@pytest.mark.asyncio
 async def test_list_firewall_rules_happy_path(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -898,6 +898,219 @@ async def test_dispatch_translates_gateway_settings_update_filters_to_mutable() 
     assert positional[0] == {"upnp_enabled": True}
 
 
+def _ddns_factory():
+    domain_manager = MagicMock()
+    domain_manager.update_dynamic_dns = AsyncMock(return_value={"_id": "ddns001"})
+    domain_manager.create_dynamic_dns = AsyncMock(return_value={"_id": "ddns_new"})
+    # get_dynamic_dns is the READ the update tool now pre-fetches for its preview;
+    # stub it so a wrong AST binding fails as a clean assertion, not a TypeError.
+    domain_manager.get_dynamic_dns = AsyncMock(return_value={"_id": "ddns001", "host_name": "old.example.com"})
+    conn_manager = MagicMock(site="default")
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+    return factory, domain_manager
+
+
+@pytest.mark.asyncio
+async def test_dispatch_real_table_binds_dynamic_dns_update_to_mutation() -> None:
+    """Regression: update_dynamic_dns pre-fetches the current entry via
+    get_dynamic_dns to render a real current-vs-proposed preview, so the AST
+    dispatcher captures the READ method first. A DISPATCH_OVERRIDES entry must
+    redirect dispatch to the mutation method (update_dynamic_dns).
+
+    Uses the REAL build_dispatch_table() — the hand-built dispatch_table the other
+    DDNS tests use would hide a wrong method binding (which the AST would pick)."""
+    entry = ToolEntry(name="unifi_update_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_update_dynamic_dns",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"entry_id": "ddns001", "update_data": {"host_name": "new.example.com"}},
+        confirm=True,
+        dispatch_table=build_dispatch_table(),
+    )
+
+    # Bound to the mutation, NOT the get_dynamic_dns read the AST captures first.
+    domain_manager.update_dynamic_dns.assert_awaited_once_with("ddns001", {"host_name": "new.example.com"})
+    domain_manager.get_dynamic_dns.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_real_table_binds_dynamic_dns_create_to_mutation() -> None:
+    """The create tool has no pre-fetch, so the AST binds it correctly — pin it in
+    the real table too, guarding against a future preview refactor."""
+    entry = ToolEntry(name="unifi_create_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_create_dynamic_dns",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"entry_data": {"host_name": "home.example.com", "service": "dyndns"}},
+        confirm=True,
+        dispatch_table=build_dispatch_table(),
+    )
+
+    domain_manager.create_dynamic_dns.assert_awaited_once_with({"host_name": "home.example.com", "service": "dyndns"})
+
+
+@pytest.mark.asyncio
+async def test_dispatch_translates_dynamic_dns_update_to_entry_id_plus_payload() -> None:
+    """unifi_update_dynamic_dns: the tool exposes ``update_data`` but the manager
+    method is ``update_dynamic_dns(entry_id, entry_data)``. The translator must
+    rename/reshape to positional ``(entry_id, filtered_payload)`` — without it the
+    /v1/actions path calls the manager with an unexpected ``update_data=`` kwarg."""
+    entry = ToolEntry(name="unifi_update_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_update_dynamic_dns",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"entry_id": "ddns001", "update_data": {"service": "noip", "interface": "wan2"}},
+        confirm=True,
+        dispatch_table={
+            "unifi_update_dynamic_dns": DispatchEntry(manager_attr="dynamic_dns_manager", method="update_dynamic_dns")
+        },
+    )
+
+    domain_manager.update_dynamic_dns.assert_awaited_once()
+    (positional, keyword) = domain_manager.update_dynamic_dns.await_args
+    assert keyword == {}, f"expected no kwargs; got {keyword}"
+    assert positional == ("ddns001", {"service": "noip", "interface": "wan2"})
+
+
+@pytest.mark.asyncio
+async def test_dispatch_dynamic_dns_update_rejects_unknown_field() -> None:
+    """Unknown keys in update_data must fail with an actionable error, not be
+    silently forwarded/dropped on the /v1/actions path."""
+    entry = ToolEntry(name="unifi_update_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    with pytest.raises(ValueError, match="Unknown or read-only fields"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_update_dynamic_dns",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"entry_id": "ddns001", "update_data": {"bogus_field": "x"}},
+            confirm=True,
+            dispatch_table={
+                "unifi_update_dynamic_dns": DispatchEntry(
+                    manager_attr="dynamic_dns_manager", method="update_dynamic_dns"
+                )
+            },
+        )
+    domain_manager.update_dynamic_dns.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_dynamic_dns_update_rejects_read_only_field() -> None:
+    """Read-only keys (id/site_id) in update_data must fail, not be dropped."""
+    entry = ToolEntry(name="unifi_update_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    with pytest.raises(ValueError, match="Unknown or read-only fields"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_update_dynamic_dns",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"entry_id": "ddns001", "update_data": {"id": "x", "service": "noip"}},
+            confirm=True,
+            dispatch_table={
+                "unifi_update_dynamic_dns": DispatchEntry(
+                    manager_attr="dynamic_dns_manager", method="update_dynamic_dns"
+                )
+            },
+        )
+    domain_manager.update_dynamic_dns.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_translates_dynamic_dns_create_to_controller_payload() -> None:
+    """unifi_create_dynamic_dns: the translator must validate + translate entry_data
+    to the controller create payload (single positional arg), so unknown keys are
+    not forwarded raw to the controller on the /v1/actions path."""
+    entry = ToolEntry(name="unifi_create_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_create_dynamic_dns",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"entry_data": {"host_name": "home.example.com", "service": "dyndns", "interface": "wan"}},
+        confirm=True,
+        dispatch_table={
+            "unifi_create_dynamic_dns": DispatchEntry(manager_attr="dynamic_dns_manager", method="create_dynamic_dns")
+        },
+    )
+
+    domain_manager.create_dynamic_dns.assert_awaited_once()
+    (positional, keyword) = domain_manager.create_dynamic_dns.await_args
+    assert keyword == {}, f"expected no kwargs; got {keyword}"
+    assert positional[0] == {"host_name": "home.example.com", "service": "dyndns", "interface": "wan"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_dynamic_dns_create_rejects_unknown_field() -> None:
+    """Unknown keys in entry_data must fail rather than being forwarded raw to the controller."""
+    entry = ToolEntry(name="unifi_create_dynamic_dns", product="network", category="dynamic_dns", manager="", method="")
+    registry = _registry_with(entry)
+    factory, domain_manager = _ddns_factory()
+
+    with pytest.raises(ValueError, match="Unknown or read-only fields"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_create_dynamic_dns",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"entry_data": {"host_name": "home.example.com", "service": "dyndns", "bogus_field": "x"}},
+            confirm=True,
+            dispatch_table={
+                "unifi_create_dynamic_dns": DispatchEntry(
+                    manager_attr="dynamic_dns_manager", method="create_dynamic_dns"
+                )
+            },
+        )
+    domain_manager.create_dynamic_dns.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_dispatch_acl_update_clears_netmask() -> None:
     """clear_destination_netmask flows through the API translator to a None mac_mask sentinel."""

--- a/apps/api/tests/unit/test_cross_layer_symmetry.py
+++ b/apps/api/tests/unit/test_cross_layer_symmetry.py
@@ -23,6 +23,7 @@ REGISTERED_PAIRS: list[tuple[str, str, str]] = [
     ("network", "client_group", "UserGroup"),
     ("network", "content_filter", "ContentFilter"),
     ("network", "dns", "DnsRecord"),
+    ("network", "dynamic_dns", "DynamicDns"),
     ("network", "firewall", "FirewallRule"),
     ("network", "firewall", "FirewallGroup"),
     ("network", "firewall", "FirewallZone"),

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -50,6 +50,7 @@ NETWORK_CATEGORY_MAP = {
     "switch": "switch",
     "system": "system",
     "dns": "dns",
+    "dynamic_dns": "dynamic_dns",
     "gateway_settings": "gateway_settings",
 }
 

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -41,6 +41,7 @@ from unifi_core.network.managers.content_filter_manager import ContentFilterMana
 from unifi_core.network.managers.device_manager import DeviceManager
 from unifi_core.network.managers.dns_manager import DnsManager
 from unifi_core.network.managers.dpi_manager import DpiManager
+from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
 from unifi_core.network.managers.event_manager import EventManager
 from unifi_core.network.managers.firewall_manager import FirewallManager
 from unifi_core.network.managers.gateway_settings_manager import GatewaySettingsManager
@@ -195,6 +196,11 @@ def get_dns_manager() -> DnsManager:
 
 
 @lru_cache
+def get_dynamic_dns_manager() -> DynamicDnsManager:
+    return DynamicDnsManager(get_connection_manager())
+
+
+@lru_cache
 def get_dpi_manager() -> DpiManager:
     return DpiManager(get_connection_manager(), get_auth())
 
@@ -301,6 +307,7 @@ client_group_manager = get_client_group_manager()
 client_manager = get_client_manager()
 content_filter_manager = get_content_filter_manager()
 dns_manager = get_dns_manager()
+dynamic_dns_manager = get_dynamic_dns_manager()
 dpi_manager = get_dpi_manager()
 device_manager = get_device_manager()
 stats_manager = get_stats_manager()

--- a/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
+++ b/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
@@ -18,6 +18,7 @@ from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.dynamic_dns import (
     MUTABLE_FIELDS,
     DynamicDns,
+    reject_unknown_fields,
 )
 from unifi_core.network.models.dynamic_dns import (
     from_controller as ddns_from_controller,
@@ -114,6 +115,7 @@ async def create_dynamic_dns(
     logger.info("unifi_create_dynamic_dns tool called (confirm=%s)", confirm)
 
     try:
+        reject_unknown_fields(entry_data)
         model = DynamicDns(**{k: v for k, v in entry_data.items() if k in MUTABLE_FIELDS})
     except Exception as exc:
         return {"success": False, "error": f"Validation error: {exc}"}
@@ -181,17 +183,27 @@ async def update_dynamic_dns(
     if not update_data:
         return {"success": False, "error": "No fields provided to update."}
 
+    try:
+        reject_unknown_fields(update_data)
+    except ValueError as exc:
+        return {"success": False, "error": f"Validation error: {exc}"}
+
     validated_data = ddns_to_update(update_data)
     if not validated_data:
         return {"success": False, "error": "No valid fields to update after validation."}
 
     if not confirm:
+        try:
+            current = await dynamic_dns_manager.get_dynamic_dns(entry_id)
+        except UniFiNotFoundError as e:
+            return {"success": False, "error": str(e)}
+        current_state = ddns_from_controller(current).model_dump(exclude_none=True)
         return redact_sensitive_fields(
             update_preview(
                 resource_type="dynamic_dns",
                 resource_id=entry_id,
-                resource_name=entry_id,
-                current_state={},
+                resource_name=current_state.get("host_name", entry_id),
+                current_state=current_state,
                 updates=validated_data,
             ),
             redact_sensitive=should_redact_sensitive_fields(),

--- a/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
+++ b/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
@@ -1,0 +1,248 @@
+"""
+Dynamic DNS management tools for UniFi Network MCP server.
+
+Provides CRUD for the controller's native Dynamic DNS provider entries via
+the V1 REST endpoint /rest/dynamicdns. The provider secret (``x_password``)
+is redacted at the egress boundary per the response redaction policy.
+"""
+
+import json
+import logging
+from typing import Annotated, Any, Dict
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.network.models.dynamic_dns import (
+    MUTABLE_FIELDS,
+    DynamicDns,
+)
+from unifi_core.network.models.dynamic_dns import (
+    from_controller as ddns_from_controller,
+)
+from unifi_core.network.models.dynamic_dns import (
+    to_controller_create as ddns_to_create,
+)
+from unifi_core.network.models.dynamic_dns import (
+    to_controller_update as ddns_to_update,
+)
+from unifi_core.redaction import redact_sensitive_fields
+from unifi_network_mcp.runtime import dynamic_dns_manager, server, should_redact_sensitive_fields
+
+logger = logging.getLogger(__name__)
+
+
+@server.tool(
+    name="unifi_list_dynamic_dns",
+    description="List all Dynamic DNS provider entries configured on the controller. "
+    "Returns hostname, service/provider, WAN interface, login, and options for each entry. "
+    "The provider password/token is redacted.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_dynamic_dns() -> Dict[str, Any]:
+    """List all Dynamic DNS entries."""
+    logger.info("unifi_list_dynamic_dns tool called")
+    try:
+        entries = await dynamic_dns_manager.list_dynamic_dns()
+        formatted = [ddns_from_controller(e).model_dump(exclude_none=True) for e in entries]
+        return redact_sensitive_fields(
+            {
+                "success": True,
+                "site": dynamic_dns_manager._connection.site,
+                "count": len(formatted),
+                "entries": formatted,
+            },
+            redact_sensitive=should_redact_sensitive_fields(),
+        )
+    except Exception as e:
+        logger.error("Error listing Dynamic DNS entries: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list Dynamic DNS entries: {e}"}
+
+
+@server.tool(
+    name="unifi_get_dynamic_dns_details",
+    description="Get details for a specific Dynamic DNS entry by ID. The provider password/token is redacted.",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def get_dynamic_dns_details(
+    entry_id: Annotated[str, Field(description="The unique identifier (_id) of the Dynamic DNS entry")],
+) -> Dict[str, Any]:
+    """Get a specific Dynamic DNS entry."""
+    logger.info("unifi_get_dynamic_dns_details tool called (entry_id=%s)", entry_id)
+    try:
+        entry = await dynamic_dns_manager.get_dynamic_dns(entry_id)
+        return redact_sensitive_fields(
+            {
+                "success": True,
+                "entry_id": entry_id,
+                "details": ddns_from_controller(entry).model_dump(exclude_none=True),
+            },
+            redact_sensitive=should_redact_sensitive_fields(),
+        )
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error getting Dynamic DNS entry %s: %s", entry_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get Dynamic DNS entry {entry_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_create_dynamic_dns",
+    description="Create a new Dynamic DNS provider entry. "
+    "Required: host_name (hostname to keep updated, e.g. 'home.example.com'), "
+    "service (provider: 'dyndns'/'noip'/'namecheap'/'cloudflare'/'custom'/...). "
+    "Optional: interface ('wan' [default] or 'wan2'), login (username), x_password (password/token), "
+    "server + custom_service (for the 'custom' service), options (list of strings). "
+    "Requires confirmation.",
+    permission_category="dynamic_dns",
+    permission_action="create",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def create_dynamic_dns(
+    entry_data: Annotated[
+        Dict[str, Any],
+        Field(description="Dynamic DNS entry data. See tool description for required and optional fields."),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the entry. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Create a new Dynamic DNS entry."""
+    logger.info("unifi_create_dynamic_dns tool called (confirm=%s)", confirm)
+
+    try:
+        model = DynamicDns(**{k: v for k, v in entry_data.items() if k in MUTABLE_FIELDS})
+    except Exception as exc:
+        return {"success": False, "error": f"Validation error: {exc}"}
+    if not model.host_name or not model.service:
+        return {"success": False, "error": "Validation error: 'host_name' and 'service' are required"}
+    validated_data = ddns_to_create(model)
+
+    if not confirm:
+        return redact_sensitive_fields(
+            create_preview(
+                resource_type="dynamic_dns",
+                resource_data=validated_data,
+                resource_name=validated_data.get("host_name", "unnamed"),
+            ),
+            redact_sensitive=should_redact_sensitive_fields(),
+        )
+
+    try:
+        result = await dynamic_dns_manager.create_dynamic_dns(validated_data)
+        if result:
+            return redact_sensitive_fields(
+                {
+                    "success": True,
+                    "message": f"Dynamic DNS entry '{validated_data.get('host_name', '')}' created successfully.",
+                    "details": json.loads(json.dumps(result, default=str)),
+                },
+                redact_sensitive=should_redact_sensitive_fields(),
+            )
+        return {
+            "success": False,
+            "error": f"Failed to create Dynamic DNS entry '{validated_data.get('host_name', '')}'.",
+        }
+    except Exception as e:
+        logger.error("Error creating Dynamic DNS entry: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to create Dynamic DNS entry: {e}"}
+
+
+@server.tool(
+    name="unifi_update_dynamic_dns",
+    description="Update an existing Dynamic DNS entry. "
+    "Pass only the fields you want to change — current values are automatically preserved. "
+    "Fields: host_name (str), service (str), server (str), login (str), x_password (str), "
+    "interface ('wan'/'wan2'), custom_service (str), options (list of strings). "
+    "Requires confirmation.",
+    permission_category="dynamic_dns",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_dynamic_dns(
+    entry_id: Annotated[
+        str, Field(description="The ID of the Dynamic DNS entry to update (from unifi_list_dynamic_dns)")
+    ],
+    update_data: Annotated[
+        Dict[str, Any],
+        Field(description="Dictionary of fields to update. See tool description for supported fields."),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, applies the update. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Update an existing Dynamic DNS entry."""
+    logger.info("unifi_update_dynamic_dns tool called (entry_id=%s, confirm=%s)", entry_id, confirm)
+
+    if not update_data:
+        return {"success": False, "error": "No fields provided to update."}
+
+    validated_data = ddns_to_update(update_data)
+    if not validated_data:
+        return {"success": False, "error": "No valid fields to update after validation."}
+
+    if not confirm:
+        return redact_sensitive_fields(
+            update_preview(
+                resource_type="dynamic_dns",
+                resource_id=entry_id,
+                resource_name=entry_id,
+                current_state={},
+                updates=validated_data,
+            ),
+            redact_sensitive=should_redact_sensitive_fields(),
+        )
+
+    try:
+        merged = await dynamic_dns_manager.update_dynamic_dns(entry_id, validated_data)
+        return {
+            "success": True,
+            "message": f"Dynamic DNS entry '{merged.get('host_name', entry_id)}' updated successfully.",
+        }
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error updating Dynamic DNS entry %s: %s", entry_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to update Dynamic DNS entry {entry_id}: {e}"}
+
+
+@server.tool(
+    name="unifi_delete_dynamic_dns",
+    description="Delete a Dynamic DNS entry. Use unifi_list_dynamic_dns to find entry IDs. Requires confirmation.",
+    permission_category="dynamic_dns",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_dynamic_dns(
+    entry_id: Annotated[
+        str, Field(description="The ID of the Dynamic DNS entry to delete (from unifi_list_dynamic_dns)")
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the entry. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Delete a Dynamic DNS entry."""
+    logger.info("unifi_delete_dynamic_dns tool called (entry_id=%s, confirm=%s)", entry_id, confirm)
+    if not confirm:
+        return create_preview(
+            resource_type="dynamic_dns",
+            resource_data={"entry_id": entry_id},
+            resource_name=entry_id,
+            warnings=["This will permanently delete the Dynamic DNS entry."],
+        )
+
+    try:
+        success = await dynamic_dns_manager.delete_dynamic_dns(entry_id)
+        if success:
+            return {"success": True, "message": f"Dynamic DNS entry '{entry_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete Dynamic DNS entry '{entry_id}'."}
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error deleting Dynamic DNS entry %s: %s", entry_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete Dynamic DNS entry '{entry_id}': {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
+++ b/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
@@ -62,15 +62,15 @@ async def list_dynamic_dns() -> Dict[str, Any]:
 
 
 @server.tool(
-    name="unifi_get_dynamic_dns_details",
+    name="unifi_get_dynamic_dns_entry_details",
     description="Get details for a specific Dynamic DNS entry by ID. The provider password/token is redacted.",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
-async def get_dynamic_dns_details(
+async def get_dynamic_dns_entry_details(
     entry_id: Annotated[str, Field(description="The unique identifier (_id) of the Dynamic DNS entry")],
 ) -> Dict[str, Any]:
     """Get a specific Dynamic DNS entry."""
-    logger.info("unifi_get_dynamic_dns_details tool called (entry_id=%s)", entry_id)
+    logger.info("unifi_get_dynamic_dns_entry_details tool called (entry_id=%s)", entry_id)
     try:
         entry = await dynamic_dns_manager.get_dynamic_dns(entry_id)
         return redact_sensitive_fields(

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 181,
+  "count": 186,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -14,6 +14,7 @@
     "unifi_create_backup": "unifi_network_mcp.tools.system",
     "unifi_create_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_create_dns_record": "unifi_network_mcp.tools.dns",
+    "unifi_create_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_create_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_create_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_create_network": "unifi_network_mcp.tools.network",
@@ -33,6 +34,7 @@
     "unifi_delete_client_group": "unifi_network_mcp.tools.client_groups",
     "unifi_delete_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_delete_dns_record": "unifi_network_mcp.tools.dns",
+    "unifi_delete_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_delete_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_delete_oon_policy": "unifi_network_mcp.tools.oon",
@@ -60,6 +62,7 @@
     "unifi_get_device_stats": "unifi_network_mcp.tools.stats",
     "unifi_get_dns_record_details": "unifi_network_mcp.tools.dns",
     "unifi_get_dpi_stats": "unifi_network_mcp.tools.stats",
+    "unifi_get_dynamic_dns_entry_details": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_get_event_types": "unifi_network_mcp.tools.events",
     "unifi_get_firewall_group_details": "unifi_network_mcp.tools.firewall",
     "unifi_get_firewall_policy_details": "unifi_network_mcp.tools.firewall",
@@ -110,6 +113,7 @@
     "unifi_list_dns_records": "unifi_network_mcp.tools.dns",
     "unifi_list_dpi_applications": "unifi_network_mcp.tools.dpi",
     "unifi_list_dpi_categories": "unifi_network_mcp.tools.dpi",
+    "unifi_list_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_list_events": "unifi_network_mcp.tools.events",
     "unifi_list_firewall_groups": "unifi_network_mcp.tools.firewall",
     "unifi_list_firewall_policies": "unifi_network_mcp.tools.firewall",
@@ -161,6 +165,7 @@
     "unifi_update_content_filter": "unifi_network_mcp.tools.content_filtering",
     "unifi_update_device_radio": "unifi_network_mcp.tools.devices",
     "unifi_update_dns_record": "unifi_network_mcp.tools.dns",
+    "unifi_update_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_update_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_update_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_update_gateway_settings": "unifi_network_mcp.tools.gateway_settings",
@@ -1558,6 +1563,106 @@
         }
       },
       "title": "Create DNS Record"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a new Dynamic DNS provider entry. Required: host_name (hostname to keep updated, e.g. 'home.example.com'), service (provider: 'dyndns'/'noip'/'namecheap'/'cloudflare'/'custom'/...). Optional: interface ('wan' [default] or 'wan2'), login (username), x_password (password/token), server + custom_service (for the 'custom' service), options (list of strings). Requires confirmation.",
+      "name": "unifi_create_dynamic_dns",
+      "permission_action": "create",
+      "permission_category": "dynamic_dns",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, creates the entry. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "entry_data": {
+              "description": "Dynamic DNS entry data. See tool description for required and optional fields.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "entry_data"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Create Dynamic DNS"
     },
     {
       "annotations": {
@@ -3566,6 +3671,106 @@
         }
       },
       "title": "Delete DNS Record"
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Delete a Dynamic DNS entry. Use unifi_list_dynamic_dns to find entry IDs. Requires confirmation.",
+      "name": "unifi_delete_dynamic_dns",
+      "permission_action": "delete",
+      "permission_category": "dynamic_dns",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the entry. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "entry_id": {
+              "description": "The ID of the Dynamic DNS entry to delete (from unifi_list_dynamic_dns)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "entry_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Delete Dynamic DNS"
     },
     {
       "annotations": {
@@ -6170,6 +6375,98 @@
         }
       },
       "title": "Get DPI Stats"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Get details for a specific Dynamic DNS entry by ID. The provider password/token is redacted.",
+      "name": "unifi_get_dynamic_dns_entry_details",
+      "schema": {
+        "input": {
+          "properties": {
+            "entry_id": {
+              "description": "The unique identifier (_id) of the Dynamic DNS entry",
+              "type": "string"
+            }
+          },
+          "required": [
+            "entry_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Get Dynamic DNS Entry Details"
     },
     {
       "annotations": {
@@ -10769,6 +11066,90 @@
         }
       },
       "title": "List DPI Categories"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List all Dynamic DNS provider entries configured on the controller. Returns hostname, service/provider, WAN interface, login, and options for each entry. The provider password/token is redacted.",
+      "name": "unifi_list_dynamic_dns",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "List Dynamic DNS"
     },
     {
       "annotations": {
@@ -15920,6 +16301,111 @@
         }
       },
       "title": "Update DNS Record"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Update an existing Dynamic DNS entry. Pass only the fields you want to change \u2014 current values are automatically preserved. Fields: host_name (str), service (str), server (str), login (str), x_password (str), interface ('wan'/'wan2'), custom_service (str), options (list of strings). Requires confirmation.",
+      "name": "unifi_update_dynamic_dns",
+      "permission_action": "update",
+      "permission_category": "dynamic_dns",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, applies the update. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "entry_id": {
+              "description": "The ID of the Dynamic DNS entry to update (from unifi_list_dynamic_dns)",
+              "type": "string"
+            },
+            "update_data": {
+              "description": "Dictionary of fields to update. See tool description for supported fields.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "entry_id",
+            "update_data"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Update Dynamic DNS"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_dynamic_dns_manager.py
+++ b/apps/network/tests/unit/test_dynamic_dns_manager.py
@@ -1,0 +1,201 @@
+"""Tests for Dynamic DNS management in DynamicDnsManager.
+
+Tests list, get, create, update, delete over the V1 ``/rest/dynamicdns``
+endpoint. Mirrors ``test_dns_manager.py`` but for the V1 REST resource.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+
+class TestDynamicDnsManager:
+    """Tests for DynamicDnsManager methods."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock ConnectionManager."""
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn._invalidate_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        return conn
+
+    @pytest.fixture
+    def ddns_manager(self, mock_connection):
+        """Create a DynamicDnsManager with mocked connection."""
+        from unifi_core.network.managers.dynamic_dns_manager import DynamicDnsManager
+
+        return DynamicDnsManager(mock_connection)
+
+    # ---- List ----
+
+    @pytest.mark.asyncio
+    async def test_list_returns_list(self, ddns_manager, mock_connection):
+        """list_dynamic_dns returns list of entry dicts."""
+        entries = [
+            {"_id": "d1", "host_name": "home.example.com", "service": "dyndns", "interface": "wan"},
+            {"_id": "d2", "host_name": "alt.example.com", "service": "noip", "interface": "wan2"},
+        ]
+        mock_connection.request.return_value = entries
+
+        result = await ddns_manager.list_dynamic_dns()
+
+        assert len(result) == 2
+        assert result[0]["host_name"] == "home.example.com"
+
+    @pytest.mark.asyncio
+    async def test_list_uses_cache(self, ddns_manager, mock_connection):
+        """list_dynamic_dns returns cached data without hitting the controller."""
+        cached = [{"_id": "d1", "host_name": "cached.example.com"}]
+        mock_connection.get_cached.return_value = cached
+
+        result = await ddns_manager.list_dynamic_dns()
+
+        assert result == cached
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_handles_error(self, ddns_manager, mock_connection):
+        """list_dynamic_dns propagates controller errors."""
+        mock_connection.request.side_effect = Exception("Connection failed")
+
+        with pytest.raises(Exception):
+            await ddns_manager.list_dynamic_dns()
+
+    # ---- Get ----
+
+    @pytest.mark.asyncio
+    async def test_get_found(self, ddns_manager, mock_connection):
+        """get_dynamic_dns returns the entry when found (list-and-filter)."""
+        entries = [
+            {"_id": "d1", "host_name": "home.example.com"},
+            {"_id": "d2", "host_name": "other.example.com"},
+        ]
+        mock_connection.request.return_value = entries
+
+        result = await ddns_manager.get_dynamic_dns("d1")
+
+        assert result is not None
+        assert result["host_name"] == "home.example.com"
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self, ddns_manager, mock_connection):
+        """get_dynamic_dns raises UniFiNotFoundError when the id is absent."""
+        mock_connection.request.return_value = [{"_id": "d1"}]
+
+        with pytest.raises(UniFiNotFoundError):
+            await ddns_manager.get_dynamic_dns("nonexistent")
+
+    # ---- Create ----
+
+    @pytest.mark.asyncio
+    async def test_create_success(self, ddns_manager, mock_connection):
+        """create_dynamic_dns returns the created entry and invalidates cache."""
+        created = {"_id": "d_new", "host_name": "new.example.com", "service": "dyndns", "interface": "wan"}
+        mock_connection.request.return_value = created
+
+        result = await ddns_manager.create_dynamic_dns(
+            {"host_name": "new.example.com", "service": "dyndns", "interface": "wan"}
+        )
+
+        assert result is not None
+        assert result["_id"] == "d_new"
+        mock_connection._invalidate_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_handles_error(self, ddns_manager, mock_connection):
+        """create_dynamic_dns propagates controller errors."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        with pytest.raises(Exception):
+            await ddns_manager.create_dynamic_dns({"host_name": "fail.example.com"})
+
+    # ---- Update ----
+
+    @pytest.mark.asyncio
+    async def test_update_success(self, ddns_manager, mock_connection):
+        """update_dynamic_dns uses fetch-merge-put and preserves unpassed fields."""
+        existing = [
+            {"_id": "d1", "host_name": "home.example.com", "service": "dyndns", "login": "user", "interface": "wan"}
+        ]
+        # First call: list (for get_dynamic_dns), second call: PUT
+        mock_connection.request.side_effect = [existing, {}]
+
+        result = await ddns_manager.update_dynamic_dns("d1", {"service": "noip"})
+
+        assert result["_id"] == "d1"
+        assert result["service"] == "noip"  # updated
+        assert result["login"] == "user"  # preserved
+        assert result["host_name"] == "home.example.com"  # preserved
+        put_call = mock_connection.request.call_args_list[1]
+        put_req = put_call[0][0]
+        assert put_req.method == "put"
+        assert "d1" in put_req.path
+
+    @pytest.mark.asyncio
+    async def test_update_not_found(self, ddns_manager, mock_connection):
+        """update_dynamic_dns raises UniFiNotFoundError when the entry is missing."""
+        mock_connection.request.return_value = []
+
+        with pytest.raises(UniFiNotFoundError):
+            await ddns_manager.update_dynamic_dns("nonexistent", {"service": "noip"})
+
+    @pytest.mark.asyncio
+    async def test_update_handles_error(self, ddns_manager, mock_connection):
+        """update_dynamic_dns propagates controller errors from the fetch."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        with pytest.raises(Exception):
+            await ddns_manager.update_dynamic_dns("d1", {"service": "noip"})
+
+    # ---- Delete ----
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, ddns_manager, mock_connection):
+        """delete_dynamic_dns sends DELETE and invalidates cache."""
+        mock_connection.request.return_value = {}
+
+        result = await ddns_manager.delete_dynamic_dns("d1")
+
+        assert result is True
+        api_req = mock_connection.request.call_args[0][0]
+        assert api_req.method == "delete"
+        assert "d1" in api_req.path
+        mock_connection._invalidate_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_handles_error(self, ddns_manager, mock_connection):
+        """delete_dynamic_dns propagates controller errors."""
+        mock_connection.request.side_effect = Exception("Failed")
+
+        with pytest.raises(Exception):
+            await ddns_manager.delete_dynamic_dns("d1")
+
+    # ---- API Path Verification ----
+
+    @pytest.mark.asyncio
+    async def test_list_uses_correct_path(self, ddns_manager, mock_connection):
+        """list_dynamic_dns uses the V1 /rest/dynamicdns endpoint."""
+        mock_connection.request.return_value = []
+
+        await ddns_manager.list_dynamic_dns()
+
+        api_req = mock_connection.request.call_args[0][0]
+        assert api_req.path == "/rest/dynamicdns"
+
+    @pytest.mark.asyncio
+    async def test_create_uses_post(self, ddns_manager, mock_connection):
+        """create_dynamic_dns uses POST to /rest/dynamicdns."""
+        mock_connection.request.return_value = {"_id": "new"}
+
+        await ddns_manager.create_dynamic_dns({"host_name": "test.example.com", "service": "dyndns"})
+
+        api_req = mock_connection.request.call_args[0][0]
+        assert api_req.method == "post"
+        assert api_req.path == "/rest/dynamicdns"

--- a/apps/network/tests/unit/test_dynamic_dns_tools.py
+++ b/apps/network/tests/unit/test_dynamic_dns_tools.py
@@ -1,0 +1,442 @@
+"""Tests for Dynamic DNS tool functions.
+
+Tests tool-layer behavior: validation, preview/confirm flow, response format,
+and secret redaction. Manager-level tests are in test_dynamic_dns_manager.py.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.redaction import REDACTED
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+# A sample without secrets, for generic list/get success assertions.
+SAMPLE_ENTRY = {
+    "_id": "ddns001",
+    "site_id": "site1",
+    "host_name": "home.example.com",
+    "service": "dyndns",
+    "login": "user",
+    "interface": "wan",
+}
+
+# A sample carrying the secret, for redaction assertions.
+SAMPLE_ENTRY_SECRET = {**SAMPLE_ENTRY, "x_password": "super-secret-token"}
+
+
+# ---------------------------------------------------------------------------
+# list_dynamic_dns
+# ---------------------------------------------------------------------------
+
+
+class TestListDynamicDns:
+    @pytest.mark.asyncio
+    async def test_list_success(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.list_dynamic_dns = AsyncMock(return_value=[SAMPLE_ENTRY])
+            mock_mgr._connection = mock_conn
+
+            from unifi_network_mcp.tools.dynamic_dns import list_dynamic_dns
+
+            result = await list_dynamic_dns()
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["entries"][0]["host_name"] == "home.example.com"
+        assert result["entries"][0]["id"] == "ddns001"
+
+    @pytest.mark.asyncio
+    async def test_list_redacts_secret_when_policy_on(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with (
+            patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr,
+            patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True),
+        ):
+            mock_mgr.list_dynamic_dns = AsyncMock(return_value=[SAMPLE_ENTRY_SECRET])
+            mock_mgr._connection = mock_conn
+
+            from unifi_network_mcp.tools.dynamic_dns import list_dynamic_dns
+
+            result = await list_dynamic_dns()
+
+        assert result["entries"][0]["x_password"] == REDACTED
+
+    @pytest.mark.asyncio
+    async def test_list_shows_secret_when_policy_off(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with (
+            patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr,
+            patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=False),
+        ):
+            mock_mgr.list_dynamic_dns = AsyncMock(return_value=[SAMPLE_ENTRY_SECRET])
+            mock_mgr._connection = mock_conn
+
+            from unifi_network_mcp.tools.dynamic_dns import list_dynamic_dns
+
+            result = await list_dynamic_dns()
+
+        assert result["entries"][0]["x_password"] == "super-secret-token"
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.list_dynamic_dns = AsyncMock(return_value=[])
+            mock_mgr._connection = mock_conn
+
+            from unifi_network_mcp.tools.dynamic_dns import list_dynamic_dns
+
+            result = await list_dynamic_dns()
+
+        assert result["success"] is True
+        assert result["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_exception(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.list_dynamic_dns = AsyncMock(side_effect=Exception("Connection lost"))
+
+            from unifi_network_mcp.tools.dynamic_dns import list_dynamic_dns
+
+            result = await list_dynamic_dns()
+
+        assert result["success"] is False
+        assert "Failed to list" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_dynamic_dns_details
+# ---------------------------------------------------------------------------
+
+
+class TestGetDynamicDnsDetails:
+    @pytest.mark.asyncio
+    async def test_get_found(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY)
+
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+
+            result = await get_dynamic_dns_details(entry_id="ddns001")
+
+        assert result["success"] is True
+        assert result["entry_id"] == "ddns001"
+        assert result["details"]["host_name"] == "home.example.com"
+        # get_details normalizes like list: '_id' -> 'id'
+        assert result["details"]["id"] == "ddns001"
+        assert "_id" not in result["details"]
+
+    @pytest.mark.asyncio
+    async def test_get_redacts_secret_when_policy_on(self):
+        with (
+            patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr,
+            patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True),
+        ):
+            mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY_SECRET)
+
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+
+            result = await get_dynamic_dns_details(entry_id="ddns001")
+
+        assert result["details"]["x_password"] == REDACTED
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.get_dynamic_dns = AsyncMock(side_effect=UniFiNotFoundError("dynamic_dns", "nonexistent"))
+
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+
+            result = await get_dynamic_dns_details(entry_id="nonexistent")
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_get_exception(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.get_dynamic_dns = AsyncMock(side_effect=Exception("Timeout"))
+
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+
+            result = await get_dynamic_dns_details(entry_id="ddns001")
+
+        assert result["success"] is False
+        assert "Failed to get" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# create_dynamic_dns
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDynamicDns:
+    @pytest.mark.asyncio
+    async def test_create_preview(self):
+        from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+        result = await create_dynamic_dns(
+            entry_data={"host_name": "home.example.com", "service": "dyndns", "interface": "wan"},
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_create_confirm_success(self):
+        created = {"_id": "ddns_new", "host_name": "home.example.com", "service": "dyndns", "interface": "wan"}
+
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.create_dynamic_dns = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+            result = await create_dynamic_dns(
+                entry_data={"host_name": "home.example.com", "service": "dyndns", "interface": "wan"},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        assert "created successfully" in result["message"]
+        assert result["details"]["_id"] == "ddns_new"
+
+    @pytest.mark.asyncio
+    async def test_create_confirm_redacts_secret(self):
+        created = {"_id": "ddns_new", "host_name": "home.example.com", "service": "dyndns", "x_password": "sekret"}
+
+        with (
+            patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr,
+            patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True),
+        ):
+            mock_mgr.create_dynamic_dns = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+            result = await create_dynamic_dns(
+                entry_data={"host_name": "home.example.com", "service": "dyndns", "x_password": "sekret"},
+                confirm=True,
+            )
+
+        assert result["details"]["x_password"] == REDACTED
+
+    @pytest.mark.asyncio
+    async def test_create_preview_redacts_secret(self):
+        """Preview (confirm=False) must not echo x_password in cleartext."""
+        with patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True):
+            from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+            result = await create_dynamic_dns(
+                entry_data={"host_name": "home.example.com", "service": "dyndns", "x_password": "sekret"},
+                confirm=False,
+            )
+
+        assert result["preview"]["will_create"]["x_password"] == REDACTED
+
+    @pytest.mark.asyncio
+    async def test_create_missing_required_field(self):
+        from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+        result = await create_dynamic_dns(
+            entry_data={"host_name": "home.example.com"},  # no service
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "Validation error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_manager_failure(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.create_dynamic_dns = AsyncMock(return_value=None)
+
+            from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+            result = await create_dynamic_dns(
+                entry_data={"host_name": "home.example.com", "service": "dyndns"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "Failed to create" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_drops_unknown_fields(self):
+        from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
+
+        result = await create_dynamic_dns(
+            entry_data={
+                "host_name": "home.example.com",
+                "service": "dyndns",
+                "bogus_field": "ignored",
+            },
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert "bogus_field" not in result["preview"]["will_create"]
+
+
+# ---------------------------------------------------------------------------
+# update_dynamic_dns
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDynamicDns:
+    @pytest.mark.asyncio
+    async def test_update_preview(self):
+        from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+        result = await update_dynamic_dns(
+            entry_id="ddns001",
+            update_data={"service": "noip"},
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_update_confirm_success(self):
+        merged = {**SAMPLE_ENTRY, "service": "noip"}
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.update_dynamic_dns = AsyncMock(return_value=merged)
+
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="ddns001",
+                update_data={"service": "noip"},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        assert "updated successfully" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_update_preview_redacts_secret(self):
+        """Preview (confirm=False) must not echo x_password in cleartext."""
+        with patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True):
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="ddns001",
+                update_data={"x_password": "sekret"},
+                confirm=False,
+            )
+
+        assert result["preview"]["proposed"]["x_password"] == REDACTED
+
+    @pytest.mark.asyncio
+    async def test_update_not_found(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.update_dynamic_dns = AsyncMock(side_effect=UniFiNotFoundError("dynamic_dns", "nonexistent"))
+
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="nonexistent",
+                update_data={"service": "noip"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_empty_data(self):
+        from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+        result = await update_dynamic_dns(
+            entry_id="ddns001",
+            update_data={},
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "No fields provided" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_manager_exception(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.update_dynamic_dns = AsyncMock(side_effect=Exception("Connection refused"))
+
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="ddns001",
+                update_data={"service": "noip"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "Failed to update" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# delete_dynamic_dns
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteDynamicDns:
+    @pytest.mark.asyncio
+    async def test_delete_preview(self):
+        from unifi_network_mcp.tools.dynamic_dns import delete_dynamic_dns
+
+        result = await delete_dynamic_dns(entry_id="ddns001", confirm=False)
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_delete_confirm_success(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.delete_dynamic_dns = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.dynamic_dns import delete_dynamic_dns
+
+            result = await delete_dynamic_dns(entry_id="ddns001", confirm=True)
+
+        assert result["success"] is True
+        assert "deleted successfully" in result["message"]
+        mock_mgr.delete_dynamic_dns.assert_called_once_with("ddns001")
+
+    @pytest.mark.asyncio
+    async def test_delete_manager_failure(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.delete_dynamic_dns = AsyncMock(return_value=False)
+
+            from unifi_network_mcp.tools.dynamic_dns import delete_dynamic_dns
+
+            result = await delete_dynamic_dns(entry_id="ddns001", confirm=True)
+
+        assert result["success"] is False
+        assert "Failed to delete" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_exception(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.delete_dynamic_dns = AsyncMock(side_effect=Exception("Connection refused"))
+
+            from unifi_network_mcp.tools.dynamic_dns import delete_dynamic_dns
+
+            result = await delete_dynamic_dns(entry_id="ddns001", confirm=True)
+
+        assert result["success"] is False
+        assert "Connection refused" in result["error"]

--- a/apps/network/tests/unit/test_dynamic_dns_tools.py
+++ b/apps/network/tests/unit/test_dynamic_dns_tools.py
@@ -277,20 +277,22 @@ class TestCreateDynamicDns:
         assert "Failed to create" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_create_drops_unknown_fields(self):
+    async def test_create_rejects_unknown_fields(self):
+        """Unknown/read-only keys are rejected with an actionable error, not
+        silently dropped."""
         from unifi_network_mcp.tools.dynamic_dns import create_dynamic_dns
 
         result = await create_dynamic_dns(
             entry_data={
                 "host_name": "home.example.com",
                 "service": "dyndns",
-                "bogus_field": "ignored",
+                "bogus_field": "x",
             },
             confirm=False,
         )
 
-        assert result["success"] is True
-        assert "bogus_field" not in result["preview"]["will_create"]
+        assert result["success"] is False
+        assert "bogus_field" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -301,16 +303,70 @@ class TestCreateDynamicDns:
 class TestUpdateDynamicDns:
     @pytest.mark.asyncio
     async def test_update_preview(self):
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY)
+
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="ddns001",
+                update_data={"service": "noip"},
+                confirm=False,
+            )
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+
+    @pytest.mark.asyncio
+    async def test_update_preview_shows_current_state(self):
+        """The preview fetches the current entry so the before/after is real,
+        not an empty current_state."""
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY)
+
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="ddns001",
+                update_data={"service": "noip"},
+                confirm=False,
+            )
+
+        # current reflects the fetched entry (was "dyndns"), proposed the change.
+        assert result["preview"]["current"]["service"] == "dyndns"
+        assert result["preview"]["proposed"]["service"] == "noip"
+
+    @pytest.mark.asyncio
+    async def test_update_preview_not_found(self):
+        """A preview for a missing entry surfaces the not-found error."""
+        with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
+            mock_mgr.get_dynamic_dns = AsyncMock(side_effect=UniFiNotFoundError("dynamic_dns", "nope"))
+
+            from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
+
+            result = await update_dynamic_dns(
+                entry_id="nope",
+                update_data={"service": "noip"},
+                confirm=False,
+            )
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_unknown_fields(self):
+        """Unknown/read-only keys are rejected with an actionable error before
+        any controller call, not silently dropped."""
         from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
 
         result = await update_dynamic_dns(
             entry_id="ddns001",
-            update_data={"service": "noip"},
-            confirm=False,
+            update_data={"service": "noip", "bogus_field": "x"},
+            confirm=True,
         )
 
-        assert result["success"] is True
-        assert result.get("requires_confirmation") is True
+        assert result["success"] is False
+        assert "bogus_field" in result["error"]
 
     @pytest.mark.asyncio
     async def test_update_confirm_success(self):
@@ -332,7 +388,12 @@ class TestUpdateDynamicDns:
     @pytest.mark.asyncio
     async def test_update_preview_redacts_secret(self):
         """Preview (confirm=False) must not echo x_password in cleartext."""
-        with patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True):
+        with (
+            patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr,
+            patch("unifi_network_mcp.tools.dynamic_dns.should_redact_sensitive_fields", return_value=True),
+        ):
+            mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY)
+
             from unifi_network_mcp.tools.dynamic_dns import update_dynamic_dns
 
             result = await update_dynamic_dns(

--- a/apps/network/tests/unit/test_dynamic_dns_tools.py
+++ b/apps/network/tests/unit/test_dynamic_dns_tools.py
@@ -121,7 +121,7 @@ class TestListDynamicDns:
 
 
 # ---------------------------------------------------------------------------
-# get_dynamic_dns_details
+# get_dynamic_dns_entry_details
 # ---------------------------------------------------------------------------
 
 
@@ -131,9 +131,9 @@ class TestGetDynamicDnsDetails:
         with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
             mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY)
 
-            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_entry_details
 
-            result = await get_dynamic_dns_details(entry_id="ddns001")
+            result = await get_dynamic_dns_entry_details(entry_id="ddns001")
 
         assert result["success"] is True
         assert result["entry_id"] == "ddns001"
@@ -150,9 +150,9 @@ class TestGetDynamicDnsDetails:
         ):
             mock_mgr.get_dynamic_dns = AsyncMock(return_value=SAMPLE_ENTRY_SECRET)
 
-            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_entry_details
 
-            result = await get_dynamic_dns_details(entry_id="ddns001")
+            result = await get_dynamic_dns_entry_details(entry_id="ddns001")
 
         assert result["details"]["x_password"] == REDACTED
 
@@ -161,9 +161,9 @@ class TestGetDynamicDnsDetails:
         with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
             mock_mgr.get_dynamic_dns = AsyncMock(side_effect=UniFiNotFoundError("dynamic_dns", "nonexistent"))
 
-            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_entry_details
 
-            result = await get_dynamic_dns_details(entry_id="nonexistent")
+            result = await get_dynamic_dns_entry_details(entry_id="nonexistent")
 
         assert result["success"] is False
         assert "not found" in result["error"]
@@ -173,9 +173,9 @@ class TestGetDynamicDnsDetails:
         with patch("unifi_network_mcp.tools.dynamic_dns.dynamic_dns_manager") as mock_mgr:
             mock_mgr.get_dynamic_dns = AsyncMock(side_effect=Exception("Timeout"))
 
-            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_details
+            from unifi_network_mcp.tools.dynamic_dns import get_dynamic_dns_entry_details
 
-            result = await get_dynamic_dns_details(entry_id="ddns001")
+            result = await get_dynamic_dns_entry_details(entry_id="ddns001")
 
         assert result["success"] is False
         assert "Failed to get" in result["error"]

--- a/packages/unifi-core/src/unifi_core/network/managers/dynamic_dns_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/dynamic_dns_manager.py
@@ -1,0 +1,125 @@
+"""Dynamic DNS management for UniFi Network MCP server.
+
+Provides CRUD operations for the controller's native Dynamic DNS provider
+entries via the V1 REST API.
+Endpoint: GET/POST/PUT/DELETE /rest/dynamicdns[/{id}]
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from aiounifi.models.api import ApiRequest
+
+from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.network.managers.connection_manager import ConnectionManager
+
+logger = logging.getLogger("unifi-network-mcp")
+
+CACHE_PREFIX_DDNS = "dynamic_dns"
+
+
+class DynamicDnsManager:
+    """Manages Dynamic DNS provider entries on the UniFi controller."""
+
+    def __init__(self, connection_manager: ConnectionManager):
+        self._connection = connection_manager
+
+    async def list_dynamic_dns(self) -> List[Dict[str, Any]]:
+        """List all Dynamic DNS entries.
+
+        Returns:
+            List of Dynamic DNS entry dicts.
+        """
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+        cache_key = f"{CACHE_PREFIX_DDNS}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key, timeout=300)
+        if cached_data is not None:
+            return cached_data
+
+        try:
+            api_request = ApiRequest(method="get", path="/rest/dynamicdns")
+            response = await self._connection.request(api_request)
+            result = response if isinstance(response, list) else []
+            self._connection._update_cache(cache_key, result, timeout=300)
+            return result
+        except Exception as e:
+            logger.error("Error listing Dynamic DNS entries: %s", e, exc_info=True)
+            raise
+
+    async def get_dynamic_dns(self, entry_id: str) -> Dict[str, Any]:
+        """Get a Dynamic DNS entry by ID.
+
+        GET by ID returns 405 on this endpoint, so we list and filter.
+
+        Raises:
+            UniFiNotFoundError: If the entry does not exist.
+        """
+        entries = await self.list_dynamic_dns()
+        for entry in entries:
+            if entry.get("_id") == entry_id:
+                return entry
+        raise UniFiNotFoundError("dynamic_dns", entry_id)
+
+    async def create_dynamic_dns(self, entry_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Create a new Dynamic DNS entry.
+
+        Args:
+            entry_data: Dict with host_name, service, interface, and provider
+                credentials (login, x_password) as required by the service.
+
+        Returns:
+            Created entry dict with _id, or the raw response on failure.
+        """
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+
+        try:
+            api_request = ApiRequest(method="post", path="/rest/dynamicdns", data=entry_data)
+            response = await self._connection.request(api_request)
+            self._connection._invalidate_cache(f"{CACHE_PREFIX_DDNS}_{self._connection.site}")
+            if isinstance(response, dict) and response.get("_id"):
+                return response
+            if isinstance(response, list) and response:
+                return response[0]
+            return response
+        except Exception as e:
+            logger.error("Error creating Dynamic DNS entry: %s", e, exc_info=True)
+            raise
+
+    async def update_dynamic_dns(self, entry_id: str, entry_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update an existing Dynamic DNS entry.
+
+        Fetches the current entry, merges the caller's partial update, and PUTs
+        the full object so unspecified fields are preserved.
+
+        Returns:
+            The merged entry dict.
+
+        Raises:
+            UniFiNotFoundError: If the entry does not exist.
+        """
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+
+        current = await self.get_dynamic_dns(entry_id)  # raises UniFiNotFoundError on miss
+        merged = {**current, **entry_data}
+
+        api_request = ApiRequest(method="put", path=f"/rest/dynamicdns/{entry_id}", data=merged)
+        await self._connection.request(api_request)
+        self._connection._invalidate_cache(f"{CACHE_PREFIX_DDNS}_{self._connection.site}")
+        return merged
+
+    async def delete_dynamic_dns(self, entry_id: str) -> bool:
+        """Delete a Dynamic DNS entry.
+
+        Returns:
+            True on success.
+        """
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+
+        api_request = ApiRequest(method="delete", path=f"/rest/dynamicdns/{entry_id}")
+        await self._connection.request(api_request)
+        self._connection._invalidate_cache(f"{CACHE_PREFIX_DDNS}_{self._connection.site}")
+        return True

--- a/packages/unifi-core/src/unifi_core/network/models/dynamic_dns.py
+++ b/packages/unifi-core/src/unifi_core/network/models/dynamic_dns.py
@@ -1,0 +1,163 @@
+"""Shared field model for Network Dynamic DNS entries (read + create/update).
+
+Mirrors the Strawberry type in
+``unifi_api.graphql.types.network.dynamic_dns``.
+
+- ``DynamicDns`` — list_dynamic_dns + get_dynamic_dns +
+  create_dynamic_dns + update_dynamic_dns
+
+The controller stores these under the V1 ``/rest/dynamicdns`` collection.
+Field names map 1:1 to the controller keys (``host_name``, ``service``,
+``server``, ``login``, ``x_password``, ``interface``, ``custom_service``,
+``options``); ``_id`` and ``site_id`` are controller-assigned read-only keys.
+
+The provider credential ``x_password`` is carried raw here — redaction happens
+at the egress boundary (see ``unifi_core.redaction``), never in the model.
+
+Factory helpers:
+- ``from_controller``      — normalise the raw controller dict → DynamicDns
+- ``to_controller_create`` — translate a DynamicDns → create payload
+- ``to_controller_update`` — filter a partial dict to mutable keys only
+
+``MUTABLE_FIELDS`` drives the cross-layer symmetry test.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Pydantic domain model
+# ---------------------------------------------------------------------------
+
+
+class DynamicDns(BaseModel):
+    """Canonical Dynamic DNS entry model (read + mutable create/update fields)."""
+
+    # --- read-only ---
+    id: Optional[str] = Field(
+        default=None,
+        description="Dynamic DNS entry ID (assigned by controller)",
+        json_schema_extra={"mutable": False},
+    )
+    site_id: Optional[str] = Field(
+        default=None,
+        description="Controller site ID this entry belongs to",
+        json_schema_extra={"mutable": False},
+    )
+
+    # --- mutable (accepted by create and update) ---
+    host_name: Optional[str] = Field(
+        default=None,
+        description="Hostname to keep updated (e.g. 'home.example.com')",
+    )
+    service: Optional[str] = Field(
+        default=None,
+        description="DDNS provider: 'dyndns', 'noip', 'namecheap', 'cloudflare', 'custom', etc.",
+    )
+    server: Optional[str] = Field(
+        default=None,
+        description="Update server host (used by the 'custom' service)",
+    )
+    login: Optional[str] = Field(
+        default=None,
+        description="Provider account username / login",
+    )
+    x_password: Optional[str] = Field(
+        default=None,
+        description="Provider password or API token (secret — redacted at egress)",
+    )
+    interface: Optional[str] = Field(
+        default=None,
+        description="WAN interface to track: 'wan' or 'wan2'",
+    )
+    custom_service: Optional[str] = Field(
+        default=None,
+        description="Custom provider identifier (used by the 'custom' service)",
+    )
+    options: Optional[List[str]] = Field(
+        default=None,
+        description="Extra provider options",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field sets
+# ---------------------------------------------------------------------------
+
+MUTABLE_FIELDS: frozenset[str] = frozenset(
+    name for name, field in DynamicDns.model_fields.items() if (field.json_schema_extra or {}).get("mutable", True)
+)
+
+READ_ONLY_FIELDS: frozenset[str] = frozenset(
+    name
+    for name, field in DynamicDns.model_fields.items()
+    if (field.json_schema_extra or {}).get("mutable", True) is False
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+# ---------------------------------------------------------------------------
+# Public factory helpers
+# ---------------------------------------------------------------------------
+
+
+def from_controller(raw: Any) -> DynamicDns:
+    """Build a DynamicDns from a controller API response dict."""
+    options_raw = _get(raw, "options")
+    options = list(options_raw) if isinstance(options_raw, list) else None
+    return DynamicDns(
+        id=_get(raw, "_id") or _get(raw, "id"),
+        site_id=_get(raw, "site_id"),
+        host_name=_get(raw, "host_name"),
+        service=_get(raw, "service"),
+        server=_get(raw, "server"),
+        login=_get(raw, "login"),
+        x_password=_get(raw, "x_password"),
+        interface=_get(raw, "interface"),
+        custom_service=_get(raw, "custom_service"),
+        options=options,
+    )
+
+
+def to_controller_create(model: DynamicDns) -> Dict[str, Any]:
+    """Produce a controller create payload from a DynamicDns."""
+    payload: Dict[str, Any] = {}
+    if model.host_name is not None:
+        payload["host_name"] = model.host_name
+    if model.service is not None:
+        payload["service"] = model.service
+    if model.server is not None:
+        payload["server"] = model.server
+    if model.login is not None:
+        payload["login"] = model.login
+    if model.x_password is not None:
+        payload["x_password"] = model.x_password
+    if model.interface is not None:
+        payload["interface"] = model.interface
+    if model.custom_service is not None:
+        payload["custom_service"] = model.custom_service
+    if model.options is not None:
+        payload["options"] = model.options
+    return payload
+
+
+def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Filter a partial dict to only mutable, recognised keys.
+
+    Read-only fields and unrecognised keys are dropped. ``None`` values are
+    dropped so an omitted field never clears controller state.
+    """
+    return {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}

--- a/packages/unifi-core/src/unifi_core/network/models/dynamic_dns.py
+++ b/packages/unifi-core/src/unifi_core/network/models/dynamic_dns.py
@@ -132,6 +132,20 @@ def from_controller(raw: Any) -> DynamicDns:
     )
 
 
+def reject_unknown_fields(fields: Dict[str, Any]) -> None:
+    """Raise ``ValueError`` if any key is not an accepted (mutable) field.
+
+    Unknown keys (typos) and read-only keys (``id``, ``site_id``) are rejected
+    with an actionable message rather than silently dropped, so a bad key
+    surfaces to the caller instead of being forwarded to — or filtered before —
+    the controller. Callers run this on the raw ``entry_data`` / ``update_data``
+    dict before translating to a controller payload.
+    """
+    unknown = set(fields) - MUTABLE_FIELDS
+    if unknown:
+        raise ValueError(f"Unknown or read-only fields: {sorted(unknown)}. Allowed fields: {sorted(MUTABLE_FIELDS)}")
+
+
 def to_controller_create(model: DynamicDns) -> Dict[str, Any]:
     """Produce a controller create payload from a DynamicDns."""
     payload: Dict[str, Any] = {}

--- a/packages/unifi-core/tests/network/models/test_dynamic_dns.py
+++ b/packages/unifi-core/tests/network/models/test_dynamic_dns.py
@@ -1,0 +1,154 @@
+"""Unit tests for the Network DynamicDns CRUD domain model."""
+
+from __future__ import annotations
+
+from unifi_core.network.models.dynamic_dns import (
+    MUTABLE_FIELDS,
+    READ_ONLY_FIELDS,
+    DynamicDns,
+    from_controller,
+    to_controller_create,
+    to_controller_update,
+)
+
+
+class TestFieldSets:
+    def test_mutable_fields_contains_expected(self) -> None:
+        for field in (
+            "host_name",
+            "service",
+            "server",
+            "login",
+            "x_password",
+            "interface",
+            "custom_service",
+            "options",
+        ):
+            assert field in MUTABLE_FIELDS, f"Expected {field!r} in MUTABLE_FIELDS"
+
+    def test_mutable_fields_excludes_read_only(self) -> None:
+        assert "id" not in MUTABLE_FIELDS
+        assert "site_id" not in MUTABLE_FIELDS
+
+    def test_read_only_fields_contains_id_and_site_id(self) -> None:
+        assert "id" in READ_ONLY_FIELDS
+        assert "site_id" in READ_ONLY_FIELDS
+
+    def test_mutable_and_read_only_are_disjoint(self) -> None:
+        overlap = MUTABLE_FIELDS & READ_ONLY_FIELDS
+        assert not overlap, f"Fields in both sets: {overlap}"
+
+    def test_mutable_and_read_only_cover_all_model_fields(self) -> None:
+        all_fields = frozenset(DynamicDns.model_fields.keys())
+        assert MUTABLE_FIELDS | READ_ONLY_FIELDS == all_fields
+
+
+class TestFromController:
+    def test_full_dict(self) -> None:
+        raw = {
+            "_id": "ddns-1",
+            "site_id": "site-1",
+            "host_name": "home.example.com",
+            "service": "dyndns",
+            "server": "",
+            "login": "user",
+            "x_password": "secret-token",
+            "interface": "wan",
+        }
+        r = from_controller(raw)
+        assert r.id == "ddns-1"
+        assert r.site_id == "site-1"
+        assert r.host_name == "home.example.com"
+        assert r.service == "dyndns"
+        assert r.login == "user"
+        assert r.interface == "wan"
+
+    def test_id_coalesces_underscore_id(self) -> None:
+        raw = {"_id": "abc", "host_name": "test.local", "service": "noip"}
+        r = from_controller(raw)
+        assert r.id == "abc"
+
+    def test_secret_carried_raw(self) -> None:
+        """from_controller carries the real secret; redaction happens at egress."""
+        raw = {"_id": "r1", "x_password": "real-secret"}
+        r = from_controller(raw)
+        assert r.x_password == "real-secret"
+
+    def test_options_list_carried(self) -> None:
+        raw = {"_id": "r2", "options": ["opt1", "opt2"]}
+        r = from_controller(raw)
+        assert r.options == ["opt1", "opt2"]
+
+    def test_handles_empty_dict(self) -> None:
+        r = from_controller({})
+        assert r.id is None
+        assert r.host_name is None
+        assert r.service is None
+
+
+class TestToControllerCreate:
+    def test_full_model(self) -> None:
+        model = DynamicDns(
+            host_name="home.example.com",
+            service="dyndns",
+            login="user",
+            x_password="secret",
+            interface="wan",
+        )
+        payload = to_controller_create(model)
+        assert payload["host_name"] == "home.example.com"
+        assert payload["service"] == "dyndns"
+        assert payload["login"] == "user"
+        assert payload["x_password"] == "secret"
+        assert payload["interface"] == "wan"
+
+    def test_none_fields_excluded(self) -> None:
+        model = DynamicDns(host_name="home.example.com", service="dyndns")
+        payload = to_controller_create(model)
+        assert "server" not in payload
+        assert "login" not in payload
+        assert "x_password" not in payload
+        assert "custom_service" not in payload
+        assert "options" not in payload
+
+    def test_read_only_excluded(self) -> None:
+        model = DynamicDns(id="should-not-appear", site_id="nope", host_name="home.example.com", service="dyndns")
+        payload = to_controller_create(model)
+        assert "id" not in payload
+        assert "site_id" not in payload
+
+
+class TestToControllerUpdate:
+    def test_filters_out_read_only(self) -> None:
+        result = to_controller_update({"id": "ignore", "site_id": "ignore", "service": "noip"})
+        assert "id" not in result
+        assert "site_id" not in result
+        assert result["service"] == "noip"
+
+    def test_drops_none_values(self) -> None:
+        result = to_controller_update({"service": None, "host_name": "home.example.com"})
+        assert "service" not in result
+        assert result["host_name"] == "home.example.com"
+
+    def test_passes_all_mutable_fields(self) -> None:
+        fields = {
+            "host_name": "home.example.com",
+            "service": "custom",
+            "server": "update.example.com",
+            "login": "user",
+            "x_password": "secret",
+            "interface": "wan2",
+            "custom_service": "custom",
+            "options": ["a", "b"],
+        }
+        result = to_controller_update(fields)
+        assert result == fields
+
+    def test_drops_unrecognised_keys(self) -> None:
+        result = to_controller_update({"unknown": "value", "service": "noip"})
+        assert "unknown" not in result
+        assert result["service"] == "noip"
+
+    def test_returns_empty_dict_when_no_mutable_fields(self) -> None:
+        result = to_controller_update({"id": "read-only"})
+        assert result == {}

--- a/packages/unifi-core/tests/network/models/test_dynamic_dns.py
+++ b/packages/unifi-core/tests/network/models/test_dynamic_dns.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
 from unifi_core.network.models.dynamic_dns import (
     MUTABLE_FIELDS,
     READ_ONLY_FIELDS,
     DynamicDns,
     from_controller,
+    reject_unknown_fields,
     to_controller_create,
     to_controller_update,
 )
@@ -144,11 +146,32 @@ class TestToControllerUpdate:
         result = to_controller_update(fields)
         assert result == fields
 
-    def test_drops_unrecognised_keys(self) -> None:
-        result = to_controller_update({"unknown": "value", "service": "noip"})
-        assert "unknown" not in result
-        assert result["service"] == "noip"
-
     def test_returns_empty_dict_when_no_mutable_fields(self) -> None:
         result = to_controller_update({"id": "read-only"})
         assert result == {}
+
+
+class TestRejectUnknownFields:
+    """The create/update flow rejects unknown or read-only keys with an
+    actionable error rather than silently dropping them (maintainer request:
+    do not reintroduce the silent-drop class the strict-kwargs protections
+    were added to avoid)."""
+
+    def test_passes_when_all_keys_mutable(self) -> None:
+        # No exception for a dict of accepted fields.
+        reject_unknown_fields({"host_name": "home.example.com", "service": "noip"})
+
+    def test_passes_on_empty(self) -> None:
+        reject_unknown_fields({})
+
+    def test_rejects_unrecognised_key(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            reject_unknown_fields({"service": "noip", "bogus_field": "x"})
+        assert "bogus_field" in str(exc.value)
+        # The message is actionable — it names the allowed fields.
+        assert "host_name" in str(exc.value)
+
+    def test_rejects_read_only_key(self) -> None:
+        with pytest.raises(ValueError) as exc:
+            reject_unknown_fields({"id": "read-only", "service": "noip"})
+        assert "id" in str(exc.value)

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (181 tools)
+# Network Server Tool Reference (186 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -199,6 +199,24 @@ Manage static DNS A/AAAA/CNAME/MX/TXT/NS/SRV records on the controller's local D
 | `unifi_delete_dns_record` | Mutate | Delete a static DNS record. |
 | `unifi_update_dns_record` | Mutate | Update an existing DNS record. |
 <!-- /AUTO:tools:dns -->
+
+---
+
+## Dynamic DNS
+
+Manage the controller's native Dynamic DNS provider entries (Settings → Internet → Dynamic DNS).
+
+<!-- AUTO:tools:dynamic_dns -->
+5 tools.
+
+| Tool | Type | Description |
+|------|------|-------------|
+| `unifi_get_dynamic_dns_entry_details` | Read | Get details for a specific Dynamic DNS entry by ID. |
+| `unifi_list_dynamic_dns` | Read | List all Dynamic DNS provider entries configured on the controller. |
+| `unifi_create_dynamic_dns` | Mutate | Create a new Dynamic DNS provider entry. |
+| `unifi_delete_dynamic_dns` | Mutate | Delete a Dynamic DNS entry. |
+| `unifi_update_dynamic_dns` | Mutate | Update an existing Dynamic DNS entry. |
+<!-- /AUTO:tools:dynamic_dns -->
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Dynamic DNS management to the Network MCP server. The controller natively manages Dynamic DNS (Settings → Internet → Dynamic DNS, backed by `/rest/dynamicdns`), but there were no tools for it — DDNS entries could only be configured by hand in the web UI.

New tools (provider-agnostic — `service` is a parameter, e.g. `dyndns`, `noip`, `namecheap`, `cloudflare`, `custom`):

- `unifi_list_dynamic_dns`
- `unifi_get_dynamic_dns_entry_details`
- `unifi_create_dynamic_dns`
- `unifi_update_dynamic_dns`
- `unifi_delete_dynamic_dns`

Implementation mirrors the DNS-record golden path:

- `DynamicDnsManager` in `unifi-core` over V1 `/rest/dynamicdns` (`get` implemented via list-and-filter since the endpoint 405s on GET-by-id)
- `DynamicDns` pydantic model with `MUTABLE_FIELDS`/`READ_ONLY_FIELDS` and `from_controller` / `to_controller_create` / `to_controller_update`
- Update uses fetch-merge-put — pass only the fields to change, current values are preserved
- Mutations follow preview-then-confirm
- The provider secret (`x_password`) is redacted on every egress path, including create/update previews and results
- Full API surface in the same PR: Strawberry `DynamicDns` type + `dynamicDns` / `dynamicDnsEntry` query fields, REST `GET /sites/{site_id}/dynamic-dns[/{entry_id}]`, mutation-ack serializer, cross-layer symmetry registration, and regenerated `schema.graphql` / `openapi.json` / reference docs / tool manifest / skill references

Note on tool naming: the list/get stems are deliberately distinct (`dynamic_dns` vs `dynamic_dns_entry_details`) because the GraphQL naming convention derives query field names from tool names and identical stems collide.

## Type of change

- [x] `feat:` new feature

## Scope

- [x] Network MCP server
- [x] API server
- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- `make ci` green at the branch tip: ruff format/lint clean, `make check-generated` no drift
- `apps/api` 908 passed (includes SerializerRegistry boot, REST route coverage, SDL/openapi/docs drift gates, new GraphQL fixture tests incl. redaction)
- `apps/network` 860 passed (manager, model, and tool tests incl. preview-redaction cases)
- `packages/unifi-core` 1332 passed
- Live-tested against a real controller (Network 10.x on UniFi OS): full create → list → get → update → delete round-trip on a throwaway entry; verified partial update preserves unmentioned fields and `x_password` is redacted in list/get/create outputs

## Notes for reviewers

- New-tool PRs can't be split smaller: the manifest, API projection, REST route, and regenerated artifacts are a single CI-enforced contract, so most of the diff is generated files (`openapi.json`, `schema.graphql`, manifests, reference docs).
- `unifi_get_dynamic_dns_entry_details` normalizes controller `_id` to `id` via `from_controller` so list/get shapes match.
- Groundwork for a follow-up: a VPN-server "alternate address" update tool (independent, ships separately).
