### PR TITLE
fix(network): use delete previews for delete tools

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/acl.py
+++ b/apps/network/src/unifi_network_mcp/tools/acl.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any, Dict, List, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.acl import (
     MUTABLE_FIELDS,
@@ -347,15 +347,13 @@ async def delete_acl_rule(
         return {"success": False, "error": "rule_id is required"}
 
     if not confirm:
-        return {
-            "success": True,
-            "requires_confirmation": True,
-            "action": "delete",
-            "resource_type": "acl_rule",
-            "rule_id": rule_id,
-            "message": f"Will delete ACL rule '{rule_id}'. Set confirm=true to execute. "
-            "WARNING: Removing an ALLOW rule may block device communication.",
-        }
+        return delete_preview(
+            resource_type="acl_rule",
+            resource_id=rule_id,
+            resource_data={"rule_id": rule_id},
+            resource_name=rule_id,
+            warnings=["Removing an ALLOW rule may block device communication."],
+        )
 
     try:
         success = await acl_manager.delete_acl_rule(rule_id)

--- a/apps/network/src/unifi_network_mcp/tools/client_groups.py
+++ b/apps/network/src/unifi_network_mcp/tools/client_groups.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Dict
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.client_group import (
     from_controller as cg_from_controller,
@@ -229,8 +229,9 @@ async def delete_client_group(
         Preview or success/failure status.
     """
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="client_group",
+            resource_id=group_id,
             resource_data={"group_id": group_id},
             resource_name=group_id,
             warnings=["Deleting a group may affect OON policies and firewall rules that reference it."],

--- a/apps/network/src/unifi_network_mcp/tools/content_filtering.py
+++ b/apps/network/src/unifi_network_mcp/tools/content_filtering.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any, Dict
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.content_filter import (
     MUTABLE_FIELDS as CF_MUTABLE_FIELDS,
@@ -195,8 +195,9 @@ async def delete_content_filter(
         Preview or success/failure status.
     """
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="content_filter",
+            resource_id=filter_id,
             resource_data={"filter_id": filter_id},
             resource_name=filter_id,
             warnings=["Deleting a content filter removes DNS-based blocking for all targeted clients/networks."],

--- a/apps/network/src/unifi_network_mcp/tools/dns.py
+++ b/apps/network/src/unifi_network_mcp/tools/dns.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Dict
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.dns import (
     DnsRecord,
@@ -209,8 +209,9 @@ async def delete_dns_record(
     """Delete a DNS record."""
     logger.info("unifi_delete_dns_record tool called (record_id=%s, confirm=%s)", record_id, confirm)
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="dns_record",
+            resource_id=record_id,
             resource_data={"record_id": record_id},
             resource_name=record_id,
             warnings=["This will permanently delete the DNS record."],

--- a/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
+++ b/apps/network/src/unifi_network_mcp/tools/dynamic_dns.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any, Dict
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.dynamic_dns import (
     MUTABLE_FIELDS,
@@ -241,8 +241,9 @@ async def delete_dynamic_dns(
     """Delete a Dynamic DNS entry."""
     logger.info("unifi_delete_dynamic_dns tool called (entry_id=%s, confirm=%s)", entry_id, confirm)
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="dynamic_dns",
+            resource_id=entry_id,
             resource_data={"entry_id": entry_id},
             resource_name=entry_id,
             warnings=["This will permanently delete the Dynamic DNS entry."],

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, toggle_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, toggle_preview, update_preview
 from unifi_core.network.models.firewall import (
     firewall_group_from_controller,
     firewall_zone_from_controller,
@@ -1155,8 +1155,9 @@ async def delete_firewall_group(
 ) -> Dict[str, Any]:
     """Deletes a firewall group."""
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="firewall_group",
+            resource_id=group_id,
             resource_data={"group_id": group_id},
             resource_name=group_id,
             warnings=["Firewall policies referencing this group via ip_group_id or port_group_id may break."],
@@ -1199,8 +1200,9 @@ async def delete_firewall_policy(
 ) -> Dict[str, Any]:
     """Delete a firewall policy by ID."""
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="firewall_policy",
+            resource_id=policy_id,
             resource_data={"policy_id": policy_id},
             resource_name=policy_id,
             warnings=["Removing an ALLOW rule may block traffic. Removing a BLOCK rule may open access."],

--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, toggle_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, toggle_preview, update_preview
 from unifi_core.network.models.ap_group import (
     from_controller as ap_group_from_controller,
 )
@@ -1336,8 +1336,9 @@ async def delete_wlan(
             resource_name = wlan_id
 
         return redact_sensitive_fields(
-            create_preview(
+            delete_preview(
                 resource_type="wlan",
+                resource_id=wlan_id,
                 resource_data=resource_data,
                 resource_name=resource_name,
                 warnings=["All devices using this SSID will be disconnected"],
@@ -1632,8 +1633,9 @@ async def delete_ap_group(
             resource_data = {"group_id": group_id}
             resource_name = group_id
 
-        return create_preview(
+        return delete_preview(
             resource_type="ap_group",
+            resource_id=group_id,
             resource_data=resource_data,
             resource_name=resource_name,
             warnings=["APs in this group may lose their SSID assignments"],

--- a/apps/network/src/unifi_network_mcp/tools/oon.py
+++ b/apps/network/src/unifi_network_mcp/tools/oon.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models.oon import (
     from_controller as oon_from_controller,
@@ -333,8 +333,9 @@ async def delete_oon_policy(
         Preview or success/failure status.
     """
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="oon_policy",
+            resource_id=policy_id,
             resource_data={"policy_id": policy_id},
             resource_name=policy_id,
             warnings=["Deleting an OON policy removes all auto-generated firewall rules associated with it."],

--- a/apps/network/src/unifi_network_mcp/tools/port_forwards.py
+++ b/apps/network/src/unifi_network_mcp/tools/port_forwards.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, Dict
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_core.confirmation import preview_response, toggle_preview, update_preview
+from unifi_core.confirmation import delete_preview, toggle_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models._actions import (
     PortForwardCreateInput,
@@ -652,12 +652,10 @@ async def delete_port_forward(
         return {"success": False, "error": "port_forward_id is required"}
 
     if not confirm:
-        return preview_response(
-            action="delete",
+        return delete_preview(
             resource_type="port_forward",
             resource_id=port_forward_id,
-            current_state={},
-            proposed_changes={"deleted": True},
+            resource_data={"port_forward_id": port_forward_id},
             resource_name=port_forward_id,
             warnings=[
                 "This permanently removes the port forward rule; external access to the forwarded "

--- a/apps/network/src/unifi_network_mcp/tools/switch.py
+++ b/apps/network/src/unifi_network_mcp/tools/switch.py
@@ -14,7 +14,7 @@ from typing import Annotated, Any, Dict, List
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.models._actions import (
     ConfigurePortAggregationInput,
@@ -224,8 +224,9 @@ async def delete_port_profile(
 ) -> Dict[str, Any]:
     """Deletes a port profile."""
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="port_profile",
+            resource_id=profile_id,
             resource_data={"profile_id": profile_id},
             resource_name=profile_id,
             warnings=["Switch ports using this profile will revert to defaults."],

--- a/apps/network/src/unifi_network_mcp/tools/system.py
+++ b/apps/network/src/unifi_network_mcp/tools/system.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from unifi_core.confirmation import create_preview, update_preview
+from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.network.models.system import (
     autobackup_to_controller_update,
     backup_from_controller,
@@ -283,8 +283,9 @@ async def delete_backup(
     """Delete a backup file."""
     logger.info("unifi_delete_backup tool called (filename=%s, confirm=%s)", filename, confirm)
     if not confirm:
-        return create_preview(
+        return delete_preview(
             resource_type="backup",
+            resource_id=filename,
             resource_data={"filename": filename},
             resource_name=filename,
             warnings=["This will permanently delete the backup file."],

--- a/apps/network/tests/unit/test_delete_preview_contracts.py
+++ b/apps/network/tests/unit/test_delete_preview_contracts.py
@@ -15,6 +15,14 @@ os.environ.setdefault("UNIFI_PASSWORD", "test")
 
 DELETE_PREVIEW_CASES = [
     (
+        "unifi_network_mcp.tools.acl",
+        "delete_acl_rule",
+        {"rule_id": "acl-1"},
+        "acl_rule",
+        "acl-1",
+        {"rule_id": "acl-1"},
+    ),
+    (
         "unifi_network_mcp.tools.client_groups",
         "delete_client_group",
         {"group_id": "group-1"},
@@ -69,6 +77,14 @@ DELETE_PREVIEW_CASES = [
         "oon_policy",
         "oon-1",
         {"policy_id": "oon-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.port_forwards",
+        "delete_port_forward",
+        {"port_forward_id": "port-forward-1"},
+        "port_forward",
+        "port-forward-1",
+        {"port_forward_id": "port-forward-1"},
     ),
     (
         "unifi_network_mcp.tools.switch",

--- a/apps/network/tests/unit/test_delete_preview_contracts.py
+++ b/apps/network/tests/unit/test_delete_preview_contracts.py
@@ -1,0 +1,166 @@
+"""Regression tests for delete-tool preview response contracts."""
+
+import importlib
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unifi_core.redaction import REDACTED
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+DELETE_PREVIEW_CASES = [
+    (
+        "unifi_network_mcp.tools.client_groups",
+        "delete_client_group",
+        {"group_id": "group-1"},
+        "client_group",
+        "group-1",
+        {"group_id": "group-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.content_filtering",
+        "delete_content_filter",
+        {"filter_id": "filter-1"},
+        "content_filter",
+        "filter-1",
+        {"filter_id": "filter-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.dns",
+        "delete_dns_record",
+        {"record_id": "dns-1"},
+        "dns_record",
+        "dns-1",
+        {"record_id": "dns-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.dynamic_dns",
+        "delete_dynamic_dns",
+        {"entry_id": "ddns-1"},
+        "dynamic_dns",
+        "ddns-1",
+        {"entry_id": "ddns-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.firewall",
+        "delete_firewall_group",
+        {"group_id": "firewall-group-1"},
+        "firewall_group",
+        "firewall-group-1",
+        {"group_id": "firewall-group-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.firewall",
+        "delete_firewall_policy",
+        {"policy_id": "policy-1"},
+        "firewall_policy",
+        "policy-1",
+        {"policy_id": "policy-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.oon",
+        "delete_oon_policy",
+        {"policy_id": "oon-1"},
+        "oon_policy",
+        "oon-1",
+        {"policy_id": "oon-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.switch",
+        "delete_port_profile",
+        {"profile_id": "profile-1"},
+        "port_profile",
+        "profile-1",
+        {"profile_id": "profile-1"},
+    ),
+    (
+        "unifi_network_mcp.tools.system",
+        "delete_backup",
+        {"filename": "backup.unf"},
+        "backup",
+        "backup.unf",
+        {"filename": "backup.unf"},
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("module_name", "function_name", "arguments", "resource_type", "resource_id", "resource_data"),
+    DELETE_PREVIEW_CASES,
+)
+async def test_delete_tool_preview_contract(
+    module_name,
+    function_name,
+    arguments,
+    resource_type,
+    resource_id,
+    resource_data,
+):
+    module = importlib.import_module(module_name)
+    delete_tool = getattr(module, function_name)
+
+    result = await delete_tool(**arguments, confirm=False)
+
+    assert result["success"] is True
+    assert result["requires_confirmation"] is True
+    assert result["action"] == "delete"
+    assert result["resource_type"] == resource_type
+    assert result["resource_id"] == resource_id
+    assert result["preview"]["will_delete"] == resource_data
+    assert result["message"].startswith(f"Will delete {resource_type}")
+
+
+@pytest.mark.asyncio
+async def test_delete_ap_group_preview_contract():
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_manager:
+        mock_manager.get_ap_group_details = AsyncMock(return_value={"name": "Upstairs APs"})
+        from unifi_network_mcp.tools.network import delete_ap_group
+
+        result = await delete_ap_group(group_id="ap-group-1", confirm=False)
+
+    assert result["success"] is True
+    assert result["requires_confirmation"] is True
+    assert result["action"] == "delete"
+    assert result["resource_type"] == "ap_group"
+    assert result["resource_id"] == "ap-group-1"
+    assert result["preview"]["will_delete"] == {
+        "group_id": "ap-group-1",
+        "name": "Upstairs APs",
+    }
+    assert result["message"] == "Will delete ap_group 'Upstairs APs'. Set confirm=true to execute."
+
+
+@pytest.mark.asyncio
+async def test_delete_wlan_preview_contract_redacts_passphrase():
+    with patch("unifi_network_mcp.tools.network.network_manager") as mock_manager:
+        mock_manager.get_wlan_details = AsyncMock(
+            return_value={
+                "name": "Guest WiFi",
+                "enabled": True,
+                "security": "wpapsk",
+                "x_passphrase": "do-not-return-this",
+            }
+        )
+        from unifi_network_mcp.tools.network import delete_wlan
+
+        result = await delete_wlan(wlan_id="wlan-1", confirm=False)
+
+    assert result["success"] is True
+    assert result["requires_confirmation"] is True
+    assert result["action"] == "delete"
+    assert result["resource_type"] == "wlan"
+    assert result["resource_id"] == "wlan-1"
+    assert result["preview"]["will_delete"] == {
+        "wlan_id": "wlan-1",
+        "name": "Guest WiFi",
+        "enabled": True,
+        "security": "wpapsk",
+        "x_passphrase": REDACTED,
+    }
+    assert result["message"] == "Will delete wlan 'Guest WiFi'. Set confirm=true to execute."

--- a/packages/unifi-core/src/unifi_core/confirmation.py
+++ b/packages/unifi-core/src/unifi_core/confirmation.py
@@ -185,3 +185,43 @@ def create_preview(
         response["warnings"] = warnings
 
     return response
+
+
+def delete_preview(
+    resource_type: str,
+    resource_id: str,
+    resource_name: Optional[str] = None,
+    resource_data: Optional[Dict[str, Any]] = None,
+    warnings: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Convenience helper for delete operations.
+
+    Args:
+        resource_type: Type of resource being deleted
+        resource_id: Unique identifier of the resource
+        resource_name: Human-readable name if available
+        resource_data: Details of the resource that will be deleted
+        warnings: Any warnings about the delete operation
+
+    Returns:
+        Preview response for delete operation
+    """
+    response: Dict[str, Any] = {
+        "success": True,
+        "requires_confirmation": True,
+        "action": "delete",
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "preview": {
+            "will_delete": resource_data if resource_data is not None else {"resource_id": resource_id},
+        },
+        "message": f"Will delete {resource_type} '{resource_name or resource_id}'. Set confirm=true to execute.",
+    }
+
+    if resource_name:
+        response["resource_name"] = resource_name
+
+    if warnings:
+        response["warnings"] = warnings
+
+    return response

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
@@ -4,6 +4,7 @@ from unifi_core.config import load_yaml_config, setup_logging
 from unifi_core.config_helpers import parse_config_bool
 from unifi_core.confirmation import (
     create_preview,
+    delete_preview,
     preview_response,
     toggle_preview,
     update_preview,
@@ -47,6 +48,7 @@ __all__ = [
     "auto_load_tools",
     "build_tool_module_map",
     "create_preview",
+    "delete_preview",
     "create_response",
     "create_task_result_from_job",
     "error_response",

--- a/packages/unifi-mcp-shared/tests/test_confirmation.py
+++ b/packages/unifi-mcp-shared/tests/test_confirmation.py
@@ -2,6 +2,7 @@
 
 from unifi_core.confirmation import (
     create_preview,
+    delete_preview,
     preview_response,
     toggle_preview,
     update_preview,
@@ -181,3 +182,38 @@ class TestCreatePreview:
             warnings=["DHCP range overlaps"],
         )
         assert result["warnings"] == ["DHCP range overlaps"]
+
+
+class TestDeletePreview:
+    """Tests for delete_preview."""
+
+    def test_basic_delete_preview(self):
+        result = delete_preview(
+            resource_type="firewall_policy",
+            resource_id="policy-1",
+            resource_data={"policy_id": "policy-1"},
+        )
+
+        assert result["success"] is True
+        assert result["requires_confirmation"] is True
+        assert result["action"] == "delete"
+        assert result["resource_id"] == "policy-1"
+        assert result["preview"]["will_delete"] == {"policy_id": "policy-1"}
+        assert result["message"] == "Will delete firewall_policy 'policy-1'. Set confirm=true to execute."
+
+    def test_defaults_payload_to_resource_id(self):
+        result = delete_preview(resource_type="network", resource_id="network-1")
+
+        assert result["preview"]["will_delete"] == {"resource_id": "network-1"}
+
+    def test_includes_resource_name_and_warnings(self):
+        result = delete_preview(
+            resource_type="wlan",
+            resource_id="wlan-1",
+            resource_name="Guest WiFi",
+            warnings=["Clients will disconnect"],
+        )
+
+        assert result["resource_name"] == "Guest WiFi"
+        assert "Guest WiFi" in result["message"]
+        assert result["warnings"] == ["Clients will disconnect"]

--- a/packages/unifi-mcp-shared/tests/test_confirmation.py
+++ b/packages/unifi-mcp-shared/tests/test_confirmation.py
@@ -7,6 +7,7 @@ from unifi_core.confirmation import (
     toggle_preview,
     update_preview,
 )
+from unifi_mcp_shared import delete_preview as shared_delete_preview
 
 
 class TestPreviewResponse:
@@ -186,6 +187,9 @@ class TestCreatePreview:
 
 class TestDeletePreview:
     """Tests for delete_preview."""
+
+    def test_reexported_from_shared_package(self):
+        assert shared_delete_preview is delete_preview
 
     def test_basic_delete_preview(self):
         result = delete_preview(


### PR DESCRIPTION
## Summary

- Add a shared `delete_preview` helper that returns `action="delete"`, the exact resource ID, and `preview.will_delete`.
- Replace incorrect create previews in 11 Network delete tools.
- Standardize the existing manual delete previews for ACL rules and port forwards.
- Add regression coverage for all 13 standard delete paths, the shared-package export, and WLAN secret redaction.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server
- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [ ] I updated generated manifests with `make manifest` when changing MCP tools. (Not applicable: no tool definitions or schemas changed.)
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-visible changes. (Not applicable: this restores the existing confirmation contract.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- `uv run --package unifi-network-mcp pytest apps/network/tests -q` - 934 passed
- `uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -q` - 359 passed
- Focused delete-preview and related tool tests - 79 passed
- Focused shared confirmation tests - 19 passed
- Ruff check and format check - passed
- Static contract audit - 13 standard delete paths use `delete_preview`; `revoke_voucher` remains an intentional custom `action="revoke"` path
- `make pre-commit` - run on Ubuntu 26.04 with GNU Make 4.4.1; the changed code and tests passed. The repository-wide gate reports the pre-existing 186/187 documentation count drift addressed by #486.

## Notes for reviewers

This changes preview metadata only. Confirmed deletion execution paths remain unchanged. Voucher revocation remains a separate domain action while using the delete policy gate. The code change does not depend on #486. No manifest, dependency, or lockfile changes.