### PR TITLE
fix(network): surface why v2 detection failed instead of a bare 404

### DIFF
--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -245,3 +245,66 @@ class TestEventManagerCommon:
         mock_connection.request.side_effect = Exception("404")
         await event_manager._ensure_api_version()
         assert event_manager._use_v2 is False
+
+    @pytest.mark.asyncio
+    async def test_failed_probe_is_logged_with_the_actual_error(self, event_manager, mock_connection, caplog):
+        """The probe error must reach the log, or a later 404 is undiagnosable."""
+        mock_connection.request.side_effect = Exception("Bad Request: unknown severity LOW")
+
+        with caplog.at_level("WARNING"):
+            await event_manager._ensure_api_version()
+
+        assert event_manager._use_v2 is False
+        assert "unknown severity LOW" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_failed_probe_is_recorded_for_later_diagnosis(self, event_manager, mock_connection):
+        mock_connection.request.side_effect = Exception("Bad Request: unknown severity LOW")
+        await event_manager._ensure_api_version()
+        assert "unknown severity LOW" in event_manager._v2_probe_error
+
+    @pytest.mark.asyncio
+    async def test_successful_probe_records_no_error(self, event_manager, mock_connection):
+        mock_connection.request.return_value = {"count": 1}
+        await event_manager._ensure_api_version()
+        assert event_manager._v2_probe_error is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_events_404_after_failed_probe_explains_both(self, event_manager, mock_connection):
+        """A 404 from a legacy path we only chose because v2 probing failed is not a bare 404."""
+        mock_connection.request.side_effect = [
+            Exception("Bad Request: unknown severity LOW"),  # v2 probe
+            Exception("received 404 Not Found"),  # legacy /stat/event
+        ]
+
+        with pytest.raises(Exception) as exc:
+            await event_manager.get_events()
+
+        message = str(exc.value)
+        assert "404" in message
+        assert "unknown severity LOW" in message, "the v2 probe failure must be surfaced, not swallowed"
+
+    @pytest.mark.asyncio
+    async def test_legacy_alarms_404_after_failed_probe_explains_both(self, event_manager, mock_connection):
+        mock_connection.request.side_effect = [
+            Exception("Bad Request: unknown severity LOW"),  # v2 probe
+            Exception("received 404 Not Found"),  # legacy /stat/alarm
+        ]
+
+        with pytest.raises(Exception) as exc:
+            await event_manager.get_alarms()
+
+        assert "unknown severity LOW" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_legacy_failure_on_a_genuinely_old_controller_is_left_alone(self, event_manager, mock_connection):
+        """No probe error recorded means legacy was a real choice — do not editorialise."""
+        event_manager._use_v2 = False
+        event_manager._v2_probe_error = None
+        mock_connection.request.side_effect = Exception("connection reset")
+
+        with pytest.raises(Exception) as exc:
+            await event_manager.get_events()
+
+        assert "connection reset" in str(exc.value)
+        assert "v2 system-log probe" not in str(exc.value)

--- a/apps/network/tests/unit/test_stats_enhanced.py
+++ b/apps/network/tests/unit/test_stats_enhanced.py
@@ -610,3 +610,49 @@ class TestDeviceManagerSpeedtest:
 
         with pytest.raises(Exception):
             await device_manager.get_speedtest_status("aa:bb:cc:dd:ee:ff")
+
+
+class TestGetAlertsFallbackDiagnostics:
+    """Both alert paths failing must explain both, not just the legacy 404."""
+
+    @pytest.fixture
+    def mock_connection(self):
+        conn = MagicMock()
+        conn.site = "default"
+        conn.request = AsyncMock()
+        conn.get_cached = MagicMock(return_value=None)
+        conn._update_cache = MagicMock()
+        conn.ensure_connected = AsyncMock(return_value=True)
+        conn.controller = MagicMock()
+        return conn
+
+    @pytest.fixture
+    def stats_manager(self, mock_connection):
+        from unifi_core.network.managers.stats_manager import StatsManager
+
+        return StatsManager(mock_connection, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_both_paths_failing_surfaces_the_v2_error_too(self, stats_manager, mock_connection):
+        mock_connection.request.side_effect = [
+            Exception("Bad Request: unknown severity LOW"),  # v2 /system-log/critical
+            Exception("received 404 Not Found"),  # legacy /stat/alarm
+        ]
+
+        with pytest.raises(Exception) as exc:
+            await stats_manager.get_alerts()
+
+        message = str(exc.value)
+        assert "404" in message
+        assert "unknown severity LOW" in message, "the v2 failure must not be swallowed"
+
+    @pytest.mark.asyncio
+    async def test_legacy_success_after_v2_failure_still_returns(self, stats_manager, mock_connection):
+        """The fallback still works — this only changes the both-failed case."""
+        mock_connection.request.side_effect = [
+            Exception("v2 unavailable"),
+            [{"_id": "a1", "archived": False}],
+        ]
+
+        result = await stats_manager.get_alerts()
+        assert result == [{"_id": "a1", "archived": False}]

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -104,6 +104,10 @@ class EventManager:
         self._connection = connection_manager
         self._cm = connection_manager  # alias mirroring protect/access naming
         self._use_v2: bool | None = None  # Auto-detect on first call
+        # Why the v2 probe failed, when it did. Newer controllers have removed the
+        # legacy paths this falls back to, so a failed probe resurfaces later as a
+        # bare 404 from an endpoint the caller never asked for.
+        self._v2_probe_error: str | None = None
         self._buffer = EventBuffer(
             max_size=int(cfg.get("buffer_size", 100)),
             ttl_seconds=int(cfg.get("buffer_ttl_seconds", 300)),
@@ -247,10 +251,34 @@ class EventManager:
             )
             await self._connection.request(api_request)
             logger.info("[events] Using v2 system-log API")
+            self._v2_probe_error = None
             return True
-        except Exception:
-            logger.info("[events] Falling back to legacy /stat/event API")
+        except Exception as probe_error:
+            # Log why, not just that. A probe that fails for a reason other than
+            # "this controller predates v2" sends every later call down a legacy
+            # path that modern controllers answer with 404, and without this the
+            # only visible symptom is that 404.
+            self._v2_probe_error = f"{type(probe_error).__name__}: {probe_error}"
+            logger.warning(
+                "[events] v2 system-log probe failed, falling back to legacy /stat/event API: %s",
+                probe_error,
+            )
             return False
+
+    def _explain_legacy_failure(self, endpoint: str, error: Exception) -> Exception:
+        """Attach the v2 probe failure to a legacy error, when it caused the fallback.
+
+        Returns the original error untouched on a controller that legitimately has
+        no v2 API — there is nothing extra to say about that case.
+        """
+        if not self._v2_probe_error:
+            return error
+        return RuntimeError(
+            f"{endpoint} failed ({error}). This controller was put on the legacy events API "
+            f"because the v2 system-log probe failed: {self._v2_probe_error}. "
+            "On current UniFi Network versions the legacy endpoint no longer exists, so the "
+            "underlying problem is the failed v2 probe, not the missing legacy path."
+        )
 
     async def _ensure_api_version(self) -> None:
         """Detect API version on first call."""
@@ -362,7 +390,7 @@ class EventManager:
             return []
         except Exception as e:
             logger.error("Error getting events (legacy): %s", e)
-            raise
+            raise self._explain_legacy_failure("/stat/event", e) from e
 
     async def get_alarms(
         self,
@@ -437,7 +465,7 @@ class EventManager:
             return alarms[:limit]
         except Exception as e:
             logger.error("Error getting alarms (legacy): %s", e)
-            raise
+            raise self._explain_legacy_failure("/stat/alarm", e) from e
 
     def get_event_type_prefixes(self) -> List[Dict[str, str]]:
         """Get a list of known event type prefixes for filtering."""

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -314,7 +314,17 @@ class StatsManager:
             alerts = await self._get_alerts_v2()
         except Exception as v2_error:
             logger.debug("V2 alert lookup failed, falling back to legacy alarms: %s", v2_error)
-            alerts = await self._get_alerts_legacy(include_archived)
+            try:
+                alerts = await self._get_alerts_legacy(include_archived)
+            except Exception as legacy_error:
+                # Report both. Current controllers have removed /stat/alarm, so the
+                # legacy error is usually a 404 that says nothing about the real
+                # problem — which is whatever made the v2 lookup fail.
+                raise RuntimeError(
+                    f"/stat/alarm failed ({legacy_error}) after the v2 system-log lookup failed "
+                    f"({v2_error}). On current UniFi Network versions the legacy endpoint no longer "
+                    "exists, so the v2 failure is the one to act on."
+                ) from legacy_error
 
         if not include_archived:
             alerts = [a for a in alerts if not a.get("archived", False)]


### PR DESCRIPTION
Refs #461 — makes that report diagnosable. Does not close it, since the underlying cause on the reporter's controller is still unknown; this is what will reveal it.

## The problem

`EventManager._detect_api_version()` probes the v2 system-log API and falls back to legacy on **any** exception, logging only that it fell back:

```python
except Exception:
    logger.info("[events] Falling back to legacy /stat/event API")
    return False
```

Current UniFi Network versions have removed `/stat/event` and `/stat/alarm`. So a probe that fails for any reason *other than* "this controller predates v2" routes every subsequent call to an endpoint that answers 404 — and that 404 is the only thing the user ever sees. It reports a missing legacy endpoint while saying nothing about the v2 failure that caused the fallback, which is the thing actually worth fixing.

That's why #461 is currently unfalsifiable: we can see the reporter gets a 404, but not why their v2 probe failed.

## What changed

The probe exception is logged at `warning` with the actual error, and retained on the manager as `_v2_probe_error`. When a legacy call then fails, the raised error explains both — what the legacy endpoint did, why the code was on the legacy path at all, and which of the two to act on.

A controller that genuinely has no v2 API records no probe error, so its failures pass through untouched. There's a regression test pinning that, because annotating a real old-controller failure with an irrelevant v2 explanation would be its own kind of misleading.

`stats_manager.get_alerts` had the same shape — v2 error logged at `debug`, legacy 404 propagating bare. Both failing now raises one error naming both causes. The fallback itself is unchanged: legacy succeeding after v2 fails still returns normally, and there's a test for that too.

## What this does *not* do

#461 also suggests keying the v2/legacy decision off the reported controller version rather than a runtime probe. I didn't do that — it's a real design change with its own failure modes, and it isn't needed to make the current report diagnosable. Worth its own issue if the logging shows probe failures are common.

## Testing

TDD — six tests written first and watched fail. The guard test (old controller, no probe error, error passed through) passed on first run and is a regression guard rather than a driver; noting that rather than implying otherwise.

- `make core-test` — 1438 passed
- network — 921 passed
- Ruff clean, `make check-generated` clean

Verified against a live UDM Pro SE on Network **10.5.67**: `/stat/alarm` and `/stat/event` both 404 there, while v2 detection succeeds — so alarms and events work, and this change is precisely what will make the failure legible on a controller where the probe *doesn't* succeed.

I could not reproduce #461 itself; the reporter's UDM Pro Max on 10.4.57 fails its probe for a reason my hardware doesn't exhibit. That is the point of this PR.

## Note on the API suite

Running `apps/api/tests` locally in a fresh worktree gives 3-4 failures (`test_manifest.py::test_loads_manifests_from_apps`, the dispatcher tests) that reproduce identically with these changes stashed. They're the same venv-state order-dependence #475 just fixed for `core-test` — `uv run --package unifi-api-server` doesn't install the protect app, so its manifest isn't discoverable. CI runs each app in its own job and is unaffected. Flagging it as a separate papercut rather than folding it in here.