### PR TITLE
fix(tooling): core-test skips the whole unifi-core suite, and --check reports drift on a clean tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: docker-build worker-build
 check: format-check lint check-generated test worker-typecheck
 
 core-test:
-	uv run --package unifi-core pytest packages/unifi-core/tests -v
+	uv run --package unifi-core --extra protect pytest packages/unifi-core/tests -v
 
 shared-test:
 	uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -v

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ build: docker-build worker-build
 check: format-check lint check-generated test worker-typecheck
 
 core-test:
-	uv run --package unifi-core --extra protect pytest packages/unifi-core/tests -v
+	# --all-extras, not a named extra: the suite spans tests/network (aiounifi),
+	# tests/protect (uiprotect) and tests/access (py-unifi-access), and naming one
+	# installs that extra's deps while leaving the others' collection to fail.
+	uv run --package unifi-core --all-extras pytest packages/unifi-core/tests -v
 
 shared-test:
 	uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -v

--- a/scripts/generate_skill_references.py
+++ b/scripts/generate_skill_references.py
@@ -234,7 +234,13 @@ def main():
 
         print(f"    Updated: {updated} categories, Missing markers: {missing}")
 
-    print(f"\nDone. {'Would update' if check_mode else 'Updated'} {total_updated} sections.")
+    if check_mode:
+        # total_updated counts the sections rendered, not the ones that differ:
+        # has_drift is the real signal. Saying "would update" when nothing would
+        # change reads as drift on a clean checkout.
+        print(f"\nDone. Checked {total_updated} sections; {'drift found' if has_drift else 'no drift'}.")
+    else:
+        print(f"\nDone. Updated {total_updated} sections.")
 
     if total_missing > 0:
         print(f"\n{total_missing} categories missing markers:")


### PR DESCRIPTION
Two independent papercuts, both of which make a clean checkout look broken. Found while preparing #474; kept out of that PR because neither is related to it.

## 1. `make core-test` skips every unifi-core test

On a clean clone:

```console
$ make core-test
ERROR packages/unifi-core/tests/protect/managers/test_alarm_facade.py
...
E   ModuleNotFoundError: No module named 'uiprotect'
!!!!!!!!!!!!! Interrupted: 7 errors during collection !!!!!!!!!!!!!
7 errors in 1.27s
make: *** [Makefile:45: core-test] Error 2
```

`uiprotect` is declared as the optional `protect` extra in `packages/unifi-core/pyproject.toml`:

```toml
protect = ["uiprotect>=15.12.2"]
```

but the target runs `uv run --package unifi-core` without asking for it. Collection aborts, so **the entire suite is skipped**, not just the protect tests — a contributor running the documented target for a `packages/unifi-core/` change gets a red result that says nothing about their change.

Adding the extra:

```console
$ make core-test
1415 passed in 4.58s
```

## 2. `--check` says "Would update 39 sections" when nothing would change

```console
$ make check-generated
Done. Would update 39 sections.
$ echo $?
0
```

Exit 0, no `Drift detected!`, nothing modified — the check passed. But the message says otherwise, and reads as pending drift on a clean tree.

`total_updated` accumulates the sections `update_reference_content` rendered, regardless of whether the result differs from what is on disk. `has_drift` (`new_content != content`) is the real signal and correctly stays `False`. So in `--check` mode the count describes work considered, not work needed.

Now:

```console
$ make check-generated
Done. Checked 39 sections; no drift.
```

The drift path is untouched. Verified by injecting a bogus tool line into `plugins/unifi-network/.../network-tools.md`:

```console
$ make check-generated
Drift detected! Run without --check to update.
make: *** [Makefile:90: check-skill-references] Error 1
```

Generating mode still prints `Updated N sections` as before.

## Verification

- `make core-test` → 1415 passed (was: 7 collection errors)
- `make check-generated` → `no drift`, exit 0; with drift injected → `Drift detected!`, exit 1
- `make lint` → All checks passed
- No generated file is modified by this PR