### PR TITLE
chore(release): require unifi-core 0.4.15 downstream

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.14,<0.5",
+    "unifi-core[network,protect,access]>=0.4.15,<0.5",
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.50.2",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "unifi-mcp-shared>=0.6.3,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.14,<0.5",
+    "unifi-core[protect]>=0.4.15,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary
- bump Protect package metadata to require `unifi-core[protect]>=0.4.15,<0.5`
- bump API package metadata to require `unifi-core[network,protect,access]>=0.4.15,<0.5`

## Verification
- `uv lock --check`
- `uv run python scripts/check_pin_alignment.py`

## Context
- follows `core/v0.4.15`, which published the shared Protect capability models used by the merged Protect/API work in #433
