### PR TITLE
feat(access): add device config read/update tools across all surfaces

### DIFF
--- a/apps/access/src/unifi_access_mcp/tools/devices.py
+++ b/apps/access/src/unifi_access_mcp/tools/devices.py
@@ -5,13 +5,15 @@ Provides tools for listing, inspecting, and rebooting Access hardware devices
 """
 
 import logging
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_access_mcp.runtime import device_manager, server
+from unifi_access_mcp.runtime import device_manager, server, should_redact_sensitive_fields
 from unifi_core.access.models._actions import RebootDeviceInput
+from unifi_core.access.models.device_configs import from_controller as device_config_from_controller
+from unifi_core.access.models.device_configs import redact_config_entries
 from unifi_core.access.models.devices import from_controller as access_device_from_controller
 from unifi_core.confirmation import preview_response
 from unifi_core.exceptions import UniFiNotFoundError
@@ -128,4 +130,105 @@ async def access_reboot_device(
         return {"success": False, "error": f"Failed to reboot device: {e}"}
 
 
-logger.info("Device tools registered: access_list_devices, access_get_device, access_reboot_device")
+@server.tool(
+    name="access_get_device_configs",
+    description=(
+        "Returns a device's settings (its configs[] array) — the per-device settings the Access web UI "
+        "edits, such as the reader voice greeting. Each entry is a {key, value, tag} record; tags group "
+        "entries by category (device_setting, device_extra, hub_action, hub_power, wiring_state, credential). "
+        "Credential-tagged and secret-named values are redacted. Use this to discover the exact keys before "
+        "calling access_update_device_config. Only available via local proxy session."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+    permission_category="device",
+    permission_action="read",
+    auth="local_only",
+)
+async def access_get_device_configs(
+    device_id: Annotated[str, Field(description="Device UUID (from access_list_devices)")],
+) -> Dict[str, Any]:
+    """Return a device's config/settings entries, redacting sensitive values."""
+    logger.info("access_get_device_configs tool called for %s", device_id)
+    redact_sensitive = should_redact_sensitive_fields()
+    try:
+        info = await device_manager.get_device_configs(device_id)
+        projected = [device_config_from_controller(c).model_dump(exclude_none=True) for c in info["configs"]]
+        configs = redact_config_entries(projected, redact_sensitive=redact_sensitive)
+        return {
+            "success": True,
+            "data": {
+                "device_id": info["device_id"],
+                "device_name": info["device_name"],
+                "is_camera": info["is_camera"],
+                "configs": configs,
+                "count": len(configs),
+            },
+        }
+    except (UniFiNotFoundError, ValueError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error getting device configs %s: %s", device_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get device configs: {e}"}
+
+
+@server.tool(
+    name="access_update_device_config",
+    description=(
+        "Update a device's settings (its configs[] entries), e.g. the reader voice greeting. Pass 'updates' "
+        "as a {key: value} map; only keys the device already exposes may be set (call access_get_device_configs "
+        "first to discover them), and credential/secret keys are refused. Requires confirm=true to execute; "
+        "confirm=false returns a preview of the current→proposed change. Only available via local proxy session."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+    permission_category="device",
+    permission_action="update",
+    auth="local_only",
+)
+async def access_update_device_config(
+    device_id: Annotated[str, Field(description="Device UUID (from access_list_devices)")],
+    updates: Annotated[
+        Dict[str, str],
+        Field(description="Map of config key → new value. Keys must already exist on the device."),
+    ],
+    is_camera: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "Override the camera-class flag for the config PUT. Omit to auto-derive from the device "
+                "(camera-class readers vs hubs)."
+            )
+        ),
+    ] = None,
+    confirm: Annotated[
+        bool,
+        Field(description="When true, applies the update. When false (default), returns a preview."),
+    ] = False,
+) -> Dict[str, Any]:
+    """Update device config entries with preview/confirm."""
+    logger.info("access_update_device_config tool called for %s (confirm=%s)", device_id, confirm)
+    try:
+        if confirm:
+            result = await device_manager.apply_update_device_config(device_id, updates, is_camera=is_camera)
+            return {"success": True, "data": result}
+
+        preview_data = await device_manager.update_device_config(device_id, updates)
+        return preview_response(
+            action="update",
+            resource_type="access_device_config",
+            resource_id=device_id,
+            current_state=preview_data["current_state"],
+            proposed_changes=preview_data["proposed_changes"],
+            resource_name=preview_data.get("device_name"),
+            warnings=["Applies persistent device settings. Credential/secret keys cannot be written."],
+        )
+    except (UniFiNotFoundError, ValueError) as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error updating device config %s: %s", device_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to update device config: {e}"}
+
+
+logger.info(
+    "Device tools registered: access_list_devices, access_get_device, access_reboot_device, "
+    "access_get_device_configs, access_update_device_config"
+)

--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 34,
+  "count": 36,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "access_create_credential": "unifi_access_mcp.tools.credentials",
@@ -8,6 +8,7 @@
     "access_get_activity_summary": "unifi_access_mcp.tools.events",
     "access_get_credential": "unifi_access_mcp.tools.credentials",
     "access_get_device": "unifi_access_mcp.tools.devices",
+    "access_get_device_configs": "unifi_access_mcp.tools.devices",
     "access_get_door": "unifi_access_mcp.tools.doors",
     "access_get_door_status": "unifi_access_mcp.tools.doors",
     "access_get_event": "unifi_access_mcp.tools.events",
@@ -30,6 +31,7 @@
     "access_revoke_credential": "unifi_access_mcp.tools.credentials",
     "access_subscribe_events": "unifi_access_mcp.tools.events",
     "access_unlock_door": "unifi_access_mcp.tools.doors",
+    "access_update_device_config": "unifi_access_mcp.tools.devices",
     "access_update_policy": "unifi_access_mcp.tools.policies"
   },
   "note": "Auto-generated with full schemas from tool decorators. Do not edit manually.",
@@ -793,6 +795,100 @@
         }
       },
       "title": "Get Device"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Returns a device's settings (its configs[] array) \u2014 the per-device settings the Access web UI edits, such as the reader voice greeting. Each entry is a {key, value, tag} record; tags group entries by category (device_setting, device_extra, hub_action, hub_power, wiring_state, credential). Credential-tagged and secret-named values are redacted. Use this to discover the exact keys before calling access_update_device_config. Only available via local proxy session.",
+      "name": "access_get_device_configs",
+      "permission_action": "read",
+      "permission_category": "device",
+      "schema": {
+        "input": {
+          "properties": {
+            "device_id": {
+              "description": "Device UUID (from access_list_devices)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "device_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Get Device Configs"
     },
     {
       "annotations": {
@@ -2941,6 +3037,115 @@
         }
       },
       "title": "Unlock Door"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Update a device's settings (its configs[] entries), e.g. the reader voice greeting. Pass 'updates' as a {key: value} map; only keys the device already exposes may be set (call access_get_device_configs first to discover them), and credential/secret keys are refused. Requires confirm=true to execute; confirm=false returns a preview of the current\u2192proposed change. Only available via local proxy session.",
+      "name": "access_update_device_config",
+      "permission_action": "update",
+      "permission_category": "device",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, applies the update. When false (default), returns a preview.",
+              "type": "boolean"
+            },
+            "device_id": {
+              "description": "Device UUID (from access_list_devices)",
+              "type": "string"
+            },
+            "is_camera": {
+              "description": "Override the camera-class flag for the config PUT. Omit to auto-derive from the device (camera-class readers vs hubs).",
+              "type": "boolean"
+            },
+            "updates": {
+              "description": "Map of config key \u2192 new value. Keys must already exist on the device.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "device_id",
+            "updates"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Update Device Config"
     },
     {
       "annotations": {

--- a/apps/access/tests/unit/test_devices.py
+++ b/apps/access/tests/unit/test_devices.py
@@ -9,6 +9,7 @@ import pytest
 from unifi_core.access.managers.connection_manager import AccessConnectionManager
 from unifi_core.access.managers.device_manager import DeviceManager
 from unifi_core.exceptions import UniFiConnectionError, UniFiNotFoundError
+from unifi_core.redaction import REDACTED
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -335,3 +336,310 @@ class TestApplyRebootDevice:
     async def test_apply_reboot_no_proxy(self, device_mgr_none):
         with pytest.raises(UniFiConnectionError, match="No proxy session"):
             await device_mgr_none.apply_reboot_device("dev-1")
+
+
+# ---------------------------------------------------------------------------
+# Device-config helpers
+# ---------------------------------------------------------------------------
+
+
+def _topology_with(device: dict) -> list:
+    """Wrap a single device dict in the nested topology4 tree shape."""
+    return [
+        {
+            "name": "Site",
+            "unique_id": "site-1",
+            "floors": [
+                {
+                    "name": "1F",
+                    "unique_id": "floor-1",
+                    "doors": [
+                        {
+                            "name": "Front Door",
+                            "unique_id": "door-1",
+                            "device_groups": [[device]],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+# A camera-class reader carries a 24-hex Protect-style id → is_camera=true.
+_READER_ID = "a1b2c3d4e5f607182930abcd"
+# A hub carries a MAC-style (12-hex) id → is_camera=false.
+_HUB_ID = "aabbccddeeff"
+
+
+def _reader_with_configs(configs: list) -> dict:
+    return {"unique_id": _READER_ID, "name": "Entry Reader", "device_type": "UA-G6", "configs": configs}
+
+
+_GREETING_CONFIGS = [
+    {"device_id": _READER_ID, "key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+    {"device_id": _READER_ID, "key": "greeting_text", "value": "welcome", "tag": "device_setting"},
+    {"device_id": _READER_ID, "key": "greeting_broadcast_name", "value": "first_name_only", "tag": "device_setting"},
+    {"device_id": _READER_ID, "key": "ssh_password", "value": "s3cr3t", "tag": "credential"},
+]
+
+
+class TestGetDeviceConfigs:
+    @pytest.mark.asyncio
+    async def test_returns_configs_and_identity(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            info = await device_mgr_proxy.get_device_configs(_READER_ID)
+        assert info["device_id"] == _READER_ID
+        assert info["device_name"] == "Entry Reader"
+        assert info["is_camera"] is True
+        assert info["configs"] == _GREETING_CONFIGS
+        mock_req.assert_awaited_once_with("GET", "devices/topology4")
+
+    @pytest.mark.asyncio
+    async def test_hub_is_not_camera(self, device_mgr_proxy, cm_proxy):
+        hub = {"unique_id": _HUB_ID, "name": "Door Hub", "configs": []}
+        topology = _topology_with(hub)
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            info = await device_mgr_proxy.get_device_configs(_HUB_ID)
+        assert info["is_camera"] is False
+        assert info["configs"] == []
+
+    @pytest.mark.asyncio
+    async def test_device_without_configs_key_returns_empty_list(self, device_mgr_proxy, cm_proxy):
+        reader = {"unique_id": _READER_ID, "name": "Reader"}
+        topology = _topology_with(reader)
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            info = await device_mgr_proxy.get_device_configs(_READER_ID)
+        assert info["configs"] == []
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs([]))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            with pytest.raises(UniFiNotFoundError):
+                await device_mgr_proxy.get_device_configs("no-such-device")
+
+    @pytest.mark.asyncio
+    async def test_empty_id_raises(self, device_mgr_proxy):
+        with pytest.raises(ValueError, match="device_id is required"):
+            await device_mgr_proxy.get_device_configs("")
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_raises(self, device_mgr_none):
+        with pytest.raises(UniFiConnectionError, match="No proxy session"):
+            await device_mgr_none.get_device_configs(_READER_ID)
+
+
+class TestUpdateDeviceConfigPreview:
+    @pytest.mark.asyncio
+    async def test_preview_shows_current_and_proposed(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            preview = await device_mgr_proxy.update_device_config(_READER_ID, {"show_entry_greet": "no"})
+        assert preview["device_id"] == _READER_ID
+        assert preview["current_state"] == {"show_entry_greet": "yes"}
+        assert preview["proposed_changes"] == {"show_entry_greet": "no"}
+
+    @pytest.mark.asyncio
+    async def test_preview_rejects_unknown_key(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            with pytest.raises(ValueError, match="Unknown config key"):
+                await device_mgr_proxy.update_device_config(_READER_ID, {"bogus_key": "x"})
+
+    @pytest.mark.asyncio
+    async def test_preview_rejects_credential_key(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            with pytest.raises(ValueError, match="credential/secret"):
+                await device_mgr_proxy.update_device_config(_READER_ID, {"ssh_password": "new"})
+
+    @pytest.mark.asyncio
+    async def test_preview_rejects_empty_updates(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            with pytest.raises(ValueError, match="No config updates"):
+                await device_mgr_proxy.update_device_config(_READER_ID, {})
+
+
+class TestApplyUpdateDeviceConfig:
+    @pytest.mark.asyncio
+    async def test_apply_puts_key_tag_value_array_with_is_camera(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [{"data": topology}, {"code": 1, "codeS": "SUCCESS"}]
+            result = await device_mgr_proxy.apply_update_device_config(
+                _READER_ID, {"show_entry_greet": "no", "greeting_text": "hello"}
+            )
+        assert result["result"] == "success"
+        assert result["updated_keys"] == ["show_entry_greet", "greeting_text"]
+        assert result["is_camera"] is True
+        put_call = mock_req.await_args_list[1]
+        assert put_call.args == ("PUT", f"device/{_READER_ID}/configs")
+        assert put_call.kwargs["params"] == {"is_camera": "true"}
+        assert put_call.kwargs["json"] == [
+            {"key": "show_entry_greet", "tag": "device_setting", "value": "no"},
+            {"key": "greeting_text", "tag": "device_setting", "value": "hello"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_apply_hub_uses_is_camera_false(self, device_mgr_proxy, cm_proxy):
+        hub_configs = [{"device_id": _HUB_ID, "key": "led_mode", "value": "on", "tag": "device_setting"}]
+        hub = {"unique_id": _HUB_ID, "name": "Door Hub", "configs": hub_configs}
+        topology = _topology_with(hub)
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [{"data": topology}, {"code": 1}]
+            result = await device_mgr_proxy.apply_update_device_config(_HUB_ID, {"led_mode": "off"})
+        assert result["is_camera"] is False
+        assert mock_req.await_args_list[1].kwargs["params"] == {"is_camera": "false"}
+
+    @pytest.mark.asyncio
+    async def test_apply_is_camera_override_respected(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.side_effect = [{"data": topology}, {"code": 1}]
+            await device_mgr_proxy.apply_update_device_config(_READER_ID, {"show_entry_greet": "no"}, is_camera=False)
+        assert mock_req.await_args_list[1].kwargs["params"] == {"is_camera": "false"}
+
+    @pytest.mark.asyncio
+    async def test_apply_rejects_unknown_key(self, device_mgr_proxy, cm_proxy):
+        topology = _topology_with(_reader_with_configs(_GREETING_CONFIGS))
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": topology}
+            with pytest.raises(ValueError, match="Unknown config key"):
+                await device_mgr_proxy.apply_update_device_config(_READER_ID, {"bogus": "x"})
+
+    @pytest.mark.asyncio
+    async def test_apply_no_proxy_raises(self, device_mgr_none):
+        with pytest.raises(UniFiConnectionError, match="No proxy session"):
+            await device_mgr_none.apply_update_device_config(_READER_ID, {"show_entry_greet": "no"})
+
+
+# ---------------------------------------------------------------------------
+# MCP tool layer: access_get_device_configs / access_update_device_config
+# ---------------------------------------------------------------------------
+
+
+def _configs_info() -> dict:
+    return {
+        "device_id": _READER_ID,
+        "device_name": "Entry Reader",
+        "is_camera": True,
+        "configs": [
+            {"device_id": _READER_ID, "key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+            {"device_id": _READER_ID, "key": "ssh_password", "value": "s3cr3t", "tag": "credential"},
+            {"device_id": _READER_ID, "key": "nacl_private_key", "value": "AbCd==", "tag": "device_extra"},
+        ],
+    }
+
+
+class TestGetDeviceConfigsTool:
+    @pytest.mark.asyncio
+    async def test_redacts_credential_and_sensitive_values_by_default(self):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            mock_mgr.get_device_configs = AsyncMock(return_value=_configs_info())
+            from unifi_access_mcp.tools.devices import access_get_device_configs
+
+            result = await access_get_device_configs(_READER_ID)
+
+        configs = result["data"]["configs"]
+        by_key = {c["key"]: c for c in configs}
+        assert result["success"] is True
+        assert by_key["ssh_password"]["value"] == REDACTED
+        assert by_key["nacl_private_key"]["value"] == REDACTED
+        assert by_key["show_entry_greet"]["value"] == "yes"
+
+    @pytest.mark.asyncio
+    async def test_policy_disable_returns_raw_values(self, monkeypatch):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            mock_mgr.get_device_configs = AsyncMock(return_value=_configs_info())
+            from unifi_access_mcp.tools.devices import access_get_device_configs
+
+            monkeypatch.setenv("UNIFI_ACCESS_REDACT_SENSITIVE_FIELDS", "false")
+            result = await access_get_device_configs(_READER_ID)
+
+        by_key = {c["key"]: c for c in result["data"]["configs"]}
+        assert by_key["ssh_password"]["value"] == "s3cr3t"
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error_envelope(self):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            mock_mgr.get_device_configs = AsyncMock(side_effect=UniFiNotFoundError("device", "x"))
+            from unifi_access_mcp.tools.devices import access_get_device_configs
+
+            result = await access_get_device_configs("x")
+
+        assert result["success"] is False
+        assert "error" in result
+
+
+class TestUpdateDeviceConfigTool:
+    @pytest.mark.asyncio
+    async def test_preview_returns_requires_confirmation(self):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            mock_mgr.update_device_config = AsyncMock(
+                return_value={
+                    "device_id": _READER_ID,
+                    "device_name": "Entry Reader",
+                    "current_state": {"show_entry_greet": "yes"},
+                    "proposed_changes": {"show_entry_greet": "no"},
+                }
+            )
+            from unifi_access_mcp.tools.devices import access_update_device_config
+
+            result = await access_update_device_config(_READER_ID, {"show_entry_greet": "no"}, confirm=False)
+
+        assert result["success"] is True
+        assert result["requires_confirmation"] is True
+        assert result["preview"]["current"] == {"show_entry_greet": "yes"}
+        assert result["preview"]["proposed"] == {"show_entry_greet": "no"}
+
+    @pytest.mark.asyncio
+    async def test_confirm_calls_apply_and_returns_success(self):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            apply_result = {
+                "device_id": _READER_ID,
+                "action": "update_config",
+                "result": "success",
+                "updated_keys": ["show_entry_greet"],
+                "is_camera": True,
+            }
+            mock_mgr.apply_update_device_config = AsyncMock(return_value=apply_result)
+            from unifi_access_mcp.tools.devices import access_update_device_config
+
+            result = await access_update_device_config(_READER_ID, {"show_entry_greet": "no"}, confirm=True)
+
+        assert result["success"] is True
+        assert result["data"] == apply_result
+        mock_mgr.apply_update_device_config.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_confirm_passes_is_camera_override(self):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            mock_mgr.apply_update_device_config = AsyncMock(return_value={"result": "success"})
+            from unifi_access_mcp.tools.devices import access_update_device_config
+
+            await access_update_device_config(_READER_ID, {"show_entry_greet": "no"}, is_camera=False, confirm=True)
+
+        _, kwargs = mock_mgr.apply_update_device_config.await_args
+        assert kwargs.get("is_camera") is False
+
+    @pytest.mark.asyncio
+    async def test_validation_error_returns_error_envelope(self):
+        with patch("unifi_access_mcp.tools.devices.device_manager") as mock_mgr:
+            mock_mgr.update_device_config = AsyncMock(side_effect=ValueError("Unknown config key(s): ['x']"))
+            from unifi_access_mcp.tools.devices import access_update_device_config
+
+            result = await access_update_device_config(_READER_ID, {"x": "1"}, confirm=False)
+
+        assert result["success"] is False
+        assert "Unknown config key" in result["error"]

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -19,6 +19,24 @@ type AccessDevice {
   location: AccessLocation
 }
 
+"""
+A single per-device config/settings entry (key/value with category tag).
+"""
+type AccessDeviceConfig {
+  deviceId: ID
+  key: String
+  value: String
+  tag: String
+  updateTime: String
+  createTime: String
+}
+
+"""A device's config/settings entries."""
+type AccessDeviceConfigPage {
+  items: [AccessDeviceConfig!]!
+  nextCursor: String
+}
+
 """Paginated page of UniFi Access devices."""
 type AccessDevicePage {
   items: [AccessDevice!]!
@@ -87,6 +105,11 @@ type AccessQuery {
 
   """Look up a single Access device by id."""
   device(controller: ID!, id: ID!): AccessDevice
+
+  """
+  List a device's config/settings entries (e.g. reader voice greeting). Secrets redacted.
+  """
+  deviceConfigs(controller: ID!, deviceId: ID!): AccessDeviceConfigPage!
 
   """List Access users (employees / cardholders, paginated)."""
   users(controller: ID!, limit: Int! = 50, cursor: String = null): UserPage!
@@ -2081,6 +2104,7 @@ Read-only access to UniFi Access resources.
 - `credential: Credential`  — Look up a single Access credential by id.
 - `credentials: CredentialPage!`  — List Access credentials (NFC / PIN / etc., paginated).
 - `device: AccessDevice`  — Look up a single Access device by id.
+- `deviceConfigs: AccessDeviceConfigPage!`  — List a device's config/settings entries (e.g. reader voice greeting). Secrets redacted.
 - `devices: AccessDevicePage!`  — List Access devices (readers / hubs / locks, paginated).
 - `door: Door`  — Look up a single Access door by id.
 - `doorGroups: DoorGroupPage!`  — List Access door groups (paginated).

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -59,6 +59,18 @@
 
 **Returns:** `object`
 
+### `GET /v1/sites/{site_id}/access-devices/{device_id}/configs` — Get Device Configs
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `device_id` (path) (required)
+- `controller` (query)
+
+
+**Returns:** `object`
+
 
 ## access/doors
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8761,6 +8761,77 @@
         ]
       }
     },
+    "/v1/sites/{site_id}/access-devices/{device_id}/configs": {
+      "get": {
+        "operationId": "get_device_configs_v1_sites__site_id__access_devices__device_id__configs_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "device_id",
+            "required": true,
+            "schema": {
+              "title": "Device Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Device Configs V1 Sites  Site Id  Access Devices  Device Id  Configs Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Device Configs",
+        "tags": [
+          "access/devices"
+        ]
+      }
+    },
     "/v1/sites/{site_id}/access/activity-summary": {
       "get": {
         "operationId": "get_access_activity_summary_v1_sites__site_id__access_activity_summary_get",

--- a/apps/api/src/unifi_api/graphql/resolvers/access.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/access.py
@@ -31,6 +31,7 @@ from strawberry.types import Info
 from unifi_api.graphql.context import GraphQLContext
 from unifi_api.graphql.permissions import IsRead
 from unifi_api.graphql.types.access.credentials import Credential
+from unifi_api.graphql.types.access.device_configs import AccessDeviceConfig
 from unifi_api.graphql.types.access.devices import AccessDevice
 from unifi_api.graphql.types.access.doors import Door, DoorGroup, DoorStatus
 from unifi_api.graphql.types.access.events import ActivitySummary, Event
@@ -196,6 +197,27 @@ async def _fetch_devices(ctx: GraphQLContext, controller: str) -> list:
                 "access",
             )
             return list(await mgr.list_devices())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_device_configs(ctx: GraphQLContext, controller: str, device_id: str) -> dict:
+    key = f"access/device-configs/{controller}/{device_id}"
+
+    async def _do() -> dict:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "access",
+                "device_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "access",
+            )
+            return await mgr.get_device_configs(device_id)
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -421,6 +443,12 @@ class AccessDevicePage:
     next_cursor: str | None
 
 
+@strawberry.type(description="A device's config/settings entries.")
+class AccessDeviceConfigPage:
+    items: list[AccessDeviceConfig]
+    next_cursor: str | None
+
+
 @strawberry.type(description="Paginated page of UniFi Access users.")
 class UserPage:
     items: list[User]
@@ -608,6 +636,26 @@ class AccessQuery:
             if _id_of(d) == id:
                 return AccessDevice.from_manager_output(d)
         return None
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description="List a device's config/settings entries (e.g. reader voice greeting). Secrets redacted.",
+    )
+    async def device_configs(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        device_id: strawberry.ID,
+    ) -> AccessDeviceConfigPage:
+        ctx: GraphQLContext = info.context
+        info_dict = await _fetch_device_configs(ctx, controller, device_id)
+        return AccessDeviceConfigPage(
+            items=[
+                AccessDeviceConfig.from_manager_output(c, redact_sensitive=ctx.redact_sensitive_fields)
+                for c in info_dict.get("configs", [])
+            ],
+            next_cursor=None,
+        )
 
     # ---- Users -----------------------------------------------------------
 

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -8,6 +8,24 @@ type AccessDevice {
   location: AccessLocation
 }
 
+"""
+A single per-device config/settings entry (key/value with category tag).
+"""
+type AccessDeviceConfig {
+  deviceId: ID
+  key: String
+  value: String
+  tag: String
+  updateTime: String
+  createTime: String
+}
+
+"""A device's config/settings entries."""
+type AccessDeviceConfigPage {
+  items: [AccessDeviceConfig!]!
+  nextCursor: String
+}
+
 """Paginated page of UniFi Access devices."""
 type AccessDevicePage {
   items: [AccessDevice!]!
@@ -76,6 +94,11 @@ type AccessQuery {
 
   """Look up a single Access device by id."""
   device(controller: ID!, id: ID!): AccessDevice
+
+  """
+  List a device's config/settings entries (e.g. reader voice greeting). Secrets redacted.
+  """
+  deviceConfigs(controller: ID!, deviceId: ID!): AccessDeviceConfigPage!
 
   """List Access users (employees / cardholders, paginated)."""
   users(controller: ID!, limit: Int! = 50, cursor: String = null): UserPage!

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -12,6 +12,9 @@ from unifi_api.graphql.type_registry import TypeRegistry
 from unifi_api.graphql.types.access.credentials import (
     Credential as AccessCredentialType,
 )
+from unifi_api.graphql.types.access.device_configs import (
+    AccessDeviceConfig as AccessDeviceConfigType,
+)
 from unifi_api.graphql.types.access.devices import (
     AccessDevice as AccessDeviceType,
 )
@@ -694,6 +697,7 @@ def build_type_registry() -> TypeRegistry:
     # access/devices (tool-keyed only)
     reg.register_tool_type("access_list_devices", AccessDeviceType, "list")
     reg.register_tool_type("access_get_device", AccessDeviceType, "detail")
+    reg.register_tool_type("access_get_device_configs", AccessDeviceConfigType, "list")
 
     # access/users
     reg.register_type("access", "users", AccessUserType)

--- a/apps/api/src/unifi_api/graphql/types/access/device_configs.py
+++ b/apps/api/src/unifi_api/graphql/types/access/device_configs.py
@@ -1,0 +1,69 @@
+"""Strawberry type for access/device configs.
+
+Projects a single per-device ``configs[]`` entry (the settings the Access web
+UI edits, e.g. the reader voice greeting) for ``access_get_device_configs``.
+
+Redaction: the secret rides in ``value`` while its name lives in ``key`` — so
+field-name redaction can't see it. ``from_manager_output`` redacts ``value``
+when the entry is credential-tagged or its key trips the shared secret
+vocabulary (:func:`is_sensitive_config`), and accepts ``redact_sensitive`` so
+the action endpoint's policy gate is honored.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+import strawberry
+from unifi_core.access.models.device_configs import is_sensitive_config
+from unifi_core.redaction import REDACTED
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return getattr(obj, key, default)
+
+
+@strawberry.type(description="A single per-device config/settings entry (key/value with category tag).")
+class AccessDeviceConfig:
+    """Mirrors the ``unifi_core`` ``DeviceConfigEntry`` model."""
+
+    device_id: strawberry.ID | None
+    key: str | None
+    value: str | None
+    tag: str | None
+    update_time: str | None
+    create_time: str | None
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "primary_key": "key",
+            "display_columns": ["key", "value", "tag"],
+        }
+
+    @classmethod
+    def from_manager_output(cls, obj: Any, *, redact_sensitive: bool = True) -> "AccessDeviceConfig":
+        key = _get(obj, "key")
+        tag = _get(obj, "tag")
+        value = _get(obj, "value")
+        if redact_sensitive and value is not None and is_sensitive_config(key, tag):
+            value = REDACTED
+        return cls(
+            device_id=_get(obj, "device_id"),
+            key=key,
+            value=value,
+            tag=tag,
+            update_time=_get(obj, "update_time"),
+            create_time=_get(obj, "create_time"),
+        )
+
+    def to_dict(self) -> dict:
+        out = asdict(self)
+        return {k: v for k, v in out.items() if not k.startswith("_") and not callable(v)}

--- a/apps/api/src/unifi_api/routes/resources/access/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/access/devices.py
@@ -133,3 +133,44 @@ async def get_access_device(
         "data": data,
         "render_hint": hint,
     }
+
+
+@router.get(
+    "/sites/{site_id}/access-devices/{device_id}/configs",
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["access/devices"],
+)
+async def get_device_configs(
+    request: Request,
+    site_id: str,
+    device_id: str,
+    controller=Depends(resolve_controller),
+) -> dict:
+    require_capability(controller, "access")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    try:
+        async with sm() as session:
+            mgr = await factory.get_domain_manager(
+                session,
+                controller.id,
+                "access",
+                "device_manager",
+            )
+            cm = await factory.get_connection_manager(session, controller.id, "access")
+            await _maybe_set_site(cm, site_id)
+            info = await mgr.get_device_configs(device_id)
+    except UniFiNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    redact_sensitive = request.app.state.config.policy.response.redact_sensitive_fields
+    type_registry = request.app.state.type_registry
+    type_class, kind = type_registry.lookup_tool("access_get_device_configs")
+    items_out = [
+        type_class.from_manager_output(c, redact_sensitive=redact_sensitive).to_dict() for c in info.get("configs", [])
+    ]
+    return {
+        "items": items_out,
+        "next_cursor": None,
+        "render_hint": type_class.render_hint(kind),
+    }

--- a/apps/api/src/unifi_api/serializers/access/devices.py
+++ b/apps/api/src/unifi_api/serializers/access/devices.py
@@ -6,9 +6,10 @@ The ``access_list_devices`` / ``access_get_device`` tools are listed in
 ``PHASE6_TYPE_MIGRATED_TOOLS`` and dispatched via the type_registry by
 both the REST routes and the action endpoint.
 
-This module now only ships ``AccessDeviceMutationAckSerializer`` for the
-``access_reboot_device`` preview-and-confirm tool, which still flows
-through the manager's preview path and produces a dict ack.
+This module ships ``AccessDeviceMutationAckSerializer`` for the
+``access_reboot_device`` and ``access_update_device_config`` preview-and-
+confirm tools, which flow through the manager's preview path and produce a
+dict ack.
 """
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
@@ -17,11 +18,13 @@ from unifi_api.serializers._base import RenderKind, Serializer, register_seriali
 @register_serializer(
     tools={
         "access_reboot_device": {"kind": RenderKind.DETAIL},
+        "access_update_device_config": {"kind": RenderKind.DETAIL},
     },
 )
 class AccessDeviceMutationAckSerializer(Serializer):
-    """DETAIL ack for ``access_reboot_device``. Preview/apply both return
-    dicts; pass through. Bool coerces to ``{"success": bool}``."""
+    """DETAIL ack for ``access_reboot_device`` / ``access_update_device_config``.
+    Preview/apply both return dicts; pass through. Bool coerces to
+    ``{"success": bool}``."""
 
     kind = RenderKind.DETAIL
 

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -120,6 +120,7 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     "access_create_credential": ("credential_manager", "apply_create_credential"),
     "access_revoke_credential": ("credential_manager", "apply_revoke_credential"),
     "access_reboot_device": ("device_manager", "apply_reboot_device"),
+    "access_update_device_config": ("device_manager", "apply_update_device_config"),
     "access_lock_door": ("door_manager", "apply_lock_door"),
     "access_unlock_door": ("door_manager", "apply_unlock_door"),
     "access_update_policy": ("policy_manager", "apply_update_policy"),

--- a/apps/api/tests/graphql/fixtures/access/test_devices.py
+++ b/apps/api/tests/graphql/fixtures/access/test_devices.py
@@ -2,6 +2,7 @@
 
 # tool: access_list_devices
 # tool: access_get_device
+# tool: access_get_device_configs
 """
 
 from __future__ import annotations
@@ -106,3 +107,70 @@ async def test_access_device_surfaces_structured_location(tmp_path, monkeypatch)
     assert loc["locationType"] == "door"
     assert loc["fullName"] == "Site - Floor 1 - Front Door"
     assert loc["level"] == 3
+
+
+@pytest.mark.asyncio
+async def test_access_device_configs_list_and_redaction(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    stub_managers(
+        monkeypatch,
+        {
+            ("access", "device_manager", "get_device_configs"): {
+                "device_id": "dev1",
+                "device_name": "Entry Reader",
+                "is_camera": True,
+                "configs": [
+                    {"device_id": "dev1", "key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+                    {"device_id": "dev1", "key": "ssh_password", "value": "s3cr3t", "tag": "credential"},
+                ],
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ deviceConfigs(controller: "{cid}", deviceId: "dev1") {{
+            items {{ key value tag }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    items = body["data"]["access"]["deviceConfigs"]["items"]
+    by_key = {it["key"]: it for it in items}
+    assert by_key["show_entry_greet"]["value"] == "yes"
+    # Credential-tagged config secrets must be redacted on the GraphQL surface too.
+    assert by_key["ssh_password"]["value"] == "***REDACTED***"
+
+
+@pytest.mark.asyncio
+async def test_access_device_configs_policy_disable_returns_raw(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access", redact_sensitive_fields=False)
+    stub_managers(
+        monkeypatch,
+        {
+            ("access", "device_manager", "get_device_configs"): {
+                "device_id": "dev1",
+                "device_name": "Entry Reader",
+                "is_camera": True,
+                "configs": [
+                    {"device_id": "dev1", "key": "ssh_password", "value": "s3cr3t", "tag": "credential"},
+                ],
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ deviceConfigs(controller: "{cid}", deviceId: "dev1") {{
+            items {{ key value }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    items = body["data"]["access"]["deviceConfigs"]["items"]
+    # Operator disabled redaction policy → raw secret surfaces (honors the override).
+    assert items[0]["value"] == "s3cr3t"

--- a/apps/api/tests/routes/resources/test_access_doors_policies.py
+++ b/apps/api/tests/routes/resources/test_access_doors_policies.py
@@ -15,22 +15,30 @@ from datetime import datetime, timezone
 import pytest
 from httpx import ASGITransport, AsyncClient
 from unifi_api.auth.api_key import generate_key, hash_key
-from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
+from unifi_api.config import (
+    ApiConfig,
+    DbConfig,
+    HttpConfig,
+    LoggingConfig,
+    PolicyConfig,
+    ResponsePolicyConfig,
+)
 from unifi_api.db.crypto import ColumnCipher, derive_key
 from unifi_api.db.models import ApiKey, Base, Controller
 from unifi_api.server import create_app
 
 
-def _cfg(tmp_path):
+def _cfg(tmp_path, *, redact_sensitive_fields: bool = True):
     return ApiConfig(
         http=HttpConfig(host="127.0.0.1", port=8080, cors_origins=()),
         logging=LoggingConfig(level="WARNING"),
         db=DbConfig(path=str(tmp_path / "state.db")),
+        policy=PolicyConfig(response=ResponsePolicyConfig(redact_sensitive_fields=redact_sensitive_fields)),
     )
 
 
-async def _bootstrap(tmp_path, products="access"):
-    app = create_app(_cfg(tmp_path))
+async def _bootstrap(tmp_path, products="access", *, redact_sensitive_fields: bool = True):
+    app = create_app(_cfg(tmp_path, redact_sensitive_fields=redact_sensitive_fields))
     async with app.state.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     sm = app.state.sessionmaker
@@ -381,6 +389,106 @@ async def test_get_access_device_404(tmp_path, monkeypatch) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(
             f"/v1/sites/default/access-devices/missing?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# access-devices/{id}/configs (nested) — access_get_device_configs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_device_configs_happy_path_and_redaction(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    info = {
+        "device_id": "dev-1",
+        "device_name": "Entry Reader",
+        "is_camera": True,
+        "configs": [
+            {"device_id": "dev-1", "key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+            {"device_id": "dev-1", "key": "ssh_password", "value": "s3cr3t", "tag": "credential"},
+        ],
+    }
+
+    async def fake_get_configs(self, device_id):
+        if device_id == "dev-1":
+            return info
+        from unifi_core.exceptions import UniFiNotFoundError
+
+        raise UniFiNotFoundError("device", device_id)
+
+    from unifi_core.access.managers.device_manager import DeviceManager
+
+    monkeypatch.setattr(DeviceManager, "get_device_configs", fake_get_configs)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access-devices/dev-1/configs?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["render_hint"]["kind"] == "list"
+    by_key = {it["key"]: it for it in body["items"]}
+    assert by_key["show_entry_greet"]["value"] == "yes"
+    assert by_key["ssh_password"]["value"] == "***REDACTED***"
+
+
+@pytest.mark.asyncio
+async def test_get_device_configs_policy_disabled_returns_raw(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, redact_sensitive_fields=False)
+    _stub_connection(app, cid)
+
+    info = {
+        "device_id": "dev-1",
+        "device_name": "Entry Reader",
+        "is_camera": True,
+        "configs": [
+            {"device_id": "dev-1", "key": "ssh_password", "value": "s3cr3t", "tag": "credential"},
+        ],
+    }
+
+    async def fake_get_configs(self, device_id):
+        return info
+
+    from unifi_core.access.managers.device_manager import DeviceManager
+
+    monkeypatch.setattr(DeviceManager, "get_device_configs", fake_get_configs)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access-devices/dev-1/configs?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+    assert r.status_code == 200, r.text
+    # Operator disabled the redaction policy → the REST surface returns the raw value.
+    assert r.json()["items"][0]["value"] == "s3cr3t"
+
+
+@pytest.mark.asyncio
+async def test_get_device_configs_404(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get_configs(self, device_id):
+        from unifi_core.exceptions import UniFiNotFoundError
+
+        raise UniFiNotFoundError("device", device_id)
+
+    from unifi_core.access.managers.device_manager import DeviceManager
+
+    monkeypatch.setattr(DeviceManager, "get_device_configs", fake_get_configs)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/access-devices/missing/configs?controller={cid}",
             headers={"Authorization": f"Bearer {key}"},
         )
     assert r.status_code == 404

--- a/packages/unifi-core/src/unifi_core/access/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/device_manager.py
@@ -17,6 +17,11 @@ import logging
 from typing import Any, Dict, List
 
 from unifi_core.access.managers.connection_manager import AccessConnectionManager
+from unifi_core.access.models.device_configs import (
+    build_config_write_body,
+    is_camera_device_id,
+    validate_config_updates,
+)
 from unifi_core.exceptions import UniFiConnectionError, UniFiNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -220,4 +225,114 @@ class DeviceManager:
             raise
         except Exception as e:
             logger.error("Failed to reboot device %s: %s", device_id, e, exc_info=True)
+            raise
+
+    # ------------------------------------------------------------------
+    # Device config (settings) read + update
+    # ------------------------------------------------------------------
+
+    async def get_device_configs(self, device_id: str) -> Dict[str, Any]:
+        """Return a device's ``configs[]`` settings array plus write metadata.
+
+        Settings live in the ``devices/topology4`` payload, so this is a
+        proxy-only read.  The returned dict is::
+
+            {"device_id", "device_name", "is_camera", "configs": [...]}
+
+        where ``configs`` is the raw controller list (secrets **not** yet
+        redacted — redaction is applied by the serving tool) and ``is_camera``
+        is the flag the config PUT requires (derived from the device id).
+
+        Raises :class:`UniFiNotFoundError` when the device is absent.
+        """
+        if not device_id:
+            raise ValueError("device_id is required")
+        if not self._cm.has_proxy:
+            raise UniFiConnectionError("No proxy session available for get_device_configs")
+        try:
+            data = await self._cm.proxy_request("GET", "devices/topology4")
+            topology = self._cm.extract_data(data)
+            devices = self._extract_devices_from_topology(topology)
+            for dev in devices:
+                if dev.get("unique_id") == device_id or dev.get("mac") == device_id:
+                    resolved_id = dev.get("unique_id") or device_id
+                    return {
+                        "device_id": resolved_id,
+                        "device_name": dev.get("name") or dev.get("alias"),
+                        "is_camera": is_camera_device_id(resolved_id),
+                        "configs": dev.get("configs") or [],
+                    }
+            raise UniFiNotFoundError("device", device_id)
+        except (UniFiConnectionError, UniFiNotFoundError, ValueError):
+            raise
+        except Exception as e:
+            logger.error("Failed to get device configs %s: %s", device_id, e, exc_info=True)
+            raise
+
+    @staticmethod
+    def _current_by_key(configs: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        return {c.get("key"): c for c in configs if isinstance(c, dict) and c.get("key")}
+
+    async def update_device_config(self, device_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+        """Preview a device-config update. Returns preview data for confirmation.
+
+        Fetches the device's live configs, validates every key against them
+        (unknown or credential/secret keys are rejected), and returns the
+        current-vs-proposed delta for the keys being changed.
+        """
+        if not device_id:
+            raise ValueError("device_id is required")
+
+        info = await self.get_device_configs(device_id)
+        current_by_key = self._current_by_key(info["configs"])
+        ok, err = validate_config_updates(updates, current_by_key)
+        if not ok:
+            raise ValueError(err)
+
+        return {
+            "device_id": info["device_id"],
+            "device_name": info["device_name"],
+            "current_state": {k: (current_by_key[k] or {}).get("value") for k in updates},
+            "proposed_changes": {k: str(v) for k, v in updates.items()},
+        }
+
+    async def apply_update_device_config(
+        self, device_id: str, updates: Dict[str, Any], is_camera: bool | None = None
+    ) -> Dict[str, Any]:
+        """Execute a device-config update on the controller.
+
+        Re-fetches the live configs (so the tag lookup and validation reflect
+        current state), builds the ``[{key, tag, value}]`` PUT body, and writes
+        it via ``PUT device/{id}/configs?is_camera=<bool>``. ``is_camera`` is
+        derived from the device id unless the caller pins it.
+        """
+        if not device_id:
+            raise ValueError("device_id is required")
+
+        info = await self.get_device_configs(device_id)
+        current_by_key = self._current_by_key(info["configs"])
+        ok, err = validate_config_updates(updates, current_by_key)
+        if not ok:
+            raise ValueError(err)
+
+        body = build_config_write_body(updates, current_by_key)
+        cam = info["is_camera"] if is_camera is None else bool(is_camera)
+        try:
+            await self._cm.proxy_request(
+                "PUT",
+                f"device/{info['device_id']}/configs",
+                params={"is_camera": "true" if cam else "false"},
+                json=body,
+            )
+            return {
+                "device_id": info["device_id"],
+                "action": "update_config",
+                "result": "success",
+                "updated_keys": list(updates.keys()),
+                "is_camera": cam,
+            }
+        except UniFiConnectionError:
+            raise
+        except Exception as e:
+            logger.error("Failed to update device config %s: %s", device_id, e, exc_info=True)
             raise

--- a/packages/unifi-core/src/unifi_core/access/models/device_configs.py
+++ b/packages/unifi-core/src/unifi_core/access/models/device_configs.py
@@ -1,0 +1,201 @@
+"""Domain model + boundary helpers for Access device configs.
+
+A UniFi Access device carries a ``configs[]`` array in the controller's
+``devices/topology4`` response — the per-device settings the Access web UI
+edits (voice greeting, sounds, display, wiring, etc.). Each entry is a
+``{device_id, key, value, tag, update_time, create_time}`` record.
+
+``DeviceConfigEntry`` mirrors the Strawberry type in
+``unifi_api.graphql.types.access.device_configs``.
+
+The domain model is lossless — it carries ``value`` verbatim, including
+secrets. Redaction is a response-boundary concern applied by the serving
+surface via :func:`redact_config_entries` (mirrors the Credential model).
+
+Write helpers (:func:`validate_config_updates`, :func:`build_config_write_body`)
+back ``access_update_device_config``: the caller supplies ``{key: value}``
+pairs, keys are validated against the device's *live* configs, and each
+entry's ``tag`` is looked up from that live config — so callers never guess a
+tag and cannot introduce keys the device does not already expose. Credential-
+and secret-named keys are refused: this tool edits device settings, not
+secrets.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from unifi_core.redaction import REDACTED, is_sensitive_key
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Config entries tagged as credentials carry live secrets (ssh_password,
+#: nacl_private_key, ...) and are never exposed or written.
+CREDENTIAL_TAG = "credential"
+
+#: Camera-class Access readers (e.g. the G6 Pro Entry) carry a 24-hex
+#: Protect-style device id and require ``is_camera=true`` on the config PUT;
+#: hubs use a MAC-style id and require ``is_camera=false``.
+_PROTECT_STYLE_ID_RE = re.compile(r"^[0-9a-fA-F]{24}$")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic domain model
+# ---------------------------------------------------------------------------
+
+
+class DeviceConfigEntry(BaseModel):
+    """A single per-device config key/value entry (read-only projection)."""
+
+    device_id: Optional[str] = Field(default=None, description="Owning device UUID")
+    key: Optional[str] = Field(default=None, description="Config key name")
+    value: Optional[str] = Field(default=None, description="Config value (redacted at egress when sensitive)")
+    tag: Optional[str] = Field(
+        default=None,
+        description="Config category (device_setting, device_extra, hub_action, hub_power, wiring_state, credential)",
+    )
+    update_time: Optional[str] = Field(default=None, description="Last-update timestamp (ISO 8601 string)")
+    create_time: Optional[str] = Field(default=None, description="Creation timestamp (ISO 8601 string)")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+# ---------------------------------------------------------------------------
+# Public factory + boundary helpers
+# ---------------------------------------------------------------------------
+
+
+def from_controller(raw: Any) -> DeviceConfigEntry:
+    """Build a :class:`DeviceConfigEntry` from a manager dict or object.
+
+    Lossless — the raw ``value`` (secret or not) is carried through. Redaction
+    is applied later by :func:`redact_config_entries` at the serving boundary.
+    """
+    return DeviceConfigEntry(
+        device_id=_get(raw, "device_id"),
+        key=_get(raw, "key"),
+        value=_get(raw, "value"),
+        tag=_get(raw, "tag"),
+        update_time=_get(raw, "update_time"),
+        create_time=_get(raw, "create_time"),
+    )
+
+
+def is_sensitive_config(key: Any, tag: Any) -> bool:
+    """Return true when a config entry carries secret material.
+
+    An entry is sensitive when the controller tags it ``credential`` OR when
+    its key name trips the shared secret vocabulary (:func:`is_sensitive_key`).
+    Routing key-name detection through the shared helper keeps the decision
+    consistent with the rest of the redaction surface.
+    """
+    if tag == CREDENTIAL_TAG:
+        return True
+    return is_sensitive_key(key)
+
+
+def redact_config_entries(entries: List[Dict[str, Any]], *, redact_sensitive: bool = True) -> List[Dict[str, Any]]:
+    """Return a copy of ``entries`` with sensitive ``value`` fields redacted.
+
+    Each entry is a dict carrying ``key``/``value``/``tag``. A ``value`` is
+    replaced with the redaction marker when the entry is sensitive (see
+    :func:`is_sensitive_config`) and the value is present. ``None`` values are
+    left as-is (nothing to hide). The input list is not mutated.
+    """
+    out: List[Dict[str, Any]] = []
+    for entry in entries:
+        projected = dict(entry)
+        if (
+            redact_sensitive
+            and projected.get("value") is not None
+            and is_sensitive_config(projected.get("key"), projected.get("tag"))
+        ):
+            projected["value"] = REDACTED
+        out.append(projected)
+    return out
+
+
+def is_camera_device_id(device_id: Any) -> bool:
+    """Return true for camera-class readers (24-hex Protect-style device id).
+
+    Verified against current firmware: the config PUT requires
+    ``is_camera=true`` for camera-class readers (e.g. the G6 Pro Entry, whose
+    device id is a 24-hex Protect-style string) and ``is_camera=false`` for
+    hubs (MAC-style id). Used as the default when the caller does not pin
+    ``is_camera`` explicitly.
+    """
+    if not isinstance(device_id, str):
+        return False
+    return bool(_PROTECT_STYLE_ID_RE.match(device_id))
+
+
+def validate_config_updates(
+    updates: Dict[str, Any], current_by_key: Dict[str, Dict[str, Any]]
+) -> Tuple[bool, Optional[str]]:
+    """Validate a ``{key: value}`` update against the device's live configs.
+
+    Rules:
+      * ``updates`` must be non-empty.
+      * every key must already exist in ``current_by_key`` (no novel keys).
+      * credential-tagged or secret-named keys are refused (this tool edits
+        device settings, not secrets).
+
+    Returns ``(True, None)`` when valid, else ``(False, message)``.
+    """
+    if not updates:
+        return False, "No config updates supplied."
+
+    writable = sorted(k for k, e in current_by_key.items() if not is_sensitive_config(k, (e or {}).get("tag")))
+
+    unknown = [k for k in updates if k not in current_by_key]
+    if unknown:
+        return (
+            False,
+            f"Unknown config key(s): {sorted(unknown)}. Writable keys on this device: {writable}",
+        )
+
+    protected = [k for k in updates if is_sensitive_config(k, (current_by_key[k] or {}).get("tag"))]
+    if protected:
+        return (
+            False,
+            f"Refusing to write credential/secret config key(s): {sorted(protected)}.",
+        )
+
+    return True, None
+
+
+def build_config_write_body(updates: Dict[str, Any], current_by_key: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Build the controller PUT body: a list of ``{key, tag, value}`` entries.
+
+    The ``tag`` for each key is taken from the device's live config so the
+    caller never has to supply it. Values are coerced to strings (the
+    controller stores config values as strings). Assumes ``updates`` has
+    already passed :func:`validate_config_updates`.
+
+    The body contains ONLY the changed keys — this is an upsert, not a
+    full-collection replace. Verified against current firmware: the Access web
+    UI itself PUTs partial ``configs`` arrays for a single-setting change (e.g.
+    a lone ``[{greeting_text, hello}]``), and unlisted entries — including the
+    device's ``credential``-tagged connectivity secrets — are preserved. This
+    is deliberately NOT a fetch-merge-put of the whole array: echoing every
+    entry back would re-send those credential secrets to the controller, which
+    the read/write redaction+refusal design exists to avoid.
+    """
+    return [
+        {"key": key, "tag": (current_by_key[key] or {}).get("tag"), "value": str(value)}
+        for key, value in updates.items()
+    ]

--- a/packages/unifi-core/tests/access/models/test_device_configs.py
+++ b/packages/unifi-core/tests/access/models/test_device_configs.py
@@ -1,0 +1,217 @@
+"""Unit tests for the Access device-config read/update domain helpers."""
+
+from __future__ import annotations
+
+from unifi_core.access.models.device_configs import (
+    build_config_write_body,
+    from_controller,
+    is_camera_device_id,
+    is_sensitive_config,
+    redact_config_entries,
+    validate_config_updates,
+)
+from unifi_core.redaction import REDACTED
+
+
+class TestFromController:
+    def test_full_dict(self) -> None:
+        # The controller returns update_time/create_time as ISO 8601 strings,
+        # not epoch ints (verified live against a UNVR).
+        raw = {
+            "device_id": "dev-1",
+            "key": "show_entry_greet",
+            "value": "yes",
+            "tag": "device_setting",
+            "update_time": "2026-04-03T12:17:26-07:00",
+            "create_time": "2026-04-01T09:00:00-07:00",
+        }
+        entry = from_controller(raw)
+        assert entry.device_id == "dev-1"
+        assert entry.key == "show_entry_greet"
+        assert entry.value == "yes"
+        assert entry.tag == "device_setting"
+        assert entry.update_time == "2026-04-03T12:17:26-07:00"
+        assert entry.create_time == "2026-04-01T09:00:00-07:00"
+
+    def test_iso_string_timestamps_do_not_raise(self) -> None:
+        # Regression: the controller sends ISO-8601 timestamp strings; the model
+        # must carry them verbatim, not reject them as non-int (bug caught by
+        # live MCP QA — apps/api masked it because Strawberry assigns loosely).
+        entry = from_controller({"key": "k", "update_time": "2026-04-03T12:17:26-07:00"})
+        assert entry.update_time == "2026-04-03T12:17:26-07:00"
+
+    def test_handles_empty_dict(self) -> None:
+        entry = from_controller({})
+        assert entry.key is None
+        assert entry.value is None
+        assert entry.tag is None
+
+    def test_handles_partial_dict(self) -> None:
+        entry = from_controller({"key": "greeting_text", "value": "welcome"})
+        assert entry.key == "greeting_text"
+        assert entry.value == "welcome"
+        assert entry.tag is None
+
+    def test_accepts_object_with_attributes(self) -> None:
+        class Obj:
+            device_id = "dev-2"
+            key = "greeting_broadcast_name"
+            value = "first_name_only"
+            tag = "device_setting"
+            update_time = None
+            create_time = None
+
+        entry = from_controller(Obj())
+        assert entry.device_id == "dev-2"
+        assert entry.key == "greeting_broadcast_name"
+        assert entry.value == "first_name_only"
+
+    def test_carries_secret_value_verbatim(self) -> None:
+        # The domain model is lossless: redaction is a response-boundary concern,
+        # not the model's job (mirrors the Credential model).
+        entry = from_controller({"key": "ssh_password", "value": "hunter2", "tag": "credential"})
+        assert entry.value == "hunter2"
+
+
+class TestIsSensitiveConfig:
+    def test_credential_tag_is_sensitive_regardless_of_key(self) -> None:
+        assert is_sensitive_config("some_opaque_key", "credential") is True
+
+    def test_sensitive_key_name_is_sensitive_even_without_credential_tag(self) -> None:
+        # ssh_password carries "password" segment; nacl_private_key carries the
+        # private-key qualifier — both must trip is_sensitive_key.
+        assert is_sensitive_config("ssh_password", "device_setting") is True
+        assert is_sensitive_config("nacl_private_key", "device_extra") is True
+
+    def test_ordinary_device_setting_is_not_sensitive(self) -> None:
+        assert is_sensitive_config("show_entry_greet", "device_setting") is False
+        assert is_sensitive_config("greeting_text", "device_setting") is False
+
+    def test_none_key_and_tag(self) -> None:
+        assert is_sensitive_config(None, None) is False
+
+
+class TestRedactConfigEntries:
+    def _entries(self) -> list[dict]:
+        return [
+            {"device_id": "d1", "key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+            {"device_id": "d1", "key": "ssh_password", "value": "hunter2", "tag": "credential"},
+            {"device_id": "d1", "key": "nacl_private_key", "value": "AbCd==", "tag": "device_extra"},
+        ]
+
+    def test_redacts_credential_tagged_value(self) -> None:
+        out = redact_config_entries(self._entries(), redact_sensitive=True)
+        cred = next(e for e in out if e["key"] == "ssh_password")
+        assert cred["value"] == REDACTED
+
+    def test_redacts_sensitive_key_value_even_without_credential_tag(self) -> None:
+        out = redact_config_entries(self._entries(), redact_sensitive=True)
+        priv = next(e for e in out if e["key"] == "nacl_private_key")
+        assert priv["value"] == REDACTED
+
+    def test_leaves_ordinary_value_untouched(self) -> None:
+        out = redact_config_entries(self._entries(), redact_sensitive=True)
+        greet = next(e for e in out if e["key"] == "show_entry_greet")
+        assert greet["value"] == "yes"
+
+    def test_preserves_non_value_fields(self) -> None:
+        out = redact_config_entries(self._entries(), redact_sensitive=True)
+        cred = next(e for e in out if e["key"] == "ssh_password")
+        assert cred["device_id"] == "d1"
+        assert cred["tag"] == "credential"
+        assert cred["key"] == "ssh_password"
+
+    def test_redact_disabled_returns_values_unchanged(self) -> None:
+        out = redact_config_entries(self._entries(), redact_sensitive=False)
+        cred = next(e for e in out if e["key"] == "ssh_password")
+        assert cred["value"] == "hunter2"
+
+    def test_none_value_is_not_replaced_with_marker(self) -> None:
+        out = redact_config_entries(
+            [{"device_id": "d1", "key": "ssh_password", "value": None, "tag": "credential"}],
+            redact_sensitive=True,
+        )
+        assert out[0]["value"] is None
+
+    def test_does_not_mutate_input(self) -> None:
+        entries = self._entries()
+        redact_config_entries(entries, redact_sensitive=True)
+        cred = next(e for e in entries if e["key"] == "ssh_password")
+        assert cred["value"] == "hunter2"
+
+
+class TestIsCameraDeviceId:
+    def test_protect_style_24_hex_is_camera(self) -> None:
+        # G6 Pro Entry / camera-class readers carry a 24-hex Protect-style id.
+        assert is_camera_device_id("a1b2c3d4e5f607182930abcd") is True
+
+    def test_mac_style_12_hex_is_not_camera(self) -> None:
+        # Hubs use a MAC-style (12-hex) id.
+        assert is_camera_device_id("aabbccddeeff") is False
+
+    def test_mac_with_colons_is_not_camera(self) -> None:
+        assert is_camera_device_id("1C:0B:8B:EE:F6:B5") is False
+
+    def test_empty_or_none_is_not_camera(self) -> None:
+        assert is_camera_device_id("") is False
+        assert is_camera_device_id(None) is False
+
+
+class TestValidateConfigUpdates:
+    def _current(self) -> dict:
+        return {
+            "show_entry_greet": {"key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+            "greeting_text": {"key": "greeting_text", "value": "welcome", "tag": "device_setting"},
+            "ssh_password": {"key": "ssh_password", "value": "hunter2", "tag": "credential"},
+        }
+
+    def test_valid_update_passes(self) -> None:
+        ok, err = validate_config_updates({"show_entry_greet": "no"}, self._current())
+        assert ok is True
+        assert err is None
+
+    def test_empty_updates_rejected(self) -> None:
+        ok, err = validate_config_updates({}, self._current())
+        assert ok is False
+        assert err
+
+    def test_unknown_key_rejected_and_lists_allowed(self) -> None:
+        ok, err = validate_config_updates({"not_a_real_key": "x"}, self._current())
+        assert ok is False
+        assert "not_a_real_key" in err
+        # error should surface the legitimately-writable keys
+        assert "show_entry_greet" in err
+
+    def test_credential_tagged_key_rejected(self) -> None:
+        ok, err = validate_config_updates({"ssh_password": "newpass"}, self._current())
+        assert ok is False
+        assert "ssh_password" in err
+
+    def test_sensitive_key_name_rejected(self) -> None:
+        current = {"api_token": {"key": "api_token", "value": "t", "tag": "device_setting"}}
+        ok, err = validate_config_updates({"api_token": "new"}, current)
+        assert ok is False
+        assert "api_token" in err
+
+
+class TestBuildConfigWriteBody:
+    def _current(self) -> dict:
+        return {
+            "show_entry_greet": {"key": "show_entry_greet", "value": "yes", "tag": "device_setting"},
+            "greeting_text": {"key": "greeting_text", "value": "welcome", "tag": "device_setting"},
+        }
+
+    def test_builds_key_tag_value_array(self) -> None:
+        body = build_config_write_body({"show_entry_greet": "no"}, self._current())
+        assert body == [{"key": "show_entry_greet", "tag": "device_setting", "value": "no"}]
+
+    def test_coerces_value_to_string(self) -> None:
+        body = build_config_write_body({"show_entry_greet": False}, self._current())
+        assert body[0]["value"] == "False"
+
+    def test_partial_update_single_entry(self) -> None:
+        body = build_config_write_body({"greeting_text": "hello"}, self._current())
+        assert len(body) == 1
+        assert body[0]["key"] == "greeting_text"
+        assert body[0]["tag"] == "device_setting"
+        assert body[0]["value"] == "hello"

--- a/plugins/unifi-access/skills/unifi-access/references/access-tools.md
+++ b/plugins/unifi-access/skills/unifi-access/references/access-tools.md
@@ -1,4 +1,4 @@
-# Access Server Tool Reference (34 tools)
+# Access Server Tool Reference (36 tools)
 
 Complete reference for `access_*` tools. All read tools are always available. All mutations are **disabled by default** — the user must explicitly enable them because Access controls physical door locks and building entry.
 
@@ -154,13 +154,15 @@ Always available, regardless of registration mode.
 ## Devices
 
 <!-- AUTO:tools:devices -->
-3 tools.
+5 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
 | `access_get_device` | Read | Returns detailed information for a single Access device including name, type, connection state, firmware version, MAC, and IP address. |
+| `access_get_device_configs` | Read | Returns a device's settings (its configs[] array) — the per-device settings the Access web UI edits, such as the reader voice greeting. |
 | `access_list_devices` | Read | Lists all Access hardware devices (hubs, readers, relays, intercoms) with their name, type, connection state, and firmware version. |
 | `access_reboot_device` | Mutate | Reboot an Access hardware device (hub, reader, relay, intercom). |
+| `access_update_device_config` | Mutate | Update a device's settings (its configs[] entries), e.g. |
 <!-- /AUTO:tools:devices -->
 
 **Tips:**


### PR DESCRIPTION
## Summary

Exposes a UniFi Access device's `configs[]` settings — the per-device settings the Access web UI edits (voice greeting, sounds, display, etc.) — which no tool surfaced before. Two new tools, wired through MCP, GraphQL, and REST:

- **`access_get_device_configs`** (read) — returns a device's config entries (`{key, value, tag}`). Credential-tagged and secret-named values are redacted at every egress (MCP tool, GraphQL type, REST route).
- **`access_update_device_config`** (preview/confirm write) — set config keys the device already exposes. Keys are validated against the device's live `configs[]`, each entry's `tag` is looked up from that live config, and credential/secret keys are refused. Writes `PUT device/{id}/configs?is_camera=<bool>` with a partial `{key, tag, value}` array (upsert).

Resolves #419 (opened first, per CONTRIBUTING).

## Layers

- **unifi-core**: `DeviceConfigEntry` model + redaction/validation/`is_camera` helpers; `DeviceManager.get_device_configs` / `update_device_config` / `apply_update_device_config`.
- **apps/access**: the two MCP tools (proxy-only); redaction gated by the response policy.
- **apps/api**: `AccessDeviceConfig` Strawberry type + `deviceConfigs` resolver, `GET /v1/sites/{site}/access-devices/{id}/configs` REST route, serializer + action dispatch, with the redaction policy threaded through both read surfaces. Regenerated `schema.graphql`, `openapi.json`, reference docs, and tool manifests.

## Testing

- Unit: full suites green (`unifi-core` + `apps/access` + `apps/api`), including the multi-surface projection + redaction contract gates.
- Live-verified against a real UNVR (current firmware) on **all three surfaces** — the read returns the device's configs with credential/secret values redacted on MCP, REST, and GraphQL; the write round-trip (`show_entry_greet` yes→no→yes) was confirmed via the action endpoint.

## Notes

- The internal v2 API uses `PUT /proxy/access/api/v2/device/{id}/configs?is_camera=<bool>`; the `?is_camera` query param is the discriminator for camera-class readers vs hubs on current firmware (this differs from the `/configs` vs `/settings` split described by the reverse-engineered `hjdhjd/unifi-access` lib — the `?is_camera` param is what the current web UI uses).
- `is_camera` is auto-derived from the device id (camera-class readers carry a 24-hex Protect-style id), with an explicit override parameter.
