### PR TITLE
docs: sync network tool count

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Used by: `apps/network`, `apps/protect`, `apps/access`.
 
 ### apps/network
 
-The UniFi Network MCP server. 186 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
+The UniFi Network MCP server. 187 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
 
 - `src/unifi_network_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,9 +119,9 @@
             </div>
           </div>
           <div class="server-list">
-            <div class="server-row network" data-product="network" data-tool-count="186">
+            <div class="server-row network" data-product="network" data-tool-count="187">
               <div><h4>Network <span>Stable</span></h4><p>Inventory, clients, routing, Wi-Fi, firewall policy, traffic, and controlled configuration.</p></div>
-              <div class="server-meta"><strong>186 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
+              <div class="server-meta"><strong>187 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
             </div>
             <div class="server-row protect" data-product="protect" data-tool-count="61">
               <div><h4>Protect <span>Beta</span></h4><p>Cameras, events, detections, recordings, devices, and incident investigation workflows.</p></div>

--- a/plugins/unifi-network/skills/unifi-network/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network/SKILL.md
@@ -5,7 +5,7 @@ description: How to manage UniFi network infrastructure — devices, clients, fi
 
 # UniFi Network MCP Server
 
-You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 186 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
+You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 187 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
 
 ## Tool Discovery
 
@@ -89,4 +89,4 @@ Cameras and access readers appear as network clients — use `unifi_lookup_by_ip
 
 ## Tool Reference
 
-For the complete list of all 186 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.
+For the complete list of all 187 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.


### PR DESCRIPTION
## Summary

Update five stale documentation references from 186 to 187 Network tools to match the generated tool manifest.

## Type of change

- [x] `docs:` documentation only

## Scope

- [x] Plugin packaging
- [x] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [ ] I updated generated manifests with `make manifest` when changing MCP tools. (Not applicable: no tool changes.)
- [ ] I added or updated tests for behavior changes. (Not applicable: documentation only.)
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- `python -m unittest discover -s tests/docs -p 'test_*.py' -v` - 74 tests passed
- `python scripts/generate_skill_references.py --check` - 39 sections checked
- `make pre-commit` - passed on Ubuntu 26.04 with GNU Make 4.4.1

## Notes for reviewers

Documentation-only change. No dependency or lockfile changes.