### PR TITLE
Add legacy firewall rule read support

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 186 tools)
+  network/          # UniFi Network MCP server (stable, 187 tools)
   protect/          # UniFi Protect MCP server (beta, 61 tools)
   access/           # UniFi Access MCP server (beta, 36 tools)
   api/              # Independent REST + GraphQL API server (beta)

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -919,6 +919,45 @@ type KnownLicensePlatePage {
   nextCursor: String
 }
 
+"""
+A rule from the legacy (pre-zone-based) firewall engine, read from V1 /rest/firewallrule. Distinct from FirewallRule, which models the V2 zone-based engine: actions are lowercase (accept/drop/reject), rules belong to a ruleset rather than a zone pair, and source/destination are flat fields rather than nested objects. Read-only.
+"""
+type LegacyFirewallRule {
+  id: ID
+  name: String
+  ruleset: String
+  ruleIndex: Int
+  action: String
+  enabled: Boolean
+  protocol: String
+  protocolV6: String
+  protocolMatchExcepted: Boolean
+  srcAddress: String
+  srcAddressIpv6: String
+  srcPort: String
+  srcMacAddress: String
+  srcFirewallgroupIds: [String!]!
+  srcNetworkconfId: String
+  srcNetworkconfType: String
+  dstAddress: String
+  dstAddressIpv6: String
+  dstPort: String
+  dstFirewallgroupIds: [String!]!
+  dstNetworkconfId: String
+  dstNetworkconfType: String
+  stateNew: Boolean
+  stateEstablished: Boolean
+  stateRelated: Boolean
+  stateInvalid: Boolean
+  icmpTypename: String
+  icmpv6Typename: String
+  ipsec: String
+  logging: Boolean
+  settingPreference: String
+  noEdit: Boolean
+  noDelete: Boolean
+}
+
 """A UniFi Protect light (PIR-triggered floodlight)."""
 type Light {
   id: ID
@@ -1181,6 +1220,11 @@ type NetworkQuery {
 
   """List firewall zones (typically a small flat list — no pagination)."""
   firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
+
+  """
+  List legacy (pre-zone-based) firewall rules. Sites still running the legacy engine return no zone-based policies or zones, so an empty firewallPolicies result does not mean no firewall rules are configured — check here as well.
+  """
+  legacyFirewallRules(controller: ID!, site: String! = "default"): [LegacyFirewallRule!]!
 
   """
   Get user-defined firewall policy ordering for a source/destination zone pair. Returns policy IDs from the UniFi integration API (UUIDs); these IDs are scoped to the ordering tool family and do NOT correspond to the policy IDs returned by firewallPolicies or other controller-API firewall queries. Requires a UniFi API key (UNIFI_API_KEY).
@@ -2222,6 +2266,7 @@ Read-only access to UniFi Network resources.
 - `gatewaySettings: GatewaySettings`  — Get gateway (USG) security / NAT / connection-tracking settings.
 - `gatewayStats: [StatPoint!]!`  — Gateway stats timeseries.
 - `ipsEvents: EventLogPage!`  — List recent IPS/IDS events (paginated).
+- `legacyFirewallRules: [LegacyFirewallRule!]!`  — List legacy (pre-zone-based) firewall rules. Sites still running the legacy engine return no zone-based policies or zones, so an empty firewallPolicies result does not mean no firewall rules are configured — check here as well.
 - `lldpNeighbors: LldpNeighbors`  — Get LLDP neighbors reported by a switch.
 - `networkDetail: Network`  — Look up a single LAN/VLAN network by id. (Named ``networkDetail`` because ``network`` is reserved for the namespace.)
 - `networkHealth: [NetworkHealth!]!`  — Get the controller's network-health subsystems list.

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -549,6 +549,19 @@ Fetch a user by listing then filtering — no native get_user method.
 
 **Returns:** `Detail_FirewallGroupModel_`
 
+### `GET /v1/sites/{site_id}/firewall/legacy-rules` — List Legacy Firewall Rules
+
+
+**Parameters:**
+
+- `site_id` (path) (required)
+- `limit` (query)
+- `cursor` (query)
+- `controller` (query)
+
+
+**Returns:** `Page_LegacyFirewallRuleModel_`
+
 ### `GET /v1/sites/{site_id}/firewall/policy-ordering` — Get firewall policy ordering for a zone pair (integration API)
 
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3672,6 +3672,368 @@
         "title": "KnownLicensePlateModel",
         "type": "object"
       },
+      "LegacyFirewallRuleModel": {
+        "additionalProperties": true,
+        "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "dst_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dst Address"
+          },
+          "dst_address_ipv6": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dst Address Ipv6"
+          },
+          "dst_firewallgroup_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Dst Firewallgroup Ids",
+            "type": "array"
+          },
+          "dst_networkconf_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dst Networkconf Id"
+          },
+          "dst_networkconf_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dst Networkconf Type"
+          },
+          "dst_port": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dst Port"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "icmp_typename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icmp Typename"
+          },
+          "icmpv6_typename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icmpv6 Typename"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ipsec": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ipsec"
+          },
+          "logging": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logging"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "no_delete": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "No Delete"
+          },
+          "no_edit": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "No Edit"
+          },
+          "protocol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol"
+          },
+          "protocol_match_excepted": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol Match Excepted"
+          },
+          "protocol_v6": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Protocol V6"
+          },
+          "rule_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rule Index"
+          },
+          "ruleset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ruleset"
+          },
+          "setting_preference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Setting Preference"
+          },
+          "src_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src Address"
+          },
+          "src_address_ipv6": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src Address Ipv6"
+          },
+          "src_firewallgroup_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Src Firewallgroup Ids",
+            "type": "array"
+          },
+          "src_mac_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src Mac Address"
+          },
+          "src_networkconf_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src Networkconf Id"
+          },
+          "src_networkconf_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src Networkconf Type"
+          },
+          "src_port": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Src Port"
+          },
+          "state_established": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Established"
+          },
+          "state_invalid": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Invalid"
+          },
+          "state_new": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State New"
+          },
+          "state_related": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Related"
+          }
+        },
+        "title": "LegacyFirewallRuleModel",
+        "type": "object"
+      },
       "NetworkModel": {
         "additionalProperties": true,
         "properties": {
@@ -5337,6 +5699,46 @@
           "items"
         ],
         "title": "Page[KnownLicensePlateModel]",
+        "type": "object"
+      },
+      "Page_LegacyFirewallRuleModel_": {
+        "additionalProperties": true,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/LegacyFirewallRuleModel"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "render_hint": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Render Hint"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Page[LegacyFirewallRuleModel]",
         "type": "object"
       },
       "Page_NetworkModel_": {
@@ -13763,6 +14165,94 @@
           }
         },
         "summary": "Get Firewall Group Details",
+        "tags": [
+          "network/firewall"
+        ]
+      }
+    },
+    "/v1/sites/{site_id}/firewall/legacy-rules": {
+      "get": {
+        "operationId": "list_legacy_firewall_rules_v1_sites__site_id__firewall_legacy_rules_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "site_id",
+            "required": true,
+            "schema": {
+              "title": "Site Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "Controller UUID; omit to use default",
+            "in": "query",
+            "name": "controller",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Controller UUID; omit to use default",
+              "title": "Controller"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_LegacyFirewallRuleModel_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Legacy Firewall Rules",
         "tags": [
           "network/firewall"
         ]

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -55,6 +55,7 @@ from unifi_api.graphql.types.network.firewall import (
     FirewallPolicyOrdering,
     FirewallRule,
     FirewallZone,
+    LegacyFirewallRule,
 )
 from unifi_api.graphql.types.network.gateway_settings import GatewaySettings
 from unifi_api.graphql.types.network.network import Network
@@ -791,6 +792,33 @@ async def _fetch_firewall_zones(
             if cm.site != site:
                 await cm.set_site(site)
             return list(await mgr.get_firewall_zones())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_legacy_firewall_rules(
+    ctx: GraphQLContext,
+    controller: str,
+    site: str,
+) -> list:
+    key = f"network/legacy-firewall-rules/{controller}/{site}"
+
+    async def _do() -> list:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "network",
+                "firewall_manager",
+            )
+            cm = await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "network",
+            )
+            if cm.site != site:
+                await cm.set_site(site)
+            return list(await mgr.get_legacy_firewall_rules())
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -3037,6 +3065,24 @@ class NetworkQuery:
         ctx: GraphQLContext = info.context
         raw = await _fetch_firewall_zones(ctx, controller, site)
         return [FirewallZone.from_manager_output(z) for z in raw]
+
+    @strawberry.field(
+        permission_classes=[IsRead],
+        description=(
+            "List legacy (pre-zone-based) firewall rules. Sites still running the legacy "
+            "engine return no zone-based policies or zones, so an empty firewallPolicies "
+            "result does not mean no firewall rules are configured — check here as well."
+        ),
+    )
+    async def legacy_firewall_rules(
+        self,
+        info: Info,
+        controller: strawberry.ID,
+        site: str = "default",
+    ) -> list[LegacyFirewallRule]:
+        ctx: GraphQLContext = info.context
+        raw = await _fetch_legacy_firewall_rules(ctx, controller, site)
+        return [LegacyFirewallRule.from_manager_output(r) for r in raw]
 
     @strawberry.field(
         permission_classes=[IsRead],

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -908,6 +908,45 @@ type KnownLicensePlatePage {
   nextCursor: String
 }
 
+"""
+A rule from the legacy (pre-zone-based) firewall engine, read from V1 /rest/firewallrule. Distinct from FirewallRule, which models the V2 zone-based engine: actions are lowercase (accept/drop/reject), rules belong to a ruleset rather than a zone pair, and source/destination are flat fields rather than nested objects. Read-only.
+"""
+type LegacyFirewallRule {
+  id: ID
+  name: String
+  ruleset: String
+  ruleIndex: Int
+  action: String
+  enabled: Boolean
+  protocol: String
+  protocolV6: String
+  protocolMatchExcepted: Boolean
+  srcAddress: String
+  srcAddressIpv6: String
+  srcPort: String
+  srcMacAddress: String
+  srcFirewallgroupIds: [String!]!
+  srcNetworkconfId: String
+  srcNetworkconfType: String
+  dstAddress: String
+  dstAddressIpv6: String
+  dstPort: String
+  dstFirewallgroupIds: [String!]!
+  dstNetworkconfId: String
+  dstNetworkconfType: String
+  stateNew: Boolean
+  stateEstablished: Boolean
+  stateRelated: Boolean
+  stateInvalid: Boolean
+  icmpTypename: String
+  icmpv6Typename: String
+  ipsec: String
+  logging: Boolean
+  settingPreference: String
+  noEdit: Boolean
+  noDelete: Boolean
+}
+
 """A UniFi Protect light (PIR-triggered floodlight)."""
 type Light {
   id: ID
@@ -1170,6 +1209,11 @@ type NetworkQuery {
 
   """List firewall zones (typically a small flat list — no pagination)."""
   firewallZones(controller: ID!, site: String! = "default"): [FirewallZone!]!
+
+  """
+  List legacy (pre-zone-based) firewall rules. Sites still running the legacy engine return no zone-based policies or zones, so an empty firewallPolicies result does not mean no firewall rules are configured — check here as well.
+  """
+  legacyFirewallRules(controller: ID!, site: String! = "default"): [LegacyFirewallRule!]!
 
   """
   Get user-defined firewall policy ordering for a source/destination zone pair. Returns policy IDs from the UniFi integration API (UUIDs); these IDs are scoped to the ordering tool family and do NOT correspond to the policy IDs returned by firewallPolicies or other controller-API firewall queries. Requires a UniFi API key (UNIFI_API_KEY).

--- a/apps/api/src/unifi_api/graphql/type_registry_init.py
+++ b/apps/api/src/unifi_api/graphql/type_registry_init.py
@@ -126,6 +126,9 @@ from unifi_api.graphql.types.network.firewall import (
 from unifi_api.graphql.types.network.firewall import (
     FirewallZone as NetworkFirewallZoneType,
 )
+from unifi_api.graphql.types.network.firewall import (
+    LegacyFirewallRule as NetworkLegacyFirewallRuleType,
+)
 from unifi_api.graphql.types.network.gateway_settings import (
     GatewaySettings as NetworkGatewaySettingsType,
 )
@@ -431,6 +434,11 @@ def build_type_registry() -> TypeRegistry:
     reg.register_tool_type(
         "unifi_list_firewall_zones",
         NetworkFirewallZoneType,
+        "list",
+    )
+    reg.register_tool_type(
+        "unifi_list_legacy_firewall_rules",
+        NetworkLegacyFirewallRuleType,
         "list",
     )
     reg.register_tool_type(

--- a/apps/api/src/unifi_api/graphql/types/network/firewall.py
+++ b/apps/api/src/unifi_api/graphql/types/network/firewall.py
@@ -29,6 +29,7 @@ from dataclasses import asdict
 from typing import Any
 
 import strawberry
+from unifi_core.network.models.firewall import legacy_firewall_rule_from_controller
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -157,6 +158,68 @@ class FirewallZone:
             networks=_get(obj, "networks") or _get(obj, "network_ids") or [],
             default_policy=_get(obj, "default_policy") or _get(obj, "default_action"),
         )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@strawberry.type(
+    description=(
+        "A rule from the legacy (pre-zone-based) firewall engine, read from V1 "
+        "/rest/firewallrule. Distinct from FirewallRule, which models the V2 "
+        "zone-based engine: actions are lowercase (accept/drop/reject), rules belong "
+        "to a ruleset rather than a zone pair, and source/destination are flat fields "
+        "rather than nested objects. Read-only."
+    )
+)
+class LegacyFirewallRule:
+    id: strawberry.ID | None
+    name: str | None
+    ruleset: str | None
+    rule_index: int | None
+    action: str | None
+    enabled: bool | None
+    protocol: str | None
+    protocol_v6: str | None
+    protocol_match_excepted: bool | None
+    src_address: str | None
+    src_address_ipv6: str | None
+    src_port: str | None
+    src_mac_address: str | None
+    src_firewallgroup_ids: list[str]
+    src_networkconf_id: str | None
+    src_networkconf_type: str | None
+    dst_address: str | None
+    dst_address_ipv6: str | None
+    dst_port: str | None
+    dst_firewallgroup_ids: list[str]
+    dst_networkconf_id: str | None
+    dst_networkconf_type: str | None
+    state_new: bool | None
+    state_established: bool | None
+    state_related: bool | None
+    state_invalid: bool | None
+    icmp_typename: str | None
+    icmpv6_typename: str | None
+    ipsec: str | None
+    logging: bool | None
+    setting_preference: str | None
+    no_edit: bool | None
+    no_delete: bool | None
+
+    @classmethod
+    def render_hint(cls, kind: str) -> dict:
+        return {
+            "kind": kind,
+            "primary_key": "id",
+            "display_columns": ["ruleset", "rule_index", "name", "action", "enabled"],
+            "sort_default": "rule_index:asc",
+        }
+
+    @classmethod
+    def from_manager_output(cls, obj: Any) -> "LegacyFirewallRule":
+        model = legacy_firewall_rule_from_controller(obj)
+        return cls(**model.model_dump())
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/apps/api/src/unifi_api/routes/resources/network/legacy_firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/legacy_firewall_rules.py
@@ -1,0 +1,96 @@
+"""GET /v1/sites/{site_id}/firewall/legacy-rules — legacy firewall rules.
+
+Rules from the pre-zone-based firewall engine, read from V1 ``/rest/firewallrule``.
+
+A site running the legacy engine returns nothing from the zone-based endpoints
+(``/firewall/policies``, ``/firewall/zones``), which is indistinguishable from
+"no firewall rules configured" unless this route is consulted as well.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from unifi_api.auth.middleware import require_scope
+from unifi_api.auth.scopes import Scope
+from unifi_api.graphql.pydantic_export import to_pydantic_model
+from unifi_api.graphql.types.network.firewall import LegacyFirewallRule
+from unifi_api.routes.resources._common import (
+    require_capability,
+    resolve_controller,
+)
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+from unifi_api.services.pydantic_models import Page
+
+router = APIRouter()
+
+
+def _rule_key(obj) -> tuple:
+    """Order by ruleset then rule_index, which is how the engine evaluates them."""
+    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
+    index = raw.get("rule_index")
+    if not isinstance(index, int) or isinstance(index, bool):
+        index = 0
+    return (raw.get("ruleset") or "", index, raw.get("_id") or raw.get("id") or "")
+
+
+def _decode_cursor(cursor: str | None) -> Cursor | None:
+    if not cursor:
+        return None
+    try:
+        return Cursor.decode(cursor)
+    except InvalidCursor:
+        raise HTTPException(status_code=400, detail="invalid cursor")
+
+
+@router.get(
+    "/sites/{site_id}/firewall/legacy-rules",
+    response_model=Page[to_pydantic_model(LegacyFirewallRule)],
+    dependencies=[Depends(require_scope(Scope.READ))],
+    tags=["network/firewall"],
+)
+async def list_legacy_firewall_rules(
+    request: Request,
+    site_id: str,
+    controller=Depends(resolve_controller),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None),
+) -> dict:
+    require_capability(controller, "network")
+    factory = request.app.state.manager_factory
+    sm = request.app.state.sessionmaker
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(
+            session,
+            controller.id,
+            "network",
+            "firewall_manager",
+        )
+        cm = await factory.get_connection_manager(session, controller.id, "network")
+        if cm.site != site_id:
+            await cm.set_site(site_id)
+        items = await mgr.get_legacy_firewall_rules()
+
+    cursor_obj = _decode_cursor(cursor)
+    page, next_cursor = paginate(
+        list(items),
+        limit=limit,
+        cursor=cursor_obj,
+        key_fn=_rule_key,
+    )
+    type_registry = request.app.state.type_registry
+    tool_type = type_registry.lookup_tool("unifi_list_legacy_firewall_rules")
+    if tool_type is not None:
+        type_class, kind = tool_type
+        rows = [type_class.from_manager_output(i).to_dict() for i in page]
+        hint = type_class.render_hint(kind)
+    else:
+        registry = request.app.state.serializer_registry
+        serializer = registry.serializer_for_tool("unifi_list_legacy_firewall_rules")
+        rows = [serializer.serialize(i) for i in page]
+        hint = registry.render_hint_for_tool("unifi_list_legacy_firewall_rules")
+    return {
+        "items": rows,
+        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "render_hint": hint,
+    }

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -114,6 +114,9 @@ from unifi_api.routes.resources.network import (
     gateway_settings as net_gateway_settings_routes,
 )
 from unifi_api.routes.resources.network import (
+    legacy_firewall_rules as net_legacy_firewall_rules_routes,
+)
+from unifi_api.routes.resources.network import (
     lldp as net_lldp_routes,
 )
 from unifi_api.routes.resources.network import (
@@ -512,6 +515,7 @@ def create_app(config: ApiConfig) -> FastAPI:
         net_ap_groups_routes,
         net_firewall_groups_routes,
         net_firewall_zones_routes,
+        net_legacy_firewall_rules_routes,
         net_gateway_settings_routes,
         net_qos_routes,
         net_dpi_routes,

--- a/apps/api/tests/graphql/fixtures/network/test_firewall.py
+++ b/apps/api/tests/graphql/fixtures/network/test_firewall.py
@@ -6,6 +6,7 @@
 # tool: unifi_get_firewall_group_details
 # tool: unifi_list_firewall_zones
 # tool: unifi_get_firewall_policy_ordering
+# tool: unifi_list_legacy_firewall_rules
 """
 
 from __future__ import annotations
@@ -152,6 +153,59 @@ async def test_firewall_zones_list(tmp_path, monkeypatch):
     assert len(zones) == 2
     names = {z["name"] for z in zones}
     assert names == {"LAN", "WAN"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_firewall_rules_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "firewall_manager", "get_legacy_firewall_rules"): [
+                {
+                    "_id": "lfr-1",
+                    "name": "Block IoT to LAN",
+                    "ruleset": "LAN_IN",
+                    "rule_index": 2001,
+                    "action": "drop",
+                    "enabled": True,
+                    "src_firewallgroup_ids": ["grp-1"],
+                    "state_established": False,
+                },
+                {
+                    "_id": "lfr-2",
+                    "name": "Allow established",
+                    "ruleset": "WAN_IN",
+                    "rule_index": 2000,
+                    "action": "accept",
+                    "enabled": True,
+                    "state_established": True,
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ legacyFirewallRules(controller: "{cid}") {{
+            id name ruleset ruleIndex action enabled srcFirewallgroupIds stateEstablished
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    rules = body["data"]["network"]["legacyFirewallRules"]
+    assert len(rules) == 2
+
+    by_id = {r["id"]: r for r in rules}
+    assert by_id["lfr-1"]["ruleset"] == "LAN_IN"
+    assert by_id["lfr-1"]["ruleIndex"] == 2001
+    # Legacy actions stay lowercase; the V2 engine's ALLOW/BLOCK casing does not apply.
+    assert by_id["lfr-1"]["action"] == "drop"
+    assert by_id["lfr-1"]["srcFirewallgroupIds"] == ["grp-1"]
+    assert by_id["lfr-1"]["stateEstablished"] is False
+    assert by_id["lfr-2"]["stateEstablished"] is True
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/unit/test_cross_layer_symmetry.py
+++ b/apps/api/tests/unit/test_cross_layer_symmetry.py
@@ -27,6 +27,7 @@ REGISTERED_PAIRS: list[tuple[str, str, str]] = [
     ("network", "firewall", "FirewallRule"),
     ("network", "firewall", "FirewallGroup"),
     ("network", "firewall", "FirewallZone"),
+    ("network", "firewall", "LegacyFirewallRule"),
     ("network", "gateway_settings", "GatewaySettings"),
     ("network", "networks", "Network"),
     ("network", "oon", "OonPolicy"),

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -5,7 +5,7 @@
   <img src="../../assets/hero-network.svg" alt="UniFi Network MCP Server" width="720">
 </p>
 
-MCP server exposing 186 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
+MCP server exposing 187 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
 
 ## Install
 
@@ -227,7 +227,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 186 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 187 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 186 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 187 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy/meta-only workflows, call the `unifi_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`.
 
@@ -13,7 +13,7 @@ These are always registered regardless of mode:
 - `unifi_batch` — Execute multiple tools in parallel
 - `unifi_batch_status` — Check batch job status
 
-## Firewall (11 tools)
+## Firewall (12 tools)
 
 - `unifi_list_firewall_policies` — List all firewall policies
 - `unifi_get_firewall_policy_details` — Get policy details by ID
@@ -21,6 +21,7 @@ These are always registered regardless of mode:
 - `unifi_create_firewall_policy` — Create a V2 zone-based policy with schema validation
 - `unifi_update_firewall_policy` — Update policy fields
 - `unifi_list_firewall_zones` — List firewall zones (V2 API)
+- `unifi_list_legacy_firewall_rules` — List legacy pre-zone-based firewall rules (V1 API)
 - `unifi_list_firewall_groups` — List firewall groups (address and port groups)
 - `unifi_get_firewall_group_details` — Get firewall group details by ID
 - `unifi_create_firewall_group` — Create a new address or port group

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -14,6 +14,7 @@ from unifi_core.confirmation import create_preview, toggle_preview, update_previ
 from unifi_core.network.models.firewall import (
     firewall_group_from_controller,
     firewall_zone_from_controller,
+    legacy_firewall_rule_from_controller,
 )
 from unifi_core.network.models.firewall import (
     from_controller as fw_from_controller,
@@ -23,6 +24,15 @@ from unifi_core.network.models.firewall import (
 )
 from unifi_core.redaction import redact_sensitive_fields
 from unifi_network_mcp.runtime import firewall_manager, server, should_redact_sensitive_fields
+
+#: Emitted when the V2 zone-based endpoints report nothing. On a site still running
+#: the pre-zone-based engine those endpoints are empty rather than absent, which is
+#: indistinguishable from "no rules configured" unless the caller is told otherwise.
+LEGACY_ENGINE_HINT = (
+    "No zone-based firewall configuration was returned. This site may still be running the "
+    "legacy (pre-zone-based) firewall engine, whose rules are not visible here. Call "
+    "unifi_list_legacy_firewall_rules before concluding that no firewall rules are configured."
+)
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +125,9 @@ async def list_firewall_policies(
     try:
         policies = await firewall_manager.get_firewall_policies(include_predefined=include_predefined)
         policies_raw = [p.raw if hasattr(p, "raw") else p for p in policies]
+        # Captured before filtering: "the controller returned nothing" is the legacy-engine
+        # signal, whereas "a filter matched nothing" says nothing about the engine.
+        controller_policy_count = len(policies_raw)
 
         if enabled_only:
             policies_raw = [p for p in policies_raw if p.get("enabled", False)]
@@ -165,7 +178,7 @@ async def list_firewall_policies(
                     entry[direction] = targeting
             formatted_policies.append(entry)
 
-        return {
+        result = {
             "success": True,
             "site": firewall_manager._connection.site,
             "search": search,
@@ -177,6 +190,9 @@ async def list_firewall_policies(
             "limit": limit,
             "policies": formatted_policies,
         }
+        if controller_policy_count == 0:
+            result["note"] = LEGACY_ENGINE_HINT
+        return result
     except Exception as e:
         logger.error("Error listing firewall policies: %s", e, exc_info=True)
         return {"success": False, "error": "Failed to list firewall policies: %s" % e}
@@ -909,12 +925,15 @@ async def list_firewall_zones() -> Dict[str, Any]:
     try:
         zones = await firewall_manager.get_firewall_zones()
         formatted = [firewall_zone_from_controller(z).model_dump(exclude_none=True) for z in zones]
-        return {
+        result = {
             "success": True,
             "site": firewall_manager._connection.site,
             "count": len(formatted),
             "zones": formatted,
         }
+        if not formatted:
+            result["note"] = LEGACY_ENGINE_HINT
+        return result
     except Exception as exc:
         logger.error("Error listing firewall zones: %s", exc, exc_info=True)
         return {"success": False, "error": f"Failed to list firewall zones: {exc}"}
@@ -928,9 +947,10 @@ async def list_firewall_zones() -> Dict[str, Any]:
     description=(
         "List legacy pre-zone-based firewall rules from the UniFi controller. "
         "Use this on sites that still use the legacy firewall engine and return no "
-        "V2 zone-based firewall policies. Returns the raw legacy rule configuration, "
-        "including ruleset, rule_index, action, source and destination groups, "
-        "protocol, ports, state matching, logging, and enabled state."
+        "V2 zone-based firewall policies. Returns ruleset, rule_index, action "
+        "(lowercase accept/drop/reject), source and destination addresses, ports, "
+        "networks and firewall groups, protocol, connection-state matching, "
+        "logging, and enabled state."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -939,13 +959,14 @@ async def list_legacy_firewall_rules() -> Dict[str, Any]:
     redact_sensitive = should_redact_sensitive_fields()
     try:
         rules = await firewall_manager.get_legacy_firewall_rules()
+        formatted = [legacy_firewall_rule_from_controller(r).model_dump(exclude_none=True) for r in rules]
         return redact_sensitive_fields(
             {
                 "success": True,
                 "engine": "legacy",
                 "site": firewall_manager._connection.site,
-                "count": len(rules),
-                "rules": json.loads(json.dumps(rules, default=str)),
+                "count": len(formatted),
+                "rules": formatted,
             },
             redact_sensitive=redact_sensitive,
         )

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -920,6 +920,44 @@ async def list_firewall_zones() -> Dict[str, Any]:
         return {"success": False, "error": f"Failed to list firewall zones: {exc}"}
 
 
+# ---- Legacy Firewall Rules (v1 REST) ----
+
+
+@server.tool(
+    name="unifi_list_legacy_firewall_rules",
+    description=(
+        "List legacy pre-zone-based firewall rules from the UniFi controller. "
+        "Use this on sites that still use the legacy firewall engine and return no "
+        "V2 zone-based firewall policies. Returns the raw legacy rule configuration, "
+        "including ruleset, rule_index, action, source and destination groups, "
+        "protocol, ports, state matching, logging, and enabled state."
+    ),
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+)
+async def list_legacy_firewall_rules() -> Dict[str, Any]:
+    """Lists legacy firewall rules for the current UniFi site."""
+    redact_sensitive = should_redact_sensitive_fields()
+    try:
+        rules = await firewall_manager.get_legacy_firewall_rules()
+        return redact_sensitive_fields(
+            {
+                "success": True,
+                "engine": "legacy",
+                "site": firewall_manager._connection.site,
+                "count": len(rules),
+                "rules": json.loads(json.dumps(rules, default=str)),
+            },
+            redact_sensitive=redact_sensitive,
+        )
+    except Exception as e:
+        logger.error("Error listing legacy firewall rules: %s", e, exc_info=True)
+        return {
+            "success": False,
+            "engine": "legacy",
+            "error": f"Failed to list legacy firewall rules: {e}",
+        }
+
+
 # ---- Firewall Groups (address-group, port-group) ----
 
 

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 186,
+  "count": 187,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -118,6 +118,7 @@
     "unifi_list_firewall_groups": "unifi_network_mcp.tools.firewall",
     "unifi_list_firewall_policies": "unifi_network_mcp.tools.firewall",
     "unifi_list_firewall_zones": "unifi_network_mcp.tools.firewall",
+    "unifi_list_legacy_firewall_rules": "unifi_network_mcp.tools.firewall",
     "unifi_list_networks": "unifi_network_mcp.tools.network",
     "unifi_list_oon_policies": "unifi_network_mcp.tools.oon",
     "unifi_list_port_forwards": "unifi_network_mcp.tools.port_forwards",
@@ -11542,6 +11543,90 @@
         }
       },
       "title": "List Firewall Zones"
+    },
+    {
+      "annotations": {
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "List legacy pre-zone-based firewall rules from the UniFi controller. Use this on sites that still use the legacy firewall engine and return no V2 zone-based firewall policies. Returns ruleset, rule_index, action (lowercase accept/drop/reject), source and destination addresses, ports, networks and firewall groups, protocol, connection-state matching, logging, and enabled state.",
+      "name": "unifi_list_legacy_firewall_rules",
+      "schema": {
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "List Legacy Firewall Rules"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -615,6 +615,81 @@ SAMPLE_LEGACY_ZONES_RESPONSE = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# get_legacy_firewall_rules — legacy v1 REST support
+# ---------------------------------------------------------------------------
+
+
+class TestGetLegacyFirewallRules:
+    """Cover retrieval and caching of legacy firewall rules."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_rules_and_updates_cache(
+        self,
+        firewall_manager,
+        mock_connection,
+    ):
+        """Rules are fetched from /rest/firewallrule and cached for the site."""
+        expected_rules = [
+            {
+                "_id": "rule-001",
+                "name": "Allow established traffic",
+                "ruleset": "LAN_IN",
+                "rule_index": 2000,
+                "action": "accept",
+                "enabled": True,
+            },
+            {
+                "_id": "rule-002",
+                "name": "Block guest access",
+                "ruleset": "GUEST_IN",
+                "rule_index": 2010,
+                "action": "drop",
+                "enabled": True,
+            },
+        ]
+        mock_connection.request = AsyncMock(return_value=expected_rules)
+
+        result = await firewall_manager.get_legacy_firewall_rules()
+
+        assert result == expected_rules
+        mock_connection.ensure_connected.assert_awaited_once()
+        mock_connection.request.assert_awaited_once()
+
+        api_request = mock_connection.request.call_args.args[0]
+        assert api_request.method == "get"
+        assert api_request.path == "/rest/firewallrule"
+
+        mock_connection._update_cache.assert_called_once_with(
+            "legacy_firewall_rules_default",
+            expected_rules,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_rules_without_controller_request(
+        self,
+        firewall_manager,
+        mock_connection,
+    ):
+        """A cached result bypasses connection and controller requests."""
+        cached_rules = [
+            {
+                "_id": "rule-cached",
+                "name": "Cached legacy rule",
+                "ruleset": "LAN_LOCAL",
+                "action": "accept",
+            }
+        ]
+        mock_connection.get_cached.return_value = cached_rules
+
+        result = await firewall_manager.get_legacy_firewall_rules()
+
+        assert result == cached_rules
+        mock_connection.ensure_connected.assert_not_awaited()
+        mock_connection.request.assert_not_awaited()
+        mock_connection._update_cache.assert_not_called()
+
+
 class TestGetFirewallZones:
     """Cover primary, fallback, and both-fail branches of get_firewall_zones."""
 

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -1217,8 +1217,8 @@ class TestListLegacyFirewallRules:
     """Cover the read-only wrapper for legacy firewall rules."""
 
     @pytest.mark.asyncio
-    async def test_returns_raw_rules_with_engine_site_and_count(self):
-        """The tool preserves legacy fields and identifies the firewall engine."""
+    async def test_projects_rules_through_the_model_with_engine_site_and_count(self):
+        """The tool projects through LegacyFirewallRule, matching the zone/group tools."""
         mock_conn = MagicMock()
         mock_conn.site = "default"
         legacy_rules = [
@@ -1229,6 +1229,10 @@ class TestListLegacyFirewallRules:
                 "rule_index": 2000,
                 "action": "accept",
                 "enabled": True,
+                "state_established": True,
+                "src_firewallgroup_ids": ["grp-1"],
+                "src_networkconf_id": "net-1",
+                "unmapped_controller_field": "dropped by the model",
             },
             {
                 "_id": "rule-002",
@@ -1254,9 +1258,19 @@ class TestListLegacyFirewallRules:
         assert result["engine"] == "legacy"
         assert result["site"] == "default"
         assert result["count"] == 2
-        assert result["rules"] == legacy_rules
-        assert result["rules"][0]["ruleset"] == "LAN_IN"
-        assert result["rules"][0]["rule_index"] == 2000
+
+        first = result["rules"][0]
+        assert first["id"] == "rule-001"
+        assert first["ruleset"] == "LAN_IN"
+        assert first["rule_index"] == 2000
+        assert first["action"] == "accept"
+        assert first["state_established"] is True
+        assert first["src_firewallgroup_ids"] == ["grp-1"]
+        assert first["src_networkconf_id"] == "net-1"
+        # The model curates the shape: unknown controller keys do not leak through,
+        # and the raw "_id" is normalised to "id".
+        assert "unmapped_controller_field" not in first
+        assert "_id" not in first
 
     @pytest.mark.asyncio
     async def test_surfaces_manager_exception_as_structured_error(self):
@@ -1265,9 +1279,7 @@ class TestListLegacyFirewallRules:
         mock_conn.site = "default"
 
         with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
-            mock_fm.get_legacy_firewall_rules = AsyncMock(
-                side_effect=Exception("Controller returned 404")
-            )
+            mock_fm.get_legacy_firewall_rules = AsyncMock(side_effect=Exception("Controller returned 404"))
             mock_fm._connection = mock_conn
 
             from unifi_network_mcp.tools.firewall import (
@@ -1281,6 +1293,79 @@ class TestListLegacyFirewallRules:
         assert "Controller returned 404" in result["error"]
         assert "rules" not in result
         assert "count" not in result
+
+
+class TestLegacyEngineHint:
+    """An empty V2 result must not read as 'no firewall rules configured'."""
+
+    @pytest.mark.asyncio
+    async def test_zones_hint_when_empty(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_zones = AsyncMock(return_value=[])
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_zones
+
+            result = await list_firewall_zones()
+
+        assert result["count"] == 0
+        assert "unifi_list_legacy_firewall_rules" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_zones_no_hint_when_populated(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_zones = AsyncMock(return_value=[{"_id": "z1", "name": "Internal"}])
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_zones
+
+            result = await list_firewall_zones()
+
+        assert result["count"] == 1
+        assert "note" not in result
+
+    @pytest.mark.asyncio
+    async def test_policies_hint_when_controller_returns_none(self):
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[])
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+            result = await list_firewall_policies()
+
+        assert result["total_count"] == 0
+        assert "unifi_list_legacy_firewall_rules" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_policies_no_hint_when_filter_excludes_everything(self):
+        """A filter matching nothing is not the same as the engine having no policies."""
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(
+                return_value=[{"_id": "p1", "name": "Allow LAN", "action": "ALLOW", "enabled": True}]
+            )
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import list_firewall_policies
+
+            result = await list_firewall_policies(search="no-such-policy-name")
+
+        # total_count is post-filter, so it is legitimately 0 here. The hint must key
+        # off the pre-filter controller result, not this.
+        assert result["returned_count"] == 0
+        assert "note" not in result
 
 
 class TestListFirewallZones:

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -1208,6 +1208,81 @@ class TestDeleteFirewallPolicy:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# list_legacy_firewall_rules — raw rule projection and error surfacing
+# ---------------------------------------------------------------------------
+
+
+class TestListLegacyFirewallRules:
+    """Cover the read-only wrapper for legacy firewall rules."""
+
+    @pytest.mark.asyncio
+    async def test_returns_raw_rules_with_engine_site_and_count(self):
+        """The tool preserves legacy fields and identifies the firewall engine."""
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+        legacy_rules = [
+            {
+                "_id": "rule-001",
+                "name": "Allow established traffic",
+                "ruleset": "LAN_IN",
+                "rule_index": 2000,
+                "action": "accept",
+                "enabled": True,
+            },
+            {
+                "_id": "rule-002",
+                "name": "Block guest access",
+                "ruleset": "GUEST_IN",
+                "rule_index": 2010,
+                "action": "drop",
+                "enabled": True,
+            },
+        ]
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_legacy_firewall_rules = AsyncMock(return_value=legacy_rules)
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import (
+                list_legacy_firewall_rules,
+            )
+
+            result = await list_legacy_firewall_rules()
+
+        assert result["success"] is True
+        assert result["engine"] == "legacy"
+        assert result["site"] == "default"
+        assert result["count"] == 2
+        assert result["rules"] == legacy_rules
+        assert result["rules"][0]["ruleset"] == "LAN_IN"
+        assert result["rules"][0]["rule_index"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_surfaces_manager_exception_as_structured_error(self):
+        """Manager failures are returned as explicit legacy-engine errors."""
+        mock_conn = MagicMock()
+        mock_conn.site = "default"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_legacy_firewall_rules = AsyncMock(
+                side_effect=Exception("Controller returned 404")
+            )
+            mock_fm._connection = mock_conn
+
+            from unifi_network_mcp.tools.firewall import (
+                list_legacy_firewall_rules,
+            )
+
+            result = await list_legacy_firewall_rules()
+
+        assert result["success"] is False
+        assert result["engine"] == "legacy"
+        assert "Controller returned 404" in result["error"]
+        assert "rules" not in result
+        assert "count" not in result
+
+
 class TestListFirewallZones:
     """Cover the tool wrapper's projection and error-surfacing behavior."""
 

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -24,6 +24,7 @@ CACHE_PREFIX_TRAFFIC_ROUTES = "traffic_routes"
 CACHE_PREFIX_PORT_FORWARDS = "port_forwards"
 CACHE_PREFIX_FIREWALL_ZONES = "firewall_zones"
 CACHE_PREFIX_FIREWALL_GROUPS = "firewall_groups"
+CACHE_PREFIX_LEGACY_FIREWALL_RULES = "legacy_firewall_rules"
 
 
 class FirewallManager:
@@ -1037,7 +1038,35 @@ class FirewallManager:
             logger.error("Error fetching firewall zones: %s", e, exc_info=True)
             raise
 
-    # ---- Firewall Groups (v1 REST: address-group, port-group) ----
+    # ---- Legacy Firewall Rules and Groups (v1 REST) ----
+
+    async def get_legacy_firewall_rules(self) -> List[Dict[str, Any]]:
+        """Get legacy pre-zone-based firewall rules for the current UniFi site."""
+        cache_key = f"{CACHE_PREFIX_LEGACY_FIREWALL_RULES}_{self._connection.site}"
+        cached = self._connection.get_cached(cache_key)
+        if cached is not None:
+            return cached
+
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+
+        try:
+            api_request = ApiRequest(method="get", path="/rest/firewallrule")
+            response = await self._connection.request(api_request)
+            data = (
+                response
+                if isinstance(response, list)
+                else response.get("data", [])
+                if isinstance(response, dict)
+                else []
+            )
+            data = [rule for rule in data if isinstance(rule, dict)]
+
+            self._connection._update_cache(cache_key, data)
+            return data
+        except Exception as e:
+            logger.error("Error getting legacy firewall rules: %s", e)
+            raise
 
     async def get_firewall_groups(self) -> List[Dict[str, Any]]:
         """Get all firewall groups (address and port groups).

--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -8,6 +8,9 @@ Mirrors the Strawberry types in
 - ``FirewallGroup`` — create/delete for firewall address/port groups.
   Mutable fields: name, group_type, members.
 - ``FirewallZone``  — read-only zone shape (no mutable fields).
+- ``LegacyFirewallRule`` — read-only pre-zone-based rule shape. The legacy
+  engine uses different field names, lowercase actions, and flat
+  source/destination fields, so it cannot share ``FirewallRule``.
 
 Factory helpers:
 - ``from_controller``              — raw dict → FirewallRule
@@ -16,6 +19,7 @@ Factory helpers:
 - ``firewall_group_from_controller`` — raw dict → FirewallGroup
 - ``to_group_create``              — FirewallGroup → create payload
 - ``firewall_zone_from_controller`` — raw dict → FirewallZone
+- ``legacy_firewall_rule_from_controller`` — raw dict → LegacyFirewallRule
 
 ``MUTABLE_FIELDS`` is for FirewallRule and drives the cross-layer
 symmetry test. Per-class aliases are provided for FirewallGroup and
@@ -211,6 +215,220 @@ FIREWALLZONE_READ_ONLY_FIELDS: frozenset[str] = frozenset(FirewallZone.model_fie
 
 
 # ---------------------------------------------------------------------------
+# LegacyFirewallRule pydantic model (read-only, pre-zone-based engine)
+# ---------------------------------------------------------------------------
+
+#: Rulesets accepted by the legacy engine, including the IPv6 variants.
+LEGACY_RULESETS: frozenset[str] = frozenset(
+    {
+        "WAN_IN",
+        "WAN_OUT",
+        "WAN_LOCAL",
+        "LAN_IN",
+        "LAN_OUT",
+        "LAN_LOCAL",
+        "GUEST_IN",
+        "GUEST_OUT",
+        "GUEST_LOCAL",
+        "WANv6_IN",
+        "WANv6_OUT",
+        "WANv6_LOCAL",
+        "LANv6_IN",
+        "LANv6_OUT",
+        "LANv6_LOCAL",
+        "GUESTv6_IN",
+        "GUESTv6_OUT",
+        "GUESTv6_LOCAL",
+    }
+)
+
+#: Legacy actions are lowercase, unlike the V2 engine's ALLOW/BLOCK/REJECT.
+LEGACY_ACTIONS: frozenset[str] = frozenset({"accept", "drop", "reject"})
+
+
+class LegacyFirewallRule(BaseModel):
+    """Canonical pre-zone-based (legacy) firewall rule model (read-only).
+
+    Distinct from :class:`FirewallRule`, which models the V2 zone-based engine.
+    The two engines use different field names, different action casing, and
+    different source/destination shapes, so they cannot share a model.
+    """
+
+    id: Optional[str] = Field(
+        default=None,
+        description="Legacy firewall rule ID",
+        json_schema_extra={"mutable": False},
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="Rule name",
+        json_schema_extra={"mutable": False},
+    )
+    ruleset: Optional[str] = Field(
+        default=None,
+        description=(
+            "Ruleset the rule belongs to, e.g. WAN_IN, LAN_OUT, GUEST_LOCAL, or an IPv6 variant such as LANv6_IN"
+        ),
+        json_schema_extra={"mutable": False},
+    )
+    rule_index: Optional[int] = Field(
+        default=None,
+        description="Evaluation order within the ruleset (lower runs first)",
+        json_schema_extra={"mutable": False},
+    )
+    action: Optional[str] = Field(
+        default=None,
+        description="Action for matched traffic: accept, drop, or reject (lowercase)",
+        json_schema_extra={"mutable": False},
+    )
+    enabled: Optional[bool] = Field(
+        default=None,
+        description="Whether the rule is active",
+        json_schema_extra={"mutable": False},
+    )
+    protocol: Optional[str] = Field(
+        default=None,
+        description="IPv4 protocol match, e.g. all, tcp, udp, tcp_udp, icmp",
+        json_schema_extra={"mutable": False},
+    )
+    protocol_v6: Optional[str] = Field(
+        default=None,
+        description="IPv6 protocol match",
+        json_schema_extra={"mutable": False},
+    )
+    protocol_match_excepted: Optional[bool] = Field(
+        default=None,
+        description="Invert the protocol match",
+        json_schema_extra={"mutable": False},
+    )
+    src_address: Optional[str] = Field(
+        default=None,
+        description="Source address or CIDR",
+        json_schema_extra={"mutable": False},
+    )
+    src_address_ipv6: Optional[str] = Field(
+        default=None,
+        description="Source IPv6 address or CIDR",
+        json_schema_extra={"mutable": False},
+    )
+    src_port: Optional[str] = Field(
+        default=None,
+        description="Source port or range",
+        json_schema_extra={"mutable": False},
+    )
+    src_mac_address: Optional[str] = Field(
+        default=None,
+        description="Source MAC address match",
+        json_schema_extra={"mutable": False},
+    )
+    src_firewallgroup_ids: List[str] = Field(
+        default_factory=list,
+        description="Source firewall group IDs (address or port groups)",
+        json_schema_extra={"mutable": False},
+    )
+    src_networkconf_id: Optional[str] = Field(
+        default=None,
+        description="Source network (VLAN) ID",
+        json_schema_extra={"mutable": False},
+    )
+    src_networkconf_type: Optional[str] = Field(
+        default=None,
+        description="How the source network is matched: ADDRv4 or NETv4",
+        json_schema_extra={"mutable": False},
+    )
+    dst_address: Optional[str] = Field(
+        default=None,
+        description="Destination address or CIDR",
+        json_schema_extra={"mutable": False},
+    )
+    dst_address_ipv6: Optional[str] = Field(
+        default=None,
+        description="Destination IPv6 address or CIDR",
+        json_schema_extra={"mutable": False},
+    )
+    dst_port: Optional[str] = Field(
+        default=None,
+        description="Destination port or range",
+        json_schema_extra={"mutable": False},
+    )
+    dst_firewallgroup_ids: List[str] = Field(
+        default_factory=list,
+        description="Destination firewall group IDs (address or port groups)",
+        json_schema_extra={"mutable": False},
+    )
+    dst_networkconf_id: Optional[str] = Field(
+        default=None,
+        description="Destination network (VLAN) ID",
+        json_schema_extra={"mutable": False},
+    )
+    dst_networkconf_type: Optional[str] = Field(
+        default=None,
+        description="How the destination network is matched: ADDRv4 or NETv4",
+        json_schema_extra={"mutable": False},
+    )
+    state_new: Optional[bool] = Field(
+        default=None,
+        description="Match connections in the NEW state",
+        json_schema_extra={"mutable": False},
+    )
+    state_established: Optional[bool] = Field(
+        default=None,
+        description="Match connections in the ESTABLISHED state",
+        json_schema_extra={"mutable": False},
+    )
+    state_related: Optional[bool] = Field(
+        default=None,
+        description="Match connections in the RELATED state",
+        json_schema_extra={"mutable": False},
+    )
+    state_invalid: Optional[bool] = Field(
+        default=None,
+        description="Match connections in the INVALID state",
+        json_schema_extra={"mutable": False},
+    )
+    icmp_typename: Optional[str] = Field(
+        default=None,
+        description="ICMP type match",
+        json_schema_extra={"mutable": False},
+    )
+    icmpv6_typename: Optional[str] = Field(
+        default=None,
+        description="ICMPv6 type match",
+        json_schema_extra={"mutable": False},
+    )
+    ipsec: Optional[str] = Field(
+        default=None,
+        description="IPsec match: match-ipsec or match-none",
+        json_schema_extra={"mutable": False},
+    )
+    logging: Optional[bool] = Field(
+        default=None,
+        description="Whether matched traffic is logged",
+        json_schema_extra={"mutable": False},
+    )
+    setting_preference: Optional[str] = Field(
+        default=None,
+        description="Whether the rule is auto-managed or manually configured",
+        json_schema_extra={"mutable": False},
+    )
+    no_edit: Optional[bool] = Field(
+        default=None,
+        description="Controller-defined rule that cannot be edited",
+        json_schema_extra={"mutable": False},
+    )
+    no_delete: Optional[bool] = Field(
+        default=None,
+        description="Controller-defined rule that cannot be deleted",
+        json_schema_extra={"mutable": False},
+    )
+
+
+LEGACYFIREWALLRULE_MUTABLE_FIELDS: frozenset[str] = frozenset()
+
+LEGACYFIREWALLRULE_READ_ONLY_FIELDS: frozenset[str] = frozenset(LegacyFirewallRule.model_fields.keys())
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
@@ -331,4 +549,62 @@ def firewall_zone_from_controller(raw: Any) -> FirewallZone:
         name=_get(raw, "name"),
         networks=list(networks),
         default_policy=_get(raw, "default_policy") or _get(raw, "default_action"),
+    )
+
+
+def _str_list(value: Any) -> List[str]:
+    """Coerce a controller value to a list of strings, dropping anything else."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _opt_bool(value: Any) -> Optional[bool]:
+    """Preserve ``False`` while treating a missing or non-bool value as unknown."""
+    return value if isinstance(value, bool) else None
+
+
+def legacy_firewall_rule_from_controller(raw: Any) -> LegacyFirewallRule:
+    """Build a LegacyFirewallRule from a ``/rest/firewallrule`` response entry."""
+    rule_index = _get(raw, "rule_index")
+    if not isinstance(rule_index, int) or isinstance(rule_index, bool):
+        try:
+            rule_index = int(rule_index)
+        except (TypeError, ValueError):
+            rule_index = None
+
+    return LegacyFirewallRule(
+        id=_get(raw, "_id") or _get(raw, "id"),
+        name=_get(raw, "name"),
+        ruleset=_get(raw, "ruleset"),
+        rule_index=rule_index,
+        action=_get(raw, "action"),
+        enabled=_opt_bool(_get(raw, "enabled")),
+        protocol=_get(raw, "protocol"),
+        protocol_v6=_get(raw, "protocol_v6"),
+        protocol_match_excepted=_opt_bool(_get(raw, "protocol_match_excepted")),
+        src_address=_get(raw, "src_address"),
+        src_address_ipv6=_get(raw, "src_address_ipv6"),
+        src_port=_get(raw, "src_port"),
+        src_mac_address=_get(raw, "src_mac_address"),
+        src_firewallgroup_ids=_str_list(_get(raw, "src_firewallgroup_ids")),
+        src_networkconf_id=_get(raw, "src_networkconf_id"),
+        src_networkconf_type=_get(raw, "src_networkconf_type"),
+        dst_address=_get(raw, "dst_address"),
+        dst_address_ipv6=_get(raw, "dst_address_ipv6"),
+        dst_port=_get(raw, "dst_port"),
+        dst_firewallgroup_ids=_str_list(_get(raw, "dst_firewallgroup_ids")),
+        dst_networkconf_id=_get(raw, "dst_networkconf_id"),
+        dst_networkconf_type=_get(raw, "dst_networkconf_type"),
+        state_new=_opt_bool(_get(raw, "state_new")),
+        state_established=_opt_bool(_get(raw, "state_established")),
+        state_related=_opt_bool(_get(raw, "state_related")),
+        state_invalid=_opt_bool(_get(raw, "state_invalid")),
+        icmp_typename=_get(raw, "icmp_typename"),
+        icmpv6_typename=_get(raw, "icmpv6_typename"),
+        ipsec=_get(raw, "ipsec"),
+        logging=_opt_bool(_get(raw, "logging")),
+        setting_preference=_get(raw, "setting_preference"),
+        no_edit=_opt_bool(_get(raw, "attr_no_edit")),
+        no_delete=_opt_bool(_get(raw, "attr_no_delete")),
     )

--- a/packages/unifi-core/tests/network/models/test_firewall.py
+++ b/packages/unifi-core/tests/network/models/test_firewall.py
@@ -7,14 +7,20 @@ from unifi_core.network.models.firewall import (
     FIREWALLGROUP_READ_ONLY_FIELDS,
     FIREWALLZONE_MUTABLE_FIELDS,
     FIREWALLZONE_READ_ONLY_FIELDS,
+    LEGACY_ACTIONS,
+    LEGACY_RULESETS,
+    LEGACYFIREWALLRULE_MUTABLE_FIELDS,
+    LEGACYFIREWALLRULE_READ_ONLY_FIELDS,
     MUTABLE_FIELDS,
     READ_ONLY_FIELDS,
     FirewallGroup,
     FirewallRule,
     FirewallZone,
+    LegacyFirewallRule,
     firewall_group_from_controller,
     firewall_zone_from_controller,
     from_controller,
+    legacy_firewall_rule_from_controller,
     to_controller_update,
     to_group_create,
 )
@@ -255,3 +261,133 @@ class TestFirewallZoneFromController:
         z = firewall_zone_from_controller({})
         assert z.id is None
         assert z.networks == []
+
+
+# ---------------------------------------------------------------------------
+# LegacyFirewallRule — pre-zone-based engine (V1 /rest/firewallrule)
+# ---------------------------------------------------------------------------
+
+#: A representative rule as the controller returns it. Field names and value
+#: shapes follow the controller-generated schema used by the Terraform/Pulumi
+#: providers, since the V2 zone-based engine uses entirely different names.
+RAW_LEGACY_RULE = {
+    "_id": "60f1a2b3c4d5e6f7a8b9c0d1",
+    "site_id": "5f0000000000000000000001",
+    "name": "Block IoT to LAN",
+    "ruleset": "LAN_IN",
+    "rule_index": 2001,
+    "action": "drop",
+    "enabled": True,
+    "protocol": "all",
+    "protocol_v6": "",
+    "protocol_match_excepted": False,
+    "src_address": "192.168.30.0/24",
+    "src_address_ipv6": "",
+    "src_port": "",
+    "src_mac_address": "",
+    "src_firewallgroup_ids": ["grp-src-1"],
+    "src_networkconf_id": "net-iot",
+    "src_networkconf_type": "NETv4",
+    "dst_address": "192.168.10.0/24",
+    "dst_address_ipv6": "",
+    "dst_port": "443",
+    "dst_firewallgroup_ids": ["grp-dst-1", "grp-dst-2"],
+    "dst_networkconf_id": "net-lan",
+    "dst_networkconf_type": "NETv4",
+    "state_new": True,
+    "state_established": False,
+    "state_related": False,
+    "state_invalid": False,
+    "icmp_typename": "",
+    "icmpv6_typename": "",
+    "ipsec": "match-none",
+    "logging": True,
+    "setting_preference": "manual",
+    "attr_no_edit": False,
+    "attr_no_delete": False,
+}
+
+
+class TestLegacyFirewallRuleModel:
+    def test_is_read_only(self) -> None:
+        assert LEGACYFIREWALLRULE_MUTABLE_FIELDS == frozenset()
+        assert LEGACYFIREWALLRULE_READ_ONLY_FIELDS == frozenset(LegacyFirewallRule.model_fields.keys())
+
+    def test_ruleset_enum_includes_ipv6_variants(self) -> None:
+        assert len(LEGACY_RULESETS) == 18
+        for name in ("WAN_IN", "LAN_OUT", "GUEST_LOCAL", "LANv6_IN", "GUESTv6_OUT", "WANv6_LOCAL"):
+            assert name in LEGACY_RULESETS
+
+    def test_legacy_actions_are_lowercase(self) -> None:
+        """The V2 engine uses ALLOW/BLOCK/REJECT; the legacy engine does not."""
+        assert LEGACY_ACTIONS == {"accept", "drop", "reject"}
+
+
+class TestLegacyFirewallRuleFromController:
+    def test_maps_every_documented_field(self) -> None:
+        r = legacy_firewall_rule_from_controller(RAW_LEGACY_RULE)
+        assert r.id == "60f1a2b3c4d5e6f7a8b9c0d1"
+        assert r.name == "Block IoT to LAN"
+        assert r.ruleset == "LAN_IN"
+        assert r.rule_index == 2001
+        assert r.action == "drop"
+        assert r.enabled is True
+        assert r.src_address == "192.168.30.0/24"
+        assert r.src_firewallgroup_ids == ["grp-src-1"]
+        assert r.src_networkconf_id == "net-iot"
+        assert r.src_networkconf_type == "NETv4"
+        assert r.dst_port == "443"
+        assert r.dst_firewallgroup_ids == ["grp-dst-1", "grp-dst-2"]
+        assert r.ipsec == "match-none"
+        assert r.logging is True
+        assert r.setting_preference == "manual"
+
+    def test_state_flags_preserve_false(self) -> None:
+        """False is a meaningful value here and must not collapse to None."""
+        r = legacy_firewall_rule_from_controller(RAW_LEGACY_RULE)
+        assert r.state_new is True
+        assert r.state_established is False
+        assert r.state_related is False
+        assert r.state_invalid is False
+
+    def test_maps_attr_flags_to_friendly_names(self) -> None:
+        r = legacy_firewall_rule_from_controller({**RAW_LEGACY_RULE, "attr_no_edit": True, "attr_no_delete": True})
+        assert r.no_edit is True
+        assert r.no_delete is True
+
+    def test_drops_site_id_and_unknown_keys(self) -> None:
+        r = legacy_firewall_rule_from_controller({**RAW_LEGACY_RULE, "totally_unknown": "x"})
+        dumped = r.model_dump()
+        assert "site_id" not in dumped
+        assert "totally_unknown" not in dumped
+
+    def test_coerces_string_rule_index(self) -> None:
+        r = legacy_firewall_rule_from_controller({"_id": "r", "rule_index": "2005"})
+        assert r.rule_index == 2005
+
+    def test_non_numeric_rule_index_becomes_none(self) -> None:
+        r = legacy_firewall_rule_from_controller({"_id": "r", "rule_index": "not-a-number"})
+        assert r.rule_index is None
+
+    def test_non_list_firewallgroup_ids_become_empty(self) -> None:
+        r = legacy_firewall_rule_from_controller({"_id": "r", "src_firewallgroup_ids": "grp-1"})
+        assert r.src_firewallgroup_ids == []
+
+    def test_non_string_group_members_are_dropped(self) -> None:
+        r = legacy_firewall_rule_from_controller({"_id": "r", "dst_firewallgroup_ids": ["ok", 7, None]})
+        assert r.dst_firewallgroup_ids == ["ok"]
+
+    def test_non_bool_enabled_becomes_none(self) -> None:
+        r = legacy_firewall_rule_from_controller({"_id": "r", "enabled": "yes"})
+        assert r.enabled is None
+
+    def test_handles_empty_dict(self) -> None:
+        r = legacy_firewall_rule_from_controller({})
+        assert r.id is None
+        assert r.ruleset is None
+        assert r.src_firewallgroup_ids == []
+        assert r.dst_firewallgroup_ids == []
+
+    def test_falls_back_to_id_key(self) -> None:
+        r = legacy_firewall_rule_from_controller({"id": "alt-id"})
+        assert r.id == "alt-id"

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (186 tools)
+# Network Server Tool Reference (187 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -107,7 +107,7 @@ Always available, regardless of registration mode.
 ## Firewall
 
 <!-- AUTO:tools:firewall -->
-14 tools.
+15 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -117,6 +117,7 @@ Always available, regardless of registration mode.
 | `unifi_list_firewall_groups` | Read | List firewall groups (address and port groups) used as reusable objects in firewall policies. |
 | `unifi_list_firewall_policies` | Read | List firewall policies configured on the Unifi Network controller. |
 | `unifi_list_firewall_zones` | Read | List controller firewall zones (V2 API). |
+| `unifi_list_legacy_firewall_rules` | Read | List legacy pre-zone-based firewall rules from the UniFi controller. |
 | `unifi_create_firewall_group` | Mutate | Create a new firewall group (address or port group). |
 | `unifi_create_firewall_policy` | Mutate | Create a V2 zone-based firewall policy with schema validation. |
 | `unifi_delete_firewall_group` | Mutate | Delete a firewall group. |


### PR DESCRIPTION
## Summary

Adds read-only support for legacy pre-zone-based UniFi firewall rules.

## Changes

- Add `FirewallManager.get_legacy_firewall_rules()`
- Fetch legacy rules through `/rest/firewallrule`
- Cache results per site
- Accept list and `{"data": [...]}` controller responses
- Add the `unifi_list_legacy_firewall_rules` MCP tool
- Redact sensitive fields using the existing redaction path
- Add manager and tool unit tests

## Validation

- 86 unit tests passed
- Ruff checks passed
- `git diff --check` passed