### PR TITLE
fix(firewall-auditor): read the legacy engine before scoring segmentation

### DIFF
--- a/plugins/unifi-network/skills/firewall-auditor/SKILL.md
+++ b/plugins/unifi-network/skills/firewall-auditor/SKILL.md
@@ -30,6 +30,7 @@ Dispatch these tool calls in **a single batch** (multiple tool uses in one assis
 
 - `unifi_list_firewall_policies`
 - `unifi_list_firewall_zones`
+- `unifi_list_legacy_firewall_rules`
 - `unifi_list_networks`
 - `unifi_list_firewall_groups`
 - `unifi_list_devices`
@@ -38,6 +39,24 @@ Dispatch these tool calls in **a single batch** (multiple tool uses in one assis
 If a tool returns `success=false`, stop the audit and surface the error. Do not partial-report.
 
 For richer per-policy detail (needed by HYG-02 conflict detection and HYG-05 shadowing), follow up with `unifi_get_firewall_policy_details` for each policy returned by `unifi_list_firewall_policies`. Batch these calls in parallel as well.
+
+### 1a. Determine which firewall engine the site runs
+
+**Do this before evaluating any benchmark.** UniFi has two firewall engines and a site runs exactly one:
+
+| Signal | Engine |
+|---|---|
+| `unifi_list_firewall_policies` and `unifi_list_firewall_zones` return entries | **zone-based** (V2, UniFi Network 9.0+ after migration) |
+| Both return zero entries and `unifi_list_legacy_firewall_rules` returns entries | **legacy** (pre-zone-based) |
+| All three return zero entries | **indeterminate** — see below |
+
+The zone-based tools do not error on a legacy site. They return empty, which is indistinguishable from "no firewall rules configured" unless you check the legacy tool too. Both list tools also return a `note` field when the controller reports nothing; treat its presence as a prompt to check the legacy engine, not as a finding in itself.
+
+Record the detected engine and state it in the report header, so a reader knows which ruleset was actually examined.
+
+**Never score segmentation from an engine you did not read.** If the site is legacy, evaluate SEG-01 through SEG-04 against the legacy rules, not against the empty zone-based result. Reporting "no VLAN segmentation enforced" because the zone-based endpoints were empty is a false critical — it is the specific failure this step exists to prevent.
+
+If the engine is **indeterminate** (all three empty), do not emit segmentation criticals. Emit a single `info` finding stating that no firewall configuration could be retrieved and that segmentation could not be assessed, and continue with the non-segmentation benchmarks. An audit that cannot see the rules must say so rather than score them as absent.
 
 ### 2. Evaluate the 16 benchmarks
 
@@ -139,9 +158,12 @@ Format depends on user intent:
 
 **Default (interactive):** human-readable summary
 - Overall score and status (with the trend)
+- **The firewall engine that was audited** (`zone-based`, `legacy`, or `indeterminate`)
 - Per-category scores
 - Critical findings called out first, then warnings, then info
 - Top 3–5 prioritised recommendations with the `fix` tool name
+
+State the engine explicitly. A reader needs to know which ruleset was examined to trust a segmentation score, and on a legacy site the zone-based remediation templates do not apply.
 
 **On request ("give me JSON" / "machine-readable"):** emit the full report as JSON with this shape:
 
@@ -150,6 +172,7 @@ Format depends on user intent:
   "timestamp": "...",
   "overall_score": 73,
   "overall_status": "needs_attention",
+  "firewall_engine": "zone-based",
   "categories": { ... from CLI ... },
   "findings": [ ... all per-instance findings ... ],
   "trend": { "previous_score": 68, "change": "+5" }
@@ -188,3 +211,5 @@ For each finding, do **not** call mutating tools yourself. The auditor reads; th
 - **Per-instance counting matters.** Five offline devices is five TOP-01 findings, not one.
 - **Severity comes from the benchmark, not the situation.** The reference defines the default severity for each benchmark. Don't downgrade a critical finding because the user "isn't worried about it" — record it accurately and let them decide what to act on.
 - **Skip the trend on rubric changes.** A `rubric_version` mismatch with the prior history entry means the math changed; report the new baseline and explain why no trend is shown.
+- **Empty is not absent.** Zero zone-based policies means either "no policies" or "this site runs the legacy engine". Never resolve that ambiguity by assuming the first — check `unifi_list_legacy_firewall_rules`. Scoring a legacy site as having no segmentation is the single most damaging false positive this audit can produce, because it reports a correctly-segmented network as critically exposed.
+- **Call out an engine change in the trend.** If the detected engine differs from the previous history entry (typically a legacy-to-zone-based migration), the two audits examined different rulesets. Report the new baseline and note the migration rather than presenting a score delta as if the security posture changed.

--- a/plugins/unifi-network/skills/firewall-auditor/references/security-benchmarks.md
+++ b/plugins/unifi-network/skills/firewall-auditor/references/security-benchmarks.md
@@ -6,6 +6,41 @@ This document defines deterministic checks for the firewall auditor skill. Each 
 
 ## Segmentation Benchmarks
 
+> **Applies to both firewall engines.** SEG-01 through SEG-04 describe a security
+> *intent*, not a rule format. Determine the active engine first (see the skill's
+> "Determine which firewall engine the site runs" step), then evaluate the
+> benchmark against that engine's rules.
+>
+> **Zone-based (V2)** — read `unifi_list_firewall_policies` and
+> `unifi_list_firewall_zones`. Rules carry `action` in uppercase
+> (`ALLOW`/`BLOCK`/`REJECT`) and nested `source`/`destination` objects keyed by
+> `zone_id` with a `matching_target`.
+>
+> **Legacy (pre-zone-based)** — read `unifi_list_legacy_firewall_rules`. Rules
+> carry `action` in lowercase (`accept`/`drop`/`reject`), belong to a `ruleset`
+> (`LAN_IN`, `LAN_OUT`, `GUEST_IN`, `WAN_IN`, … including IPv6 variants such as
+> `LANv6_IN`), and express matching through flat fields: `src_address` /
+> `dst_address` (CIDR), `src_networkconf_id` / `dst_networkconf_id` (VLAN
+> references), `src_firewallgroup_ids` / `dst_firewallgroup_ids` (address/port
+> group references), and `src_port` / `dst_port`. Evaluation order is
+> `rule_index` ascending within a ruleset, so "positioned before" means a lower
+> `rule_index` in the same ruleset.
+>
+> A legacy rule satisfies a segmentation benchmark when it is `enabled`, its
+> `action` is `drop` or `reject`, and its source and destination match the VLANs
+> the benchmark names — whether expressed as a CIDR, a network reference, or a
+> firewall group.
+>
+> **Remediation differs.** The `unifi_create_firewall_policy` templates below
+> create zone-based policies and will not work on a legacy site — this server has
+> no legacy firewall write path. For a legacy site, report the gap and direct the
+> user to the UniFi UI, or to migrating to the zone-based firewall. Note that
+> migration is one-way with no in-product rollback, so present it as a decision
+> rather than a recommended fix.
+>
+> **Never emit a segmentation finding for an engine you did not read.** An empty
+> result from the engine that is not in use is not evidence of a missing rule.
+
 ### SEG-01: IoT VLAN Inter-VLAN Isolation
 
 **Name:** IoT-to-LAN block rule exists
@@ -13,9 +48,10 @@ This document defines deterministic checks for the firewall auditor skill. Each 
 **What to check:** Verify at least one enabled firewall rule exists that blocks traffic from the IoT VLAN (source) to RFC 1918 private address ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16), excluding the IoT subnet itself. The rule must be enabled and positioned before any allow rules for the same traffic.
 
 **MCP tools needed:**
-- `list_firewall_rules` — retrieve all firewall rules
-- `list_networks` — identify IoT VLAN subnet and VLAN ID
-- `list_firewall_groups` — check if RFC 1918 ranges are grouped
+- `unifi_list_firewall_policies` — retrieve all firewall rules
+- `unifi_list_legacy_firewall_rules` — retrieve legacy rules (the only source on a pre-zone-based site)
+- `unifi_list_networks` — identify IoT VLAN subnet and VLAN ID
+- `unifi_list_firewall_groups` — check if RFC 1918 ranges are grouped
 
 **Severity:** critical
 
@@ -44,9 +80,10 @@ unifi_create_firewall_policy:
 **What to check:** Verify the guest VLAN has an enabled firewall rule blocking access to all private/local subnets (RFC 1918). Additionally verify no allow rules exist for guest-to-LAN traffic above the block rule in rule index order.
 
 **MCP tools needed:**
-- `list_firewall_rules` — retrieve all rules, check ruleset, action, source, destination
-- `list_networks` — identify guest network VLAN and subnet
-- `list_wlans` — confirm which WLAN maps to the guest network
+- `unifi_list_firewall_policies` — retrieve all rules, check ruleset, action, source, destination
+- `unifi_list_legacy_firewall_rules` — retrieve legacy rules (the only source on a pre-zone-based site)
+- `unifi_list_networks` — identify guest network VLAN and subnet
+- `unifi_list_wlans` — confirm which WLAN maps to the guest network
 
 **Severity:** critical
 
@@ -75,9 +112,10 @@ unifi_create_firewall_policy:
 **What to check:** Verify the management VLAN has an inbound rule that blocks traffic from non-management VLANs. Check that only explicitly whitelisted source IPs or groups (admin workstations) are permitted to initiate connections to the management VLAN.
 
 **MCP tools needed:**
-- `list_firewall_rules` — find rules referencing management VLAN as destination
-- `list_networks` — identify management VLAN subnet and VLAN ID
-- `list_firewall_groups` — check for admin workstation IP group definitions
+- `unifi_list_firewall_policies` — find rules referencing management VLAN as destination
+- `unifi_list_legacy_firewall_rules` — retrieve legacy rules (the only source on a pre-zone-based site)
+- `unifi_list_networks` — identify management VLAN subnet and VLAN ID
+- `unifi_list_firewall_groups` — check for admin workstation IP group definitions
 
 **Severity:** critical
 
@@ -150,12 +188,13 @@ Choose the firewall path or the ACL path based on how admin identity is actually
 
 **Name:** No implicit allow between VLANs
 
-**What to check:** For every VLAN pair (source, destination) identified in `list_networks`, verify that at least one explicit firewall rule exists governing traffic between them (either allow or block). A pair with no matching rule relies on default behavior — flag this as a finding. Exclude the VLAN's own subnet (intra-VLAN traffic is out of scope).
+**What to check:** For every VLAN pair (source, destination) identified in `unifi_list_networks`, verify that at least one explicit firewall rule exists governing traffic between them (either allow or block). A pair with no matching rule relies on default behavior — flag this as a finding. Exclude the VLAN's own subnet (intra-VLAN traffic is out of scope).
 
 **MCP tools needed:**
-- `list_networks` — enumerate all VLANs and their subnets
-- `list_firewall_rules` — enumerate all rules and map coverage
-- `list_firewall_groups` — resolve group memberships for rule sources/destinations
+- `unifi_list_networks` — enumerate all VLANs and their subnets
+- `unifi_list_firewall_policies` — enumerate all rules and map coverage
+- `unifi_list_legacy_firewall_rules` — retrieve legacy rules (the only source on a pre-zone-based site)
+- `unifi_list_firewall_groups` — resolve group memberships for rule sources/destinations
 
 **Severity:** warning
 
@@ -223,8 +262,8 @@ unifi_create_firewall_policy:
 **What to check:** Verify a LAN-in or LAN-local rule exists that intercepts DNS traffic (UDP/TCP port 53) from client VLANs and either blocks external DNS or redirects to an approved resolver IP. Check that no rule explicitly allows port 53 to arbitrary destinations before such a rule.
 
 **MCP tools needed:**
-- `list_firewall_rules` — check for port 53 rules in LAN_IN and LAN_LOCAL rulesets
-- `list_networks` — enumerate client-facing VLANs
+- `unifi_list_firewall_policies` — check for port 53 rules in LAN_IN and LAN_LOCAL rulesets
+- `unifi_list_networks` — enumerate client-facing VLANs
 
 **Severity:** warning
 
@@ -268,8 +307,8 @@ Neither is currently exposed through MCP tooling. Tracked separately for future 
 **What to check:** Verify at least one IP group exists named with a threat/block indicator (e.g., contains "threat", "block", "malicious", or "blacklist" in the name). Verify that IP group is referenced in at least one enabled WAN_OUT or LAN_IN drop rule. An empty IP group with no associated rule is also a finding.
 
 **MCP tools needed:**
-- `list_firewall_groups` — find threat-related groups, check member count
-- `list_firewall_rules` — verify group is referenced in enabled drop rules
+- `unifi_list_firewall_groups` — find threat-related groups, check member count
+- `unifi_list_firewall_policies` — verify group is referenced in enabled drop rules
 
 **Severity:** informational
 
@@ -303,7 +342,7 @@ unifi_create_firewall_policy:
 **What to check:** For every disabled firewall rule, check whether an enabled rule exists with an identical or overlapping source, destination, port, and action. If a disabled rule's traffic is fully covered by an enabled rule, the disabled rule is redundant. Report the disabled rule name and the matching enabled rule name.
 
 **MCP tools needed:**
-- `list_firewall_rules` — retrieve all rules with enabled status, source, destination, port, action fields
+- `unifi_list_firewall_policies` — retrieve all rules with enabled status, source, destination, port, action fields
 
 **Severity:** warning
 
@@ -323,7 +362,7 @@ delete_firewall_rule:
 **What to check:** For each pair of enabled rules with overlapping or identical source/destination/port criteria, check whether their actions conflict (one allows, one drops). When a conflict exists, determine whether rule index ordering resolves the conflict predictably. Flag cases where index order causes the less restrictive rule to win.
 
 **MCP tools needed:**
-- `list_firewall_rules` — retrieve all enabled rules with index, action, source, destination, port fields
+- `unifi_list_firewall_policies` — retrieve all enabled rules with index, action, source, destination, port fields
 
 **Severity:** critical
 
@@ -341,12 +380,12 @@ update_firewall_rule:
 
 **Name:** All rule references resolve to valid objects
 
-**What to check:** For every firewall rule that references a network ID or IP group ID in its source or destination, verify that the referenced object exists in `list_networks` or `list_firewall_groups` respectively. Also verify that referenced IP groups have at least one member. Report any rule with a dangling reference.
+**What to check:** For every firewall rule that references a network ID or IP group ID in its source or destination, verify that the referenced object exists in `unifi_list_networks` or `unifi_list_firewall_groups` respectively. Also verify that referenced IP groups have at least one member. Report any rule with a dangling reference.
 
 **MCP tools needed:**
-- `list_firewall_rules` — extract network and IP group references from each rule
-- `list_networks` — validate network IDs exist
-- `list_firewall_groups` — validate group IDs exist and are non-empty
+- `unifi_list_firewall_policies` — extract network and IP group references from each rule
+- `unifi_list_networks` — validate network IDs exist
+- `unifi_list_firewall_groups` — validate group IDs exist and are non-empty
 
 **Severity:** warning
 
@@ -366,7 +405,7 @@ delete_firewall_rule:
 **What to check:** Inspect the name/description field of every firewall rule. Flag rules whose names match default patterns: empty string, "Rule", "New Rule", "Untitled", numeric-only names, or names matching the pattern `Rule \d+`. A rule with no human-readable description is informational; a rule with a default placeholder name is a warning.
 
 **MCP tools needed:**
-- `list_firewall_rules` — retrieve name and description fields for all rules
+- `unifi_list_firewall_policies` — retrieve name and description fields for all rules
 
 **Severity:** warning
 
@@ -388,7 +427,7 @@ update_firewall_rule:
 **What to check:** For each pair of enabled rules in the same ruleset, check whether a rule with a lower index has a source/destination/port that is a superset of a rule with a higher index and the same action. The higher-index rule is then unreachable (shadowed). Also flag cases where a higher-index specific allow rule is preceded by a lower-index broad drop rule (rendering the specific allow dead).
 
 **MCP tools needed:**
-- `list_firewall_rules` — retrieve all enabled rules with index, action, source, destination, port, and ruleset fields
+- `unifi_list_firewall_policies` — retrieve all enabled rules with index, action, source, destination, port, and ruleset fields
 
 **Severity:** warning
 
@@ -408,10 +447,10 @@ update_firewall_rule:
 
 **Name:** No adopted devices in offline state
 
-**What to check:** Retrieve all devices via `list_devices`. For every device with `state != 1` (not connected/online), report it as a finding. Include the device name, MAC address, device type, and last-seen timestamp in the finding detail.
+**What to check:** Retrieve all devices via `unifi_list_devices`. For every device with `state != 1` (not connected/online), report it as a finding. Include the device name, MAC address, device type, and last-seen timestamp in the finding detail.
 
 **MCP tools needed:**
-- `list_devices` — retrieve all devices with state, name, mac, type, last_seen fields
+- `unifi_list_devices` — retrieve all devices with state, name, mac, type, last_seen fields
 
 **Severity:** critical
 
@@ -429,10 +468,10 @@ get_device_details:
 
 **Name:** No devices with available firmware upgrades pending
 
-**What to check:** Retrieve all devices via `list_devices`. For every device where `upgradeable = true`, report it as a finding with the device name, current firmware version, and available firmware version. Devices running outdated firmware may have known security vulnerabilities.
+**What to check:** Retrieve all devices via `unifi_list_devices`. For every device where `upgradeable = true`, report it as a finding with the device name, current firmware version, and available firmware version. Devices running outdated firmware may have known security vulnerabilities.
 
 **MCP tools needed:**
-- `list_devices` — retrieve all devices with upgradeable, version, upgrade_to_firmware fields
+- `unifi_list_devices` — retrieve all devices with upgradeable, version, upgrade_to_firmware fields
 
 **Severity:** warning
 
@@ -449,12 +488,12 @@ upgrade_device_firmware:
 
 **Name:** All switch uplinks carry consistent VLAN trunk configurations
 
-**What to check:** For each managed switch, retrieve its port configuration via `list_switch_ports` or `get_device_details`. For each trunk/uplink port, verify that the set of allowed VLANs matches the expected set defined by the connected VLANs in `list_networks`. Flag any uplink that is missing a VLAN that exists on the network, or carries a VLAN not defined in `list_networks`.
+**What to check:** For each managed switch, retrieve its port configuration via `unifi_get_switch_ports` or `unifi_get_device_details`. For each trunk/uplink port, verify that the set of allowed VLANs matches the expected set defined by the connected VLANs in `unifi_list_networks`. Flag any uplink that is missing a VLAN that exists on the network, or carries a VLAN not defined in `unifi_list_networks`.
 
 **MCP tools needed:**
-- `list_devices` — identify managed switches by type
-- `get_device_details` — retrieve port profiles and VLAN assignments per port
-- `list_networks` — enumerate defined VLANs
+- `unifi_list_devices` — identify managed switches by type
+- `unifi_get_device_details` — retrieve port profiles and VLAN assignments per port
+- `unifi_list_networks` — enumerate defined VLANs
 
 **Severity:** warning
 
@@ -473,12 +512,12 @@ update_device_port_profile:
 
 **Name:** All defined port profiles are in use
 
-**What to check:** Retrieve all port profiles via `list_port_profiles`. For each profile, check whether it is referenced by at least one port on at least one switch (via `get_device_details`). Any profile with zero references across all devices is orphaned. Report profile name and ID.
+**What to check:** Retrieve all port profiles via `unifi_list_port_profiles`. For each profile, check whether it is referenced by at least one port on at least one switch (via `unifi_get_device_details`). Any profile with zero references across all devices is orphaned. Report profile name and ID.
 
 **MCP tools needed:**
-- `list_port_profiles` — retrieve all defined port profiles with IDs and names
-- `list_devices` — enumerate managed switches
-- `get_device_details` — retrieve per-port profile assignments
+- `unifi_list_port_profiles` — retrieve all defined port profiles with IDs and names
+- `unifi_list_devices` — enumerate managed switches
+- `unifi_get_device_details` — retrieve per-port profile assignments
 
 **Severity:** informational
 


### PR DESCRIPTION
Closes the other half of #440. #471 gave the server a way to read pre-zone-based firewall rules; the auditor still couldn't see them.

## The problem this fixes

A site on the legacy firewall engine scored as having **zero VLAN segmentation** no matter how well segmented it actually was. SEG-01/02/03 are `critical`, so a correctly-configured network got reported as critically exposed. That false critical is what #440 was originally filed about — and adding a read tool alone did not fix it, because nothing told the auditor to go look.

## Changes

**Engine detection, before any benchmark runs.** The zone-based endpoints don't error on a legacy site — they return empty, which is indistinguishable from "no firewall rules configured". The skill now determines the engine explicitly:

| Signal | Engine |
|---|---|
| policies/zones return entries | zone-based |
| both empty, legacy rules return entries | legacy |
| all three empty | indeterminate |

**SEG-01–04 evaluate against whichever engine is in use.** The benchmarks describe a security *intent*, not a rule format, so the section preamble now documents how that intent maps onto legacy rules: lowercase `accept`/`drop`/`reject` actions, `ruleset` membership, `rule_index` ordering (so "positioned before" means a lower index in the same ruleset), and the flat `src_`/`dst_` address, network and firewall-group fields.

**Remediation honesty.** The `unifi_create_firewall_policy` templates build zone-based policies and won't work on a legacy site — this server has no legacy firewall write path. On legacy, the auditor reports the gap and points at the UniFi UI or migration, and is told to present migration as a decision rather than a fix, since it's one-way with no in-product rollback.

**Indeterminate no longer means "absent".** If nothing can be retrieved from any engine, the auditor emits a single `info` finding saying segmentation could not be assessed, instead of criticals.

**Engine in the report.** Stated in the header and added to the JSON shape as `firewall_engine`, so a reader knows which ruleset was examined. Also a tip to flag an engine change in the trend rather than presenting a legacy-to-zone-based migration as a security-posture delta.

## Drive-by: the benchmark reference named tools that don't exist

While updating the SEG tool lists I checked every tool name in `security-benchmarks.md` against the network manifest:

- **`list_firewall_rules` — 11 occurrences, does not exist.** It's a pre-`76cb5d1` name, left behind when the legacy V1 firewall path was removed. The auditor was being told to call a tool that hasn't existed for months.
- **`list_switch_ports` — 1 occurrence, has never existed.** Replaced with `unifi_get_switch_ports`.
- The remaining 23 were missing the `unifi_` prefix.

All 35 are fixed, and every tool name in the file now resolves against `tools_manifest.json`. I verified each replacement exists rather than assuming.

## Testing

This is skill content — prompt text with no automated coverage, so there are no unit tests to add and I'm not claiming any. `make check-generated` passes and only these two files change.

What I did verify is the tool behaviour the skill now depends on, live against a UDM SE:

- `/rest/firewallrule` returns **200 with an empty list** on a zone-based-migrated controller, not a 404 — so the detection step reads a clean empty rather than an error
- The detection table resolves correctly on this controller: 8 zones, 51 policies, 0 legacy rules → `zone-based`
- The `note` hint the skill keys off is correctly **absent** when the controller returns real data, and correctly absent on a filter miss

The populated-legacy path remains unexercised — no legacy hardware was available. If anyone on #440 still runs the legacy engine, a sanitised `/rest/firewallrule` payload would let us confirm both this and the `LegacyFirewallRule` model against real data.

Refs #440 — I'd suggest closing that issue once this lands, since both halves are then done.