### PR TITLE
ci(worker): pin npm 11 for release publish

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -114,7 +114,9 @@ jobs:
       - name: Install worker dependencies
         run: npm ci --prefix apps/worker/worker
       - name: Publish package
-        run: npm publish --provenance --access public
+        # npm 12.0.0 broke provenance publish in this workflow; keep this pinned
+        # until a newer npm version is proven in a Worker release.
+        run: npx npm@11.18.0 publish --provenance --access public
         working-directory: apps/worker
       - name: Publish summary
         env:


### PR DESCRIPTION
## Summary
- pin Worker release publishing to `npm@11.18.0`
- document why the publish step must not float to npm 12 yet

## Why
- `worker/v1.3.7` failed because `npm@latest` resolved to npm 12.0.0 and crashed loading `sigstore`
- `worker/v1.3.8` got past provenance with the default npm but npm rejected the package PUT with E404
- the last successful release, `worker/v1.3.6`, used `npm@11.18.0` for the same provenance publish flow

## Verification
- `git diff --check`

## Release note
- after this lands, retry Worker as `worker/v1.3.9`; npm currently remains at `unifi-mcp-worker@1.3.6`.
