### PR TITLE
fix(api): declare unifi-mcp-shared, and catch undeclared deps in the pin gate

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,13 +24,14 @@ COPY apps/network/pyproject.toml apps/network/pyproject.toml
 COPY apps/protect/pyproject.toml apps/protect/pyproject.toml
 COPY apps/access/pyproject.toml apps/access/pyproject.toml
 
-# Copy api source and its workspace dependency (unifi-core).
-# unifi-core source is REQUIRED — without it, hatch-vcs fails with
+# Copy api source and its workspace dependencies (unifi-core, unifi-mcp-shared).
+# Their source is REQUIRED — without it, hatch-vcs fails with
 # FileNotFoundError writing _version.py.
 COPY apps/api/src apps/api/src
 COPY apps/api/alembic.ini apps/api/alembic.ini
 COPY apps/api/alembic apps/api/alembic
 COPY packages/unifi-core/src packages/unifi-core/src
+COPY packages/unifi-mcp-shared/src packages/unifi-mcp-shared/src
 
 # Install all packages using uv sync (respects lockfile for reproducible builds)
 RUN uv sync --frozen --no-dev --package unifi-api-server
@@ -57,6 +58,7 @@ COPY --from=builder /build/apps/api/src /build/apps/api/src
 COPY --from=builder /build/apps/api/alembic /build/apps/api/alembic
 COPY --from=builder /build/apps/api/alembic.ini /build/apps/api/alembic.ini
 COPY --from=builder /build/packages/unifi-core/src /build/packages/unifi-core/src
+COPY --from=builder /build/packages/unifi-mcp-shared/src /build/packages/unifi-mcp-shared/src
 
 ENV PATH="/build/.venv/bin:$PATH"
 ENV UNIFI_API_STATE_DIR=/var/lib/unifi-api

--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -1,7 +1,12 @@
 .PHONY: test lint format format-fix
 
 test:
-	cd ../.. && uv run --package unifi-api-server pytest apps/api/tests -v
+	# --all-packages first, mirroring .github/workflows/test-api.yml. These tests
+	# build a registry from every product's tools_manifest.json, and
+	# ManifestRegistry.load_from_apps() silently skips products that are not
+	# installed. Without the sync the suite fails on imports or, worse, passes a
+	# thinner registry than CI exercises.
+	cd ../.. && uv sync --all-packages && uv run --package unifi-api-server pytest apps/api/tests -v
 
 lint:
 	cd ../.. && uv run ruff check apps/api/src apps/api/tests

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -9,6 +9,10 @@ dependencies = [
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
     "unifi-core[network,protect,access]>=0.4.21,<0.5",
+    # services/manifest.py imports unifi_mcp_shared.meta_tools. unifi-core does not
+    # depend on shared (import direction is app -> shared -> core), so this must be
+    # declared directly or a PyPI install has no unifi_mcp_shared.
+    "unifi-mcp-shared>=0.6.6,<0.7",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",
@@ -38,6 +42,7 @@ dev = [
 
 [tool.uv.sources]
 unifi-core = { workspace = true }
+unifi-mcp-shared = { workspace = true }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "aiohttp>=3.14.3",
     "python-dotenv>=1.2.2",
     "unifi-mcp-shared>=0.6.6,<0.7",
+    # location_timeline.py imports unifi_core.event_timeline directly. This resolves
+    # today only as a transitive of unifi-mcp-shared; declare it so it does not.
+    "unifi-core>=0.4.21,<0.5",
 ]
 
 [project.scripts]
@@ -41,6 +44,7 @@ packages = ["src/unifi_mcp_relay"]
 
 [tool.uv.sources]
 unifi-mcp-shared = { workspace = true }
+unifi-core = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -58,19 +58,42 @@ class Downstream:
     src: Path
     dist_name: str
     smoke_import: str
+    root_module: str
 
 
 DOWNSTREAM_PACKAGES: list[Downstream] = [
-    Downstream(REPO / "apps/network", "unifi-network-mcp", "unifi_network_mcp.main"),
-    Downstream(REPO / "apps/protect", "unifi-protect-mcp", "unifi_protect_mcp.main"),
-    Downstream(REPO / "apps/access", "unifi-access-mcp", "unifi_access_mcp.main"),
-    Downstream(REPO / "apps/api", "unifi-api-server", "unifi_api"),
+    Downstream(REPO / "apps/network", "unifi-network-mcp", "unifi_network_mcp.main", "unifi_network_mcp"),
+    Downstream(REPO / "apps/protect", "unifi-protect-mcp", "unifi_protect_mcp.main", "unifi_protect_mcp"),
+    Downstream(REPO / "apps/access", "unifi-access-mcp", "unifi_access_mcp.main", "unifi_access_mcp"),
+    Downstream(REPO / "apps/api", "unifi-api-server", "unifi_api", "unifi_api"),
     Downstream(
         REPO / "packages/unifi-mcp-relay",
         "unifi-mcp-relay",
         "unifi_mcp_relay.discovery",
+        "unifi_mcp_relay",
     ),
 ]
+
+# Imports every submodule of a package and reports the ones that fail with a
+# missing module. Only ModuleNotFoundError is treated as a failure: that is the
+# signature of an undeclared dependency. Other exceptions at import time are a
+# different problem and are not this gate's business.
+_WALK_IMPORTS = """
+import importlib, pkgutil, sys
+root = importlib.import_module("{root}")
+missing = []
+for mod in pkgutil.walk_packages(root.__path__, root.__name__ + "."):
+    try:
+        importlib.import_module(mod.name)
+    except ModuleNotFoundError as exc:
+        missing.append((mod.name, exc.name))
+    except Exception:
+        pass
+if missing:
+    for mod_name, dep in missing:
+        print("  {{}} -> missing dependency: {{}}".format(mod_name, dep))
+    sys.exit(1)
+"""
 
 
 def run_capture(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
@@ -121,6 +144,22 @@ def check_downstream(pkg: Downstream, downstream_wheel: Path, find_links: Path, 
             f"resolved to an upstream version that does not contain the imported "
             f"code path.\n\n"
             f"{(exc.stderr or '').strip()[-2000:]}"
+        )
+
+    # Importing one entrypoint only proves that module's imports resolve. An
+    # undeclared dependency used anywhere else in the package stays invisible:
+    # unifi-api-server shipped for three releases importing unifi_mcp_shared
+    # from services/manifest.py without declaring it, because `import unifi_api`
+    # alone succeeds. Walk every submodule so the whole surface is covered.
+    try:
+        run_capture([str(py), "-c", _WALK_IMPORTS.format(root=pkg.root_module)])
+    except subprocess.CalledProcessError as exc:
+        return False, (
+            f"Importing every submodule of `{pkg.root_module}` failed after install. "
+            f"Some module imports a package that is not declared in this package's "
+            f"dependencies, so a fresh PyPI install crashes when that module is "
+            f"first imported.\n\n"
+            f"{(exc.stdout or '').strip()[-2000:]}\n{(exc.stderr or '').strip()[-1000:]}"
         )
 
     return True, "OK"

--- a/uv.lock
+++ b/uv.lock
@@ -1819,6 +1819,7 @@ dependencies = [
     { name = "strawberry-graphql", extra = ["fastapi"] },
     { name = "typer" },
     { name = "unifi-core", extra = ["access", "network", "protect"] },
+    { name = "unifi-mcp-shared" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1846,6 +1847,7 @@ requires-dist = [
     { name = "strawberry-graphql", extras = ["fastapi"], specifier = ">=0.323.2,<0.324.0" },
     { name = "typer", specifier = ">=0.26.8" },
     { name = "unifi-core", extras = ["access", "network", "protect"], editable = "packages/unifi-core" },
+    { name = "unifi-mcp-shared", editable = "packages/unifi-mcp-shared" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.51.0" },
 ]
 
@@ -1914,6 +1916,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "mcp", extra = ["cli"] },
     { name = "python-dotenv" },
+    { name = "unifi-core" },
     { name = "unifi-mcp-shared" },
     { name = "websockets" },
 ]
@@ -1931,6 +1934,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "unifi-core", editable = "packages/unifi-core" },
     { name = "unifi-mcp-shared", editable = "packages/unifi-mcp-shared" },
     { name = "websockets", specifier = ">=16.1" },
 ]


### PR DESCRIPTION
Started as the local/CI test-parity papercut I flagged after the release. Chasing it turned up a shipped bug.

## The shipped bug

`unifi-api-server` cannot import `unifi_api.services.manifest` from a clean PyPI install:

```
ModuleNotFoundError: No module named 'unifi_mcp_shared'
```

`manifest.py` has imported `unifi_mcp_shared.meta_tools` since #282 (2026-05-17), but the package never declared the dependency. `unifi-core` cannot supply it transitively — the import direction is `app -> shared -> core`, so core must not depend on shared.

Confirmed against the published wheels: **0.9.0, 0.10.0 and 0.11.0 all fail identically**. So this predates today's release rather than being introduced by it. In the workspace `[tool.uv.sources]` resolves it, which is why local runs, `uv lock --check` and every CI job are green.

## Why the pin-alignment gate missed it

The gate does the right thing structurally — installs each downstream wheel into a clean venv and smoke-imports it. But it imported a single entrypoint, and for this package that entrypoint was the bare `unifi_api`, which imports fine on its own. Every other package pointed at a deeper module (`.main`, `.discovery`), so they were incidentally better covered.

It now walks every submodule after the entrypoint import, reporting each failing module with the dependency it could not find. Only `ModuleNotFoundError` counts — other import-time exceptions are a different problem and not this gate's business.

Verified by deleting the new declaration again:

```
[FAIL] unifi-api-server
  unifi_api.__main__ -> missing dependency: unifi_mcp_shared
  unifi_api.cli -> missing dependency: unifi_mcp_shared
  unifi_api.routes.actions -> missing dependency: unifi_mcp_shared
```

With the declaration restored, all five downstream wheels pass.

## Second finding

The same audit caught `unifi-mcp-relay` importing `unifi_core.event_timeline` while declaring only `unifi-mcp-shared`. That one works today purely because shared pulls core in transitively — latent rather than live, but it would break the moment that transitive edge changed. Declared it.

## The original papercut

`apps/api/Makefile` now runs `uv sync --all-packages` before pytest, matching `.github/workflows/test-api.yml`.

These tests build a registry from all three products' manifests, and `ManifestRegistry.load_from_apps()` **silently skips products that are not installed** — deliberate and correct at runtime, since the API should serve any subset of products, but it makes the test outcome depend on venv state. From a fresh worktree the suite previously died with 80 collection errors while CI was green. Now: 945 passed.

## Follow-up

`unifi-api-server 0.11.0` on PyPI is broken for standalone installs and wants a patch release once this lands. Worth noting the practical blast radius is small — the Docker images and the plugin install path both bring shared in by other means, which is likely why this went unreported for two and a half months.