### PR TITLE
chore: add pre-pr push gate and committed git hooks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Pre-push gate. Runs `make pre-pr` (format-check + lint + generated-artifact
+# drift + clean-tree) before allowing a push, so drift and formatting misses
+# are caught locally regardless of which editor or tooling is in use. The
+# full test suite runs in CI.
+#
+# Install with `make install-hooks` (sets core.hooksPath=.githooks).
+# Bypass for work-in-progress with `git push --no-verify`.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! make pre-pr; then
+	echo ""
+	echo "pre-push blocked: 'make pre-pr' failed. Fix the issues above, or run"
+	echo "'git push --no-verify' to bypass (discouraged on shared branches)."
+	exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ make sync              # Install Python workspace + worker npm dependencies
 make lint              # Lint all packages
 make format            # Format all packages
 make pre-commit        # Format + lint + test
+make pre-pr            # Fast pre-push gate: format check + lint + drift + clean tree
+make install-hooks     # Install committed git hooks (core.hooksPath=.githooks)
 
 # Individual packages
 make core-test         # Run unifi-core tests
@@ -76,6 +78,14 @@ make access-test       # Run access server tests
 make access-lint       # Lint access server
 make access-manifest   # Regenerate access tools manifest
 ```
+
+### Git hooks
+
+Run `make install-hooks` once after cloning. It sets `core.hooksPath=.githooks`,
+which installs a `pre-push` hook that runs `make pre-pr` (format check, lint, and
+generated-artifact drift) before every push. This catches formatting and drift
+misses locally regardless of which editor or tool you use. Bypass a single push
+with `git push --no-verify`; the full test suite still runs in CI.
 
 ## App-Level Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help sync build check test lint format format-check format-fix manifest generate server-manifests skill-references \
        check-skill-references check-generated pre-commit ci core-test shared-test protocol-smoke \
        relay-test worker-install worker-test worker-typecheck worker-build worker-check docker-relay \
-       docker-build docker-up docker-down docker-logs
+       docker-build docker-up docker-down docker-logs pre-pr install-hooks
 
 help:
 	@echo "UniFi MCP Ecosystem — Top-Level Commands"
@@ -21,6 +21,8 @@ help:
 	@echo "  make server-manifests  Regenerate server.json for all apps (MCP Registry)"
 	@echo "  make skill-references  Update skill tool tables from manifests"
 	@echo "  make pre-commit     Format + generate + lint + test + drift checks"
+	@echo "  make pre-pr         Fast pre-push gate: format-check + lint + drift + clean tree"
+	@echo "  make install-hooks  Install committed git hooks (core.hooksPath=.githooks)"
 	@echo ""
 	@echo "  make docker-build   Build all Docker images"
 	@echo "  make docker-up      Start all servers (docker compose)"
@@ -113,6 +115,26 @@ docker-relay:
 pre-commit: format generate lint test check-generated worker-typecheck
 
 ci: check
+
+# Fast pre-push gate (bound to git push via .githooks/pre-push). Runs the
+# check-only, no-mutation subset that catches the silent misses (formatting,
+# lint, generated-artifact drift) plus a clean-tree assertion. The full test
+# suite runs in CI, not here, to keep this hook fast.
+pre-pr: format-check lint check-generated
+	@if ! git diff --quiet || ! git diff --cached --quiet; then \
+		echo "pre-pr: uncommitted tracked changes present — commit or stash before pushing"; \
+		git status --short; \
+		exit 1; \
+	fi
+	@echo "pre-pr gate passed (format-check, lint, check-generated, clean tree)"
+
+# Point git at the committed hooks so every clone gets the same pre-push gate.
+# Run once after cloning. chmod is insurance: git silently skips a hook that
+# lost its executable bit.
+install-hooks:
+	chmod +x .githooks/pre-push
+	git config core.hooksPath .githooks
+	@echo "Installed git hooks: core.hooksPath=.githooks (pre-push runs 'make pre-pr')"
 
 docker-build:
 	docker compose -f docker/docker-compose.yml build


### PR DESCRIPTION
## Summary

Adds an opt-in pre-push quality gate so formatting, lint, and generated-artifact drift are caught locally before a push instead of surfacing as a red PR.

- `make pre-pr` — fast, check-only gate: `format-check` + `lint` + `check-generated`, plus an assertion that the tracked working tree is clean (untracked files are ignored). Fail-closed; no mutations.
- `.githooks/pre-push` — committed hook that runs `make pre-pr` and blocks the push on failure.
- `make install-hooks` — run once after cloning; sets `core.hooksPath=.githooks` (and re-applies the hook's executable bit, since git silently skips a non-executable hook).
- CONTRIBUTING.md documents the setup.

The full test suite intentionally stays in CI — the gate covers only the fast checks that most often slip through (the same drift class that `make check-generated` exists for), keeping the hook cheap enough to leave enabled.

## Type of change

- [x] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [x] Documentation

(Also touches the root `Makefile` and adds `.githooks/` — repo tooling; no server/package code changes.)

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

`make pre-commit` not run in full: this change is Makefile/docs/hook-only (no Python or worker code), so the relevant checks were the gate itself plus format/lint/drift, all run as described below.

## Testing

- `make pre-pr` on a dirty tree: correctly fails with the offending `git status --short` output (exit 1)
- `make pre-pr` on a clean tree: passes (format-check, lint, check-generated all green)
- `make install-hooks` then a real `git push`: the hook fires, runs the gate, and the push proceeds only after it passes
- Hook file mode verified `100755` in the index (git silently skips non-executable hooks)

## Notes for reviewers

- Opt-in by design: contributors who never run `make install-hooks` see no behavior change. A single push can bypass with `git push --no-verify`; CI remains the authoritative gate.
- The clean-tree assertion is there to stop half-committed regenerated artifacts from being pushed alongside stale committed ones.
