### PR TITLE
fix(plugins): preserve settings on Windows PowerShell 5.1

### DIFF
--- a/.github/workflows/test-plugin-setup.yml
+++ b/.github/workflows/test-plugin-setup.yml
@@ -1,0 +1,39 @@
+name: "Test: Plugin setup scripts"
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "plugins/*/scripts/**"
+      - "scripts/smoke-plugin-setup.*"
+      - ".github/workflows/test-plugin-setup.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, develop]
+    paths:
+      - "plugins/*/scripts/**"
+      - "scripts/smoke-plugin-setup.*"
+      - ".github/workflows/test-plugin-setup.yml"
+
+jobs:
+  windows-powershell-51:
+    name: Windows PowerShell 5.1 compatibility
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run with Windows PowerShell 5.1
+        shell: powershell
+        run: .\scripts\smoke-plugin-setup.ps1 -ExpectedVersionPrefix 5.1
+
+  powershell-7:
+    name: PowerShell 7 compatibility
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run with PowerShell 7
+        shell: pwsh
+        run: .\scripts\smoke-plugin-setup.ps1 -ExpectedVersionPrefix 7.

--- a/plugins/unifi-access/scripts/set-env.ps1
+++ b/plugins/unifi-access/scripts/set-env.ps1
@@ -9,6 +9,34 @@ param(
     [string[]]$KeyValuePairs
 )
 
+function ConvertTo-MutableMap {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        $result = @{}
+        foreach ($key in $InputObject.Keys) {
+            $result[$key] = $InputObject[$key]
+        }
+        return $result
+    }
+
+    if ($InputObject.GetType().FullName -eq 'System.Management.Automation.PSCustomObject') {
+        $result = @{}
+        foreach ($property in $InputObject.PSObject.Properties) {
+            $result[$property.Name] = $property.Value
+        }
+        return $result
+    }
+
+    throw "$Description must be a JSON object."
+}
+
 if (-not $KeyValuePairs -or $KeyValuePairs.Count -eq 0) {
     Write-Error "Usage: set-env.ps1 KEY1=VALUE1 KEY2=VALUE2 ..."
     exit 1
@@ -35,20 +63,29 @@ if (-not (Test-Path $dir)) {
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
 }
 
-# Read existing settings or start fresh
-if (Test-Path $settingsFile) {
+# Read and validate existing settings or start fresh.
+if (Test-Path -LiteralPath $settingsFile) {
     try {
-        $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json -AsHashtable
+        $parsedSettings = Get-Content -LiteralPath $settingsFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parsedSettings) {
+            throw 'The settings document must be a JSON object.'
+        }
+        $settings = ConvertTo-MutableMap -InputObject $parsedSettings -Description 'The settings document'
+
+        if ($settings.ContainsKey('env')) {
+            if ($null -eq $settings['env']) {
+                throw 'The env setting must be a JSON object.'
+            }
+            $settings['env'] = ConvertTo-MutableMap -InputObject $settings['env'] -Description 'The env setting'
+        } else {
+            $settings['env'] = @{}
+        }
     } catch {
-        $settings = @{}
+        Write-Error "Failed to read or parse $settingsFile. Original file was not modified. $($_.Exception.Message)"
+        exit 1
     }
 } else {
-    $settings = @{}
-}
-
-# Ensure env object exists
-if (-not $settings.ContainsKey('env')) {
-    $settings['env'] = @{}
+    $settings = @{ env = @{} }
 }
 
 # Merge new vars
@@ -56,9 +93,42 @@ foreach ($key in $newVars.Keys) {
     $settings['env'][$key] = $newVars[$key]
 }
 
-# Write back with formatting
-$json = $settings | ConvertTo-Json -Depth 10
-Set-Content -Path $settingsFile -Value $json -Encoding UTF8
+# Generate and structurally validate the complete replacement beside the
+# destination. The adjacent paths guarantee same-volume file operations.
+$tempFile = "$settingsFile.tmp.$PID.$([Guid]::NewGuid().ToString('N'))"
+$backupFile = "$settingsFile.backup.$PID.$([Guid]::NewGuid().ToString('N'))"
+try {
+    $json = $settings | ConvertTo-Json -Depth 100 -WarningAction Stop -ErrorAction Stop
+    Set-Content -LiteralPath $tempFile -Value $json -Encoding UTF8 -ErrorAction Stop
+    Get-Content -LiteralPath $tempFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop | Out-Null
+
+    $tempFullPath = [IO.Path]::GetFullPath($tempFile)
+    $settingsFullPath = [IO.Path]::GetFullPath($settingsFile)
+    $backupFullPath = [IO.Path]::GetFullPath($backupFile)
+    if ([IO.File]::Exists($settingsFullPath)) {
+        [IO.File]::Replace($tempFullPath, $settingsFullPath, $backupFullPath)
+        [IO.File]::Delete($backupFullPath)
+    } else {
+        [IO.File]::Move($tempFullPath, $settingsFullPath)
+    }
+} catch {
+    $saveError = $_.Exception.Message
+    Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+
+    $recoveryMessage = 'Existing settings remain at the original path.'
+    if ([IO.File]::Exists([IO.Path]::GetFullPath($backupFile))) {
+        try {
+            [IO.File]::Copy([IO.Path]::GetFullPath($backupFile), [IO.Path]::GetFullPath($settingsFile), $true)
+            [IO.File]::Delete([IO.Path]::GetFullPath($backupFile))
+            $recoveryMessage = 'Existing settings were restored from the recovery backup.'
+        } catch {
+            $recoveryMessage = "Existing settings recovery backup retained at $backupFile."
+        }
+    }
+
+    Write-Error "Failed to save $settingsFile. $recoveryMessage $saveError"
+    exit 1
+}
 
 # Report what was set (mask sensitive values)
 foreach ($key in $newVars.Keys) {

--- a/plugins/unifi-network/scripts/set-env.ps1
+++ b/plugins/unifi-network/scripts/set-env.ps1
@@ -9,6 +9,34 @@ param(
     [string[]]$KeyValuePairs
 )
 
+function ConvertTo-MutableMap {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        $result = @{}
+        foreach ($key in $InputObject.Keys) {
+            $result[$key] = $InputObject[$key]
+        }
+        return $result
+    }
+
+    if ($InputObject.GetType().FullName -eq 'System.Management.Automation.PSCustomObject') {
+        $result = @{}
+        foreach ($property in $InputObject.PSObject.Properties) {
+            $result[$property.Name] = $property.Value
+        }
+        return $result
+    }
+
+    throw "$Description must be a JSON object."
+}
+
 if (-not $KeyValuePairs -or $KeyValuePairs.Count -eq 0) {
     Write-Error "Usage: set-env.ps1 KEY1=VALUE1 KEY2=VALUE2 ..."
     exit 1
@@ -35,20 +63,29 @@ if (-not (Test-Path $dir)) {
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
 }
 
-# Read existing settings or start fresh
-if (Test-Path $settingsFile) {
+# Read and validate existing settings or start fresh.
+if (Test-Path -LiteralPath $settingsFile) {
     try {
-        $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json -AsHashtable
+        $parsedSettings = Get-Content -LiteralPath $settingsFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parsedSettings) {
+            throw 'The settings document must be a JSON object.'
+        }
+        $settings = ConvertTo-MutableMap -InputObject $parsedSettings -Description 'The settings document'
+
+        if ($settings.ContainsKey('env')) {
+            if ($null -eq $settings['env']) {
+                throw 'The env setting must be a JSON object.'
+            }
+            $settings['env'] = ConvertTo-MutableMap -InputObject $settings['env'] -Description 'The env setting'
+        } else {
+            $settings['env'] = @{}
+        }
     } catch {
-        $settings = @{}
+        Write-Error "Failed to read or parse $settingsFile. Original file was not modified. $($_.Exception.Message)"
+        exit 1
     }
 } else {
-    $settings = @{}
-}
-
-# Ensure env object exists
-if (-not $settings.ContainsKey('env')) {
-    $settings['env'] = @{}
+    $settings = @{ env = @{} }
 }
 
 # Merge new vars
@@ -56,9 +93,42 @@ foreach ($key in $newVars.Keys) {
     $settings['env'][$key] = $newVars[$key]
 }
 
-# Write back with formatting
-$json = $settings | ConvertTo-Json -Depth 10
-Set-Content -Path $settingsFile -Value $json -Encoding UTF8
+# Generate and structurally validate the complete replacement beside the
+# destination. The adjacent paths guarantee same-volume file operations.
+$tempFile = "$settingsFile.tmp.$PID.$([Guid]::NewGuid().ToString('N'))"
+$backupFile = "$settingsFile.backup.$PID.$([Guid]::NewGuid().ToString('N'))"
+try {
+    $json = $settings | ConvertTo-Json -Depth 100 -WarningAction Stop -ErrorAction Stop
+    Set-Content -LiteralPath $tempFile -Value $json -Encoding UTF8 -ErrorAction Stop
+    Get-Content -LiteralPath $tempFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop | Out-Null
+
+    $tempFullPath = [IO.Path]::GetFullPath($tempFile)
+    $settingsFullPath = [IO.Path]::GetFullPath($settingsFile)
+    $backupFullPath = [IO.Path]::GetFullPath($backupFile)
+    if ([IO.File]::Exists($settingsFullPath)) {
+        [IO.File]::Replace($tempFullPath, $settingsFullPath, $backupFullPath)
+        [IO.File]::Delete($backupFullPath)
+    } else {
+        [IO.File]::Move($tempFullPath, $settingsFullPath)
+    }
+} catch {
+    $saveError = $_.Exception.Message
+    Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+
+    $recoveryMessage = 'Existing settings remain at the original path.'
+    if ([IO.File]::Exists([IO.Path]::GetFullPath($backupFile))) {
+        try {
+            [IO.File]::Copy([IO.Path]::GetFullPath($backupFile), [IO.Path]::GetFullPath($settingsFile), $true)
+            [IO.File]::Delete([IO.Path]::GetFullPath($backupFile))
+            $recoveryMessage = 'Existing settings were restored from the recovery backup.'
+        } catch {
+            $recoveryMessage = "Existing settings recovery backup retained at $backupFile."
+        }
+    }
+
+    Write-Error "Failed to save $settingsFile. $recoveryMessage $saveError"
+    exit 1
+}
 
 # Report what was set (mask sensitive values)
 foreach ($key in $newVars.Keys) {

--- a/plugins/unifi-protect/scripts/set-env.ps1
+++ b/plugins/unifi-protect/scripts/set-env.ps1
@@ -9,6 +9,34 @@ param(
     [string[]]$KeyValuePairs
 )
 
+function ConvertTo-MutableMap {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        $result = @{}
+        foreach ($key in $InputObject.Keys) {
+            $result[$key] = $InputObject[$key]
+        }
+        return $result
+    }
+
+    if ($InputObject.GetType().FullName -eq 'System.Management.Automation.PSCustomObject') {
+        $result = @{}
+        foreach ($property in $InputObject.PSObject.Properties) {
+            $result[$property.Name] = $property.Value
+        }
+        return $result
+    }
+
+    throw "$Description must be a JSON object."
+}
+
 if (-not $KeyValuePairs -or $KeyValuePairs.Count -eq 0) {
     Write-Error "Usage: set-env.ps1 KEY1=VALUE1 KEY2=VALUE2 ..."
     exit 1
@@ -35,20 +63,29 @@ if (-not (Test-Path $dir)) {
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
 }
 
-# Read existing settings or start fresh
-if (Test-Path $settingsFile) {
+# Read and validate existing settings or start fresh.
+if (Test-Path -LiteralPath $settingsFile) {
     try {
-        $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json -AsHashtable
+        $parsedSettings = Get-Content -LiteralPath $settingsFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parsedSettings) {
+            throw 'The settings document must be a JSON object.'
+        }
+        $settings = ConvertTo-MutableMap -InputObject $parsedSettings -Description 'The settings document'
+
+        if ($settings.ContainsKey('env')) {
+            if ($null -eq $settings['env']) {
+                throw 'The env setting must be a JSON object.'
+            }
+            $settings['env'] = ConvertTo-MutableMap -InputObject $settings['env'] -Description 'The env setting'
+        } else {
+            $settings['env'] = @{}
+        }
     } catch {
-        $settings = @{}
+        Write-Error "Failed to read or parse $settingsFile. Original file was not modified. $($_.Exception.Message)"
+        exit 1
     }
 } else {
-    $settings = @{}
-}
-
-# Ensure env object exists
-if (-not $settings.ContainsKey('env')) {
-    $settings['env'] = @{}
+    $settings = @{ env = @{} }
 }
 
 # Merge new vars
@@ -56,9 +93,42 @@ foreach ($key in $newVars.Keys) {
     $settings['env'][$key] = $newVars[$key]
 }
 
-# Write back with formatting
-$json = $settings | ConvertTo-Json -Depth 10
-Set-Content -Path $settingsFile -Value $json -Encoding UTF8
+# Generate and structurally validate the complete replacement beside the
+# destination. The adjacent paths guarantee same-volume file operations.
+$tempFile = "$settingsFile.tmp.$PID.$([Guid]::NewGuid().ToString('N'))"
+$backupFile = "$settingsFile.backup.$PID.$([Guid]::NewGuid().ToString('N'))"
+try {
+    $json = $settings | ConvertTo-Json -Depth 100 -WarningAction Stop -ErrorAction Stop
+    Set-Content -LiteralPath $tempFile -Value $json -Encoding UTF8 -ErrorAction Stop
+    Get-Content -LiteralPath $tempFile -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop | Out-Null
+
+    $tempFullPath = [IO.Path]::GetFullPath($tempFile)
+    $settingsFullPath = [IO.Path]::GetFullPath($settingsFile)
+    $backupFullPath = [IO.Path]::GetFullPath($backupFile)
+    if ([IO.File]::Exists($settingsFullPath)) {
+        [IO.File]::Replace($tempFullPath, $settingsFullPath, $backupFullPath)
+        [IO.File]::Delete($backupFullPath)
+    } else {
+        [IO.File]::Move($tempFullPath, $settingsFullPath)
+    }
+} catch {
+    $saveError = $_.Exception.Message
+    Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+
+    $recoveryMessage = 'Existing settings remain at the original path.'
+    if ([IO.File]::Exists([IO.Path]::GetFullPath($backupFile))) {
+        try {
+            [IO.File]::Copy([IO.Path]::GetFullPath($backupFile), [IO.Path]::GetFullPath($settingsFile), $true)
+            [IO.File]::Delete([IO.Path]::GetFullPath($backupFile))
+            $recoveryMessage = 'Existing settings were restored from the recovery backup.'
+        } catch {
+            $recoveryMessage = "Existing settings recovery backup retained at $backupFile."
+        }
+    }
+
+    Write-Error "Failed to save $settingsFile. $recoveryMessage $saveError"
+    exit 1
+}
 
 # Report what was set (mask sensitive values)
 foreach ($key in $newVars.Keys) {

--- a/scripts/smoke-plugin-setup.ps1
+++ b/scripts/smoke-plugin-setup.ps1
@@ -214,3 +214,7 @@ if ($script:Failures.Count -gt 0) {
     }
     exit 1
 }
+
+# Expected negative child-process cases leave $LASTEXITCODE set to 1 in the
+# calling shell. Declare the successful harness result explicitly for CI.
+exit 0

--- a/scripts/smoke-plugin-setup.ps1
+++ b/scripts/smoke-plugin-setup.ps1
@@ -1,0 +1,216 @@
+param(
+    [string]$RepositoryRoot = (Split-Path $PSScriptRoot -Parent),
+    [string]$ExpectedVersionPrefix = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$script:Passes = 0
+$script:Failures = New-Object System.Collections.Generic.List[string]
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if ($Condition) {
+        Write-Host "  [OK]   $Message"
+        $script:Passes++
+    } else {
+        Write-Host "  [FAIL] $Message"
+        $script:Failures.Add($Message)
+    }
+}
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Message)
+    Assert-True -Condition ($Actual -eq $Expected) -Message $Message
+}
+
+function Get-CurrentShellPath {
+    if ($PSVersionTable.PSEdition -eq 'Desktop') {
+        return Join-Path $PSHOME 'powershell.exe'
+    }
+    if ($null -ne $IsWindows -and $IsWindows) {
+        return Join-Path $PSHOME 'pwsh.exe'
+    }
+    return Join-Path $PSHOME 'pwsh'
+}
+
+function Invoke-SetEnv {
+    param(
+        [string]$Workspace,
+        [string]$ScriptPath,
+        [string[]]$Arguments
+    )
+
+    Push-Location $Workspace
+    try {
+        # Windows PowerShell 5.1 promotes native stderr records to terminating
+        # NativeCommandError exceptions when the caller uses Stop. Expected
+        # failure scenarios need the child exit code and output instead.
+        $previousErrorActionPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        try {
+            $output = & (Get-CurrentShellPath) -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath @Arguments 2>&1
+            $exitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output = ($output | Out-String)
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function New-ScenarioWorkspace {
+    param([string]$Root, [string]$Name)
+    $workspace = Join-Path $Root $Name
+    New-Item -ItemType Directory -Path (Join-Path $workspace '.claude') -Force | Out-Null
+    return $workspace
+}
+
+function Get-BytesBase64 {
+    param([string]$Path)
+    return [Convert]::ToBase64String([IO.File]::ReadAllBytes($Path))
+}
+
+function Assert-NoReplacementArtifacts {
+    param([string]$Workspace, [string]$Message)
+    $settingsDirectory = Join-Path $Workspace '.claude'
+    $artifacts = @(Get-ChildItem -LiteralPath $settingsDirectory -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -like 'settings.local.json.tmp.*' -or $_.Name -like 'settings.local.json.backup.*'
+    })
+    Assert-Equal -Actual $artifacts.Count -Expected 0 -Message $Message
+}
+
+function New-NestedSettingsJson {
+    param([int]$Depth)
+    $value = '{"leaf":"preserved"}'
+    for ($index = $Depth - 1; $index -ge 0; $index--) {
+        $value = '{"level' + $index + '":' + $value + '}'
+    }
+    return '{"env":{"EXISTING":"keep"},"deep":' + $value + '}'
+}
+
+function Get-NestedLeaf {
+    param($Settings, [int]$Depth)
+    $current = $Settings.deep
+    for ($index = 0; $index -lt $Depth; $index++) {
+        $property = $current.PSObject.Properties["level$index"]
+        if ($null -eq $property) {
+            return $null
+        }
+        $current = $property.Value
+    }
+    return $current.leaf
+}
+
+function Test-IsWindows {
+    return [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
+}
+
+$networkScript = Join-Path $RepositoryRoot 'plugins/unifi-network/scripts/set-env.ps1'
+$protectScript = Join-Path $RepositoryRoot 'plugins/unifi-protect/scripts/set-env.ps1'
+$accessScript = Join-Path $RepositoryRoot 'plugins/unifi-access/scripts/set-env.ps1'
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ('unifi-mcp-plugin-setup-' + [Guid]::NewGuid().ToString('N'))
+
+try {
+    New-Item -ItemType Directory -Path $testRoot | Out-Null
+
+    if ($ExpectedVersionPrefix) {
+        Assert-True -Condition ($PSVersionTable.PSVersion.ToString().StartsWith($ExpectedVersionPrefix)) -Message 'expected PowerShell version is running'
+    }
+
+    Write-Host '== Cross-plugin parity =='
+    $networkHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $networkScript).Hash
+    Assert-Equal (Get-FileHash -Algorithm SHA256 -LiteralPath $protectScript).Hash $networkHash 'Protect writer matches Network writer'
+    Assert-Equal (Get-FileHash -Algorithm SHA256 -LiteralPath $accessScript).Hash $networkHash 'Access writer matches Network writer'
+
+    Write-Host '== Empty workspace =='
+    $workspace = New-ScenarioWorkspace $testRoot 'empty'
+    $result = Invoke-SetEnv $workspace $networkScript @('UNIFI_NETWORK_HOST=192.0.2.1', 'UNIFI_NETWORK_USERNAME=test-user')
+    Assert-Equal $result.ExitCode 0 'empty-workspace write exits zero'
+    $settingsPath = Join-Path $workspace '.claude/settings.local.json'
+    $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+    Assert-Equal $settings.env.UNIFI_NETWORK_HOST '192.0.2.1' 'empty-workspace host is written'
+    Assert-Equal $settings.env.UNIFI_NETWORK_USERNAME 'test-user' 'empty-workspace username is written'
+    Assert-NoReplacementArtifacts $workspace 'empty-workspace write removes replacement artifacts'
+
+    Write-Host '== Existing settings preservation =='
+    $workspace = New-ScenarioWorkspace $testRoot 'preserve'
+    $settingsPath = Join-Path $workspace '.claude/settings.local.json'
+    $fixture = '{"permissions":{"allow":["Read"]},"env":{"EXISTING":"keep","UNIFI_NETWORK_HOST":"192.0.2.10"},"custom":{"nested":true}}'
+    [IO.File]::WriteAllText($settingsPath, $fixture)
+    $result = Invoke-SetEnv $workspace $networkScript @('UNIFI_NETWORK_HOST=192.0.2.20', 'UNIFI_NETWORK_USERNAME=test-user')
+    Assert-Equal $result.ExitCode 0 'existing-settings merge exits zero'
+    $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+    Assert-Equal @($settings.permissions.allow).Count 1 'single-item permissions array remains an array'
+    Assert-Equal $settings.permissions.allow[0] 'Read' 'permissions value is preserved'
+    Assert-True ($settings.custom.nested -eq $true) 'custom nested value is preserved'
+    Assert-Equal $settings.env.EXISTING 'keep' 'unrelated environment value is preserved'
+    Assert-Equal $settings.env.UNIFI_NETWORK_HOST '192.0.2.20' 'matching environment value is updated'
+    Assert-Equal $settings.env.UNIFI_NETWORK_USERNAME 'test-user' 'new environment value is inserted'
+    Assert-True ($result.Output -match 'te\*\*\*er') 'sensitive output remains masked'
+    Assert-True ($result.Output -notmatch 'test-user') 'raw sensitive output is not printed'
+    Assert-NoReplacementArtifacts $workspace 'successful merge removes replacement artifacts'
+
+    Write-Host '== Deep settings preservation =='
+    $workspace = New-ScenarioWorkspace $testRoot 'deep-valid'
+    $settingsPath = Join-Path $workspace '.claude/settings.local.json'
+    [IO.File]::WriteAllText($settingsPath, (New-NestedSettingsJson 12))
+    $result = Invoke-SetEnv $workspace $networkScript @('UNIFI_NETWORK_HOST=192.0.2.1')
+    Assert-Equal $result.ExitCode 0 'valid deeply nested settings exit zero'
+    $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+    Assert-Equal (Get-NestedLeaf $settings 12) 'preserved' 'deeply nested leaf is preserved'
+    Assert-NoReplacementArtifacts $workspace 'deeply nested merge removes replacement artifacts'
+
+    $unsafeFixtures = @(
+        [pscustomobject]@{ Name = 'malformed'; Content = '{ broken' },
+        [pscustomobject]@{ Name = 'array-root'; Content = '["not-an-object"]' },
+        [pscustomobject]@{ Name = 'array-env'; Content = '{"permissions":{"allow":["Read"]},"env":["not-an-object"]}' },
+        [pscustomobject]@{ Name = 'depth-overflow'; Content = (New-NestedSettingsJson 101) }
+    )
+
+    foreach ($fixtureCase in $unsafeFixtures) {
+        Write-Host "== Unsafe input: $($fixtureCase.Name) =="
+        $workspace = New-ScenarioWorkspace $testRoot $fixtureCase.Name
+        $settingsPath = Join-Path $workspace '.claude/settings.local.json'
+        [IO.File]::WriteAllText($settingsPath, $fixtureCase.Content)
+        $before = Get-BytesBase64 $settingsPath
+        $result = Invoke-SetEnv $workspace $networkScript @('UNIFI_NETWORK_HOST=192.0.2.1')
+        Assert-True ($result.ExitCode -ne 0) "$($fixtureCase.Name) exits nonzero"
+        Assert-Equal (Get-BytesBase64 $settingsPath) $before "$($fixtureCase.Name) remains byte-for-byte unchanged"
+        Assert-NoReplacementArtifacts $workspace "$($fixtureCase.Name) removes replacement artifacts"
+    }
+
+    if (Test-IsWindows) {
+        Write-Host '== Replacement failure =='
+        $workspace = New-ScenarioWorkspace $testRoot 'replace-failure'
+        $settingsPath = Join-Path $workspace '.claude/settings.local.json'
+        $fixture = '{"permissions":{"allow":["Read"]},"env":{"EXISTING":"keep"}}'
+        [IO.File]::WriteAllText($settingsPath, $fixture)
+        $before = Get-BytesBase64 $settingsPath
+        (Get-Item -LiteralPath $settingsPath).IsReadOnly = $true
+        try {
+            $result = Invoke-SetEnv $workspace $networkScript @('UNIFI_NETWORK_HOST=192.0.2.1')
+            Assert-True ($result.ExitCode -ne 0) 'replacement failure exits nonzero'
+            Assert-Equal (Get-BytesBase64 $settingsPath) $before 'replacement failure preserves original bytes'
+            Assert-NoReplacementArtifacts $workspace 'replacement failure removes replacement artifacts'
+        } finally {
+            (Get-Item -LiteralPath $settingsPath).IsReadOnly = $false
+        }
+    }
+} finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}
+
+Write-Host ''
+Write-Host "PowerShell $($PSVersionTable.PSVersion): $($script:Passes) passed, $($script:Failures.Count) failed"
+if ($script:Failures.Count -gt 0) {
+    foreach ($failure in $script:Failures) {
+        Write-Host "  - $failure"
+    }
+    exit 1
+}

--- a/scripts/smoke-plugin-setup.sh
+++ b/scripts/smoke-plugin-setup.sh
@@ -90,7 +90,7 @@ assert_no_crlf() {
 # --- 1. Scripts are byte-identical across all three plugins (drift guard) ---
 echo ""
 echo "== 1. Cross-plugin script parity =="
-for script in check-prereqs.sh set-env.sh check-prereqs.ps1; do
+for script in check-prereqs.sh set-env.sh check-prereqs.ps1 set-env.ps1; do
   reference="$REPO_ROOT/plugins/${PLUGINS[0]}/scripts/$script"
   for plugin in "${PLUGINS[@]:1}"; do
     other="$REPO_ROOT/plugins/$plugin/scripts/$script"


### PR DESCRIPTION
## Summary

- make all three plugin `set-env.ps1` writers compatible with Windows PowerShell 5.1
- fail closed when existing settings cannot be parsed or safely serialized
- replace settings through a validated adjacent temporary file with recovery backup support
- add regression coverage for Windows PowerShell 5.1, PowerShell 7, unsafe inputs, replacement failure, masking, and cross-plugin parity

## Root cause

Windows PowerShell 5.1 does not support `ConvertFrom-Json -AsHashtable`. The previous catch path treated that parse failure as an empty settings object and then overwrote `.claude/settings.local.json`, silently discarding permissions and unrelated settings.

## User impact

Stock Windows users can run the documented setup flow without losing existing Claude settings. Unsafe existing input now produces a non-zero error and remains byte-for-byte unchanged.

## Validation

- Physical Windows 11 / Windows PowerShell 5.1.26100.8894: 35 passed, 0 failed
- PowerShell 7.5.4: 31 passed, 0 failed
- Bash plugin setup smoke suite: passed
- `make pre-commit`: passed

Closes #454