### PR TITLE
chore(release): require core 0.4.20 for WLAN fields

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.17,<0.5",
+    "unifi-core[network,protect,access]>=0.4.20,<0.5",
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.17,<0.5",
+    "unifi-core[network]>=0.4.20,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## What changed

- Raise the Network package's `unifi-core` floor to `0.4.20`.
- Raise the API package's `unifi-core` floor to `0.4.20`.

## Why

PR #449 adds five WLAN roaming fields to the shared `unifi-core` model. `core/v0.4.20` is now published, so the downstream Network and API wheels must require that version before their release tags are cut. This prevents either wheel from resolving against an older core that does not contain the fields.

## Verification

- `uv lock --check`
- `uv run python scripts/check_pin_alignment.py`
- Built Network and API wheels and inspected `Requires-Dist` metadata for `unifi-core>=0.4.20,<0.5`
- `make pre-commit`
