### PR TITLE
feat(network): add unifi_search_device_by_mac cross-site lookup

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Annotated, Any, Dict, List, Optional
 
+from aiounifi.models.api import ApiRequest
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
@@ -27,13 +28,29 @@ from unifi_core.network.models._actions import (
 from unifi_core.network.models.devices import radio_to_controller_update
 
 # Import the global FastMCP server instance, config, and managers
-from unifi_network_mcp.runtime import device_manager, server
+from unifi_network_mcp.runtime import (
+    connection_manager,
+    device_manager,
+    server,
+    system_manager,
+)
 
 logger = logging.getLogger(__name__)
 
 
 # Model prefixes for USP Smart Power devices that may report as 'uap' type
 _POWER_DEVICE_MODELS = {"UP1", "UP6", "USP"}
+
+# Controller device state codes -> human-readable status.
+_DEVICE_STATE_MAP = {
+    0: "offline",
+    1: "online",
+    2: "pending_adoption",
+    4: "managed_by_other/adopting",
+    5: "provisioning",
+    6: "upgrading",
+    11: "error/heartbeat_missed",
+}
 
 
 def _rogue_ap_summary(ap: dict[str, Any]) -> dict[str, Any]:
@@ -203,19 +220,10 @@ async def list_devices(
             devices_raw = devices_raw[:limit]
 
         formatted_devices = []
-        state_map = {
-            0: "offline",
-            1: "online",
-            2: "pending_adoption",
-            4: "managed_by_other/adopting",
-            5: "provisioning",
-            6: "upgrading",
-            11: "error/heartbeat_missed",
-        }
 
         for device in devices_raw:
             device_state = device.get("state", 0)
-            device_status_str = state_map.get(device_state, f"unknown_state ({device_state})")
+            device_status_str = _DEVICE_STATE_MAP.get(device_state, f"unknown_state ({device_state})")
 
             category = classify_device(device)
 
@@ -437,15 +445,6 @@ async def get_device_details(
 
             # Basic — essential device info
             if include_all or "basic" in sections:
-                state_map = {
-                    0: "offline",
-                    1: "online",
-                    2: "pending_adoption",
-                    4: "managed_by_other/adopting",
-                    5: "provisioning",
-                    6: "upgrading",
-                    11: "error/heartbeat_missed",
-                }
                 device_state = device_raw.get("state", 0)
                 device_data.update(
                     {
@@ -454,7 +453,7 @@ async def get_device_details(
                         "model": device_raw.get("model"),
                         "type": device_raw.get("type"),
                         "ip": device_raw.get("ip"),
-                        "status": state_map.get(device_state, f"unknown ({device_state})"),
+                        "status": _DEVICE_STATE_MAP.get(device_state, f"unknown ({device_state})"),
                         "uptime": str(timedelta(seconds=device_raw.get("uptime", 0)))
                         if device_raw.get("uptime")
                         else None,
@@ -546,6 +545,77 @@ async def get_device_details(
     except Exception as e:
         logger.error("Error getting device details for %s: %s", mac_address, e, exc_info=True)
         return {"success": False, "error": f"Failed to get device details for {mac_address}: {e}"}
+
+
+@server.tool(
+    name="unifi_search_device_by_mac",
+    description=(
+        "Search EVERY site on the controller for a device by MAC address and report which site "
+        "adopted it. UniFi's native search is per-site only — this iterates all sites from "
+        "/api/self/sites and matches each site's device-basic list, returning the site "
+        "name/description plus basic device info (model, type, status). Use when you have a MAC "
+        "but don't know which site the device lives on. Returns found=false if no site has it."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def search_device_by_mac(
+    mac_address: Annotated[
+        str,
+        Field(description="Device MAC address in format AA:BB:CC:DD:EE:FF"),
+    ],
+) -> Dict[str, Any]:
+    """Locate a device across all sites by MAC address."""
+    mac = mac_address.strip().lower()
+    if not mac:
+        return {"success": False, "error": "mac_address is required"}
+
+    try:
+        sites = await system_manager.get_sites()
+    except Exception as e:
+        logger.error("search_device_by_mac: failed to list sites: %s", e)
+        return {"success": False, "error": f"Failed to list sites: {e}"}
+
+    sites_searched = 0
+    for site in sites:
+        site_name = getattr(site, "name", None)
+        if not site_name:
+            continue
+        try:
+            request = ApiRequest(method="get", path=f"/api/s/{site_name}/stat/device-basic")
+            devices = await connection_manager.request(request)
+        except Exception as e:
+            # A single unreadable site (e.g. permissions) must not abort the whole search.
+            logger.warning("search_device_by_mac: query for site '%s' failed: %s", site_name, e)
+            continue
+        sites_searched += 1
+        if not isinstance(devices, list):
+            continue
+        for device in devices:
+            if str(device.get("mac", "")).lower() == mac:
+                state = device.get("state", 0)
+                return {
+                    "success": True,
+                    "found": True,
+                    "site_name": site_name,
+                    "site_desc": getattr(site, "description", None),
+                    "sites_searched": sites_searched,
+                    "device": {
+                        "mac": device.get("mac"),
+                        "name": device.get("name") or device.get("model"),
+                        "model": device.get("model"),
+                        "type": device.get("type"),
+                        "status": _DEVICE_STATE_MAP.get(state, f"unknown ({state})"),
+                        "adopted": device.get("adopted", False),
+                    },
+                }
+
+    return {
+        "success": True,
+        "found": False,
+        "mac": mac,
+        "sites_searched": sites_searched,
+        "total_sites": len(sites),
+    }
 
 
 @server.tool(

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 186,
+  "count": 187,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -140,6 +140,7 @@
     "unifi_rename_device": "unifi_network_mcp.tools.devices",
     "unifi_reorder_firewall_policies": "unifi_network_mcp.tools.firewall",
     "unifi_revoke_voucher": "unifi_network_mcp.tools.hotspot",
+    "unifi_search_device_by_mac": "unifi_network_mcp.tools.devices",
     "unifi_set_client_ip_settings": "unifi_network_mcp.tools.clients",
     "unifi_set_device_led": "unifi_network_mcp.tools.devices",
     "unifi_set_jumbo_frames": "unifi_network_mcp.tools.switch",
@@ -13659,6 +13660,98 @@
         }
       },
       "title": "Revoke Voucher"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Search EVERY site on the controller for a device by MAC address and report which site adopted it. UniFi's native search is per-site only \u2014 this iterates all sites from /api/self/sites and matches each site's device-basic list, returning the site name/description plus basic device info (model, type, status). Use when you have a MAC but don't know which site the device lives on. Returns found=false if no site has it.",
+      "name": "unifi_search_device_by_mac",
+      "schema": {
+        "input": {
+          "properties": {
+            "mac_address": {
+              "description": "Device MAC address in format AA:BB:CC:DD:EE:FF",
+              "type": "string"
+            }
+          },
+          "required": [
+            "mac_address"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Search Device By Mac"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_devices_filtering.py
+++ b/apps/network/tests/unit/test_devices_filtering.py
@@ -390,3 +390,82 @@ def test_rogue_ap_pagination_bounds_are_in_schema_and_validate_inputs():
             limit_adapter.validate_python(invalid_limit)
     with pytest.raises(ValidationError):
         offset_adapter.validate_python(-1)
+
+
+def _mock_site(name, desc):
+    s = MagicMock()
+    s.name = name
+    s.description = desc
+    return s
+
+
+@pytest.mark.asyncio
+async def test_search_device_by_mac_found_on_later_site():
+    # Iterates all sites and returns the one whose device-basic list contains the MAC.
+    sites = [_mock_site("aaa111", "HQ"), _mock_site("bbb222", "Branch")]
+
+    async def fake_request(req):
+        if "/api/s/bbb222/" in req.path:
+            return [{"mac": "78:45:58:46:2d:7c", "model": "UAL6", "type": "uap", "state": 1, "adopted": True}]
+        return [{"mac": "aa:bb:cc:00:00:01", "model": "US24", "type": "usw", "state": 1}]
+
+    with patch("unifi_network_mcp.tools.devices.system_manager") as mock_sm, patch(
+        "unifi_network_mcp.tools.devices.connection_manager"
+    ) as mock_cm:
+        mock_sm.get_sites = AsyncMock(return_value=sites)
+        mock_cm.request = AsyncMock(side_effect=fake_request)
+
+        from unifi_network_mcp.tools.devices import search_device_by_mac
+
+        result = await search_device_by_mac("78:45:58:46:2D:7C")  # mixed case, must normalise
+
+    assert result["success"] is True
+    assert result["found"] is True
+    assert result["site_name"] == "bbb222"
+    assert result["site_desc"] == "Branch"
+    assert result["device"]["model"] == "UAL6"
+    assert result["device"]["status"] == "online"
+
+
+@pytest.mark.asyncio
+async def test_search_device_by_mac_not_found():
+    sites = [_mock_site("aaa111", "HQ")]
+    with patch("unifi_network_mcp.tools.devices.system_manager") as mock_sm, patch(
+        "unifi_network_mcp.tools.devices.connection_manager"
+    ) as mock_cm:
+        mock_sm.get_sites = AsyncMock(return_value=sites)
+        mock_cm.request = AsyncMock(return_value=[{"mac": "aa:bb:cc:00:00:01"}])
+
+        from unifi_network_mcp.tools.devices import search_device_by_mac
+
+        result = await search_device_by_mac("de:ad:be:ef:00:00")
+
+    assert result["success"] is True
+    assert result["found"] is False
+    assert result["total_sites"] == 1
+    assert result["sites_searched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_device_by_mac_skips_failing_site():
+    # A site that errors (e.g. no read permission) must not abort the search.
+    sites = [_mock_site("boom", "Broken"), _mock_site("good", "Working")]
+
+    async def fake_request(req):
+        if "/api/s/boom/" in req.path:
+            raise Exception("403 forbidden")
+        return [{"mac": "11:22:33:44:55:66", "model": "U6-Pro", "type": "uap", "state": 1}]
+
+    with patch("unifi_network_mcp.tools.devices.system_manager") as mock_sm, patch(
+        "unifi_network_mcp.tools.devices.connection_manager"
+    ) as mock_cm:
+        mock_sm.get_sites = AsyncMock(return_value=sites)
+        mock_cm.request = AsyncMock(side_effect=fake_request)
+
+        from unifi_network_mcp.tools.devices import search_device_by_mac
+
+        result = await search_device_by_mac("11:22:33:44:55:66")
+
+    assert result["found"] is True
+    assert result["site_name"] == "good"
+    assert result["sites_searched"] == 1  # only the reachable site counted

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (186 tools)
+# Network Server Tool Reference (187 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -70,7 +70,7 @@ Always available, regardless of registration mode.
 ## Devices
 
 <!-- AUTO:tools:devices -->
-21 tools.
+22 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -82,6 +82,7 @@ Always available, regardless of registration mode.
 | `unifi_list_available_channels` | Read | List allowed RF channels for the site's regulatory domain. |
 | `unifi_list_devices` | Read | Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_categ... |
 | `unifi_list_rogue_aps` | Read | List neighboring/rogue APs detected by your access points. |
+| `unifi_search_device_by_mac` | Read | Search EVERY site on the controller for a device by MAC address and report which site adopted it. |
 | `unifi_adopt_device` | Mutate | Adopt a pending device into the Unifi Network by MAC address |
 | `unifi_force_provision_device` | Mutate | Force re-provision a device, pushing the current configuration from the controller to the device. |
 | `unifi_locate_device` | Mutate | Toggle device locate mode (LED blinking) to physically identify a device. |


### PR DESCRIPTION
## Summary

Adds `unifi_search_device_by_mac`, a read-only tool that locates a device across **all** sites by MAC address. UniFi's native search is per-site only — there's no built-in way to find which site adopted a device when you only have its MAC.

It iterates every site from `/api/self/sites` (`system_manager.get_sites()`) and matches each site's `/api/s/{site}/stat/device-basic` list, returning the owning site's name/description plus basic device info (model, type, status). A single unreadable site (e.g. permissions) is logged and skipped rather than aborting the whole search.

Also deduplicates the device state-code map into a module-level `_DEVICE_STATE_MAP` reused by `list_devices` and `get_device_details` (was previously inlined twice).

## Testing

- 3 new unit tests: found-on-later-site (with mixed-case MAC normalisation), not-found, skips-failing-site.
- `pytest apps/network/tests/unit/test_devices_filtering.py` -> 20 passed.
- `ruff check` clean.
- Regenerated `tools_manifest.json` and the network skill reference (186 -> 187 tools).