### PR TITLE
fix(network): reach the v2 security log when the legacy IPS endpoint answers empty

### DIFF
--- a/apps/network/tests/unit/test_stats_enhanced.py
+++ b/apps/network/tests/unit/test_stats_enhanced.py
@@ -265,9 +265,50 @@ class TestStatsManagerEnhanced:
 
         await stats_manager.get_ips_events(limit=10)
 
-        call_args = mock_connection.request.call_args
-        api_request = call_args[0][0]
+        # An empty legacy answer now triggers the v2 fallback, so the legacy
+        # request is the first call rather than the last one.
+        api_request = mock_connection.request.call_args_list[0][0][0]
+        assert api_request.path == "/stat/ips/event"
         assert api_request.data["_limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_get_ips_events_empty_legacy_falls_back_to_v2(self, stats_manager, mock_connection):
+        """An empty legacy response must still reach the v2 security log.
+
+        Controllers that moved IPS events to the v2 system log answer
+        /stat/ips/event with 200 and an empty list rather than failing, so a
+        fallback guarded only by an exception never runs for them.
+        """
+        v2_events = [{"key": "EVT_IPS_IpsAlert"}]
+        mock_connection.request.side_effect = [[], v2_events]
+
+        result = await stats_manager.get_ips_events()
+
+        assert result == v2_events
+        assert mock_connection.request.call_count == 2
+        assert mock_connection.request.call_args_list[0][0][0].path == "/stat/ips/event"
+        assert mock_connection.request.call_args_list[1][0][0].path == "/system-log/critical"
+
+    @pytest.mark.asyncio
+    async def test_get_ips_events_non_empty_legacy_skips_v2(self, stats_manager, mock_connection):
+        """A controller still populating the legacy endpoint must not be double-queried."""
+        legacy_events = [{"event_type": "alert"}]
+        mock_connection.request.return_value = legacy_events
+
+        result = await stats_manager.get_ips_events()
+
+        assert result == legacy_events
+        assert mock_connection.request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_ips_events_v2_failure_after_empty_legacy_returns_empty(self, stats_manager, mock_connection):
+        """A failing v2 fallback must not turn an empty result into an exception."""
+        mock_connection.request.side_effect = [[], Exception("v2 unavailable")]
+
+        result = await stats_manager.get_ips_events()
+
+        assert result == []
+        assert mock_connection.request.call_count == 2
 
     @pytest.mark.asyncio
     async def test_get_client_sessions(self, stats_manager, mock_connection):

--- a/apps/network/tests/unit/test_stats_enhanced.py
+++ b/apps/network/tests/unit/test_stats_enhanced.py
@@ -302,12 +302,36 @@ class TestStatsManagerEnhanced:
 
     @pytest.mark.asyncio
     async def test_get_ips_events_v2_failure_after_empty_legacy_returns_empty(self, stats_manager, mock_connection):
-        """A failing v2 fallback must not turn an empty result into an exception."""
+        """A failing v2 fallback must not turn an empty result into an exception.
+
+        A controller old enough to have no v2 endpoint answers exactly this way,
+        so raising here would break setups the legacy endpoint still serves.
+        """
         mock_connection.request.side_effect = [[], Exception("v2 unavailable")]
 
         result = await stats_manager.get_ips_events()
 
         assert result == []
+        assert mock_connection.request.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_ips_events_v2_failure_is_not_cached(self, stats_manager, mock_connection):
+        """A degraded empty result must not be cached as a confirmed quiet period."""
+        mock_connection.request.side_effect = [[], Exception("v2 unavailable")]
+
+        await stats_manager.get_ips_events()
+
+        mock_connection._update_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_ips_events_non_list_legacy_falls_back_to_v2(self, stats_manager, mock_connection):
+        """A malformed legacy answer must reach v2 rather than be coerced to []."""
+        v2_events = [{"key": "EVT_IPS_IpsAlert"}]
+        mock_connection.request.side_effect = [{"unexpected": "envelope"}, v2_events]
+
+        result = await stats_manager.get_ips_events()
+
+        assert result == v2_events
         assert mock_connection.request.call_count == 2
 
     @pytest.mark.asyncio

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -515,6 +515,17 @@ class StatsManager:
             except Exception as legacy_error:
                 logger.debug("Legacy IPS endpoint failed, falling back to v2 security logs: %s", legacy_error)
                 response = await self._get_security_events_v2(start_time, end_time, limit)
+            else:
+                # A controller that has moved IPS events to the v2 system log answers
+                # this endpoint 200 with an empty list rather than failing, so the
+                # fallback above never fires on the versions it exists for.
+                if not response:
+                    logger.debug("Legacy IPS endpoint returned no events, trying v2 security logs")
+                    try:
+                        response = await self._get_security_events_v2(start_time, end_time, limit)
+                    except Exception as v2_error:
+                        logger.debug("v2 security log fallback failed: %s", v2_error)
+                        response = []
             result = response if isinstance(response, list) else []
             self._connection._update_cache(cache_key, result, timeout=300)
             return result

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -519,13 +519,18 @@ class StatsManager:
                 # A controller that has moved IPS events to the v2 system log answers
                 # this endpoint 200 with an empty list rather than failing, so the
                 # fallback above never fires on the versions it exists for.
-                if not response:
+                if not isinstance(response, list) or not response:
                     logger.debug("Legacy IPS endpoint returned no events, trying v2 security logs")
                     try:
                         response = await self._get_security_events_v2(start_time, end_time, limit)
                     except Exception as v2_error:
+                        # Deliberately not raising, unlike the branch above: legacy did
+                        # answer here, and a controller old enough to have no v2 endpoint
+                        # answers exactly this way. Returning early leaves the result
+                        # uncached, so a transient v2 outage is retried on the next call
+                        # rather than held as "no threats" for the whole TTL.
                         logger.debug("v2 security log fallback failed: %s", v2_error)
-                        response = []
+                        return []
             result = response if isinstance(response, list) else []
             self._connection._update_cache(cache_key, result, timeout=300)
             return result


### PR DESCRIPTION
Fixes #473.

## The problem

`get_ips_events` guards its v2 fallback with `except Exception`, so it runs only when `/stat/ips/event` raises. Controllers that moved IPS events to the v2 system log do not raise — they answer `200` with an empty list. The fallback therefore never fires on the versions it exists for, and the tool returns `success: true, count: 0` on a controller that has threat data.

The tool description already documents the premise ("on newer UniFi OS / Network Application versions, IPS events may not populate this legacy endpoint"), so the code states the case it cannot reach.

Observed on a UDM SE running Network 10.4.57, `unifi-network-mcp` 0.24.1: `count: 0` for hourly, daily and weekly, while `unifi_get_anomalies` returns 8 entries and `unifi_get_system_info` is fine on the same session.

## The change

An empty — or non-list — legacy response is treated as inconclusive and v2 is tried as well.

Two decisions that are less obvious than they look:

**A v2 failure after an empty legacy answer does not raise.** This is deliberately asymmetric with the existing `except` branch, which propagates. A controller old enough to have no v2 endpoint answers exactly this shape — legacy `200 []`, then v2 unavailable — so propagating would turn a setup the legacy endpoint still serves correctly into a hard failure. The asymmetry is stated in a comment rather than left to be re-derived.

**The degraded result is returned early, so it is not cached.** Writing it to the 5-minute cache would hold a transient v2 outage as a confirmed quiet period, and on a security-event endpoint that is the difference between "no threats" and "we could not tell". A retry within the TTL now re-probes instead of replaying the empty answer.

The trigger is `not isinstance(response, list) or not response` rather than `not response`, to match the normalisation two lines below: a malformed non-list answer was previously coerced to `[]` without ever reaching v2 — the same silent-empty bug in a different shape.

## Tests

`apps/network/tests/unit/test_stats_enhanced.py`, alongside the existing ones for this file:

- empty legacy → v2 is reached, its events are returned
- non-empty legacy → v2 is **not** called (no double query for controllers still populating the legacy endpoint)
- non-list legacy → v2 is reached rather than the answer being coerced to `[]`
- v2 failure after empty legacy → returns `[]` rather than raising
- v2 failure after empty legacy → nothing is written to the cache

`test_get_ips_events_custom_limit` asserted on the **last** request, which is now the v2 one. It asserts on the legacy call explicitly instead, and gains the path assertion it was missing.

## Verification

```
uv run pytest apps/network/tests/unit/test_stats_enhanced.py   →  47 passed
make lint                                                      →  All checks passed
make check-generated                                           →  no drift
```

One caveat, stated rather than hidden: `make core-test` fails in my environment on 7 collection errors, `ModuleNotFoundError: No module named 'uiprotect'`, in `packages/unifi-core/tests/protect/`. I confirmed it fails identically on `main` without this change, so it is not a regression here — but it does mean the documented target for a `packages/unifi-core/` change could not exercise this code. The tests that do cover this file live under `apps/network/tests/unit/`, following the existing layout for `stats_manager`. I have a one-line fix for that target and will send it separately rather than mix it into this PR.