### PR TITLE
feat(network): add unifi_delete_port_forward tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 180 tools)
+  network/          # UniFi Network MCP server (stable, 181 tools)
   protect/          # UniFi Protect MCP server (beta, 59 tools)
   access/           # UniFi Access MCP server (beta, 34 tools)
   worker/           # Cloudflare Worker gateway + npm CLI

--- a/apps/api/src/unifi_api/serializers/network/port_forwards.py
+++ b/apps/api/src/unifi_api/serializers/network/port_forwards.py
@@ -2,8 +2,8 @@
 
 Phase 6 PR2 Task 22 migrated the read shape (PortForward LIST + DETAIL) to
 a Strawberry type at ``unifi_api.graphql.types.network.port_forward``. Only
-the mutation ack remains here — it covers create/update/toggle for port
-forward rules.
+the mutation ack remains here — it covers create/update/toggle/delete for
+port forward rules.
 """
 
 from typing import Any
@@ -26,13 +26,15 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
         "unifi_create_simple_port_forward": {"kind": RenderKind.DETAIL},
         "unifi_update_port_forward": {"kind": RenderKind.DETAIL},
         "unifi_toggle_port_forward": {"kind": RenderKind.DETAIL},
+        "unifi_delete_port_forward": {"kind": RenderKind.DETAIL},
     },
 )
 class PortForwardMutationAckSerializer(Serializer):
     """DETAIL ack for port forward mutations.
 
-    ``create_*`` returns a dict (or None); ``update_*`` / ``toggle_*``
-    return ``bool``."""
+    ``create_*`` returns a dict (or None); ``update_*`` / ``toggle_*`` /
+    ``delete_*`` return ``bool`` (the manager result the /v1/actions
+    dispatcher serializes)."""
 
     @staticmethod
     def serialize(obj) -> dict:

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -310,14 +310,15 @@ def _translate_update_firewall_policy(args: dict[str, Any]) -> tuple[tuple[Any, 
 
 
 # ---------------------------------------------------------------------------
-# Network — toggle_port_forward
+# Network — port forward id rename
 # ---------------------------------------------------------------------------
-# Tool exposes ``port_forward_id``; manager method ``toggle_port_forward``
-# takes ``rule_id``.
+# Port forward tools expose ``port_forward_id``; the firewall_manager methods
+# (``toggle_port_forward`` / ``delete_port_forward``) take ``rule_id``. Shared
+# by both, mirroring ``_rename_mac_address_to_client_mac``.
 
 
-def _translate_toggle_port_forward(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    """Rename ``port_forward_id`` → ``rule_id`` for firewall_manager.toggle_port_forward."""
+def _rename_port_forward_id_to_rule_id(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Rename ``port_forward_id`` → ``rule_id`` for firewall_manager port-forward methods."""
     out = dict(args)
     if "port_forward_id" in out:
         out["rule_id"] = out.pop("port_forward_id")
@@ -415,8 +416,9 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslator] = {
     "unifi_list_clients": _translate_list_clients,
     # Network — firewall: kwarg rename
     "unifi_update_firewall_policy": _translate_update_firewall_policy,
-    # Network — port forward toggle: kwarg rename
-    "unifi_toggle_port_forward": _translate_toggle_port_forward,
+    # Network — port forward toggle/delete: kwarg rename (port_forward_id → rule_id)
+    "unifi_toggle_port_forward": _rename_port_forward_id_to_rule_id,
+    "unifi_delete_port_forward": _rename_port_forward_id_to_rule_id,
     # Network — device radio update: flatten → (device_mac, radio_id, updates)
     "unifi_update_device_radio": _translate_update_device_radio,
     # Network — stats: convert duration string to duration_hours integer

--- a/apps/api/tests/serializers/test_network_misc.py
+++ b/apps/api/tests/serializers/test_network_misc.py
@@ -71,6 +71,7 @@ def test_port_forward_mutation_ack_dispatches_for_all_mutations() -> None:
         "unifi_create_simple_port_forward",
         "unifi_update_port_forward",
         "unifi_toggle_port_forward",
+        "unifi_delete_port_forward",
     ):
         s = reg.serializer_for_tool(tool)
         out = s.serialize_action(True, tool_name=tool)

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -1337,6 +1337,47 @@ async def test_dispatch_translates_toggle_port_forward_id_to_rule_id() -> None:
     domain_manager.toggle_port_forward.assert_awaited_once_with(rule_id="pf001")
 
 
+@pytest.mark.asyncio
+async def test_dispatch_translates_delete_port_forward_id_to_rule_id() -> None:
+    """unifi_delete_port_forward: tool sends port_forward_id; manager takes rule_id."""
+    entry = ToolEntry(
+        name="unifi_delete_port_forward",
+        product="network",
+        category="port_forwards",
+        manager="",
+        method="",
+    )
+    registry = _registry_with(entry)
+
+    domain_manager = MagicMock()
+    domain_manager.delete_port_forward = AsyncMock(return_value=True)
+
+    conn_manager = MagicMock()
+    conn_manager.site = "default"
+    conn_manager.set_site = AsyncMock()
+
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_delete_port_forward",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"port_forward_id": "pf001"},
+        confirm=True,
+        dispatch_table={
+            "unifi_delete_port_forward": DispatchEntry(manager_attr="firewall_manager", method="delete_port_forward"),
+        },
+    )
+
+    domain_manager.delete_port_forward.assert_awaited_once_with(rule_id="pf001")
+
+
 # ---------------------------------------------------------------------------
 # Network — update_device_radio: flatten to (device_mac, radio_id, updates)
 # ---------------------------------------------------------------------------

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -219,7 +219,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 180 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 181 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 180 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 181 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy/meta-only workflows, call the `unifi_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`.
 
@@ -91,7 +91,7 @@ Gateway-wide security / NAT / connection-tracking settings (the controller's `us
 
 - `unifi_get_traffic_flows` — Query historical UniFi Traffic Flows from Insights > Flows, with pagination and filters for time range, client, host, port, protocol, application, and direction
 
-## Port Forwarding (6 tools)
+## Port Forwarding (7 tools)
 
 - `unifi_list_port_forwards` — List all port forwarding rules
 - `unifi_get_port_forward` — Get rule details by ID
@@ -99,6 +99,7 @@ Gateway-wide security / NAT / connection-tracking settings (the controller's `us
 - `unifi_create_port_forward` — Create with full schema validation
 - `unifi_create_simple_port_forward` — Create with simplified schema
 - `unifi_update_port_forward` — Update rule fields
+- `unifi_delete_port_forward` — Delete a rule by ID (requires delete permission)
 
 ## QoS / Traffic Shaping (6 tools)
 

--- a/apps/network/src/unifi_network_mcp/tools/port_forwards.py
+++ b/apps/network/src/unifi_network_mcp/tools/port_forwards.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, Dict
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_core.confirmation import toggle_preview, update_preview
+from unifi_core.confirmation import preview_response, toggle_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models._actions import (
     PortForwardCreateInput,
@@ -578,3 +578,78 @@ async def create_simple_port_forward(
         "port_forward_id": created.get("_id"),
         "details": json.loads(json.dumps(created, default=str)),
     }
+
+
+@server.tool(
+    name="unifi_delete_port_forward",
+    description="Delete a port forwarding rule by ID. Requires confirmation. "
+    "WARNING: This permanently removes the rule; external access to the forwarded "
+    "service will stop. It cannot be undone - you must recreate the rule to restore it.",
+    permission_category="port_forwards",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_port_forward(
+    port_forward_id: Annotated[
+        str,
+        Field(
+            description="Unique identifier (_id) of the port forwarding rule to delete (from unifi_list_port_forwards)"
+        ),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(
+            description="When true, deletes the rule. When false (default), returns a preview. "
+            "WARNING: This permanently removes the rule and cannot be undone"
+        ),
+    ] = False,
+) -> Dict[str, Any]:
+    """Delete a port forwarding rule by its ID. Requires confirmation.
+
+    Args:
+        port_forward_id (str): The unique identifier (_id) of the port forwarding rule to delete.
+        confirm (bool): Must be explicitly set to `True` to execute the deletion. Defaults to `False`,
+            which returns a preview of the delete action.
+
+    Returns:
+        A dictionary containing:
+        - success (bool): Indicates if the operation was successful.
+        - message (str): A confirmation message on success.
+        - error (str, optional): An error message if the operation failed (e.g., rule not found).
+
+    Example response (success):
+    {
+        "success": True,
+        "message": "Port forward '60f5a9b3e4b0f4a7f7d6e8c1' deleted successfully."
+    }
+    """
+    if not port_forward_id:
+        return {"success": False, "error": "port_forward_id is required"}
+
+    if not confirm:
+        return preview_response(
+            action="delete",
+            resource_type="port_forward",
+            resource_id=port_forward_id,
+            current_state={},
+            proposed_changes={"deleted": True},
+            resource_name=port_forward_id,
+            warnings=[
+                "This permanently removes the port forward rule; external access to the forwarded "
+                "service will stop. It cannot be undone - you must recreate the rule to restore it."
+            ],
+        )
+
+    try:
+        success = await firewall_manager.delete_port_forward(port_forward_id)
+        if success:
+            return {
+                "success": True,
+                "message": f"Port forward '{port_forward_id}' deleted successfully.",
+            }
+        return {"success": False, "error": f"Failed to delete port forward '{port_forward_id}'."}
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error deleting port forward %s: %s", port_forward_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete port forward {port_forward_id}: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 180,
+  "count": 181,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -36,6 +36,7 @@
     "unifi_delete_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
     "unifi_delete_oon_policy": "unifi_network_mcp.tools.oon",
+    "unifi_delete_port_forward": "unifi_network_mcp.tools.port_forwards",
     "unifi_delete_port_profile": "unifi_network_mcp.tools.switch",
     "unifi_delete_wlan": "unifi_network_mcp.tools.network",
     "unifi_force_provision_device": "unifi_network_mcp.tools.devices",
@@ -3865,6 +3866,106 @@
         }
       },
       "title": "Delete OON Policy"
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Delete a port forwarding rule by ID. Requires confirmation. WARNING: This permanently removes the rule; external access to the forwarded service will stop. It cannot be undone - you must recreate the rule to restore it.",
+      "name": "unifi_delete_port_forward",
+      "permission_action": "delete",
+      "permission_category": "port_forwards",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the rule. When false (default), returns a preview. WARNING: This permanently removes the rule and cannot be undone",
+              "type": "boolean"
+            },
+            "port_forward_id": {
+              "description": "Unique identifier (_id) of the port forwarding rule to delete (from unifi_list_port_forwards)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "port_forward_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Delete Port Forward"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -724,3 +724,43 @@ class TestCreatePortForwardResponseShapes:
         assert result is not None
         assert result["_id"] == "abc123"
         assert result["name"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# delete_port_forward — V1 DELETE endpoint + guards
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePortForward:
+    """Direct manager coverage for delete_port_forward (issued the V1 DELETE and invalidates cache)."""
+
+    @pytest.mark.asyncio
+    async def test_delete_port_forward_success(self, firewall_manager, mock_connection):
+        """Happy path: issues DELETE /rest/portforward/<id>, invalidates cache, returns True."""
+        mock_connection.request = AsyncMock(return_value={})
+
+        result = await firewall_manager.delete_port_forward("pf_001")
+
+        assert result is True
+        api_request = mock_connection.request.call_args[0][0]
+        assert api_request.method == "delete"
+        assert api_request.path == "/rest/portforward/pf_001"
+        mock_connection._invalidate_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_port_forward_not_connected_raises(self, firewall_manager, mock_connection):
+        """When the connection can't be established, raise ConnectionError before any request."""
+        mock_connection.ensure_connected = AsyncMock(return_value=False)
+
+        with pytest.raises(ConnectionError):
+            await firewall_manager.delete_port_forward("pf_001")
+
+        mock_connection.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_port_forward_reraises_request_error(self, firewall_manager, mock_connection):
+        """A controller/request error propagates (the manager re-raises)."""
+        mock_connection.request = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await firewall_manager.delete_port_forward("pf_001")

--- a/apps/network/tests/unit/test_port_forwards.py
+++ b/apps/network/tests/unit/test_port_forwards.py
@@ -1,0 +1,104 @@
+"""Tests for the port forward delete tool (unifi_delete_port_forward)."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unifi_core.exceptions import UniFiNotFoundError
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+# ---------------------------------------------------------------------------
+# delete_port_forward
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePortForward:
+    """Test the unifi_delete_port_forward tool."""
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self):
+        """Confirmed delete should call the manager and return success."""
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.delete_port_forward = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.port_forwards import delete_port_forward
+
+            result = await delete_port_forward(port_forward_id="pf_001", confirm=True)
+
+        assert result["success"] is True
+        assert "deleted successfully" in result["message"]
+        mock_fm.delete_port_forward.assert_called_once_with("pf_001")
+
+    @pytest.mark.asyncio
+    async def test_delete_preview(self):
+        """Unconfirmed delete should return a delete preview and NOT call the manager."""
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.delete_port_forward = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.port_forwards import delete_port_forward
+
+            result = await delete_port_forward(port_forward_id="pf_001", confirm=False)
+
+        assert result["success"] is True
+        assert result.get("requires_confirmation") is True
+        assert result.get("action") == "delete"
+        assert result.get("warnings")  # a non-empty warning is surfaced
+        mock_fm.delete_port_forward.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_manager_failure(self):
+        """Delete should return an error when the manager returns False."""
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.delete_port_forward = AsyncMock(return_value=False)
+
+            from unifi_network_mcp.tools.port_forwards import delete_port_forward
+
+            result = await delete_port_forward(port_forward_id="pf_001", confirm=True)
+
+        assert result["success"] is False
+        assert "Failed to delete" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self):
+        """A UniFiNotFoundError from the manager surfaces as a clean error."""
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.delete_port_forward = AsyncMock(side_effect=UniFiNotFoundError("port_forward", "pf_missing"))
+
+            from unifi_network_mcp.tools.port_forwards import delete_port_forward
+
+            result = await delete_port_forward(port_forward_id="pf_missing", confirm=True)
+
+        assert result["success"] is False
+        assert "pf_missing" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_generic_exception_handled(self):
+        """A non-UniFi exception from the manager is caught and returned as an error, not raised."""
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.delete_port_forward = AsyncMock(side_effect=RuntimeError("boom"))
+
+            from unifi_network_mcp.tools.port_forwards import delete_port_forward
+
+            result = await delete_port_forward(port_forward_id="pf_001", confirm=True)
+
+        assert result["success"] is False
+        assert "Failed to delete port forward" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_requires_id(self):
+        """An empty port_forward_id is rejected before any manager call."""
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.delete_port_forward = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.port_forwards import delete_port_forward
+
+            result = await delete_port_forward(port_forward_id="", confirm=True)
+
+        assert result["success"] is False
+        assert "required" in result["error"]
+        mock_fm.delete_port_forward.assert_not_called()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Used by: `apps/network`, `apps/protect`, `apps/access`.
 
 ### apps/network
 
-The UniFi Network MCP server. 180 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
+The UniFi Network MCP server. 181 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
 
 - `src/unifi_network_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch

--- a/plugins/unifi-network/skills/unifi-network/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network/SKILL.md
@@ -5,7 +5,7 @@ description: How to manage UniFi network infrastructure — devices, clients, fi
 
 # UniFi Network MCP Server
 
-You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 180 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
+You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 181 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
 
 ## Tool Discovery
 
@@ -89,4 +89,4 @@ Cameras and access readers appear as network clients — use `unifi_lookup_by_ip
 
 ## Tool Reference
 
-For the complete list of all 180 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.
+For the complete list of all 181 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (180 tools)
+# Network Server Tool Reference (181 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -205,7 +205,7 @@ Manage static DNS A/AAAA/CNAME/MX/TXT/NS/SRV records on the controller's local D
 ## Port Forwarding
 
 <!-- AUTO:tools:port_forwards -->
-6 tools.
+7 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -213,6 +213,7 @@ Manage static DNS A/AAAA/CNAME/MX/TXT/NS/SRV records on the controller's local D
 | `unifi_get_port_forward` | Read | Get a specific port forwarding rule by ID from your Unifi Network controller. |
 | `unifi_list_port_forwards` | Read | List all port forwarding rules on your Unifi Network controller. |
 | `unifi_create_simple_port_forward` | Mutate | Create a port forward using a simplified schema. |
+| `unifi_delete_port_forward` | Mutate | Delete a port forwarding rule by ID. |
 | `unifi_toggle_port_forward` | Mutate | Toggle a port forwarding rule on or off on your Unifi Network controller. |
 | `unifi_update_port_forward` | Mutate | Update specific fields of an existing port forwarding rule using schema validation. |
 <!-- /AUTO:tools:port_forwards -->


### PR DESCRIPTION
## Summary

Adds `unifi_delete_port_forward` — a confirmation-gated, destructive delete for port
forwarding rules. Port forwards were the **only mutating network resource without a delete
tool** (11 siblings — ACL rules, firewall groups/policies, WLANs, DNS records, etc. — already
have one). `FirewallManager.delete_port_forward` has existed since the initial commit but was
never surfaced as a tool, so callers could *disable* a rule via `unifi_toggle_port_forward`
but not *remove* it (GUI-only until now).

No new manager code — the existing method is now exposed through the MCP tool layer and the
API `/v1/actions` path.

## Type of change
- [x] `feat:` new feature

## Scope
- [x] Network MCP server  [x] API server

## What changed

**MCP (`apps/network`):** new `unifi_delete_port_forward` tool —
`permission_category=port_forwards` / `action=delete`, `destructiveHint=True`,
`idempotentHint=True`. Preview (`confirm=false`) uses `preview_response(action="delete")` with
an irreversibility warning; the confirmed path delegates to
`firewall_manager.delete_port_forward`. Thin wrapper, no business logic.

**API (`apps/api`):** register the delete tool's mutation-ack projection (DETAIL) so
`test_serializer_coverage` passes and `/v1/actions` serializes it. Generalized the toggle
dispatch-arg translator into a shared `_rename_port_forward_id_to_rule_id`
(`port_forward_id` -> `rule_id`), now used by both toggle and delete — mirroring the existing
`_rename_mac_address_to_client_mac` shared helper. No Strawberry type / REST route / SDL
change — the serializer is projection config, not schema.

## Files changed

| Area | Files |
|---|---|
| MCP | `tools/port_forwards.py` (new tool) |
| API | `serializers/network/port_forwards.py` (ack projection), `services/dispatch_overrides.py` (shared id translator) |
| Tests | `test_port_forwards.py` (tool), `test_firewall_manager.py::TestDeletePortForward` (manager), `test_actions_dispatcher.py` (translator), `serializers/test_network_misc.py` (ack coverage) |
| Generated | `tools_manifest.json` (180 -> 181), network skill reference |

## Checklist
- [x] Read `AGENTS.md` / `CONTRIBUTING.md`.
- [x] Added/updated tests for the new behavior.
- [x] Regenerated all generated artifacts (`make manifest` -> tool manifest + skill reference).
- [x] No credentials, tokens, controller addresses, or private data (test fixtures use synthetic IDs).
- [ ] `make pre-commit` — `make` isn't available on my host; ran the equivalents individually
      (workspace `ruff check`/`format`, per-package `pytest`, regenerated + drift-checked every
      artifact). Full gate runs in CI.

## Testing

| Environment | |
|---|---|
| **Device** | UniFi Dream Machine Pro Max |
| **UniFi OS** | 5.0.16 |
| **Network application** | 10.1.89 |
| **MCP client** | Claude Code (stdio) |

| Live test (real tool code vs the UDM; rule created + deleted, nothing left behind) | Result |
|---|---|
| Create a disposable **disabled** rule on an unused high port | ✅ |
| Preview (`confirm=false`) — no write; irreversibility warning fired; rule still present on re-read | ✅ |
| Confirmed delete (`confirm=true`) — `deleted successfully` | ✅ |
| Re-read — rule gone from the controller | ✅ |

Unit/static (per package; `uv run pytest` trampoline-fails on my host so the workspace venv is used directly):
- `apps/network` — tool tests (preview / success / manager-failure / not-found / empty-id / generic-exception) + direct manager coverage for `delete_port_forward` (success / not-connected / re-raise) + tool-map sync.
- `apps/api` — cross-layer symmetry + all four `*_drift` gates + serializer coverage + the dispatch-translator test.
- `ruff check` + `ruff format --check` clean workspace-wide; working tree clean after regenerating every artifact.

## Notes for reviewers
- **Preview helper divergence (intentional).** This tool uses `preview_response(action="delete", ...)`,
  whereas the three existing delete tools (`delete_firewall_policy`, `delete_firewall_group`,
  `delete_acl_rule`) call `create_preview(...)`, which hard-codes `action="create"` / `will_create`
  in the response — semantically wrong for a delete. I used the correct helper here rather than copy
  the siblings. Happy to file a follow-up adding a `delete_preview` helper and migrating the three
  siblings if you'd prefer consistency now.
- **`confirm` on `/v1/actions`.** `unifi_delete_port_forward` is not in `CONFIRM_REQUIRED_TOOLS`,
  consistent with every sibling delete tool — the preview-then-confirm gate is an MCP-layer contract;
  the API layer treats `confirm` as caller-supplied. No behavior change vs siblings; flagging for awareness.
- **Shared translator.** `_translate_toggle_port_forward` -> `_rename_port_forward_id_to_rule_id`; the
  body is byte-identical, so toggle behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
