### PR TITLE
fix(discovery): rank multi-word tool searches

### DIFF
--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -2902,7 +2902,7 @@
               "type": "boolean"
             },
             "search": {
-              "description": "Case-insensitive substring match against tool name and description.",
+              "description": "Case-insensitive token search over tool names and descriptions. Ignores common words and one-character terms; multi-word queries require at least half of usable terms (minimum two). Terms of four or more characters also match token prefixes. Results are ranked by exact phrase and name matches, with at most 20 returned. An empty string applies no filter; a non-empty query with no usable terms returns no tools.",
               "type": "string"
             }
           },

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -15116,7 +15116,7 @@
               "type": "boolean"
             },
             "search": {
-              "description": "Case-insensitive substring match against tool name and description.",
+              "description": "Case-insensitive token search over tool names and descriptions. Ignores common words and one-character terms; multi-word queries require at least half of usable terms (minimum two). Terms of four or more characters also match token prefixes. Results are ranked by exact phrase and name matches, with at most 20 returned. An empty string applies no filter; a non-empty query with no usable terms returns no tools.",
               "type": "string"
             }
           },

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -4970,7 +4970,7 @@
               "type": "boolean"
             },
             "search": {
-              "description": "Case-insensitive substring match against tool name and description.",
+              "description": "Case-insensitive token search over tool names and descriptions. Ignores common words and one-character terms; multi-word queries require at least half of usable terms (minimum two). Terms of four or more characters also match token prefixes. Results are ranked by exact phrase and name matches, with at most 20 returned. An empty string applies no filter; a non-empty query with no usable terms returns no tools.",
               "type": "string"
             }
           },

--- a/apps/worker/worker/src/relay-object.ts
+++ b/apps/worker/worker/src/relay-object.ts
@@ -3,7 +3,7 @@ import { DurableObject } from "cloudflare:workers";
 import type { RelayStub } from "./mcp-handler";
 import { handleMcpRequest } from "./mcp-handler";
 import { hashToken, generateToken, extractBearerToken } from "./auth";
-import { toolInputSchema, toolServerOrigin } from "./tool-info";
+import { buildToolIndexEntries, TOOL_INDEX_META_TOOL, toolInputSchema, toolServerOrigin } from "./tool-info";
 import type {
   Env,
   ToolInfo,
@@ -27,42 +27,6 @@ import { PROTOCOL_VERSION, TOOL_CALL_TIMEOUT_MS } from "./types";
 // ---------------------------------------------------------------------------
 
 const MAX_LOCATION_NAME_LENGTH = 128;
-
-const META_TOOL_INDEX: ToolInfo = {
-  name: "unifi_tool_index",
-  title: "UniFi Tool Index",
-  description:
-    "Discover available UniFi tools. Returns names and descriptions by default. " +
-    "Use 'category' to filter by area (e.g. clients, firewall, devices), " +
-    "'search' for keyword matching, or 'include_schemas' for full parameter schemas. " +
-    "Use this to discover tools before calling unifi_execute.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      category: {
-        type: "string",
-        description: "Optional category filter (e.g., 'clients', 'devices', 'firewall')",
-      },
-      search: {
-        type: "string",
-        description: "Optional search term to filter tools by name or description",
-      },
-      include_schemas: {
-        type: "boolean",
-        description:
-          "Include full input schemas per tool. Defaults to false. " +
-          "Set true with a category or search filter to get parameter details for specific tools.",
-        default: false,
-      },
-    },
-  },
-  annotations: {
-    readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
-  },
-};
 
 const META_TOOL_EXECUTE: ToolInfo = {
   name: "unifi_execute",
@@ -168,7 +132,12 @@ const META_TOOL_LOCATION_TIMELINE: ToolInfo = {
   },
 };
 
-const META_TOOLS: ToolInfo[] = [META_TOOL_INDEX, META_TOOL_EXECUTE, META_TOOL_BATCH, META_TOOL_LOCATION_TIMELINE];
+const META_TOOLS: ToolInfo[] = [
+  TOOL_INDEX_META_TOOL,
+  META_TOOL_EXECUTE,
+  META_TOOL_BATCH,
+  META_TOOL_LOCATION_TIMELINE,
+];
 
 // ---------------------------------------------------------------------------
 // Relay Durable Object
@@ -773,56 +742,11 @@ export class RelayObject extends DurableObject<Env> implements RelayStub {
     const category = args.category as string | undefined;
     const search = args.search as string | undefined;
     const includeSchemas = Boolean(args.include_schemas);
-
-    // Build tool list with location metadata
-    const toolEntries: Array<{
-      name: string;
-      title?: string;
-      description: string;
-      locations: string[];
-      annotations?: ToolAnnotations;
-      inputSchema?: Record<string, unknown>;
-    }> = [];
-
-    const seen = new Set<string>();
-    for (const [locationId, tools] of this.locationTools) {
-      for (const tool of tools) {
-        if (!seen.has(tool.name)) {
-          seen.add(tool.name);
-          const entry: (typeof toolEntries)[number] = {
-            name: tool.name,
-            description: tool.description,
-            locations: this.toolToLocations.get(tool.name) || [locationId],
-            annotations: tool.annotations,
-          };
-          if (tool.title) {
-            entry.title = tool.title;
-          }
-          if (includeSchemas && tool.inputSchema) {
-            entry.inputSchema = tool.inputSchema;
-          }
-          toolEntries.push(entry);
-        }
-      }
-    }
-
-    let filtered = toolEntries;
-
-    // Filter by category (matches tools whose name or description contains the category)
-    if (category) {
-      const cat = category.toLowerCase();
-      filtered = filtered.filter(
-        (t) => t.name.toLowerCase().includes(cat) || t.description.toLowerCase().includes(cat),
-      );
-    }
-
-    // Filter by search term
-    if (search) {
-      const term = search.toLowerCase();
-      filtered = filtered.filter(
-        (t) => t.name.toLowerCase().includes(term) || t.description.toLowerCase().includes(term),
-      );
-    }
+    const filtered = buildToolIndexEntries(this.locationTools, this.toolToLocations, {
+      category,
+      search,
+      includeSchemas,
+    });
 
     return {
       success: true,

--- a/apps/worker/worker/src/tool-info.ts
+++ b/apps/worker/worker/src/tool-info.ts
@@ -1,5 +1,180 @@
 import type { ToolInfo } from "./types";
 
+export const TOOL_INDEX_META_TOOL: ToolInfo = {
+  name: "unifi_tool_index",
+  title: "UniFi Tool Index",
+  description:
+    "Discover available UniFi tools. Returns names and descriptions by default. " +
+    "Use 'category' to filter by area (e.g. clients, firewall, devices), " +
+    "'search' for keyword matching, or 'include_schemas' for full parameter schemas. " +
+    "Use this to discover tools before calling unifi_execute.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      category: {
+        type: "string",
+        description: "Optional category filter (e.g., 'clients', 'devices', 'firewall')",
+      },
+      search: {
+        type: "string",
+        description:
+          "Case-insensitive token search over tool names and descriptions. " +
+          "Ignores common words and one-character terms; multi-word queries require at least half " +
+          "of usable terms (minimum two). Terms of four or more characters also match token prefixes. " +
+          "Results are ranked by exact phrase and name matches, with at most 20 returned. " +
+          "An empty string applies no filter; a non-empty query with no usable terms returns no tools.",
+      },
+      include_schemas: {
+        type: "boolean",
+        description:
+          "Include full input schemas per tool. Defaults to false. " +
+          "Set true with a category or search filter to get parameter details for specific tools.",
+        default: false,
+      },
+    },
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};
+
+const TOKEN_PATTERN = /[a-z0-9]+/g;
+export const MAX_TOOL_SEARCH_RESULTS = 20;
+const SEARCH_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "how",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "this",
+  "to",
+  "with",
+]);
+
+function tokenize(value: string): string[] {
+  return value.toLowerCase().match(TOKEN_PATTERN) ?? [];
+}
+
+function isTokenMatch(query: string, candidate: string): boolean {
+  return candidate === query || (query.length >= 4 && candidate.startsWith(query));
+}
+
+function containsExactPhrase(tokens: string[], queryTokens: string[]): boolean {
+  return tokens.some((_, start) => queryTokens.every((query, offset) => tokens[start + offset] === query));
+}
+
+export function rankToolsBySearch<T extends Pick<ToolInfo, "name" | "description">>(
+  tools: T[],
+  search: string,
+): T[] {
+  const queryTokens = [
+    ...new Set(tokenize(search).filter((token) => token.length >= 2 && !SEARCH_STOP_WORDS.has(token))),
+  ];
+  if (queryTokens.length === 0) {
+    return [];
+  }
+
+  const requiredMatches = queryTokens.length === 1 ? 1 : Math.max(2, Math.ceil(queryTokens.length / 2));
+
+  return tools
+    .map((tool, index) => {
+      const nameTokens = tokenize(tool.name);
+      const descriptionTokens = tokenize(tool.description);
+      const allTokens = [...nameTokens, ...descriptionTokens];
+      const tokenMatches = queryTokens.filter((query) => allTokens.some((candidate) => isTokenMatch(query, candidate)));
+      const nameMatches = queryTokens.filter((query) => nameTokens.some((candidate) => isTokenMatch(query, candidate)));
+      const exactPhrase =
+        containsExactPhrase(nameTokens, queryTokens) || containsExactPhrase(descriptionTokens, queryTokens) ? 1 : 0;
+      return { tool, index, exactPhrase, nameMatches: nameMatches.length, tokenMatches: tokenMatches.length };
+    })
+    .filter(({ tokenMatches }) => tokenMatches >= requiredMatches)
+    .sort(
+      (a, b) =>
+        b.exactPhrase - a.exactPhrase ||
+        b.nameMatches - a.nameMatches ||
+        b.tokenMatches - a.tokenMatches ||
+        a.index - b.index,
+    )
+    .slice(0, MAX_TOOL_SEARCH_RESULTS)
+    .map(({ tool }) => tool);
+}
+
+export interface ToolIndexOptions {
+  category?: string;
+  search?: string;
+  includeSchemas?: boolean;
+}
+
+export interface ToolIndexEntry extends Pick<ToolInfo, "name" | "description"> {
+  title?: string;
+  locations: string[];
+  annotations?: ToolInfo["annotations"];
+  inputSchema?: Record<string, unknown>;
+}
+
+export function buildToolIndexEntries(
+  locationTools: Map<string, ToolInfo[]>,
+  toolToLocations: Map<string, string[]>,
+  options: ToolIndexOptions = {},
+): ToolIndexEntry[] {
+  const entries: ToolIndexEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const [locationId, tools] of locationTools) {
+    for (const tool of tools) {
+      if (seen.has(tool.name)) {
+        continue;
+      }
+
+      seen.add(tool.name);
+      const entry: ToolIndexEntry = {
+        name: tool.name,
+        description: tool.description,
+        locations: toolToLocations.get(tool.name) ?? [locationId],
+        annotations: tool.annotations,
+      };
+      if (tool.title) {
+        entry.title = tool.title;
+      }
+      const inputSchema = toolInputSchema(tool);
+      if (options.includeSchemas && inputSchema) {
+        entry.inputSchema = inputSchema;
+      }
+      entries.push(entry);
+    }
+  }
+
+  let filtered = entries;
+  if (options.category) {
+    const category = options.category.toLowerCase();
+    filtered = filtered.filter(
+      (tool) =>
+        tool.name.toLowerCase().includes(category) || tool.description.toLowerCase().includes(category),
+    );
+  }
+  if (options.search) {
+    filtered = rankToolsBySearch(filtered, options.search);
+  }
+  return filtered;
+}
+
 export function toolInputSchema(tool: ToolInfo): Record<string, unknown> | undefined {
   return tool.inputSchema ?? tool.input_schema;
 }

--- a/apps/worker/worker/test/relay-object.test.ts
+++ b/apps/worker/worker/test/relay-object.test.ts
@@ -18,7 +18,7 @@ import type { ToolInfo, AggregatedResponse } from "../src/types";
 // ---------------------------------------------------------------------------
 
 import { handleMcpRequest, type RelayStub } from "../src/mcp-handler";
-import { toolInputSchema, toolServerOrigin } from "../src/tool-info";
+import { buildToolIndexEntries, toolInputSchema, toolServerOrigin } from "../src/tool-info";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -100,41 +100,11 @@ function createMockRelay(
       args: Record<string, unknown>,
     ): Promise<Record<string, unknown> | AggregatedResponse> {
       if (toolName === "unifi_tool_index") {
-        const allTools = getAggregatedTools();
-        const includeSchemas = Boolean(args.include_schemas);
-        let filtered = allTools.map((t) => {
-          const entry: Record<string, unknown> = {
-            name: t.name,
-            description: t.description,
-            locations: toolToLocations.get(t.name) || [],
-            annotations: t.annotations,
-          };
-          if (t.title) {
-            entry.title = t.title;
-          }
-          if (includeSchemas && t.inputSchema) {
-            entry.inputSchema = t.inputSchema;
-          }
-          return entry;
+        const filtered = buildToolIndexEntries(locationTools, toolToLocations, {
+          category: args.category as string | undefined,
+          search: args.search as string | undefined,
+          includeSchemas: Boolean(args.include_schemas),
         });
-        const category = args.category as string | undefined;
-        const search = args.search as string | undefined;
-        if (category) {
-          const cat = category.toLowerCase();
-          filtered = filtered.filter(
-            (t) =>
-              (t.name as string).toLowerCase().includes(cat) ||
-              (t.description as string).toLowerCase().includes(cat),
-          );
-        }
-        if (search) {
-          const term = search.toLowerCase();
-          filtered = filtered.filter(
-            (t) =>
-              (t.name as string).toLowerCase().includes(term) ||
-              (t.description as string).toLowerCase().includes(term),
-          );
-        }
         return { success: true, data: { tools: filtered, total: filtered.length, multi_location: locationTools.size > 1 } };
       }
       return { success: false, error: `Tool not found: ${toolName}` };

--- a/apps/worker/worker/test/tool-info.test.ts
+++ b/apps/worker/worker/test/tool-info.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  buildToolIndexEntries,
+  MAX_TOOL_SEARCH_RESULTS,
+  rankToolsBySearch,
+  TOOL_INDEX_META_TOOL,
+} from "../src/tool-info";
+import type { ToolInfo } from "../src/types";
+
+interface SearchFixture {
+  tools: ToolInfo[];
+  cases: Array<{ search: string; expected: string[] }>;
+}
+
+const fixturePath = fileURLToPath(
+  String(new URL("../../../../tests/fixtures/tool_search_cases.json", import.meta.url)),
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as SearchFixture;
+
+describe("rankToolsBySearch", () => {
+  for (const testCase of fixture.cases) {
+    it(`matches the shared contract for ${JSON.stringify(testCase.search)}`, () => {
+      expect(rankToolsBySearch(fixture.tools, testCase.search).map((tool) => tool.name)).toEqual(
+        testCase.expected,
+      );
+    });
+  }
+
+  it("prioritizes an exact phrase", () => {
+    const tools: ToolInfo[] = [
+      { name: "unifi_firewall_policy_update", description: "Modify policy configuration" },
+      { name: "unifi_exact_wall_policy", description: "Apply the wall policy update workflow" },
+    ];
+
+    expect(rankToolsBySearch(tools, "wall policy update").map((tool) => tool.name)).toEqual([
+      "unifi_exact_wall_policy",
+      "unifi_firewall_policy_update",
+    ]);
+  });
+
+  it("does not create an exact phrase across name and description", () => {
+    const tools: ToolInfo[] = [
+      { name: "unifi_wall_alpha", description: "Configure policy update" },
+      { name: "unifi_wall", description: "Policy update settings" },
+    ];
+
+    expect(rankToolsBySearch(tools, "wall policy update").map((tool) => tool.name)).toEqual([
+      "unifi_wall_alpha",
+      "unifi_wall",
+    ]);
+  });
+
+  it("preserves source order for ties", () => {
+    const tools: ToolInfo[] = [
+      { name: "unifi_alpha", description: "Inspect client details" },
+      { name: "unifi_beta", description: "Inspect client details" },
+    ];
+
+    expect(rankToolsBySearch(tools, "inspect client").map((tool) => tool.name)).toEqual([
+      "unifi_alpha",
+      "unifi_beta",
+    ]);
+  });
+
+  it("caps broad searches", () => {
+    const tools: ToolInfo[] = Array.from({ length: 25 }, (_, index) => ({
+      name: `unifi_client_${String(index).padStart(2, "0")}`,
+      description: "Inspect a client",
+    }));
+
+    expect(rankToolsBySearch(tools, "client").map((tool) => tool.name)).toEqual(
+      tools.slice(0, MAX_TOOL_SEARCH_RESULTS).map((tool) => tool.name),
+    );
+  });
+});
+
+describe("buildToolIndexEntries", () => {
+  const locationTools = new Map([["location-1", fixture.tools]]);
+  const toolToLocations = new Map(fixture.tools.map((tool) => [tool.name, ["location-1"]]));
+
+  it("applies the production catalog search path", () => {
+    expect(
+      buildToolIndexEntries(locationTools, toolToLocations, { search: "update tx power" }).map(
+        (tool) => tool.name,
+      ),
+    ).toEqual(["unifi_update_device_radio", "unifi_get_device_radio"]);
+  });
+
+  it("treats an empty search as no filter", () => {
+    expect(buildToolIndexEntries(locationTools, toolToLocations, { search: "" })).toHaveLength(
+      fixture.tools.length,
+    );
+  });
+});
+
+describe("TOOL_INDEX_META_TOOL", () => {
+  it("describes ranked token search in its public schema", () => {
+    const properties = TOOL_INDEX_META_TOOL.inputSchema?.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const description = properties.search.description as string;
+
+    expect(description).toContain("token search");
+    expect(description).toContain("at most 20");
+    expect(description).toContain("no usable terms returns no tools");
+  });
+});

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -145,7 +145,13 @@ def register_meta_tools(
                 },
                 "search": {
                     "type": "string",
-                    "description": "Case-insensitive substring match against tool name and description.",
+                    "description": (
+                        "Case-insensitive token search over tool names and descriptions. "
+                        "Ignores common words and one-character terms; multi-word queries require at least half "
+                        "of usable terms (minimum two). Terms of four or more characters also match token prefixes. "
+                        "Results are ranked by exact phrase and name matches, with at most 20 returned. "
+                        "An empty string applies no filter; a non-empty query with no usable terms returns no tools."
+                    ),
                 },
                 "include_schemas": {
                     "type": "boolean",

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict
@@ -63,6 +64,86 @@ class ToolMetadata:
 
 # Global dictionary mapping tool names to their metadata
 TOOL_REGISTRY: Dict[str, ToolMetadata] = {}
+
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+_MAX_SEARCH_RESULTS = 20
+_SEARCH_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "how",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "with",
+    }
+)
+
+
+def _tokenize(value: str) -> tuple[str, ...]:
+    return tuple(_TOKEN_PATTERN.findall(value.lower()))
+
+
+def _token_matches(query: str, candidate: str) -> bool:
+    return candidate == query or (len(query) >= 4 and candidate.startswith(query))
+
+
+def _contains_exact_phrase(tokens: tuple[str, ...], query_tokens: tuple[str, ...]) -> bool:
+    phrase_length = len(query_tokens)
+    return any(
+        tokens[start : start + phrase_length] == query_tokens for start in range(len(tokens) - phrase_length + 1)
+    )
+
+
+def _rank_tools_by_search(tools: list[Dict[str, Any]], search: str) -> list[Dict[str, Any]]:
+    query_tokens = tuple(
+        dict.fromkeys(token for token in _tokenize(search) if len(token) >= 2 and token not in _SEARCH_STOP_WORDS)
+    )
+    if not query_tokens:
+        return []
+
+    required_matches = 1 if len(query_tokens) == 1 else max(2, (len(query_tokens) + 1) // 2)
+    ranked: list[tuple[tuple[int, int, int], Dict[str, Any]]] = []
+
+    for tool in tools:
+        name_tokens = _tokenize(tool.get("name", ""))
+        description_tokens = _tokenize(tool.get("description", ""))
+        all_tokens = name_tokens + description_tokens
+
+        matched_tokens = tuple(
+            query_token
+            for query_token in query_tokens
+            if any(_token_matches(query_token, candidate) for candidate in all_tokens)
+        )
+        if len(matched_tokens) < required_matches:
+            continue
+
+        name_matches = sum(
+            1 for query_token in query_tokens if any(_token_matches(query_token, c) for c in name_tokens)
+        )
+        exact_phrase = int(
+            _contains_exact_phrase(name_tokens, query_tokens)
+            or _contains_exact_phrase(description_tokens, query_tokens)
+        )
+        ranked.append(((exact_phrase, name_matches, len(matched_tokens)), tool))
+
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return [tool for _score, tool in ranked[:_MAX_SEARCH_RESULTS]]
 
 
 def register_tool(
@@ -128,7 +209,7 @@ def get_tool_index(
         manifest_path: Path to the tools_manifest.json file for lazy mode.
         category: Filter to tools in this category (e.g. "clients", "firewall").
                   Derived from the last segment of the tool's module path.
-        search: Case-insensitive substring filter applied to tool name and description.
+        search: Case-insensitive token search ranked over tool name and description.
         include_schemas: If True, include full input/output schemas per tool.
 
     Returns:
@@ -159,14 +240,9 @@ def get_tool_index(
         cat_lower = category.lower()
         all_tools = [t for t in all_tools if _category(t.get("name", "")).lower() == cat_lower]
 
-    # Apply search filter (name + description)
+    # Apply bounded token search over name + description.
     if search:
-        search_lower = search.lower()
-        all_tools = [
-            t
-            for t in all_tools
-            if search_lower in t.get("name", "").lower() or search_lower in t.get("description", "").lower()
-        ]
+        all_tools = _rank_tools_by_search(all_tools, search)
 
     # Strip schemas unless explicitly requested
     if not include_schemas:
@@ -246,7 +322,7 @@ async def tool_index_handler(args: Dict[str, Any] | None = None) -> Dict[str, An
 
     Accepts optional filter args:
         category (str): Filter by tool category (module suffix, e.g. "clients").
-        search (str): Case-insensitive substring match on name/description.
+        search (str): Case-insensitive token search ranked over name/description.
         include_schemas (bool): Include full schemas per tool. Defaults to False.
 
     Returns:

--- a/packages/unifi-mcp-shared/tests/test_meta_tools.py
+++ b/packages/unifi-mcp-shared/tests/test_meta_tools.py
@@ -59,6 +59,25 @@ def _register_test_meta_tools(*, server, prefix, start_async_tool=None, get_job_
     return registered
 
 
+def test_tool_index_schema_describes_ranked_token_search():
+    register_tool = Mock()
+    register_meta_tools(
+        server=SimpleNamespace(),
+        tool_decorator=_capture_tools()[1],
+        tool_index_handler=AsyncMock(return_value={}),
+        start_async_tool=AsyncMock(),
+        get_job_status=AsyncMock(),
+        register_tool=register_tool,
+        prefix="unifi",
+    )
+
+    index_call = next(call for call in register_tool.call_args_list if call.kwargs["name"] == "unifi_tool_index")
+    description = index_call.kwargs["input_schema"]["properties"]["search"]["description"]
+    assert "token search" in description
+    assert "at most 20" in description
+    assert "no usable terms returns no tools" in description
+
+
 @pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
 async def test_execute_normalizes_structured_inner_result(prefix):
     payload = {"success": True, "data": {"id": "abc"}}

--- a/packages/unifi-mcp-shared/tests/test_tool_index.py
+++ b/packages/unifi-mcp-shared/tests/test_tool_index.py
@@ -1,6 +1,7 @@
 """Tests for the shared tool_index module."""
 
 import json
+from pathlib import Path
 
 import pytest
 from unifi_mcp_shared.tool_index import (
@@ -9,6 +10,8 @@ from unifi_mcp_shared.tool_index import (
     get_tool_index,
     register_tool,
 )
+
+SEARCH_FIXTURE = json.loads((Path(__file__).resolve().parents[3] / "tests/fixtures/tool_search_cases.json").read_text())
 
 
 @pytest.fixture(autouse=True)
@@ -299,6 +302,79 @@ class TestGetToolIndex:
         register_tool(name="unifi_list_clients", description="List clients")
         index = get_tool_index(registration_mode="eager", search="LIST")
         assert index["count"] == 1
+
+    @pytest.mark.parametrize(
+        ("search", "expected"),
+        [(case["search"], case["expected"]) for case in SEARCH_FIXTURE["cases"]],
+        ids=[case["search"] or "empty" for case in SEARCH_FIXTURE["cases"]],
+    )
+    def test_search_contract_matches_shared_fixture(self, search, expected):
+        for tool in SEARCH_FIXTURE["tools"]:
+            register_tool(**tool)
+
+        index = get_tool_index(registration_mode="eager", search=search)
+
+        assert [tool["name"] for tool in index["tools"]] == expected
+
+    def test_search_prioritizes_exact_phrase(self):
+        register_tool(name="unifi_firewall_policy_update", description="Modify policy configuration")
+        register_tool(name="unifi_exact_wall_policy", description="Apply the wall policy update workflow")
+
+        index = get_tool_index(registration_mode="eager", search="wall policy update")
+
+        assert [tool["name"] for tool in index["tools"]] == [
+            "unifi_exact_wall_policy",
+            "unifi_firewall_policy_update",
+        ]
+
+    def test_search_does_not_create_exact_phrase_across_fields(self):
+        register_tool(name="unifi_wall_alpha", description="Configure policy update")
+        register_tool(name="unifi_wall", description="Policy update settings")
+
+        index = get_tool_index(registration_mode="eager", search="wall policy update")
+
+        assert [tool["name"] for tool in index["tools"]] == ["unifi_wall_alpha", "unifi_wall"]
+
+    def test_search_preserves_source_order_for_ties(self):
+        register_tool(name="unifi_alpha", description="Inspect client details")
+        register_tool(name="unifi_beta", description="Inspect client details")
+
+        index = get_tool_index(registration_mode="eager", search="inspect client")
+
+        assert [tool["name"] for tool in index["tools"]] == ["unifi_alpha", "unifi_beta"]
+
+    def test_search_caps_results(self):
+        for index in range(25):
+            register_tool(name=f"unifi_client_{index:02}", description="Inspect a client")
+
+        result = get_tool_index(registration_mode="eager", search="client")
+
+        assert result["count"] == 20
+        assert [tool["name"] for tool in result["tools"]] == [f"unifi_client_{index:02}" for index in range(20)]
+
+    def test_empty_search_applies_no_filter(self):
+        for tool in SEARCH_FIXTURE["tools"]:
+            register_tool(**tool)
+
+        result = get_tool_index(registration_mode="eager", search="")
+
+        assert result["count"] == len(SEARCH_FIXTURE["tools"])
+        assert "filtered" not in result
+
+    def test_search_contract_in_lazy_mode(self, tmp_path):
+        manifest_path = tmp_path / "tools_manifest.json"
+        manifest_path.write_text(json.dumps({"tools": SEARCH_FIXTURE["tools"], "count": len(SEARCH_FIXTURE["tools"])}))
+
+        result = get_tool_index(
+            registration_mode="lazy",
+            manifest_path=manifest_path,
+            search="update tx power",
+        )
+
+        assert [tool["name"] for tool in result["tools"]] == [
+            "unifi_update_device_radio",
+            "unifi_get_device_radio",
+        ]
 
     # --- Categories metadata ---
 

--- a/tests/fixtures/tool_search_cases.json
+++ b/tests/fixtures/tool_search_cases.json
@@ -1,0 +1,110 @@
+{
+  "tools": [
+    {
+      "name": "unifi_update_device_radio",
+      "description": "Update radio settings including tx power and channel configuration"
+    },
+    {
+      "name": "unifi_get_device_radio",
+      "description": "Get radio configuration and live tx power statistics"
+    },
+    {
+      "name": "unifi_update_wlan",
+      "description": "Update a WLAN including radio settings"
+    },
+    {
+      "name": "unifi_get_client_wifi_details",
+      "description": "Get WiFi details including power information for a client"
+    },
+    {
+      "name": "unifi_update_firewall_policy",
+      "description": "Update an existing firewall policy"
+    },
+    {
+      "name": "unifi_update_firewall_group",
+      "description": "Update an existing firewall group"
+    },
+    {
+      "name": "unifi_create_firewall_policy",
+      "description": "Create a firewall policy to control traffic"
+    },
+    {
+      "name": "unifi_update_dns_record",
+      "description": "Update a DNS TXT record"
+    },
+    {
+      "name": "unifi_list_clients",
+      "description": "List connected clients"
+    },
+    {
+      "name": "unifi_list_devices",
+      "description": "List network devices"
+    }
+  ],
+  "cases": [
+    {
+      "search": "update wlan radio tx power",
+      "expected": [
+        "unifi_update_device_radio",
+        "unifi_update_wlan",
+        "unifi_get_device_radio"
+      ]
+    },
+    {
+      "search": "update tx power",
+      "expected": [
+        "unifi_update_device_radio",
+        "unifi_get_device_radio"
+      ]
+    },
+    {
+      "search": "wifi update tx power",
+      "expected": [
+        "unifi_update_device_radio",
+        "unifi_get_client_wifi_details",
+        "unifi_get_device_radio"
+      ]
+    },
+    {
+      "search": "tx radio",
+      "expected": [
+        "unifi_update_device_radio",
+        "unifi_get_device_radio"
+      ]
+    },
+    {
+      "search": "to update firewall",
+      "expected": [
+        "unifi_update_firewall_policy",
+        "unifi_update_firewall_group"
+      ]
+    },
+    {
+      "search": "client",
+      "expected": [
+        "unifi_get_client_wifi_details",
+        "unifi_list_clients"
+      ]
+    },
+    {
+      "search": "x",
+      "expected": []
+    },
+    {
+      "search": "   ",
+      "expected": []
+    },
+    {
+      "search": "!!!",
+      "expected": []
+    },
+    {
+      "search": "the and to",
+      "expected": []
+    },
+    {
+      "search": "nonexistent capability",
+      "expected": []
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- replace whole-string tool-index filtering with deterministic token-based ranking
- ignore low-signal terms, require meaningful multi-word coverage, preserve stable ties, and cap results at 20
- keep short technical tokens exact-only so `tx` does not match DNS `TXT` records
- keep local Python and Cloudflare Worker discovery behavior aligned through a shared fixture
- route Worker catalog construction through a directly tested production helper
- update public schemas and regenerate all three app manifests

## Why

Natural agent searches such as `update wlan radio tx power` returned no tools unless the exact phrase appeared verbatim. Agents could therefore conclude that an existing capability did not exist.

Originally reported by @ldenaeyer in #448.

Fixes #478.

## Testing

- `make pre-commit` passed after final manifest generation
- shared focused suite: 93 passed
- Worker focused suite: 41 passed; TypeScript typecheck passed
- real Network manifest:
  - `update wlan radio tx power` -> 3 results, `unifi_update_device_radio` first
  - `update tx power` -> 2 results, `unifi_update_device_radio` first
  - `wifi update tx power` -> 4 results, `unifi_update_device_radio` first
  - `to update firewall` -> 2 results
  - broad searches -> capped at 20
- two independent pre-PR reviews completed; all findings remediated and re-reviewed

## Live smoke

- all-server read-only hardware smoke completed
- `unifi_tool_index`, `protect_tool_index`, and `access_tool_index` all returned `status: ok`
- documented unrelated Access `access_get_activity_summary` `CODE_SYSTEM_ERROR -3` was skipped by the harness
- no mutations were run because this change only affects local discovery filtering

<details>
<summary>Targeted stdio MCP discovery output</summary>

```text
network lazy: update wlan radio tx power -> 3 tools, first=unifi_update_device_radio
network eager: update wlan radio tx power -> 3 tools, first=unifi_update_device_radio
network meta_only: tool index -> 1 tools, first=unifi_tool_index
protect lazy: list smart detection events -> 11 tools, first=protect_list_smart_detections
protect eager: list smart detection events -> 10 tools, first=protect_list_smart_detections
protect meta_only: tool index -> 1 tools, first=protect_tool_index
access lazy: list door access events -> 20 tools, first=access_list_events
access eager: list door access events -> 20 tools, first=access_list_events
access meta_only: tool index -> 1 tools, first=access_tool_index
```

</details>