### PR TITLE
fix(access): use supported API detail lookups

### DIFF
--- a/apps/access/tests/unit/test_devices.py
+++ b/apps/access/tests/unit/test_devices.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+from unifi_access_api import UnifiAccessApiClient
+from unifi_access_api.models.door import Device
 
 from unifi_core.access.managers.connection_manager import AccessConnectionManager
 from unifi_core.access.managers.device_manager import DeviceManager
@@ -20,7 +22,7 @@ from unifi_core.redaction import REDACTED
 def cm_api():
     cm = AccessConnectionManager(host="192.168.1.1", username="", password="", api_key="test-key")
     cm._api_client_available = True
-    cm._api_client = AsyncMock()
+    cm._api_client = create_autospec(UnifiAccessApiClient, instance=True)
     return cm
 
 
@@ -30,6 +32,15 @@ def cm_proxy():
     cm._proxy_available = True
     cm._proxy_session = MagicMock()
     return cm
+
+
+@pytest.fixture
+def cm_both(cm_api):
+    cm_api._proxy_available = True
+    cm_api._proxy_session = MagicMock()
+    cm_api.username = "admin"
+    cm_api.password = "secret"
+    return cm_api
 
 
 @pytest.fixture
@@ -48,6 +59,11 @@ def device_mgr_proxy(cm_proxy):
 
 
 @pytest.fixture
+def device_mgr_both(cm_both):
+    return DeviceManager(cm_both)
+
+
+@pytest.fixture
 def device_mgr_none(cm_none):
     return DeviceManager(cm_none)
 
@@ -60,14 +76,9 @@ def device_mgr_none(cm_none):
 class TestListDevices:
     @pytest.mark.asyncio
     async def test_list_devices_api(self, device_mgr_api, cm_api):
-        mock_device = MagicMock()
-        mock_device.id = "dev-1"
-        mock_device.name = "Hub Pro"
-        mock_device.type = "hub"
-        mock_device.connected = True
-        mock_device.firmware_version = "2.1.0"
+        mock_device = Device(id="dev-1", name="Hub Pro", type="hub", is_online=True)
 
-        cm_api._api_client.get_devices = AsyncMock(return_value=[mock_device])
+        cm_api._api_client.get_devices.return_value = [mock_device]
 
         devices = await device_mgr_api.list_devices()
 
@@ -216,21 +227,47 @@ class TestListDevices:
 class TestGetDevice:
     @pytest.mark.asyncio
     async def test_get_device_api(self, device_mgr_api, cm_api):
-        mock_device = MagicMock()
-        mock_device.id = "dev-1"
-        mock_device.name = "Hub Pro"
-        mock_device.type = "hub"
-        mock_device.connected = True
-        mock_device.firmware_version = "2.1.0"
-        mock_device.mac = "AA:BB:CC:DD:EE:FF"
-        mock_device.ip = "192.168.1.100"
+        devices = [
+            Device(id="dev-2", name="Reader"),
+            Device.model_validate(
+                {
+                    "id": "dev-1",
+                    "name": "Hub Pro",
+                    "type": "hub",
+                    "is_online": True,
+                    "firmware_version": "2.1.0",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "ip": "192.168.1.100",
+                }
+            ),
+        ]
 
-        cm_api._api_client.get_device = AsyncMock(return_value=mock_device)
+        cm_api._api_client.get_devices.return_value = devices
 
         detail = await device_mgr_api.get_device("dev-1")
 
         assert detail["id"] == "dev-1"
+        assert detail["connected"] is True
         assert detail["mac"] == "AA:BB:CC:DD:EE:FF"
+        cm_api._api_client.get_devices.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_get_device_api_not_found(self, device_mgr_api, cm_api):
+        cm_api._api_client.get_devices.return_value = [Device(id="dev-2", name="Reader")]
+
+        with pytest.raises(UniFiNotFoundError):
+            await device_mgr_api.get_device("missing-device")
+
+    @pytest.mark.asyncio
+    async def test_get_device_dual_auth_prefers_api_collection(self, device_mgr_both, cm_both):
+        cm_both._api_client.get_devices.return_value = [Device(id="dev-1", name="Hub Pro")]
+
+        with patch.object(cm_both, "proxy_request", new_callable=AsyncMock) as proxy_request:
+            detail = await device_mgr_both.get_device("dev-1")
+
+        assert detail["id"] == "dev-1"
+        cm_both._api_client.get_devices.assert_awaited_once_with()
+        proxy_request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_get_device_proxy(self, device_mgr_proxy, cm_proxy):
@@ -294,16 +331,19 @@ class TestGetDevice:
 class TestRebootDevice:
     @pytest.mark.asyncio
     async def test_reboot_device_preview_api(self, device_mgr_api, cm_api):
-        mock_device = MagicMock()
-        mock_device.id = "dev-1"
-        mock_device.name = "Hub Pro"
-        mock_device.type = "hub"
-        mock_device.connected = True
-        mock_device.firmware_version = "2.1.0"
-        mock_device.mac = "AA:BB:CC:DD:EE:FF"
-        mock_device.ip = "192.168.1.100"
+        mock_device = Device.model_validate(
+            {
+                "id": "dev-1",
+                "name": "Hub Pro",
+                "type": "hub",
+                "is_online": True,
+                "firmware_version": "2.1.0",
+                "mac": "AA:BB:CC:DD:EE:FF",
+                "ip": "192.168.1.100",
+            }
+        )
 
-        cm_api._api_client.get_device = AsyncMock(return_value=mock_device)
+        cm_api._api_client.get_devices.return_value = [mock_device]
 
         preview = await device_mgr_api.reboot_device("dev-1")
 

--- a/apps/access/tests/unit/test_doors.py
+++ b/apps/access/tests/unit/test_doors.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
+from unifi_access_api import UnifiAccessApiClient
+from unifi_access_api.models.door import Door
 
 from unifi_core.access.managers.connection_manager import AccessConnectionManager
 from unifi_core.access.managers.door_manager import _LOCATIONS_EXPAND, DoorManager
@@ -20,7 +22,7 @@ def cm_api():
     """ConnectionManager with API client available."""
     cm = AccessConnectionManager(host="192.168.1.1", username="", password="", api_key="test-key")
     cm._api_client_available = True
-    cm._api_client = AsyncMock()
+    cm._api_client = create_autospec(UnifiAccessApiClient, instance=True)
     return cm
 
 
@@ -79,21 +81,22 @@ class TestListDoors:
     @pytest.mark.asyncio
     async def test_list_doors_api_client(self, door_mgr_api, cm_api):
         """list_doors uses API client when available."""
-        mock_door = MagicMock()
-        mock_door.id = "door-1"
-        mock_door.name = "Front Door"
-        mock_door.door_position_status = "closed"
-        mock_door.lock_relay_status = "locked"
+        mock_door = Door(
+            id="door-1",
+            name="Front Door",
+            door_position_status="close",
+            door_lock_relay_status="lock",
+        )
 
-        cm_api._api_client.get_doors = AsyncMock(return_value=[mock_door])
+        cm_api._api_client.get_doors.return_value = [mock_door]
 
         doors = await door_mgr_api.list_doors()
 
         assert len(doors) == 1
         assert doors[0]["id"] == "door-1"
         assert doors[0]["name"] == "Front Door"
-        assert doors[0]["door_position_status"] == "closed"
-        assert doors[0]["lock_relay_status"] == "locked"
+        assert doors[0]["door_position_status"] == "close"
+        assert doors[0]["lock_relay_status"] == "lock"
 
     @pytest.mark.asyncio
     async def test_list_doors_proxy(self, door_mgr_proxy, cm_proxy):
@@ -190,13 +193,14 @@ class TestListDoors:
     @pytest.mark.asyncio
     async def test_list_doors_prefers_api_client(self, door_mgr_both, cm_both):
         """list_doors prefers API client over proxy when both available."""
-        mock_door = MagicMock()
-        mock_door.id = "door-1"
-        mock_door.name = "Main Door"
-        mock_door.door_position_status = "open"
-        mock_door.lock_relay_status = "unlocked"
+        mock_door = Door(
+            id="door-1",
+            name="Main Door",
+            door_position_status="open",
+            door_lock_relay_status="unlock",
+        )
 
-        cm_both._api_client.get_doors = AsyncMock(return_value=[mock_door])
+        cm_both._api_client.get_doors.return_value = [mock_door]
 
         doors = await door_mgr_both.list_doors()
 
@@ -213,21 +217,44 @@ class TestListDoors:
 class TestGetDoor:
     @pytest.mark.asyncio
     async def test_get_door_api_client(self, door_mgr_api, cm_api):
-        """get_door returns detailed door info via API client."""
-        mock_door = MagicMock()
-        mock_door.id = "door-1"
-        mock_door.name = "Front Door"
-        mock_door.door_position_status = "closed"
-        mock_door.lock_relay_status = "locked"
-        mock_door.camera_resource_id = "cam-1"
-        mock_door.door_guard = None
+        """get_door filters the API client's supported collection call by ID."""
+        doors = [
+            Door(id="door-2", name="Back Door"),
+            Door(
+                id="door-1",
+                name="Front Door",
+                door_position_status="close",
+                door_lock_relay_status="lock",
+            ),
+        ]
 
-        cm_api._api_client.get_door = AsyncMock(return_value=mock_door)
+        cm_api._api_client.get_doors.return_value = doors
 
         detail = await door_mgr_api.get_door("door-1")
 
         assert detail["id"] == "door-1"
-        assert detail["camera_resource_id"] == "cam-1"
+        assert detail["name"] == "Front Door"
+        assert detail["door_position_status"] == "close"
+        assert detail["lock_relay_status"] == "lock"
+        cm_api._api_client.get_doors.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_get_door_api_client_not_found(self, door_mgr_api, cm_api):
+        cm_api._api_client.get_doors.return_value = [Door(id="door-2", name="Back Door")]
+
+        with pytest.raises(UniFiNotFoundError):
+            await door_mgr_api.get_door("missing-door")
+
+    @pytest.mark.asyncio
+    async def test_get_door_dual_auth_prefers_api_collection(self, door_mgr_both, cm_both):
+        cm_both._api_client.get_doors.return_value = [Door(id="door-1", name="Front Door")]
+
+        with patch.object(cm_both, "proxy_request", new_callable=AsyncMock) as proxy_request:
+            detail = await door_mgr_both.get_door("door-1")
+
+        assert detail["id"] == "door-1"
+        cm_both._api_client.get_doors.assert_awaited_once_with()
+        proxy_request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_get_door_proxy(self, door_mgr_proxy, cm_proxy):
@@ -274,18 +301,20 @@ class TestGetDoorStatus:
     @pytest.mark.asyncio
     async def test_get_door_status_api(self, door_mgr_api, cm_api):
         """get_door_status extracts status fields via API client."""
-        mock_door = MagicMock()
-        mock_door.id = "door-1"
-        mock_door.name = "Front Door"
-        mock_door.door_position_status = "closed"
-        mock_door.lock_relay_status = "locked"
-
-        cm_api._api_client.get_door = AsyncMock(return_value=mock_door)
+        cm_api._api_client.get_doors.return_value = [
+            Door(
+                id="door-1",
+                name="Front Door",
+                door_position_status="close",
+                door_lock_relay_status="lock",
+            )
+        ]
 
         status = await door_mgr_api.get_door_status("door-1")
 
-        assert status["lock_relay_status"] == "locked"
-        assert status["door_position_status"] == "closed"
+        assert status["lock_relay_status"] == "lock"
+        assert status["door_position_status"] == "close"
+        cm_api._api_client.get_doors.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_get_door_status_proxy(self, door_mgr_proxy, cm_proxy):
@@ -351,13 +380,14 @@ class TestUnlockDoor:
     @pytest.mark.asyncio
     async def test_unlock_door_preview(self, door_mgr_api, cm_api):
         """unlock_door returns preview data."""
-        mock_door = MagicMock()
-        mock_door.id = "door-1"
-        mock_door.name = "Front Door"
-        mock_door.door_position_status = "closed"
-        mock_door.lock_relay_status = "locked"
-
-        cm_api._api_client.get_door = AsyncMock(return_value=mock_door)
+        cm_api._api_client.get_doors.return_value = [
+            Door(
+                id="door-1",
+                name="Front Door",
+                door_position_status="close",
+                door_lock_relay_status="lock",
+            )
+        ]
 
         preview = await door_mgr_api.unlock_door("door-1", duration=5)
 

--- a/packages/unifi-core/src/unifi_core/access/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/device_manager.py
@@ -52,12 +52,27 @@ _COMPACT_DEVICE_KEYS = frozenset(
     }
 )
 
+_API_DEVICE_LIST_KEYS = ("id", "name", "type", "connected", "firmware_version")
+
 
 class DeviceManager:
     """Reads and mutates device data from the Access controller."""
 
     def __init__(self, connection_manager: AccessConnectionManager) -> None:
         self._cm = connection_manager
+
+    @staticmethod
+    def _api_device_to_dict(device: Any) -> Dict[str, Any]:
+        """Translate a py-unifi-access Device into the manager response dialect."""
+        return {
+            "id": device.id,
+            "name": getattr(device, "name", None),
+            "type": getattr(device, "type", None),
+            "connected": getattr(device, "is_online", None),
+            "firmware_version": getattr(device, "firmware_version", None),
+            "mac": getattr(device, "mac", None),
+            "ip": getattr(device, "ip", None),
+        }
 
     # ------------------------------------------------------------------
     # Read-only methods
@@ -120,16 +135,11 @@ class DeviceManager:
             if self._cm.has_api_client:
                 # API client already returns minimal 5-field dicts; compact is irrelevant.
                 devices = await self._cm.api_client.get_devices()
-                return [
-                    {
-                        "id": getattr(d, "id", None),
-                        "name": getattr(d, "name", None),
-                        "type": getattr(d, "type", None),
-                        "connected": getattr(d, "connected", None),
-                        "firmware_version": getattr(d, "firmware_version", None),
-                    }
-                    for d in devices
-                ]
+                result = []
+                for device in devices:
+                    translated = self._api_device_to_dict(device)
+                    result.append({key: translated[key] for key in _API_DEVICE_LIST_KEYS})
+                return result
             elif self._cm.has_proxy:
                 data = await self._cm.proxy_request("GET", "devices/topology4")
                 topology = self._cm.extract_data(data)
@@ -156,16 +166,11 @@ class DeviceManager:
             raise ValueError("device_id is required")
         try:
             if self._cm.has_api_client:
-                device = await self._cm.api_client.get_device(device_id)
-                return {
-                    "id": getattr(device, "id", None),
-                    "name": getattr(device, "name", None),
-                    "type": getattr(device, "type", None),
-                    "connected": getattr(device, "connected", None),
-                    "firmware_version": getattr(device, "firmware_version", None),
-                    "mac": getattr(device, "mac", None),
-                    "ip": getattr(device, "ip", None),
-                }
+                devices = await self._cm.api_client.get_devices()
+                device = next((device for device in devices if device.id == device_id), None)
+                if device is None:
+                    raise UniFiNotFoundError("device", device_id)
+                return self._api_device_to_dict(device)
             elif self._cm.has_proxy:
                 data = await self._cm.proxy_request("GET", "devices/topology4")
                 topology = self._cm.extract_data(data)

--- a/packages/unifi-core/src/unifi_core/access/managers/door_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/door_manager.py
@@ -34,12 +34,26 @@ _COMPACT_DOOR_KEYS = frozenset({"id", "name", "location_type", "access_method", 
 # Fields to keep per nested device in compact mode.
 _COMPACT_DOOR_DEVICE_KEYS = frozenset({"name", "id", "device_type", "online", "direction"})
 
+_API_DOOR_LIST_KEYS = ("id", "name", "door_position_status", "lock_relay_status")
+
 
 class DoorManager:
     """Reads and mutates door data from the Access controller."""
 
     def __init__(self, connection_manager: AccessConnectionManager) -> None:
         self._cm = connection_manager
+
+    @staticmethod
+    def _api_door_to_dict(door: Any) -> Dict[str, Any]:
+        """Translate a py-unifi-access Door into the manager response dialect."""
+        return {
+            "id": door.id,
+            "name": door.name,
+            "door_position_status": getattr(door, "door_position_status", None),
+            "lock_relay_status": getattr(door, "door_lock_relay_status", None),
+            "camera_resource_id": getattr(door, "camera_resource_id", None),
+            "door_guard": getattr(door, "door_guard", None),
+        }
 
     # ------------------------------------------------------------------
     # Read-only methods
@@ -72,15 +86,11 @@ class DoorManager:
             if self._cm.has_api_client:
                 # API client already returns minimal 4-field dicts; compact is irrelevant.
                 doors = await self._cm.api_client.get_doors()
-                return [
-                    {
-                        "id": d.id,
-                        "name": d.name,
-                        "door_position_status": getattr(d, "door_position_status", None),
-                        "lock_relay_status": getattr(d, "lock_relay_status", None),
-                    }
-                    for d in doors
-                ]
+                result = []
+                for door in doors:
+                    translated = self._api_door_to_dict(door)
+                    result.append({key: translated[key] for key in _API_DOOR_LIST_KEYS})
+                return result
             elif self._cm.has_proxy:
                 data = await self._cm.proxy_request("GET", f"dashboard/locations?{_LOCATIONS_EXPAND}")
                 # Response is {"data": {"locations": [...]}}
@@ -111,15 +121,11 @@ class DoorManager:
             raise ValueError("door_id is required")
         try:
             if self._cm.has_api_client:
-                door = await self._cm.api_client.get_door(door_id)
-                return {
-                    "id": door.id,
-                    "name": door.name,
-                    "door_position_status": getattr(door, "door_position_status", None),
-                    "lock_relay_status": getattr(door, "lock_relay_status", None),
-                    "camera_resource_id": getattr(door, "camera_resource_id", None),
-                    "door_guard": getattr(door, "door_guard", None),
-                }
+                doors = await self._cm.api_client.get_doors()
+                door = next((door for door in doors if door.id == door_id), None)
+                if door is None:
+                    raise UniFiNotFoundError("door", door_id)
+                return self._api_door_to_dict(door)
             elif self._cm.has_proxy:
                 data = await self._cm.proxy_request("GET", f"dashboard/locations?{_LOCATIONS_EXPAND}")
                 # Response is {"data": {"locations": [...]}}
@@ -143,39 +149,13 @@ class DoorManager:
 
         Tries the API client first, then falls back to the proxy path.
         """
-        if not door_id:
-            raise ValueError("door_id is required")
-        try:
-            if self._cm.has_api_client:
-                door = await self._cm.api_client.get_door(door_id)
-                return {
-                    "id": door.id,
-                    "name": door.name,
-                    "door_position_status": getattr(door, "door_position_status", None),
-                    "lock_relay_status": getattr(door, "lock_relay_status", None),
-                }
-            elif self._cm.has_proxy:
-                data = await self._cm.proxy_request("GET", f"dashboard/locations?{_LOCATIONS_EXPAND}")
-                # Response is {"data": {"locations": [...]}}
-                inner = self._cm.extract_data(data)
-                locations = inner.get("locations", inner) if isinstance(inner, dict) else inner
-                if isinstance(locations, list):
-                    for loc in locations:
-                        if isinstance(loc, dict) and loc.get("id") == door_id:
-                            return {
-                                "id": loc.get("id", door_id),
-                                "name": loc.get("name"),
-                                "door_position_status": loc.get("door_position_status"),
-                                "lock_relay_status": loc.get("lock_relay_status"),
-                            }
-                raise UniFiNotFoundError("door", door_id)
-            else:
-                raise UniFiConnectionError("No auth path available for get_door_status")
-        except (UniFiConnectionError, UniFiNotFoundError, ValueError):
-            raise
-        except Exception as e:
-            logger.error("Failed to get door status %s: %s", door_id, e, exc_info=True)
-            raise
+        door = await self.get_door(door_id)
+        return {
+            "id": door.get("id", door_id),
+            "name": door.get("name"),
+            "door_position_status": door.get("door_position_status"),
+            "lock_relay_status": door.get("lock_relay_status"),
+        }
 
     async def list_door_groups(self) -> List[Dict[str, Any]]:
         """Return all access groups (door groupings).


### PR DESCRIPTION
## Summary

- replace unsupported singular Access API detail calls with supported collection lookups filtered by exact resource ID
- normalize the real `py-unifi-access` door and device fields at the `unifi-core` manager boundary
- reuse the canonical door lookup for status reads and keep dual-auth routing on the official API path when it is available
- harden tests with autospecced clients and real upstream models so nonexistent SDK methods cannot be mocked accidentally

## Root cause

`py-unifi-access` 1.3.0 exposes `get_doors()` and `get_devices()`, but not `get_door()` or `get_device()`. The managers called those nonexistent singular methods and translated legacy field names. Permissive `AsyncMock` fixtures silently invented the missing methods and fields, so unit tests passed while live dual-auth calls failed.

## Architecture

The fix remains inside the door and device domain managers: the connection manager continues to own only transport and authentication, while each resource manager owns collection lookup, exact-ID selection, not-found behavior, and upstream-to-domain field translation. No proxy fallback is introduced when the official API client is available.

## Verification

- `make pre-commit`
- `uv run pytest packages/unifi-core/tests` — 1,408 passed
- `uv run pytest apps/access/tests` — 191 passed
- `uv run python scripts/live_smoke.py --server access --phase safe` — exit 0; `access_get_device`, `access_get_door`, and `access_get_door_status` passed against a dual-auth controller

## Release

Patch release: `core/v0.4.19`. Existing downstream constraints already accept `unifi-core>=0.4.17,<0.5`; this change adds no new cross-package API or import.
