### PR TITLE
fix: standardize delete previews across servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 
 | Server | Status | Tools | Package |
 |--------|--------|-------|---------|
-| [Network](apps/network/) | Stable | 186 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
-| [Protect](apps/protect/) | Beta | 61 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
-| [Access](apps/access/) | Beta | 36 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
+| [Network](apps/network/) | Stable | 187 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
+| [Protect](apps/protect/) | Stable | 61 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
+| [Access](apps/access/) | Stable | 36 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
 
 ## Cloud Relay
 
@@ -252,8 +252,8 @@ This is a monorepo with shared packages:
 ```
 apps/
   network/          # UniFi Network MCP server (stable, 187 tools)
-  protect/          # UniFi Protect MCP server (beta, 61 tools)
-  access/           # UniFi Access MCP server (beta, 36 tools)
+  protect/          # UniFi Protect MCP server (stable, 61 tools)
+  access/           # UniFi Access MCP server (stable, 36 tools)
   api/              # Independent REST + GraphQL API server (beta)
   worker/           # Cloudflare Worker gateway + npm CLI
 packages/

--- a/apps/access/src/unifi_access_mcp/tools/visitors.py
+++ b/apps/access/src/unifi_access_mcp/tools/visitors.py
@@ -20,7 +20,7 @@ from unifi_core.access.models.visitors import (
 from unifi_core.access.models.visitors import (
     to_controller_create as visitor_to_controller_create,
 )
-from unifi_core.confirmation import create_preview, preview_response
+from unifi_core.confirmation import create_preview, delete_preview
 from unifi_core.exceptions import UniFiNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -173,12 +173,10 @@ async def access_delete_visitor(
             return {"success": True, "data": result}
 
         preview_data = await visitor_manager.delete_visitor(visitor_id)
-        return preview_response(
-            action="delete",
+        return delete_preview(
             resource_type="visitor_pass",
             resource_id=visitor_id,
-            current_state=preview_data["current_state"],
-            proposed_changes=preview_data["proposed_changes"],
+            resource_data=preview_data["current_state"],
             resource_name=preview_data.get("visitor_name"),
             warnings=["This will permanently remove the visitor pass and revoke all associated access."],
         )

--- a/apps/access/tests/unit/test_delete_preview_contracts.py
+++ b/apps/access/tests/unit/test_delete_preview_contracts.py
@@ -1,0 +1,63 @@
+"""Regression tests for Access delete and revoke preview contracts."""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_ACCESS_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_ACCESS_USERNAME", "test")
+os.environ.setdefault("UNIFI_ACCESS_PASSWORD", "test")
+
+
+@pytest.mark.asyncio
+async def test_delete_visitor_uses_standard_delete_preview() -> None:
+    with patch("unifi_access_mcp.tools.visitors.visitor_manager") as mock_manager:
+        mock_manager.delete_visitor = AsyncMock(
+            return_value={
+                "visitor_id": "visitor-1",
+                "visitor_name": "Smoke Visitor",
+                "current_state": {
+                    "id": "visitor-1",
+                    "name": "Smoke Visitor",
+                    "status": "active",
+                },
+                "proposed_changes": {"action": "delete"},
+            }
+        )
+        from unifi_access_mcp.tools.visitors import access_delete_visitor
+
+        result = await access_delete_visitor("visitor-1", confirm=False)
+
+    assert result["success"] is True
+    assert result["requires_confirmation"] is True
+    assert result["action"] == "delete"
+    assert result["resource_type"] == "visitor_pass"
+    assert result["resource_id"] == "visitor-1"
+    assert result["resource_name"] == "Smoke Visitor"
+    assert result["preview"]["will_delete"] == {
+        "id": "visitor-1",
+        "name": "Smoke Visitor",
+        "status": "active",
+    }
+    assert result["warnings"] == ["This will permanently remove the visitor pass and revoke all associated access."]
+
+
+@pytest.mark.asyncio
+async def test_revoke_credential_preserves_revoke_action() -> None:
+    with patch("unifi_access_mcp.tools.credentials.credential_manager") as mock_manager:
+        mock_manager.revoke_credential = AsyncMock(
+            return_value={
+                "current_state": {"id": "credential-1", "type": "nfc"},
+                "proposed_changes": {"action": "revoke"},
+            }
+        )
+        from unifi_access_mcp.tools.credentials import access_revoke_credential
+
+        result = await access_revoke_credential("credential-1", confirm=False)
+
+    assert result["success"] is True
+    assert result["requires_confirmation"] is True
+    assert result["action"] == "revoke"
+    assert result["resource_id"] == "credential-1"
+    assert result["preview"]["proposed"] == {"action": "revoke"}

--- a/apps/api/src/unifi_api/graphql/types/access/credentials.py
+++ b/apps/api/src/unifi_api/graphql/types/access/credentials.py
@@ -7,8 +7,8 @@ Phase 6 PR4 Task B migration target. The single read serializer
 
 Resource-registered (LIST + DETAIL paths). Mutation acks
 (``access_create_credential`` / ``access_revoke_credential``) stay in
-``serializers/access/credentials.py`` — both flow through the manager's
-preview path and produce dict acks.
+``serializers/access/credentials.py``; the API action path dispatches to
+the manager mutation methods and serializes their dict acknowledgements.
 """
 
 from __future__ import annotations

--- a/apps/api/src/unifi_api/graphql/types/access/visitors.py
+++ b/apps/api/src/unifi_api/graphql/types/access/visitors.py
@@ -7,8 +7,8 @@ Phase 6 PR4 Task B migration target. The single read serializer
 
 Resource-registered (LIST + DETAIL paths). Mutation acks
 (``access_create_visitor`` / ``access_delete_visitor``) stay in
-``serializers/access/visitors.py`` — both flow through the manager's
-preview path and produce dict acks.
+``serializers/access/visitors.py``; the API action path dispatches to
+the manager mutation methods and serializes their dict acknowledgements.
 
 VisitorManager surfaces ``valid_from`` / ``valid_until`` (with
 ``access_start`` / ``access_end`` fallbacks). ``from_manager_output``

--- a/apps/api/src/unifi_api/serializers/access/credentials.py
+++ b/apps/api/src/unifi_api/serializers/access/credentials.py
@@ -7,9 +7,9 @@ listed in ``PHASE6_TYPE_MIGRATED_TOOLS`` and dispatched via the
 type_registry by both the REST routes and the action endpoint.
 
 This module now only ships ``CredentialMutationAckSerializer`` for the
-``access_create_credential`` / ``access_revoke_credential`` preview-and-
-confirm tools, which still flow through the manager's preview path and
-produce dict acks.
+``access_create_credential`` / ``access_revoke_credential`` mutation tools.
+The API action dispatcher invokes their manager mutation methods and
+this serializer projects the resulting dict acknowledgements.
 """
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
@@ -22,7 +22,7 @@ from unifi_api.serializers._base import RenderKind, Serializer, register_seriali
     },
 )
 class CredentialMutationAckSerializer(Serializer):
-    """Pass-through ack for credential preview/apply dicts."""
+    """Pass-through ack for credential mutation dicts."""
 
     kind = RenderKind.DETAIL
 

--- a/apps/api/src/unifi_api/serializers/access/visitors.py
+++ b/apps/api/src/unifi_api/serializers/access/visitors.py
@@ -7,9 +7,9 @@ to a Strawberry type in ``unifi_api.graphql.types.access.visitors``. The
 both the REST routes and the action endpoint.
 
 This module now only ships ``VisitorMutationAckSerializer`` for the
-``access_create_visitor`` / ``access_delete_visitor`` preview-and-
-confirm tools, which still flow through the manager's preview path and
-produce dict acks.
+``access_create_visitor`` / ``access_delete_visitor`` mutation tools.
+The API action dispatcher invokes their manager mutation methods and
+this serializer projects the resulting dict acknowledgements.
 """
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
@@ -22,7 +22,7 @@ from unifi_api.serializers._base import RenderKind, Serializer, register_seriali
     },
 )
 class VisitorMutationAckSerializer(Serializer):
-    """Pass-through ack for visitor preview/apply dicts."""
+    """Pass-through ack for visitor mutation dicts."""
 
     kind = RenderKind.DETAIL
 

--- a/apps/api/src/unifi_api/serializers/protect/alarms.py
+++ b/apps/api/src/unifi_api/serializers/protect/alarms.py
@@ -7,9 +7,9 @@ Phase 6 PR3 Task B — the read serializers (``AlarmStatusSerializer``,
 listed in ``PHASE6_TYPE_MIGRATED_TOOLS`` and dispatched via the
 type_registry by both REST routes and the action endpoint.
 
-This module now only ships ``AlarmMutationAckSerializer`` for
-arm/disarm preview-and-confirm tools, which still flow through the
-manager's preview path and produce dict acks.
+This module now only ships ``AlarmMutationAckSerializer`` for alarm
+mutations. The API action dispatcher invokes the manager or facade mutation
+method and this serializer projects the resulting acknowledgement.
 """
 
 from typing import Any

--- a/apps/api/src/unifi_api/services/actions.py
+++ b/apps/api/src/unifi_api/services/actions.py
@@ -282,14 +282,15 @@ async def dispatch_action(
             f"tool '{tool_name}' requires product '{entry.product}', controller supports {controller_products!r}"
         )
 
+    if not confirm and (entry.permission_action == "delete" or tool_name in CONFIRM_REQUIRED_TOOLS):
+        raise ValueError(f"tool '{tool_name}' requires confirm=true")
+
     table = dispatch_table if dispatch_table is not None else _get_table()
     binding = table.get(tool_name)
     if binding is None:
         raise DispatchEntryMissing(
             f"no dispatch entry for tool '{tool_name}' (no manager.method() call discovered in tool body)"
         )
-    if tool_name in CONFIRM_REQUIRED_TOOLS and not confirm:
-        raise ValueError(f"tool '{tool_name}' requires confirm=true")
     if "include_sensitive" in args:
         raise ValueError(INCLUDE_SENSITIVE_UNSUPPORTED_ERROR)
     marker_paths = redaction_marker_paths(args)

--- a/apps/api/src/unifi_api/services/manifest.py
+++ b/apps/api/src/unifi_api/services/manifest.py
@@ -57,8 +57,9 @@ class ToolNotFound(Exception):
 class ToolEntry:
     """Resolved manifest entry for a single tool.
 
-    ``manager`` and ``method`` are intentionally empty strings for now — the
-    manifests do not carry that information. Task 12 will fill the gap.
+    ``manager`` and ``method`` are intentionally empty strings because the
+    manifests do not carry that information. ``permission_action`` is retained
+    so the action dispatcher can enforce confirmation before delete operations.
     """
 
     name: str
@@ -66,6 +67,7 @@ class ToolEntry:
     category: str
     manager: str
     method: str
+    permission_action: str = ""
 
 
 class ManifestRegistry:
@@ -138,12 +140,16 @@ def _parse_manifest(data: Any, product: str) -> dict[str, ToolEntry]:
             category = tool.get("permission_category")
             if not isinstance(category, str) or not category:
                 category = _category_from_module(module_map.get(name, ""))
+            permission_action = tool.get("permission_action")
+            if not isinstance(permission_action, str):
+                permission_action = ""
             entries[name] = ToolEntry(
                 name=name,
                 product=product,
                 category=category,
                 manager="",
                 method="",
+                permission_action=permission_action,
             )
         return entries
 

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -613,6 +613,82 @@ async def test_dispatch_protect_update_viewer_routes_to_apply_viewer_update() ->
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("tool_name", "product"),
+    [
+        ("unifi_delete_dns_record", "network"),
+        ("protect_alarm_delete_rule", "protect"),
+        ("access_delete_visitor", "access"),
+    ],
+)
+async def test_dispatch_delete_actions_require_confirm(tool_name: str, product: str) -> None:
+    entry = ToolEntry(
+        name=tool_name,
+        product=product,
+        category="test",
+        manager="",
+        method="",
+        permission_action="delete",
+    )
+    registry = _registry_with(entry)
+    factory = MagicMock()
+
+    with pytest.raises(ValueError, match="requires confirm=true"):
+        await dispatch_action(
+            registry=registry,
+            factory=factory,
+            session=MagicMock(),
+            tool_name=tool_name,
+            controller_id="cid",
+            controller_products=[product],
+            site="default",
+            args={},
+            confirm=False,
+            dispatch_table={},
+        )
+
+    factory.get_domain_manager.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_confirmed_delete_reaches_manager() -> None:
+    entry = ToolEntry(
+        name="access_delete_visitor",
+        product="access",
+        category="visitor",
+        manager="",
+        method="",
+        permission_action="delete",
+    )
+    registry = _registry_with(entry)
+    manager = MagicMock()
+    manager.apply_delete_visitor = AsyncMock(return_value={"visitor_id": "visitor-1", "result": "success"})
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+
+    result = await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="access_delete_visitor",
+        controller_id="cid",
+        controller_products=["access"],
+        site="default",
+        args={"visitor_id": "visitor-1"},
+        confirm=True,
+        dispatch_table={
+            "access_delete_visitor": DispatchEntry(
+                manager_attr="visitor_manager",
+                method="apply_delete_visitor",
+            )
+        },
+    )
+
+    assert result == {"visitor_id": "visitor-1", "result": "success"}
+    manager.apply_delete_visitor.assert_awaited_once_with(visitor_id="visitor-1")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("tool_name", "args"),
     [
         ("protect_update_sensor_settings", {"sensor_id": "sensor-1", "settings": {"name": "Garage"}}),

--- a/apps/api/tests/test_manifest.py
+++ b/apps/api/tests/test_manifest.py
@@ -1,7 +1,7 @@
 """Manifest lookup table tests."""
 
 import pytest
-from unifi_api.services.manifest import ManifestRegistry, ToolNotFound
+from unifi_api.services.manifest import ManifestRegistry, ToolNotFound, _parse_manifest
 
 
 def test_loads_manifests_from_apps() -> None:
@@ -37,6 +37,33 @@ def test_unknown_tool_raises() -> None:
     reg = ManifestRegistry.load_from_apps()
     with pytest.raises(ToolNotFound):
         reg.resolve("definitely_not_a_real_tool_name_xyz")
+
+
+def test_parse_manifest_retains_permission_action() -> None:
+    entries = _parse_manifest(
+        {
+            "module_map": {"access_delete_visitor": "unifi_access_mcp.tools.visitors"},
+            "tools": [
+                {
+                    "name": "access_delete_visitor",
+                    "permission_category": "visitor",
+                    "permission_action": "delete",
+                }
+            ],
+        },
+        "access",
+    )
+
+    assert entries["access_delete_visitor"].permission_action == "delete"
+
+
+def test_module_map_fallback_has_no_permission_action() -> None:
+    entries = _parse_manifest(
+        {"module_map": {"legacy_tool": "unifi_network_mcp.tools.system"}},
+        "network",
+    )
+
+    assert entries["legacy_tool"].permission_action == ""
 
 
 def _some_known_network(reg) -> list[str]:

--- a/apps/protect/src/unifi_protect_mcp/tools/alarm.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/alarm.py
@@ -15,7 +15,7 @@ from typing import Annotated, Any, Dict, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_core.confirmation import preview_response, update_preview
+from unifi_core.confirmation import delete_preview, preview_response, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.models._actions import (
     AlarmArmInput,
@@ -393,12 +393,10 @@ async def protect_alarm_delete_rule(
             return {"success": False, "error": f"Invalid input: {e.errors()[0]['msg']}"}
         if not confirm:
             current, complete = await alarm_facade.get_rule(rule_id)
-            return preview_response(
-                action="delete",
+            return delete_preview(
                 resource_type="alarm_rule",
                 resource_id=rule_id,
-                current_state={"title": current.get("title")},
-                proposed_changes={"deleted": True},
+                resource_data={"rule_id": rule_id, "title": current.get("title")},
                 resource_name=current.get("title") or rule_id,
             )
 

--- a/apps/protect/src/unifi_protect_mcp/tools/recognition.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/recognition.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Dict, List, Optional
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
-from unifi_core.confirmation import preview_response, update_preview
+from unifi_core.confirmation import delete_preview, preview_response, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.models._actions import (
     DeleteKnownFaceInput,
@@ -362,12 +362,10 @@ async def protect_delete_known_face(
 
         preview_data = await recognition_manager.delete_known_face(face_id)
         if not confirm:
-            return preview_response(
-                action="delete",
+            return delete_preview(
                 resource_type="known_face",
                 resource_id=face_id,
-                current_state=preview_data["face"],
-                proposed_changes={"deleted": True},
+                resource_data=preview_data["face"],
                 resource_name=preview_data["face"].get("name") or preview_data["face"].get("matched_name"),
                 warnings=preview_data["warnings"],
             )
@@ -491,12 +489,10 @@ async def protect_delete_known_license_plate(
 
         preview_data = await recognition_manager.delete_known_license_plate(plate_id)
         if not confirm:
-            return preview_response(
-                action="delete",
+            return delete_preview(
                 resource_type="known_license_plate",
                 resource_id=plate_id,
-                current_state=preview_data["license_plate"],
-                proposed_changes={"deleted": True},
+                resource_data=preview_data["license_plate"],
                 resource_name=preview_data["license_plate"].get("name")
                 or preview_data["license_plate"].get("matched_name"),
                 warnings=preview_data["warnings"],

--- a/apps/protect/tests/unit/test_alarm_tools.py
+++ b/apps/protect/tests/unit/test_alarm_tools.py
@@ -58,6 +58,11 @@ async def test_delete_rule_preview_uses_facade_get_rule():
 
     assert result["success"] is True
     assert result["requires_confirmation"] is True
+    assert result["action"] == "delete"
+    assert result["resource_type"] == "alarm_rule"
+    assert result["resource_id"] == "uuid-1"
+    assert result["resource_name"] == "Rule"
+    assert result["preview"]["will_delete"] == {"rule_id": "uuid-1", "title": "Rule"}
     facade.get_rule.assert_awaited_once_with("uuid-1")
 
 

--- a/apps/protect/tests/unit/test_recognition.py
+++ b/apps/protect/tests/unit/test_recognition.py
@@ -451,6 +451,11 @@ class TestProtectKnownFaceMutationTools:
 
         assert result["success"] is True
         assert result["requires_confirmation"] is True
+        assert result["action"] == "delete"
+        assert result["resource_type"] == "known_face"
+        assert result["resource_id"] == "face-1"
+        assert result["resource_name"] == "Assigned"
+        assert result["preview"]["will_delete"] == {"id": "face-1", "name": "Assigned"}
         assert result["warnings"] == ["destructive"]
 
     @pytest.mark.asyncio
@@ -759,6 +764,11 @@ class TestProtectKnownLicensePlateMutationTools:
 
         assert result["success"] is True
         assert result["requires_confirmation"] is True
+        assert result["action"] == "delete"
+        assert result["resource_type"] == "known_license_plate"
+        assert result["resource_id"] == "plate-1"
+        assert result["resource_name"] == "Assigned"
+        assert result["preview"]["will_delete"] == {"id": "plate-1", "name": "Assigned"}
         assert result["warnings"] == ["destructive"]
         mock_recognition_manager.apply_delete_known_license_plate.assert_not_called()
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,11 +124,11 @@
               <div class="server-meta"><strong>187 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
             </div>
             <div class="server-row protect" data-product="protect" data-tool-count="61">
-              <div><h4>Protect <span>Beta</span></h4><p>Cameras, events, detections, recordings, devices, and incident investigation workflows.</p></div>
+              <div><h4>Protect <span>Stable</span></h4><p>Cameras, events, detections, recordings, devices, and incident investigation workflows.</p></div>
               <div class="server-meta"><strong>61 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/protect">unifi-protect-mcp</a></div>
             </div>
             <div class="server-row access" data-product="access" data-tool-count="36">
-              <div><h4>Access <span>Beta</span></h4><p>Doors, visitors, credentials, policies, devices, and activity records.</p></div>
+              <div><h4>Access <span>Stable</span></h4><p>Doors, visitors, credentials, policies, devices, and activity records.</p></div>
               <div class="server-meta"><strong>36 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/access">unifi-access-mcp</a></div>
             </div>
           </div>

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1102,6 +1102,20 @@ class LiveSmokeRunner:
             "lifecycle:update",
         )
         await self.call("unifi_get_dns_record_details", {"record_id": record_id}, "lifecycle:get")
+        preview = await self.call(
+            "unifi_delete_dns_record",
+            {"record_id": record_id, "confirm": False},
+            "lifecycle:preview-delete",
+        )
+        self.record_check(
+            "unifi_delete_dns_record",
+            "lifecycle:verify-preview",
+            preview.success is True
+            and preview.summary.get("action") == "delete"
+            and preview.summary.get("resource_id") == record_id
+            and "will_delete" in preview.summary.get("preview_keys", []),
+            "delete preview identifies the disposable DNS record",
+        )
         delete = await self.call(
             "unifi_delete_dns_record",
             {"record_id": record_id, "confirm": True},
@@ -1195,6 +1209,20 @@ class LiveSmokeRunner:
             {"group_id": group_id, "group_data": {"name": f"{name}-updated"}, "confirm": True},
             "lifecycle:update",
         )
+        preview = await self.call(
+            "unifi_delete_client_group",
+            {"group_id": group_id, "confirm": False},
+            "lifecycle:preview-delete",
+        )
+        self.record_check(
+            "unifi_delete_client_group",
+            "lifecycle:verify-preview",
+            preview.success is True
+            and preview.summary.get("action") == "delete"
+            and preview.summary.get("resource_id") == group_id
+            and "will_delete" in preview.summary.get("preview_keys", []),
+            "delete preview identifies the disposable client group",
+        )
         delete = await self.call(
             "unifi_delete_client_group",
             {"group_id": group_id, "confirm": True},
@@ -1228,6 +1256,20 @@ class LiveSmokeRunner:
                 "confirm": True,
             },
             "lifecycle:update",
+        )
+        preview = await self.call(
+            "unifi_delete_firewall_group",
+            {"group_id": group_id, "confirm": False},
+            "lifecycle:preview-delete",
+        )
+        self.record_check(
+            "unifi_delete_firewall_group",
+            "lifecycle:verify-preview",
+            preview.success is True
+            and preview.summary.get("action") == "delete"
+            and preview.summary.get("resource_id") == group_id
+            and "will_delete" in preview.summary.get("preview_keys", []),
+            "delete preview identifies the disposable firewall group",
         )
         delete = await self.call(
             "unifi_delete_firewall_group",
@@ -1610,6 +1652,20 @@ class LiveSmokeRunner:
             "lifecycle:update",
         )
         await self.call("protect_alarm_get_rule", {"rule_id": rule_id}, "lifecycle:get")
+        preview = await self.call(
+            "protect_alarm_delete_rule",
+            {"rule_id": rule_id, "confirm": False},
+            "lifecycle:preview-delete",
+        )
+        self.record_check(
+            "protect_alarm_delete_rule",
+            "lifecycle:verify-preview",
+            preview.success is True
+            and preview.summary.get("action") == "delete"
+            and preview.summary.get("resource_id") == rule_id
+            and "will_delete" in preview.summary.get("preview_keys", []),
+            "delete preview identifies the disposable alarm rule",
+        )
         delete = await self.call(
             "protect_alarm_delete_rule",
             {"rule_id": rule_id, "confirm": True},
@@ -1696,6 +1752,20 @@ class LiveSmokeRunner:
             self.skip("access_delete_visitor", "lifecycle", "visitor create did not return an id")
             return
         self.report.created_resources.append({"type": "visitor", "id": visitor_id, "name": args["name"]})
+        preview = await self.call(
+            "access_delete_visitor",
+            {"visitor_id": visitor_id, "confirm": False},
+            "lifecycle:preview-delete",
+        )
+        self.record_check(
+            "access_delete_visitor",
+            "lifecycle:verify-preview",
+            preview.success is True
+            and preview.summary.get("action") == "delete"
+            and preview.summary.get("resource_id") == visitor_id
+            and "will_delete" in preview.summary.get("preview_keys", []),
+            "delete preview identifies the disposable visitor",
+        )
         delete = await self.call(
             "access_delete_visitor",
             {"visitor_id": visitor_id, "confirm": True},
@@ -1733,6 +1803,9 @@ def summarize_payload(data: dict[str, Any]) -> dict[str, Any]:
         summary["resource_id"] = resource_id
     for collection, items in collection_items(data).items():
         summary[f"{collection}_count"] = len(items)
+    preview = data.get("preview")
+    if isinstance(preview, dict):
+        summary["preview_keys"] = sorted(preview)
     if "error" in data:
         summary["error"] = data["error"]
     if "_meta" in data:
@@ -1743,6 +1816,7 @@ def summarize_payload(data: dict[str, Any]) -> dict[str, Any]:
 def find_resource_id(data: Any) -> str | None:
     if isinstance(data, dict):
         for key in (
+            "resource_id",
             "id",
             "_id",
             "record_id",

--- a/tests/docs/test_site_content.py
+++ b/tests/docs/test_site_content.py
@@ -711,6 +711,23 @@ class ContentReconciliationTests(unittest.TestCase):
                         f"{path} must state the current {product} tool count",
                     )
 
+    def test_server_status_table_matches_manifests_and_current_stability(self):
+        readme = Path("README.md").read_text(encoding="utf-8")
+        homepage = Path("docs/index.html").read_text(encoding="utf-8")
+        counts = manifest_counts()
+
+        for product in ("Network", "Protect", "Access"):
+            with self.subTest(product=product):
+                self.assertRegex(
+                    readme,
+                    rf"\| \[{product}\][^\n]*\| Stable \| {counts[product.lower()]} \|",
+                )
+
+        for product in ("Protect", "Access"):
+            with self.subTest(product=product):
+                self.assertIn(f"<h4>{product} <span>Stable</span></h4>", homepage)
+                self.assertNotRegex(homepage, rf"<h4>{product} <span>Beta</span></h4>")
+
     def test_readme_and_homepage_link_all_non_server_products(self):
         surfaces = {
             Path("README.md"): Path("README.md").read_text(encoding="utf-8"),

--- a/tests/test_live_smoke_response_sizes.py
+++ b/tests/test_live_smoke_response_sizes.py
@@ -116,6 +116,7 @@ async def test_call_records_sizes_before_unwrapping(monkeypatch):
 def test_summarize_payload_preserves_only_safe_bounded_response_metadata():
     data = {
         "success": True,
+        "resource_id": "resource-1",
         "summary_mode": True,
         "history_seconds": 3_600,
         "omitted_sections": ["radio_activity", "wan_activity", "wan_history", "wifi_activity"],
@@ -125,6 +126,7 @@ def test_summarize_payload_preserves_only_safe_bounded_response_metadata():
         "offset": 2,
         "next_offset": 4,
         "has_more": True,
+        "preview": {"will_delete": {"id": "resource-1"}},
         "rogue_aps": [{"ssid": "controller-value"}],
     }
 
@@ -132,6 +134,7 @@ def test_summarize_payload_preserves_only_safe_bounded_response_metadata():
 
     assert summary == {
         "success": True,
+        "resource_id": "resource-1",
         "summary_mode": True,
         "history_seconds": 3_600,
         "omitted_sections": ["radio_activity", "wan_activity", "wan_history", "wifi_activity"],
@@ -141,6 +144,7 @@ def test_summarize_payload_preserves_only_safe_bounded_response_metadata():
         "offset": 2,
         "next_offset": 4,
         "has_more": True,
+        "preview_keys": ["will_delete"],
         "rogue_aps_count": 1,
     }
     assert "rogue_aps" not in summary


### PR DESCRIPTION
## Summary

- Adopt the shared `delete_preview` contract for the supported Protect and Access delete previews:
  - `protect_alarm_delete_rule`
  - `protect_delete_known_face`
  - `protect_delete_known_license_plate`
  - `access_delete_visitor`
- Preserve intentional `action="revoke"` behavior for credentials/vouchers and unsupported-operation behavior for Protect liveview/recording deletion.
- Retain manifest `permission_action` in the API registry and reject every API delete-policy action at `confirm=false` before manager resolution.
- Promote the Protect and Access MCP servers from Beta to Stable across current public status/documentation surfaces.
- Permanently extend disposable live-smoke lifecycles to assert `preview.will_delete` before confirmed cleanup.
- Correct the stale Network count in the README status table and add a drift test for status/count rows.

## Why

PR #487 introduced the correct shared delete-preview response but only adopted it in Network. Protect and Access had semantically correct but inconsistent generic preview shapes. The API audit also found that its action dispatcher bypasses MCP tool functions and could dispatch most delete actions directly even when the request's top-level `confirm` remained false.

Protect and Access have now soaked long enough to be presented as Stable. Historical plans/specifications retain their original beta wording; unrelated Relay, Worker, and API Server beta labels are unchanged.

## API impact

The REST/GraphQL mutation serializers continue to shape confirmed manager acknowledgements, so no schema or generated API artifact changes are needed. The behavioral change is in `/v1/actions/{tool}`: entries with `permission_action="delete"` now require top-level `confirm=true`, consistently across Network, Protect, and Access.

## Testing

- `make pre-commit` — passed, including 951 API tests and all package/doc/worker gates
- Focused Protect tests — 45 passed
- Focused Access tests — 35 passed
- Focused API tests — 88 passed
- Documentation tests — 75 passed
- Live-smoke response tests — 7 passed
- `make manifest` and `make check-generated` — no drift
- Ruff check + format check — passed

## Live smoke

Independent local-controller smoke was staged readonly first, then safe lifecycles. No pre-existing resource was deleted.

<details>
<summary>Network safe lifecycle (raw relevant output)</summary>

```text
network lifecycle:create ok: unifi_create_dns_record
network lifecycle:update ok: unifi_update_dns_record
network lifecycle:get ok: unifi_get_dns_record_details
network lifecycle:preview-delete ok: unifi_delete_dns_record
network lifecycle:verify-preview ok: unifi_delete_dns_record - delete preview identifies the disposable DNS record
network lifecycle:delete ok: unifi_delete_dns_record
network lifecycle:create ok: unifi_create_client_group
network lifecycle:update ok: unifi_update_client_group
network lifecycle:preview-delete ok: unifi_delete_client_group
network lifecycle:verify-preview ok: unifi_delete_client_group - delete preview identifies the disposable client group
network lifecycle:delete ok: unifi_delete_client_group
network lifecycle:create ok: unifi_create_firewall_group
network lifecycle:update ok: unifi_update_firewall_group
network lifecycle:preview-delete ok: unifi_delete_firewall_group
network lifecycle:verify-preview ok: unifi_delete_firewall_group - delete preview identifies the disposable firewall group
network lifecycle:delete ok: unifi_delete_firewall_group
network lifecycle:verify-changed ok: unifi_update_gateway_settings - broadcast_ping False -> True
network lifecycle:verify-siblings-preserved ok: unifi_update_gateway_settings - no keys dropped; dns_verification intact
network lifecycle:revert ok: unifi_update_gateway_settings - broadcast_ping restored to False
statuses: ok=159 pending_approval=32 skipped=52 failures=0
created=3 cleaned=3
SUMMARY orphaned_network_markers=0
```
</details>

<details>
<summary>Protect safe + targeted recognition previews (raw relevant output)</summary>

```text
protect lifecycle:create ok: protect_alarm_create_rule
protect lifecycle:update ok: protect_alarm_update_rule
protect lifecycle:get ok: protect_alarm_get_rule
protect lifecycle:preview-delete ok: protect_alarm_delete_rule
protect lifecycle:verify-preview ok: protect_alarm_delete_rule - delete preview identifies the disposable alarm rule
protect lifecycle:delete ok: protect_alarm_delete_rule
statuses: ok=58 pending_approval=11 skipped=16 failures=0
created=1 cleaned=1
PASS protect_delete_known_face: live id preserved; no mutation executed
PASS protect_delete_known_license_plate: live id preserved; no mutation executed
SUMMARY passed=2 skipped=0 connected=True
SUMMARY orphaned_protect_markers=0
```
</details>

<details>
<summary>Access safe result and known capability limitation</summary>

```text
access readonly ok: access_list_visitors
access preview ok: access_create_visitor
access lifecycle:create skipped: access_create_visitor
access lifecycle skipped: access_delete_visitor - visitor create did not return an id
statuses: ok=30 pending_approval=5 skipped=14 failures=0
created=0 cleaned=0
```

The local controller returns HTTP 404 / `CODE_NOT_FOUND` for the existing guessed internal visitor POST endpoint, unchanged from prior `main` smoke. No visitor was created or deleted. Investigation confirmed the supported visitor family is the public Access Developer API and the current API token returns 401 for that family. Migration and a mandatory disposable visitor lifecycle are tracked in #488.
</details>

<details>
<summary>API delete confirmation gate (raw output)</summary>

```text
PASS unifi_delete_dns_record: confirm=false rejected before manager resolution
PASS protect_alarm_delete_rule: confirm=false rejected before manager resolution
PASS access_delete_visitor: confirm=false rejected before manager resolution
SUMMARY passed=3 manager_calls=0
```
</details>

## Follow-up

- #488 migrates the currently non-functional guessed Access visitor mutation path to the supported Developer API family, with scoped IDs, visitor-authorized API-key remediation, and disposable create/get/preview/delete live validation.
