### PR TITLE
ci(worker): use configured npm for release publish

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install worker dependencies
         run: npm ci --prefix apps/worker/worker
       - name: Publish package
-        run: npx npm@latest publish --provenance --access public
+        run: npm publish --provenance --access public
         working-directory: apps/worker
       - name: Publish summary
         env:


### PR DESCRIPTION
## Summary
- use the npm installed by `actions/setup-node` for Worker release publishing
- avoid resolving `npm@latest` during the publish step, which failed on `worker/v1.3.7` with an internal missing `sigstore` module

## Verification
- `git diff --check`

## Release note
- `worker/v1.3.7` tag exists but npm publish failed before GitHub Release/version sync; after this lands, release Worker as `worker/v1.3.8`.
