### PR TITLE
chore(deps): raise unifi-core and unifi-mcp-shared floors to the released versions

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Access MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.5,<0.7",
+    "unifi-mcp-shared>=0.6.6,<0.7",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.20,<0.5",
+    "unifi-core[network,protect,access]>=0.4.21,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -5,11 +5,11 @@ description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.5,<0.7",
+    "unifi-mcp-shared>=0.6.6,<0.7",
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.20,<0.5",
+    "unifi-core[network]>=0.4.21,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "pyyaml>=6.0",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Protect MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.5,<0.7",
+    "unifi-mcp-shared>=0.6.6,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
     "unifi-core[protect]>=0.4.17,<0.5",

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "python-dotenv>=1.2.2",
-    "unifi-mcp-shared>=0.6.5,<0.7",
+    "unifi-mcp-shared>=0.6.6,<0.7",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Release-sequencing step between the library tags (`core/v0.4.21`, `shared/v0.6.6`, both now on PyPI) and the app tags.

## Why this is needed

`apps/network` and `apps/api` both import `legacy_firewall_rule_from_controller` from `unifi_core`. That symbol landed in #471 and does not exist in **0.4.20** — the floor both packages declared.

This is invisible to CI. The uv workspace `[tool.uv.sources]` override takes precedence over the version range, so every job resolves the in-tree package and passes, including `uv lock --check`. The mismatch only surfaces when pip resolves the *published* wheel against PyPI: `>=0.4.20` is satisfied by `0.4.20`, and the import fails at startup for anyone doing `pip install unifi-api-server`.

## Changes

| Package | Floor |
|---|---|
| network, api | `unifi-core` → `>=0.4.21` |
| network, protect, access, relay | `unifi-mcp-shared` → `>=0.6.6` |

Caps unchanged (`<0.5`, `<0.7`), so this stays inside the existing series.

## Verification

Checked against the published artifacts, not the workspace — that distinction is the whole point here.

Installing `unifi-core==0.4.21` straight from PyPI:

```
symbol present in published 0.4.21: LAN_IN drop 2001
rulesets: 18
schedule_mode nesting: {'schedule': {'mode': 'EVERY_DAY'}}
```

Built wheel metadata after the change:

```
network:  unifi-core[network]<0.5,>=0.4.21   unifi-mcp-shared<0.7,>=0.6.6
api:      unifi-core[access,network,protect]<0.5,>=0.4.21
protect:  unifi-core[protect]<0.5,>=0.4.17   unifi-mcp-shared<0.7,>=0.6.6
access:   unifi-core[access]<0.5,>=0.4.17    unifi-mcp-shared<0.7,>=0.6.6
relay:    unifi-mcp-shared<0.7,>=0.6.6
```

`protect` and `access` keep their `unifi-core>=0.4.17` floor deliberately — neither uses any core symbol added since, so raising it would be churn without a reason.

App tags follow once this lands.