### PR TITLE
chore(deps): align issue 421 release floors

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -5,11 +5,11 @@ description = "UniFi Access MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.3,<0.7",
+    "unifi-mcp-shared>=0.6.5,<0.7",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.
-    "unifi-core[access]>=0.4.14,<0.5",
+    "unifi-core[access]>=0.4.17,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.15,<0.5",
+    "unifi-core[network,protect,access]>=0.4.17,<0.5",
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -5,11 +5,11 @@ description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.3,<0.7",
+    "unifi-mcp-shared>=0.6.5,<0.7",
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.16,<0.5",
+    "unifi-core[network]>=0.4.17,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -5,10 +5,10 @@ description = "UniFi Protect MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.3,<0.7",
+    "unifi-mcp-shared>=0.6.5,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.15,<0.5",
+    "unifi-core[protect]>=0.4.17,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "python-dotenv>=1.2.2",
-    "unifi-mcp-shared>=0.6.3,<0.7",
+    "unifi-mcp-shared>=0.6.5,<0.7",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Require `unifi-core>=0.4.17` for the Network, Protect, Access, and API packages.
- Require `unifi-mcp-shared>=0.6.5` for Network, Protect, Access, and Relay.
- Prevent fresh installs from resolving older published dependencies that do not contain the response-serialization APIs introduced by #441.

## Why

The issue #421 implementation added new imports from `unifi-mcp-shared`, but the original PR did not change `pyproject.toml`, so the pin-alignment CI gate was not triggered. A clean wheel installation reproduced import failures when the downstream packages resolved the previous minimum Shared version.

Core 0.4.17 and Shared 0.6.5 are now published. This follow-up aligns downstream wheel metadata before their release tags are created.

## Validation

- `uv run python scripts/check_pin_alignment.py` — all five downstream wheels install and import cleanly from their declared bounds.
- `make pre-commit` — passed.
- `uv lock --check` — passed with no lockfile change required.

Follow-up to #441 and #421.
