### PR TITLE
fix(network): persist port-forward targets

### DIFF
--- a/.agents/skills/extend-unifi-api/SKILL.md
+++ b/.agents/skills/extend-unifi-api/SKILL.md
@@ -464,6 +464,8 @@ Manager methods: `list_{resource}s()`, `get_{resource}(id)`, `create_{resource}(
 
 **V2 ObjectID vs. Integration UUID:** ObjectIDs are controller-local; if implementing cross-controller queries, use Integration UUID path instead. Test against multi-controller setups.
 
+**ConnectionManager auto-appends the configured site — pass site-relative paths, not site-prefixed paths:** `ConnectionManager` injects the configured site segment into the request path automatically. Tools/managers must build `ApiRequest` paths relative to the site, not include a full site-prefixed path themselves — doing so double-prefixes the site segment and breaks the request. Found reviewing a community cross-site device-lookup tool contribution that built a fully site-prefixed path manually.
+
 **Pass-through test pattern:** For tools that pass raw manager output to API without transformation, validate shape compatibility with Strawberry type expectations via snapshot or schema-compliance tests.
 
 **`_coerce_list_result` for kind=list action tools:** `apps/api/src/unifi_api/routes/actions.py` automatically calls `_coerce_list_result()` for any action tool whose type has `kind="list"`. It unwraps single-key dict envelopes to a bare list; bare lists pass through. If your manager returns a multi-key dict, `_coerce_list_result` will raise — ensure output is a bare list or single-key envelope.

--- a/apps/network/src/unifi_network_mcp/tools/port_forwards.py
+++ b/apps/network/src/unifi_network_mcp/tools/port_forwards.py
@@ -17,7 +17,13 @@ from unifi_core.network.models._actions import (
     PortForwardUpdateInput,
 )
 from unifi_core.network.models.port_forwards import (
+    PortForward,
+)
+from unifi_core.network.models.port_forwards import (
     from_controller as pf_from_controller,
+)
+from unifi_core.network.models.port_forwards import (
+    to_controller_create as pf_to_create,
 )
 from unifi_core.network.models.port_forwards import (
     to_controller_update as pf_to_update,
@@ -197,6 +203,7 @@ async def toggle_port_forward(
 
         rule_name = rule.get("name", port_forward_id)
         current_enabled = rule.get("enabled", False)
+        normalized = pf_from_controller(rule)
 
         # Return preview when confirm=false
         if not confirm:
@@ -207,7 +214,7 @@ async def toggle_port_forward(
                 current_enabled=current_enabled,
                 additional_info={
                     "dst_port": rule.get("dst_port"),
-                    "fwd_ip": rule.get("fwd_ip"),
+                    "fwd_ip": normalized.fwd_ip,
                     "fwd_port": rule.get("fwd_port"),
                 },
             )
@@ -305,21 +312,19 @@ async def create_port_forward(
         return {"success": False, "error": err}
 
     try:
-        # Prepare data for the manager
-        rule_data = {
-            "name": validated.name,
-            "dst_port": validated.dst_port,
-            "fwd_port": validated.fwd_port,
-            "fwd_ip": validated.fwd_ip,
-            "proto": validated.protocol.replace("_", "/"),  # Manager expects 'tcp/udp'
-            "protocol_match_excepted": False,
-            "enabled": validated.enabled,
-            "log": validated.log,
-        }
-
-        # Handle optional source IP
-        if validated.src_ip:
-            rule_data["src"] = validated.src_ip
+        rule_data = pf_to_create(
+            PortForward(
+                name=validated.name,
+                dst_port=validated.dst_port,
+                fwd_port=validated.fwd_port,
+                fwd_ip=validated.fwd_ip,
+                fwd_protocol=validated.protocol,
+                enabled=validated.enabled,
+                src=validated.src_ip or None,
+                log=validated.log,
+            )
+        )
+        rule_data["protocol_match_excepted"] = False
 
         logger.info(
             "Attempting to create port forward: %s (%s %s -> %s:%s)",
@@ -361,13 +366,16 @@ async def create_port_forward(
             e,
             exc_info=True,
         )
-        return {"success": False, "error": str(e)}
+        return {
+            "success": False,
+            "error": f"Failed to create port forward '{port_forward_data.get('name', 'unknown')}': {e}",
+        }
 
 
 # --- NEW UPDATE TOOL ---
 @server.tool(
     name="unifi_update_port_forward",
-    description="Update specific fields of an existing port forwarding rule using schema validation. Requires confirmation.",
+    description="Update specific fields of an existing port forwarding rule using schema validation. Pass only the fields you want to change — current values are automatically preserved. Requires confirmation.",
     permission_category="port_forwards",
     permission_action="update",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
@@ -460,26 +468,33 @@ async def update_port_forward(
             "error": "Update data is effectively empty or invalid.",
         }
 
-    # Prepare the payload for the manager update function
-    update_payload = {}
-    updated_fields_list = []
-    for key, value in validated_data.items():
-        updated_fields_list.append(key)
-        if key == "protocol":
-            update_payload["proto"] = value.replace("_", "/")
-        elif key == "src_ip":
-            update_payload["src"] = value if value else None
-        elif key == "log":
-            update_payload["log"] = value
-        else:
-            update_payload[key] = value
+    canonical_updates = dict(validated_data)
+    if "protocol" in canonical_updates:
+        canonical_updates["fwd_protocol"] = canonical_updates.pop("protocol")
+    if "src_ip" in canonical_updates:
+        canonical_updates["src"] = canonical_updates.pop("src_ip") or None
+    update_payload = pf_to_update(canonical_updates)
+    updated_fields_list = list(validated_data)
+
+    try:
+        current_obj = await firewall_manager.get_port_forward_by_id(port_forward_id)
+        current_raw = current_obj.raw if hasattr(current_obj, "raw") else current_obj
+        current_state = pf_from_controller(current_raw).model_dump()
+        current_protocol = current_state.pop("fwd_protocol")
+        current_state["protocol"] = current_protocol.replace("/", "_") if current_protocol else None
+        current_state["src_ip"] = current_state.pop("src")
+    except UniFiNotFoundError as e:
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        logger.error("Error getting port forward %s for update: %s", port_forward_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to get port forward {port_forward_id} for update: {e}"}
 
     if not confirm:
         return update_preview(
             resource_type="port_forward",
             resource_id=port_forward_id,
-            resource_name=port_forward_id,
-            current_state={},
+            resource_name=current_state.get("name") or port_forward_id,
+            current_state=current_state,
             updates=validated_data,
         )
 
@@ -540,8 +555,7 @@ async def create_simple_port_forward(
     except ValidationError as exc:
         return {"success": False, "error": exc.errors()[0]["msg"]}
 
-    # Build API payload matching existing V1 schema keys
-    payload: Dict[str, Any] = {
+    preview_payload: Dict[str, Any] = {
         "name": r.name,
         "dst_port": str(r.ext_port),
         "fwd_port": str(r.int_port if r.int_port is not None else r.ext_port),
@@ -557,9 +571,20 @@ async def create_simple_port_forward(
     if not confirm:
         return {
             "success": True,
-            "preview": payload,
+            "preview": preview_payload,
             "message": "Set confirm=true to apply.",
         }
+
+    payload = pf_to_create(
+        PortForward(
+            name=preview_payload["name"],
+            dst_port=preview_payload["dst_port"],
+            fwd_port=preview_payload["fwd_port"],
+            fwd_ip=preview_payload["fwd_ip"],
+            fwd_protocol=preview_payload["protocol"],
+            enabled=preview_payload["enabled"],
+        )
+    )
 
     try:
         created = await firewall_manager.create_port_forward(payload)

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -16963,7 +16963,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Update specific fields of an existing port forwarding rule using schema validation. Requires confirmation.",
+      "description": "Update specific fields of an existing port forwarding rule using schema validation. Pass only the fields you want to change \u2014 current values are automatically preserved. Requires confirmation.",
       "name": "unifi_update_port_forward",
       "permission_action": "update",
       "permission_category": "port_forwards",

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -679,11 +679,11 @@ class TestGetFirewallZones:
 
 
 # ---------------------------------------------------------------------------
-# create_port_forward — V1 POST response shape handling (issue #207)
+# create_port_forward — V1 POST response shape handling
 #
 # UDM-SE 8.4.x returns a bare list `[{...}]` from POST /rest/portforward
 # while older firmware returns the wrapped shape `{"data": [{...}]}`. The
-# manager must extract the created rule from both shapes — see #207.
+# manager must extract the created rule from both shapes.
 # ---------------------------------------------------------------------------
 
 
@@ -692,12 +692,12 @@ SAMPLE_CREATED_PORT_FORWARD = {
     "name": "test",
     "dst_port": "80",
     "fwd_port": "80",
-    "fwd_ip": "10.0.0.1",
+    "fwd": "10.0.0.1",
 }
 
 
 class TestCreatePortForwardResponseShapes:
-    """Issue #207 — create_port_forward must accept both wrapped and bare-list responses."""
+    """create_port_forward must accept both wrapped and bare-list responses."""
 
     @pytest.mark.asyncio
     async def test_create_port_forward_handles_wrapped_response_shape(self, firewall_manager, mock_connection):
@@ -705,7 +705,7 @@ class TestCreatePortForwardResponseShapes:
         mock_connection.request = AsyncMock(return_value={"data": [copy.deepcopy(SAMPLE_CREATED_PORT_FORWARD)]})
 
         result = await firewall_manager.create_port_forward(
-            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd_ip": "10.0.0.1"}
+            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd": "10.0.0.1"}
         )
 
         assert result is not None
@@ -714,16 +714,101 @@ class TestCreatePortForwardResponseShapes:
 
     @pytest.mark.asyncio
     async def test_create_port_forward_handles_bare_list_response_shape(self, firewall_manager, mock_connection):
-        """UDM-SE 8.4.x returns [{...}] — manager must extract the rule (regression test for #207)."""
+        """UDM-SE 8.4.x returns [{...}] and the manager extracts the rule."""
         mock_connection.request = AsyncMock(return_value=[copy.deepcopy(SAMPLE_CREATED_PORT_FORWARD)])
 
         result = await firewall_manager.create_port_forward(
-            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd_ip": "10.0.0.1"}
+            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd": "10.0.0.1"}
         )
 
         assert result is not None
         assert result["_id"] == "abc123"
         assert result["name"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_requires_controller_forward_field(self, firewall_manager, mock_connection):
+        result = await firewall_manager.create_port_forward(
+            {"name": "test", "dst_port": "80", "fwd_port": "80", "fwd_ip": "10.0.0.1"}
+        )
+
+        assert result is None
+        mock_connection.request.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update_port_forward — full-object merge and persistence verification
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePortForward:
+    @pytest.mark.asyncio
+    async def test_preserves_unmentioned_fields_and_verifies_persistence(self, firewall_manager, mock_connection):
+        before_raw = {
+            "_id": "pf_001",
+            "name": "Web Server",
+            "enabled": True,
+            "fwd": "192.168.1.10",
+            "fwd_port": "443",
+        }
+        after_raw = {**before_raw, "fwd": "192.168.1.20"}
+        before = MagicMock(raw=copy.deepcopy(before_raw))
+        after = MagicMock(raw=after_raw)
+        events = []
+
+        async def get_rule(_rule_id):
+            events.append("lookup")
+            return before if len(events) == 1 else after
+
+        mock_connection._invalidate_cache.side_effect = lambda _key: events.append("invalidate")
+
+        with patch.object(
+            firewall_manager,
+            "get_port_forward_by_id",
+            new=AsyncMock(side_effect=get_rule),
+        ):
+            result = await firewall_manager.update_port_forward("pf_001", {"fwd": "192.168.1.20"})
+
+        assert result is True
+        request = mock_connection.request.call_args[0][0]
+        assert request.path == "/rest/portforward/pf_001"
+        assert request.data["fwd"] == "192.168.1.20"
+        assert request.data["fwd_port"] == "443"
+        assert before.raw == before_raw
+        assert events == ["lookup", "invalidate", "lookup"]
+        mock_connection._invalidate_cache.assert_called_once_with("port_forwards_default")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_controller_does_not_persist_update(self, firewall_manager):
+        from unifi_core.exceptions import UniFiOperationError
+
+        before_raw = {"_id": "pf_001", "name": "Web Server", "fwd": "192.168.1.10"}
+        before = MagicMock(raw=copy.deepcopy(before_raw))
+        unchanged = MagicMock(raw=copy.deepcopy(before_raw))
+
+        with patch.object(
+            firewall_manager,
+            "get_port_forward_by_id",
+            new_callable=AsyncMock,
+            side_effect=[before, unchanged],
+        ):
+            with pytest.raises(UniFiOperationError, match="did not persist field.*fwd"):
+                await firewall_manager.update_port_forward("pf_001", {"fwd": "192.168.1.20"})
+
+    @pytest.mark.asyncio
+    async def test_raises_when_refetched_rule_is_malformed(self, firewall_manager):
+        from unifi_core.exceptions import UniFiOperationError
+
+        before = MagicMock(raw={"_id": "pf_001", "fwd": "192.168.1.10"})
+        malformed = MagicMock(raw=None)
+
+        with patch.object(
+            firewall_manager,
+            "get_port_forward_by_id",
+            new_callable=AsyncMock,
+            side_effect=[before, malformed],
+        ):
+            with pytest.raises(UniFiOperationError, match="Could not verify port forward"):
+                await firewall_manager.update_port_forward("pf_001", {"fwd": "192.168.1.20"})
 
 
 # ---------------------------------------------------------------------------

--- a/apps/network/tests/unit/test_port_forwards.py
+++ b/apps/network/tests/unit/test_port_forwards.py
@@ -1,15 +1,263 @@
-"""Tests for the port forward delete tool (unifi_delete_port_forward)."""
+"""Tests for port-forward tools."""
 
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
 
 os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
 os.environ.setdefault("UNIFI_USERNAME", "test")
 os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+# ---------------------------------------------------------------------------
+# create_port_forward
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePortForward:
+    @pytest.mark.asyncio
+    async def test_full_create_maps_to_controller_fields(self):
+        created = {"_id": "pf_001", "name": "Web Server", "fwd": "192.168.1.10"}
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.create_port_forward = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.port_forwards import create_port_forward
+
+            result = await create_port_forward(
+                {
+                    "name": "Web Server",
+                    "dst_port": "443",
+                    "fwd_port": "8443",
+                    "fwd_ip": "192.168.1.10",
+                    "protocol": "tcp_udp",
+                }
+            )
+
+        assert result["success"] is True
+        payload = mock_fm.create_port_forward.await_args.args[0]
+        assert payload["fwd"] == "192.168.1.10"
+        assert payload["proto"] == "tcp/udp"
+        assert "fwd_ip" not in payload
+        assert "fwd_protocol" not in payload
+
+    @pytest.mark.asyncio
+    async def test_full_create_omits_empty_source(self):
+        created = {"_id": "pf_001", "name": "Web Server", "fwd": "192.168.1.10"}
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.create_port_forward = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.port_forwards import create_port_forward
+
+            await create_port_forward(
+                {
+                    "name": "Web Server",
+                    "dst_port": "443",
+                    "fwd_port": "8443",
+                    "fwd_ip": "192.168.1.10",
+                    "src_ip": "",
+                }
+            )
+
+        payload = mock_fm.create_port_forward.await_args.args[0]
+        assert "src" not in payload
+
+    @pytest.mark.asyncio
+    async def test_simple_create_preview_stays_user_facing(self):
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            from unifi_network_mcp.tools.port_forwards import create_simple_port_forward
+
+            result = await create_simple_port_forward(
+                {"name": "Web Server", "ext_port": "443", "to_ip": "192.168.1.10"},
+                confirm=False,
+            )
+
+        assert result["preview"]["fwd_ip"] == "192.168.1.10"
+        assert result["preview"]["protocol"] == "tcp_udp"
+        assert "fwd" not in result["preview"]
+        mock_fm.create_port_forward.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_simple_create_confirm_maps_to_controller_fields(self):
+        created = {"_id": "pf_001", "name": "Web Server", "fwd": "192.168.1.10"}
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.create_port_forward = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.port_forwards import create_simple_port_forward
+
+            result = await create_simple_port_forward(
+                {
+                    "name": "Web Server",
+                    "ext_port": "443",
+                    "int_port": "8443",
+                    "to_ip": "192.168.1.10",
+                    "protocol": "both",
+                    "enabled": False,
+                },
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        payload = mock_fm.create_port_forward.await_args.args[0]
+        assert payload == {
+            "name": "Web Server",
+            "dst_port": "443",
+            "fwd_port": "8443",
+            "fwd": "192.168.1.10",
+            "proto": "tcp/udp",
+            "enabled": False,
+        }
+
+
+# ---------------------------------------------------------------------------
+# update_port_forward
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePortForward:
+    @pytest.mark.asyncio
+    async def test_preview_uses_normalized_current_state(self):
+        current = MagicMock(
+            raw={
+                "_id": "pf_001",
+                "name": "Web Server",
+                "fwd": "192.168.1.10",
+                "proto": "tcp",
+            }
+        )
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(return_value=current)
+
+            from unifi_network_mcp.tools.port_forwards import update_port_forward
+
+            result = await update_port_forward(
+                port_forward_id="pf_001",
+                update_data={"fwd_ip": "192.168.1.20"},
+                confirm=False,
+            )
+
+        assert result["success"] is True
+        assert result["resource_name"] == "Web Server"
+        assert result["preview"]["current"]["fwd_ip"] == "192.168.1.10"
+        assert result["preview"]["proposed"]["fwd_ip"] == "192.168.1.20"
+        mock_fm.update_port_forward.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preview_normalizes_protocol_to_public_value(self):
+        current = MagicMock(raw={"_id": "pf_001", "name": "Web Server", "proto": "tcp/udp"})
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(return_value=current)
+
+            from unifi_network_mcp.tools.port_forwards import update_port_forward
+
+            result = await update_port_forward(
+                port_forward_id="pf_001",
+                update_data={"protocol": "tcp_udp"},
+                confirm=False,
+            )
+
+        assert result["preview"]["current"]["protocol"] == "tcp_udp"
+        assert result["preview"]["proposed"]["protocol"] == "tcp_udp"
+
+    @pytest.mark.asyncio
+    async def test_confirm_maps_forward_ip_to_controller_field(self):
+        current = MagicMock(raw={"_id": "pf_001", "name": "Web Server", "fwd": "192.168.1.10"})
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(return_value=current)
+            mock_fm.update_port_forward = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.port_forwards import update_port_forward
+
+            result = await update_port_forward(
+                port_forward_id="pf_001",
+                update_data={"fwd_ip": "192.168.1.20"},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        assert result["updated_fields"] == ["fwd_ip"]
+        mock_fm.update_port_forward.assert_awaited_once_with("pf_001", {"fwd": "192.168.1.20"})
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_returns_structured_error(self):
+        current = MagicMock(raw={"_id": "pf_001", "name": "Web Server", "fwd": "192.168.1.10"})
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(return_value=current)
+            mock_fm.update_port_forward = AsyncMock(
+                side_effect=UniFiOperationError("Controller accepted the request but did not persist field(s): fwd")
+            )
+
+            from unifi_network_mcp.tools.port_forwards import update_port_forward
+
+            result = await update_port_forward(
+                port_forward_id="pf_001",
+                update_data={"fwd_ip": "192.168.1.20"},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "did not persist field(s): fwd" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_prefetch_not_found_returns_structured_error(self):
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(side_effect=UniFiNotFoundError("port_forward", "missing"))
+
+            from unifi_network_mcp.tools.port_forwards import update_port_forward
+
+            result = await update_port_forward(
+                port_forward_id="missing",
+                update_data={"fwd_ip": "192.168.1.20"},
+                confirm=False,
+            )
+
+        assert result == {"success": False, "error": "port_forward 'missing' not found"}
+
+
+# ---------------------------------------------------------------------------
+# toggle_port_forward
+# ---------------------------------------------------------------------------
+
+
+class TestTogglePortForward:
+    @pytest.mark.asyncio
+    async def test_preview_normalizes_forward_ip(self):
+        current = MagicMock(
+            raw={
+                "_id": "pf_001",
+                "name": "Web Server",
+                "enabled": True,
+                "fwd": "192.168.1.10",
+                "fwd_port": "8443",
+            }
+        )
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(return_value=current)
+
+            from unifi_network_mcp.tools.port_forwards import toggle_port_forward
+
+            result = await toggle_port_forward("pf_001", confirm=False)
+
+        assert result["preview"]["current"]["fwd_ip"] == "192.168.1.10"
+        mock_fm.update_port_forward.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_returns_structured_error(self):
+        current = MagicMock(raw={"_id": "pf_001", "name": "Web Server", "enabled": True})
+        with patch("unifi_network_mcp.tools.port_forwards.firewall_manager") as mock_fm:
+            mock_fm.get_port_forward_by_id = AsyncMock(return_value=current)
+            mock_fm.update_port_forward = AsyncMock(
+                side_effect=UniFiOperationError("Controller accepted the request but did not persist field(s): enabled")
+            )
+
+            from unifi_network_mcp.tools.port_forwards import toggle_port_forward
+
+            result = await toggle_port_forward("pf_001", confirm=True)
+
+        assert result["success"] is False
+        assert "did not persist field(s): enabled" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -11,7 +11,7 @@ from aiounifi.models.port_forward import PortForward
 from aiounifi.models.traffic_route import TrafficRoute
 
 from unifi_core.auth import UniFiAuth
-from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
 from unifi_core.merge import deep_merge
 from unifi_core.network.managers.connection_manager import ConnectionManager
 
@@ -793,7 +793,7 @@ class FirewallManager:
             for key, value in updates.items():
                 updated_data[key] = value
 
-            logger.info("Updating port forward %s with full data: %s", rule_id, updated_data)
+            logger.debug("Updating port forward %s with full data: %s", rule_id, updated_data)
 
             api_request = ApiRequest(
                 method="put",
@@ -806,6 +806,22 @@ class FirewallManager:
             # Invalidate cache
             cache_key = f"{CACHE_PREFIX_PORT_FORWARDS}_{self._connection.site}"
             self._connection._invalidate_cache(cache_key)
+
+            refetched_obj = await self.get_port_forward_by_id(rule_id)
+            refetched = refetched_obj.raw if hasattr(refetched_obj, "raw") else None
+            if not isinstance(refetched, dict):
+                raise UniFiOperationError(f"Could not verify port forward '{rule_id}' after update")
+
+            unpersisted = [
+                key
+                for key, requested in updates.items()
+                if rule_to_update_obj.raw.get(key) != requested
+                and refetched.get(key) == rule_to_update_obj.raw.get(key)
+            ]
+            if unpersisted:
+                raise UniFiOperationError(
+                    f"Controller accepted the request but did not persist field(s): {', '.join(sorted(unpersisted))}"
+                )
 
             logger.info("Successfully submitted update for port forward %s.", rule_id)
             return True
@@ -846,13 +862,13 @@ class FirewallManager:
 
         Args:
             rule_data: Dictionary containing the rule configuration. Expected keys:
-                       name (str), dst_port (str), fwd_port (str), fwd_ip (str),
-                       protocol (str, optional), enabled (bool, optional), etc.
+                       name (str), dst_port (str), fwd_port (str), fwd (str),
+                       proto (str, optional), enabled (bool, optional), etc.
 
         Returns:
             The created rule data dict, or None if creation failed.
         """
-        required_keys = {"name", "dst_port", "fwd_port", "fwd_ip"}
+        required_keys = {"name", "dst_port", "fwd_port", "fwd"}
         if not required_keys.issubset(rule_data.keys()):
             missing = required_keys - rule_data.keys()
             logger.error("Missing required keys for creating port forward: %s", missing)
@@ -868,7 +884,7 @@ class FirewallManager:
             response = await self._connection.request(api_request)
 
             # V1 POST may return either {"data": [{...}]} (older firmware) or a bare
-            # list [{...}] (UDM-SE 8.4.x and similar). Handle both — see #207.
+            # list [{...}] (UDM-SE 8.4.x and similar).
             data = (
                 response
                 if isinstance(response, list)

--- a/packages/unifi-core/src/unifi_core/network/models/port_forwards.py
+++ b/packages/unifi-core/src/unifi_core/network/models/port_forwards.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
+_CONTROLLER_FIELD_NAMES = {"fwd_protocol": "proto", "fwd_ip": "fwd"}
+
 # ---------------------------------------------------------------------------
 # Pydantic domain model
 # ---------------------------------------------------------------------------
@@ -137,17 +139,24 @@ def to_controller_create(model: PortForward) -> Dict[str, Any]:
     for field_name in MUTABLE_FIELDS:
         value = getattr(model, field_name, None)
         if value is not None:
-            payload[field_name] = value
-    # Map fwd_protocol → proto for controller compatibility
-    if "fwd_protocol" in payload:
-        payload["proto"] = payload.pop("fwd_protocol")
+            if field_name == "fwd_protocol":
+                value = value.replace("_", "/")
+            payload[_CONTROLLER_FIELD_NAMES.get(field_name, field_name)] = value
     return payload
 
 
 def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
-    """Filter a partial dict to only mutable, recognised keys.
+    """Translate a partial canonical dict to controller update fields.
 
     Read-only fields and unrecognised keys are dropped.
-    ``None`` values are dropped; boolean ``False`` is preserved.
+    ``None`` values are dropped except for ``src``, where it removes a source
+    restriction. Boolean ``False`` is preserved.
     """
-    return {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
+    payload: Dict[str, Any] = {}
+    for key, value in fields.items():
+        if key not in MUTABLE_FIELDS or (value is None and key != "src"):
+            continue
+        if key == "fwd_protocol":
+            value = value.replace("_", "/")
+        payload[_CONTROLLER_FIELD_NAMES.get(key, key)] = value
+    return payload

--- a/packages/unifi-core/tests/network/models/test_port_forwards.py
+++ b/packages/unifi-core/tests/network/models/test_port_forwards.py
@@ -98,6 +98,8 @@ class TestToControllerCreate:
         payload = to_controller_create(model)
         assert payload["proto"] == "tcp"
         assert "fwd_protocol" not in payload
+        assert payload["fwd"] == "192.168.1.10"
+        assert "fwd_ip" not in payload
 
     def test_read_only_fields_excluded(self) -> None:
         model = PortForward(id="should-not-appear", site_id="site", name="Test")
@@ -120,6 +122,18 @@ class TestToControllerUpdate:
     def test_toggle_payload(self) -> None:
         result = to_controller_update({"enabled": True})
         assert result == {"enabled": True}
+
+    def test_maps_forward_ip_to_controller_field(self) -> None:
+        result = to_controller_update({"fwd_ip": "192.168.1.20"})
+        assert result == {"fwd": "192.168.1.20"}
+
+    def test_maps_protocol_to_controller_field(self) -> None:
+        result = to_controller_update({"fwd_protocol": "tcp_udp"})
+        assert result == {"proto": "tcp/udp"}
+
+    def test_preserves_none_for_source_removal(self) -> None:
+        result = to_controller_update({"src": None})
+        assert result == {"src": None}
 
     def test_drops_unrecognised_keys(self) -> None:
         result = to_controller_update({"unknown": "value", "name": "Valid"})


### PR DESCRIPTION
## What changed

- translate public `fwd_ip` and protocol values to the controller's `fwd` and `proto` fields for both port-forward create tools and updates
- keep create/update/toggle previews in the public field dialect while loading real current controller state
- re-read port forwards after PUT and return an actionable error when the controller accepts but does not persist a requested field
- update manager validation, cache-verification coverage, tool tests, model tests, and the generated Network manifest
- include the co-evolved Myco skill guidance for site-relative `ConnectionManager` paths as a separate commit

## Why

UniFi accepts unknown fields on `/rest/portforward` without applying them. `unifi_update_port_forward` passed `fwd_ip` instead of the controller's `fwd`, then reported success without verifying persistence. Both create paths had the same dialect mismatch on current UDM SE firmware.

Fixes #472

## Testing

- `make format-check`
- `make lint`
- `make check-generated`
- `make test` (4,401 Python tests passed across all suites)
- `make worker-typecheck`
- `uv run python scripts/live_smoke.py --server network --phase readonly`
- two independent review passes; all findings addressed, final result: no findings

### Live UDM SE lifecycle

Both rules were disabled, used TEST-NET destinations, and were deleted with absence verified in `finally` cleanup.

<details>
<summary>Raw targeted lifecycle assertions</summary>

```json
{
  "full_create_raw_fwd": true,
  "full_create_no_raw_fwd_ip": true,
  "simple_preview_user_facing": true,
  "simple_create_raw_fwd": true,
  "update_raw_fwd_persisted": true
}
```

</details>
