### PR TITLE
fix(protect): send full automations POST body on legacy alarm rule create

### DIFF
--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
@@ -27,6 +27,7 @@ from unifi_core.protect.models.alarm_rules import (
     alarm_rule_from_controller,
     alarm_rule_from_legacy,
     alarm_rule_to_legacy_body,
+    alarm_rule_to_legacy_create_body,
     alarm_rule_to_v2_body,
 )
 
@@ -88,7 +89,7 @@ class AlarmRulesFacade:
             raw = await self._service.create_rule(body)
             return alarm_rule_from_controller(raw).model_dump(exclude_none=True), True
 
-        body = alarm_rule_to_legacy_body(fields)
+        body = alarm_rule_to_legacy_create_body(fields)
         raw = await self._legacy.create_rule(body)
         return alarm_rule_from_legacy(raw).model_dump(exclude_none=True), False
 

--- a/packages/unifi-core/src/unifi_core/protect/models/alarm_rules.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/alarm_rules.py
@@ -245,6 +245,37 @@ def alarm_rule_to_legacy_body(fields: dict[str, Any]) -> dict[str, Any]:
     return body
 
 
+def alarm_rule_to_legacy_create_body(fields: dict[str, Any]) -> dict[str, Any]:
+    """Serialize canonical write fields to a COMPLETE legacy automations POST body.
+
+    ``POST /proxy/protect/api/automations`` rejects an incomplete body with
+    400 "Failed to parse 'request-body'". :func:`alarm_rule_to_legacy_body`
+    emits only the write subset the canonical shape can express
+    (``name``/``enable``/``sources``/``conditions``/``actions``); create must
+    additionally supply the structural fields the controller requires but the
+    canonical shape has no field for — ``isCreatedBySystem``,
+    ``historyConditions``, ``schedules``, and ``cooldown``. Their defaults match
+    the reference implementation (Hovborg/unifi-protect-bridge
+    ``automation_payloads.py``) and a live Protect 7.0 rule.
+
+    Update does NOT use this: it read-modify-writes the full existing rule, so
+    the structural fields are already present and ``alarm_rule_to_legacy_body``
+    stays sparse for that merge.
+    """
+    body: dict[str, Any] = {
+        "enable": True,  # a newly-created rule defaults to enabled
+        "isCreatedBySystem": False,
+        "sources": [],
+        "conditions": [],
+        "historyConditions": [],
+        "schedules": [],
+        "actions": [],
+        "cooldown": {"enable": False, "timeout": 600000},
+    }
+    body.update(alarm_rule_to_legacy_body(fields))
+    return body
+
+
 ALARM_RULE_MUTABLE_FIELDS: frozenset[str] = frozenset()
 ALARM_RULE_READ_ONLY_FIELDS: frozenset[str] = frozenset(AlarmRule.model_fields.keys())
 # Alias required by the model-symmetry test harness — read-only model pattern.

--- a/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
@@ -303,7 +303,7 @@ async def test_create_rule_falls_back_to_legacy_when_v2_write_unavailable():
     facade._legacy.create_rule.assert_awaited_once()
 
 
-# --- issue #2: legacy create must POST the full raw envelope ------------------
+# --- Legacy create must POST the full raw envelope ----------------------------
 
 
 @pytest.mark.asyncio

--- a/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
@@ -303,6 +303,59 @@ async def test_create_rule_falls_back_to_legacy_when_v2_write_unavailable():
     facade._legacy.create_rule.assert_awaited_once()
 
 
+# --- issue #2: legacy create must POST the full raw envelope ------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rule_legacy_sends_complete_raw_body():
+    """The legacy POST body must carry the full structural envelope, not just the
+    sparse write subset. The canonical shape can't express historyConditions /
+    schedules / cooldown / isCreatedBySystem, so create scaffolds them — omitting
+    them makes Protect reject the POST with 400 'Failed to parse request-body'."""
+    facade = _facade(service_list=[])  # v2 empty -> route to legacy
+
+    await facade.create_rule(
+        {
+            "title": "New",
+            "enabled": True,
+            "triggers": [{"data": {"condition": {"type": "is", "source": "smartDetectLine", "value": "Arrival"}}}],
+            "actions": [{"action_id": "HTTP_REQUEST", "data": {"type": "HTTP_REQUEST", "metadata": {}, "order": -1}}],
+            "scope": {"sources": [{"device": "AABBCCDDEEFF", "type": "include"}]},
+        }
+    )
+
+    facade._legacy.create_rule.assert_awaited_once()
+    (body,) = facade._legacy.create_rule.await_args.args
+    assert body["name"] == "New"
+    assert body["conditions"] == [{"condition": {"type": "is", "source": "smartDetectLine", "value": "Arrival"}}]
+    assert body["isCreatedBySystem"] is False
+    assert body["historyConditions"] == []
+    assert body["schedules"] == []
+    assert body["cooldown"] == {"enable": False, "timeout": 600000}
+
+
+@pytest.mark.asyncio
+async def test_create_rule_legacy_preserves_license_plate_known_value():
+    """An LPR trigger (license_plate_known + plate-group value) must reach the
+    controller intact through create — the raw API keys off the value."""
+    facade = _facade(service_list=[])
+
+    await facade.create_rule(
+        {
+            "title": "Vehicle Arrival",
+            "triggers": [
+                {"data": {"condition": {"type": "is", "source": "license_plate_known", "value": "plate-group-123"}}}
+            ],
+            "actions": [{"action_id": "HTTP_REQUEST", "data": {"type": "HTTP_REQUEST", "metadata": {}, "order": -1}}],
+        }
+    )
+
+    (body,) = facade._legacy.create_rule.await_args.args
+    condition = body["conditions"][0]["condition"]
+    assert condition["source"] == "license_plate_known"
+    assert condition["value"] == "plate-group-123"
+
+
 # --- Bug 1: legacy ids with a `_new` suffix must route, not be rejected --------
 
 

--- a/packages/unifi-core/tests/protect/models/test_alarm_rules.py
+++ b/packages/unifi-core/tests/protect/models/test_alarm_rules.py
@@ -112,7 +112,7 @@ def test_canonical_rule_enabled_defaults_none_for_v2():
     assert rule.enabled is None
 
 
-# --- alarm_rule_to_legacy_create_body: full POST envelope (issue #2) ----------
+# --- alarm_rule_to_legacy_create_body: full POST envelope ---------------------
 #
 # The canonical write shape carries only title/enabled/triggers/actions/scope,
 # but POST /proxy/protect/api/automations rejects an incomplete body with

--- a/packages/unifi-core/tests/protect/models/test_alarm_rules.py
+++ b/packages/unifi-core/tests/protect/models/test_alarm_rules.py
@@ -110,3 +110,107 @@ def test_alarm_rule_from_legacy_maps_to_canonical():
 def test_canonical_rule_enabled_defaults_none_for_v2():
     rule = alarm_rule_from_controller(_RAW_RULE)
     assert rule.enabled is None
+
+
+# --- alarm_rule_to_legacy_create_body: full POST envelope (issue #2) ----------
+#
+# The canonical write shape carries only title/enabled/triggers/actions/scope,
+# but POST /proxy/protect/api/automations rejects an incomplete body with
+# 400 "Failed to parse 'request-body'". Create must scaffold the structural
+# fields the controller requires that the canonical shape can't express
+# (isCreatedBySystem, historyConditions, schedules, cooldown). Verified against
+# Hovborg/unifi-protect-bridge automation_payloads.py and the AlarmManager
+# raw-rule fixture. Update does NOT use this — it deep-merges onto the full
+# existing rule, so alarm_rule_to_legacy_body stays sparse.
+
+
+def test_legacy_create_body_scaffolds_full_envelope():
+    from unifi_core.protect.models.alarm_rules import alarm_rule_to_legacy_create_body
+
+    body = alarm_rule_to_legacy_create_body(
+        {
+            "title": "Vehicle Arrival Rule",
+            "enabled": True,
+            "triggers": [{"data": {"condition": {"type": "is", "source": "smartDetectLine", "value": "Arrival"}}}],
+            "actions": [
+                {
+                    "action_id": "HTTP_REQUEST",
+                    "data": {
+                        "type": "HTTP_REQUEST",
+                        "metadata": {
+                            "url": "https://homeassistant.local/api/webhook/x",
+                            "method": "POST",
+                            "headers": [],
+                            "timeout": 30000,
+                            "useThumbnail": True,
+                        },
+                        "order": -1,
+                    },
+                }
+            ],
+            "scope": {"sources": [{"device": "AABBCCDDEEFF", "type": "include"}]},
+        }
+    )
+
+    # Translated write fields come through from the canonical body.
+    assert body["name"] == "Vehicle Arrival Rule"
+    assert body["enable"] is True
+    assert body["sources"] == [{"device": "AABBCCDDEEFF", "type": "include"}]
+    assert body["conditions"] == [{"condition": {"type": "is", "source": "smartDetectLine", "value": "Arrival"}}]
+    assert body["actions"][0]["type"] == "HTTP_REQUEST"
+    # Structural envelope the canonical shape can't express — required by POST.
+    assert body["isCreatedBySystem"] is False
+    assert body["historyConditions"] == []
+    assert body["schedules"] == []
+    assert body["cooldown"] == {"enable": False, "timeout": 600000}
+
+
+def test_legacy_create_body_defaults_when_fields_omitted():
+    from unifi_core.protect.models.alarm_rules import alarm_rule_to_legacy_create_body
+
+    body = alarm_rule_to_legacy_create_body({"title": "X", "actions": [{"data": {"type": "webhook"}}]})
+
+    assert body["enable"] is True  # a newly-created rule defaults to enabled
+    assert body["sources"] == []
+    assert body["conditions"] == []
+    assert body["historyConditions"] == []
+    assert body["schedules"] == []
+    assert body["cooldown"] == {"enable": False, "timeout": 600000}
+
+
+def test_legacy_create_body_preserves_explicit_disabled():
+    from unifi_core.protect.models.alarm_rules import alarm_rule_to_legacy_create_body
+
+    body = alarm_rule_to_legacy_create_body(
+        {"title": "X", "enabled": False, "actions": [{"data": {"type": "webhook"}}]}
+    )
+    assert body["enable"] is False
+
+
+def test_legacy_create_body_preserves_license_plate_known_value():
+    """The license_plate_known condition carries the plate-group id in ``value``;
+    the raw API keys off it, so create must pass the whole condition verbatim."""
+    from unifi_core.protect.models.alarm_rules import alarm_rule_to_legacy_create_body
+
+    lpr = {"condition": {"type": "is", "source": "license_plate_known", "value": "plate-group-123"}}
+    body = alarm_rule_to_legacy_create_body(
+        {"title": "LPR Rule", "triggers": [{"data": lpr}], "actions": [{"data": {"type": "webhook"}}]}
+    )
+
+    assert body["conditions"] == [lpr]
+    assert body["conditions"][0]["condition"]["source"] == "license_plate_known"
+    assert body["conditions"][0]["condition"]["value"] == "plate-group-123"
+
+
+def test_legacy_create_body_does_not_alias_defaults_across_calls():
+    """Each call must produce independent mutable defaults — mutating one body's
+    schedules/cooldown must not bleed into the next."""
+    from unifi_core.protect.models.alarm_rules import alarm_rule_to_legacy_create_body
+
+    first = alarm_rule_to_legacy_create_body({"title": "A", "actions": [{"data": {"type": "webhook"}}]})
+    first["schedules"].append("mutated")
+    first["cooldown"]["timeout"] = 1
+
+    second = alarm_rule_to_legacy_create_body({"title": "B", "actions": [{"data": {"type": "webhook"}}]})
+    assert second["schedules"] == []
+    assert second["cooldown"] == {"enable": False, "timeout": 600000}


### PR DESCRIPTION
## Problem

`protect_alarm_create_rule` fails with `400 "Failed to parse 'request-body'"` from `POST /proxy/protect/api/automations` whenever the active backend is the legacy automations API. `list_rules` / `get_rule` / `update_rule` / `delete_rule` all work — only creating a new rule fails.

## Root cause

The legacy create path builds its POST body via `alarm_rule_to_legacy_body()`, which emits only the canonical write subset — `name` / `enable` / `sources` / `conditions` / `actions`. The raw automations endpoint requires the full structural envelope, so the body is missing `historyConditions`, `schedules`, `cooldown`, and `isCreatedBySystem`, which is what the controller rejects.

`update_rule` is unaffected because it read-modify-writes the full existing rule (`deep_merge(current_raw, translated)`), so those fields are always present. Create has no base to merge onto and shipped the sparse body straight to the controller.

## Fix

- Add `alarm_rule_to_legacy_create_body()`, which scaffolds the structural fields the canonical write shape can't express — `isCreatedBySystem`, `historyConditions`, `schedules`, `cooldown` (defaults matched to a live Protect 7.0 rule and the `Hovborg/unifi-protect-bridge` `automation_payloads.py` reference) — then overlays the caller's write fields on top.
- `AlarmRulesFacade.create_rule`'s legacy branch uses it; `alarm_rule_to_legacy_body` is left sparse so `update` semantics are unchanged (it keeps merging onto the current rule).

The fix is centralized in `unifi-core`, so every caller that reaches `AlarmRulesFacade.create_rule` shares the corrected legacy payload construction. The generic API action dispatcher has a separate pre-existing `body` → `fields` argument-translation gap; that broader dispatcher issue is outside this PR.

## Tests

- New unit tests assert the actual body sent to the controller (not just which backend is chosen), and specifically cover the `license_plate_known` trigger's `value` round-tripping verbatim through create.
- `unifi-core` and `apps/protect` suites pass; ruff (format + check) clean.

## Verification

Deployed and exercised against a real Protect controller (legacy automations backend): `create_rule` now succeeds, `get_rule` round-trips identically, and `delete_rule` cleans up. No more 400.

### Maintainer verification

I independently validated the branch against my Protect hardware. I forced only backend selection to the legacy facade path while keeping the real controller transport, cloned a controller-accepted non-system rule as disabled, and confirmed create → get → delete with legacy coverage metadata and cleanup. I also ran the full Protect safe phase and the repository pre-commit gate.

<details>
<summary>Targeted legacy create/get/delete output</summary>

```text
protect targeted:create ok: protect_alarm_create_rule
protect targeted:get ok: protect_alarm_get_rule
protect targeted:delete ok: protect_alarm_delete_rule
coverage complete: false
cleanup_confirmed: true
```

</details>

<details>
<summary>Full Protect safe-phase lifecycle output</summary>

```text
protect lifecycle:create ok: protect_alarm_create_rule
protect lifecycle:update ok: protect_alarm_update_rule
protect lifecycle:get ok: protect_alarm_get_rule
protect lifecycle:delete ok: protect_alarm_delete_rule

56 ok, 16 expected skips, 11 correctly held for approval
created resource id matched cleaned resource id
```

</details>

<details>
<summary>Repository gate</summary>

```text
$ make pre-commit
ruff: passed
generated artifact drift: passed
all Python package/app suites: passed
MCP registration modes: passed
Worker tests and typecheck: passed
exit code: 0
```

</details>
