### PR TITLE
fix(network): nest content-filter schedule_mode as schedule.mode

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/content_filtering.py
+++ b/apps/network/src/unifi_network_mcp/tools/content_filtering.py
@@ -126,7 +126,8 @@ async def update_content_filter(
             "current values are automatically preserved. "
             "Allowed keys: name, enabled (bool), blocked_categories (list), "
             "safe_search (list: 'GOOGLE'/'YOUTUBE'/'BING'), "
-            "client_macs (list of MACs), network_ids (list)"
+            "client_macs (list of MACs), network_ids (list), "
+            "schedule_mode ('ALWAYS'/'EVERY_DAY'/'EVERY_WEEK'/'CUSTOM'/'ONE_TIME_ONLY')"
         ),
     ],
     confirm: Annotated[

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -15991,7 +15991,7 @@
               "type": "boolean"
             },
             "filter_data": {
-              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, enabled (bool), blocked_categories (list), safe_search (list: 'GOOGLE'/'YOUTUBE'/'BING'), client_macs (list of MACs), network_ids (list)",
+              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, enabled (bool), blocked_categories (list), safe_search (list: 'GOOGLE'/'YOUTUBE'/'BING'), client_macs (list of MACs), network_ids (list), schedule_mode ('ALWAYS'/'EVERY_DAY'/'EVERY_WEEK'/'CUSTOM'/'ONE_TIME_ONLY')",
               "type": "object"
             },
             "filter_id": {

--- a/apps/network/tests/unit/test_content_filter_manager.py
+++ b/apps/network/tests/unit/test_content_filter_manager.py
@@ -214,6 +214,29 @@ class TestContentFilterManager:
         assert result == put_request.data
 
     @pytest.mark.asyncio
+    async def test_update_content_filter_preserves_schedule_siblings(self, content_filter_manager, mock_connection):
+        """A partial schedule update must not drop repeat_on_days / time_all_day."""
+        existing_filter = {
+            "_id": "cf1",
+            "name": "Default",
+            "categories": ["ADVERTISEMENT"],
+            "schedule": {"mode": "ALWAYS", "repeat_on_days": ["mon", "tue"], "time_all_day": False},
+        }
+        mock_connection.request.side_effect = [
+            [existing_filter],
+            {},
+        ]
+
+        await content_filter_manager.update_content_filter("cf1", {"schedule": {"mode": "EVERY_DAY"}})
+
+        put_request = mock_connection.request.call_args_list[1][0][0]
+        assert put_request.data["schedule"] == {
+            "mode": "EVERY_DAY",
+            "repeat_on_days": ["mon", "tue"],
+            "time_all_day": False,
+        }
+
+    @pytest.mark.asyncio
     async def test_update_content_filter_not_found(self, content_filter_manager, mock_connection):
         """Test update_content_filter raises UniFiNotFoundError when filter not found."""
         mock_connection.request.return_value = []

--- a/apps/network/tests/unit/test_content_filter_tools.py
+++ b/apps/network/tests/unit/test_content_filter_tools.py
@@ -43,6 +43,36 @@ class TestUpdateContentFilter:
         mock_manager.update_content_filter.assert_awaited_once_with("cf1", {"categories": ["MALWARE", "PHISHING"]})
 
     @pytest.mark.asyncio
+    async def test_confirm_nests_schedule_mode(self):
+        """schedule_mode must reach the manager nested, or the controller 400s."""
+        with patch("unifi_network_mcp.tools.content_filtering.content_filter_manager") as mock_manager:
+            mock_manager.update_content_filter = AsyncMock(return_value={"name": "Default"})
+            from unifi_network_mcp.tools.content_filtering import update_content_filter
+
+            result = await update_content_filter(
+                filter_id="cf1",
+                filter_data={"schedule_mode": "EVERY_DAY"},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        mock_manager.update_content_filter.assert_awaited_once_with("cf1", {"schedule": {"mode": "EVERY_DAY"}})
+
+    @pytest.mark.asyncio
+    async def test_preview_keeps_schedule_mode_in_caller_dialect(self):
+        with patch("unifi_network_mcp.tools.content_filtering.content_filter_manager"):
+            from unifi_network_mcp.tools.content_filtering import update_content_filter
+
+            result = await update_content_filter(
+                filter_id="cf1",
+                filter_data={"schedule_mode": "EVERY_DAY"},
+                confirm=False,
+            )
+
+        assert result["requires_confirmation"] is True
+        assert result["preview"]["proposed"] == {"schedule_mode": "EVERY_DAY"}
+
+    @pytest.mark.asyncio
     async def test_unknown_fields_are_rejected(self):
         """The endpoint 400s on unrecognised fields, so they must never reach the controller."""
         with patch("unifi_network_mcp.tools.content_filtering.content_filter_manager") as mock_manager:

--- a/packages/unifi-core/src/unifi_core/network/models/content_filter.py
+++ b/packages/unifi-core/src/unifi_core/network/models/content_filter.py
@@ -13,9 +13,12 @@ Factory helpers:
 
 ``MUTABLE_FIELDS`` drives the cross-layer symmetry test.
 
-NOTE: ``schedule_mode`` is included in the mutable set regardless of whether
-it appears in the JSON Schema dict — it was silently dropped by the old
-schema-based path and must be passed through to the controller.
+NOTE: ``schedule_mode`` is included in the mutable set regardless of whether it
+appears in the JSON Schema dict. The controller has no flat ``schedule_mode``
+field — it stores the value as ``schedule.mode`` and rejects unrecognised keys
+outright — so ``to_controller_update`` nests it. The manager deep-merges onto the
+fetched profile, which preserves the ``schedule`` siblings the controller returns
+(``repeat_on_days``, ``time_all_day``).
 """
 
 from __future__ import annotations
@@ -71,7 +74,11 @@ class ContentFilter(BaseModel):
     )
     schedule_mode: Optional[str] = Field(
         default=None,
-        description="Schedule mode for the filter (e.g. ALWAYS)",
+        description=(
+            "When the filter is in force. One of ALWAYS, EVERY_DAY, EVERY_WEEK, CUSTOM, "
+            "ONE_TIME_ONLY. Sent to the controller as schedule.mode; the day/time detail "
+            "of a non-ALWAYS schedule is not settable through this field."
+        ),
     )
 
 
@@ -161,4 +168,8 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     # Map blocked_categories → categories
     if "blocked_categories" in result:
         result["categories"] = result.pop("blocked_categories")
+    # Nest schedule_mode → schedule.mode. The manager deep-merges onto the fetched
+    # profile, so sibling keys (repeat_on_days, time_all_day) are preserved.
+    if "schedule_mode" in result:
+        result["schedule"] = {"mode": result.pop("schedule_mode")}
     return result

--- a/packages/unifi-core/tests/network/models/test_content_filter.py
+++ b/packages/unifi-core/tests/network/models/test_content_filter.py
@@ -137,9 +137,28 @@ class TestToControllerUpdate:
         # Since enabled=False is a valid update value:
         assert "enabled" not in result or result.get("enabled") is False
 
-    def test_passes_schedule_mode(self) -> None:
+    def test_nests_schedule_mode_under_schedule(self) -> None:
+        """The controller stores the mode nested; a flat schedule_mode is rejected with a 400."""
         result = to_controller_update({"schedule_mode": "ALWAYS"})
-        assert result["schedule_mode"] == "ALWAYS"
+        assert result["schedule"] == {"mode": "ALWAYS"}
+        assert "schedule_mode" not in result
+
+    def test_nests_every_accepted_schedule_mode(self) -> None:
+        for mode in ("ALWAYS", "CUSTOM", "EVERY_DAY", "EVERY_WEEK", "ONE_TIME_ONLY"):
+            result = to_controller_update({"schedule_mode": mode})
+            assert result["schedule"] == {"mode": mode}
+
+    def test_schedule_mode_nests_alongside_other_fields(self) -> None:
+        result = to_controller_update({"name": "Kids", "schedule_mode": "EVERY_DAY", "blocked_categories": ["ADULT"]})
+        assert result == {"name": "Kids", "schedule": {"mode": "EVERY_DAY"}, "categories": ["ADULT"]}
+
+    def test_schedule_mode_round_trips_from_controller(self) -> None:
+        """A value read off the controller must be writable back unchanged."""
+        raw = {"_id": "cf-rt", "schedule": {"mode": "EVERY_WEEK", "repeat_on_days": ["mon"], "time_all_day": False}}
+        model = from_controller(raw)
+        assert model.schedule_mode == "EVERY_WEEK"
+        result = to_controller_update({"schedule_mode": model.schedule_mode})
+        assert result["schedule"] == {"mode": "EVERY_WEEK"}
 
     def test_maps_blocked_categories_to_categories(self) -> None:
         """The controller rejects the public alias outright, so it must be renamed."""


### PR DESCRIPTION
Fixes #476

## What changed

`to_controller_update()` in `packages/unifi-core/src/unifi_core/network/models/content_filter.py` now nests `schedule_mode` as `schedule: {mode: ...}` instead of passing it through flat.

Also documents the accepted values on the Pydantic field and in the `filter_data` tool description, which regenerates one line of `tools_manifest.json`.

## Why

The content-filtering endpoint has no flat `schedule_mode` field — it stores the value at `schedule.mode`, and it rejects unrecognised keys outright rather than ignoring them. So every update carrying `schedule_mode` failed:

```
400 JSON parse error: Unrecognized field "schedule_mode"
    (class com.ubnt.g.c.j.<redacted>), not marked as ignorable
```

The field was reachable but unusable: it is in `MUTABLE_FIELDS`, it is exposed on the Strawberry type, and `from_controller()` already flattens `schedule.mode` into it on the read side. You could read the value and never write it back.

This is the same bug family as #462 (`blocked_categories` vs `categories`) and was found while validating #463 on hardware.

Sibling preservation comes for free: the manager deep-merges onto the fetched profile, so `repeat_on_days` and `time_all_day` survive a partial `schedule` update. There is a manager-level regression test pinning that, since the fix depends on it.

## Accepted values

The controller enumerates them in its own rejection message, so this list is authoritative rather than guessed:

`ALWAYS`, `EVERY_DAY`, `EVERY_WEEK`, `CUSTOM`, `ONE_TIME_ONLY`

## Known gap

The day/time detail of a non-`ALWAYS` schedule is still not settable — `schedule` is not itself a mutable key, so `repeat_on_days` and `time_all_day` can only be preserved, not authored. Setting a mode like `EVERY_WEEK` without being able to say *which* days is of limited use on its own. Deliberately out of scope here; worth its own issue if anyone wants it.

## Testing

TDD — the four model tests and the tool test were written first and watched fail with `KeyError: 'schedule'` before the fix. `test_passes_schedule_mode` asserted the flat pass-through that caused the 400, so it was encoding the bug; it now asserts the nesting.

Two of the added tests passed on first run and are regression guards rather than TDD drivers: the manager sibling-preservation test (`deep_merge` was already correct) and the preview-dialect test.

- `ruff format` / `ruff check` clean
- `make check-generated` exit 0
- unifi-core: 1421 passed
- network: 885 passed
- api: 943 passed

<details>
<summary>Live verification against a UDM SE (through the real tool path)</summary>

```
[1] preview caller-dialect       : True  {'schedule_mode': 'EVERY_DAY'}
[2] preview wrote nothing        : True
[3] no 400, tool succeeded       : True
[4] schedule.mode applied        : True  {"mode": "EVERY_DAY", "repeat_on_days": [], "time_all_day": false}
[5] schedule siblings preserved  : True
[6] no stray schedule_mode key   : True
[7] other fields preserved       : True  {'name': True, 'enabled': True, 'categories': True,
                                          'network_ids': True, 'safe_search': True, 'client_macs': True,
                                          'allow_list': True, 'block_list': True}
[8] combined schedule+categories : True  mode=EVERY_WEEK cats=['ADVERTISEMENT', 'MALWARE']
[9] round-trip read->write       : True  (read 'EVERY_WEEK' back and wrote it unchanged)
[10] restored to baseline        : True
```

Mutating cycle run against a disabled profile and restored to baseline afterwards.
</details>