### PR TITLE
fix(access): migrate visitors to Developer API

### DIFF
--- a/apps/access/docs/configuration.md
+++ b/apps/access/docs/configuration.md
@@ -44,7 +44,7 @@ Logs in via `/api/auth/login` on the UniFi OS Console and proxies requests throu
 | `UNIFI_ACCESS_PASSWORD` | Yes | Admin password |
 | `UNIFI_ACCESS_PORT` | No (443) | UniFi OS Console HTTPS port |
 
-When both paths are available, each tool selects the most appropriate one. Most mutating tools (door lock/unlock, credential management, policies, visitors, events) require the local proxy session. See the `auth` metadata on each tool for which path it uses.
+When both paths are available, each tool selects the appropriate one. Visitor list/get/create/delete operations require the Access Developer API token on port 12445; credential management, policies, and other proxy-backed capabilities require the local session. See the `auth` metadata on each tool for its exact requirement.
 
 ## Server Settings
 

--- a/apps/access/docs/tools.md
+++ b/apps/access/docs/tools.md
@@ -50,10 +50,10 @@ In lazy mode, an additional meta-tool is available:
 
 ## Visitors (4 tools)
 
-- `access_list_visitors` -- List all visitor passes with name, status, time range, and doors
-- `access_get_visitor` -- Detailed visitor pass info: name, access period, doors, status
-- `access_create_visitor` -- Create a time-bounded visitor pass with optional doors and contact info. Confirm required. Proxy session only.
-- `access_delete_visitor` -- Permanently remove a visitor pass. Confirm required. Proxy session only.
+- `access_list_visitors` -- List Access Developer API visitor passes with family-scoped UUIDs, names, status, and time range
+- `access_get_visitor` -- Get Developer API visitor details by a UUID returned from the visitor family
+- `access_create_visitor` -- Create a time-bounded visitor with optional contact/company metadata. Confirm and Access API token required.
+- `access_delete_visitor` -- Revoke a Developer API visitor pass; Access retains a cancelled historical record. Confirm and Access API token required.
 
 ## Devices (3 tools)
 

--- a/apps/access/docs/troubleshooting.md
+++ b/apps/access/docs/troubleshooting.md
@@ -36,9 +36,9 @@
 
 **Symptoms:** Some tools work but others return "proxy session required" errors.
 
-**Explanation:** Most mutating tools (lock/unlock, credential management, policies, visitors) require the local proxy session (port 443 with username/password). If only the API key is configured, these tools will be unavailable.
+**Explanation:** Credential management, policies, and other proxy-backed mutations require the local session (port 443 with username/password). Visitor operations are different: list/get/create/delete use the Access Developer API and require `UNIFI_ACCESS_API_KEY` on port 12445.
 
-**Fix:** Ensure both `UNIFI_ACCESS_USERNAME`/`UNIFI_ACCESS_PASSWORD` and `UNIFI_ACCESS_API_KEY` are set for full functionality.
+**Fix:** Configure both `UNIFI_ACCESS_USERNAME`/`UNIFI_ACCESS_PASSWORD` and `UNIFI_ACCESS_API_KEY` for full functionality. For visitor-only failures, verify the Access API token and port 12445 first.
 
 ### "Access application not found" errors
 

--- a/apps/access/src/unifi_access_mcp/tools/visitors.py
+++ b/apps/access/src/unifi_access_mcp/tools/visitors.py
@@ -28,11 +28,15 @@ logger = logging.getLogger(__name__)
 
 @server.tool(
     name="access_list_visitors",
-    description=("Lists all visitor passes with their name, status, valid time range, and assigned doors."),
+    description=(
+        "List visitor passes from the UniFi Access Developer API. Returned UUIDs are scoped to the "
+        "Access Developer API visitor tool family — pass them only to access_get_visitor and "
+        "access_delete_visitor; do not pass them to other Access user or credential tools."
+    ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
     permission_category="visitor",
     permission_action="read",
-    auth="local_only",
+    auth="api_key_only",
 )
 async def access_list_visitors() -> Dict[str, Any]:
     """List all visitors."""
@@ -49,16 +53,20 @@ async def access_list_visitors() -> Dict[str, Any]:
 @server.tool(
     name="access_get_visitor",
     description=(
-        "Returns detailed information for a single visitor pass including "
-        "name, access time range, assigned doors, and status."
+        "Return one visitor pass from the UniFi Access Developer API. The visitor UUID must come "
+        "from access_list_visitors and is scoped to this visitor tool family — do not pass IDs "
+        "from other Access user or credential tools."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
     permission_category="visitor",
     permission_action="read",
-    auth="local_only",
+    auth="api_key_only",
 )
 async def access_get_visitor(
-    visitor_id: Annotated[str, Field(description="Visitor UUID (from access_list_visitors)")],
+    visitor_id: Annotated[
+        str,
+        Field(description="Access Developer API visitor UUID from access_list_visitors; visitor-family scoped"),
+    ],
 ) -> Dict[str, Any]:
     """Get detailed visitor information by ID."""
     logger.info("access_get_visitor tool called for %s", visitor_id)
@@ -76,32 +84,60 @@ async def access_get_visitor(
 @server.tool(
     name="access_create_visitor",
     description=(
-        "Create a new visitor pass with a name and access time range. "
-        "Optionally assign specific doors and contact information. "
-        "Requires confirm=true to execute. Only available via local proxy session."
+        "Create a visitor pass in the UniFi Access Developer API. The returned UUID is scoped to "
+        "the Access Developer API visitor tool family — use it only with access_get_visitor and "
+        "access_delete_visitor. Requires a UniFi Access API token and confirm=true to execute."
     ),
     annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=False),
     permission_category="visitor",
     permission_action="create",
-    auth="local_only",
+    auth="api_key_only",
 )
 async def access_create_visitor(
     name: Annotated[str, Field(description="Visitor display name")],
     access_start: Annotated[
-        str,
-        Field(description="Start of access period as ISO 8601 timestamp (e.g., 2026-03-17T09:00:00Z)"),
-    ],
+        str | None,
+        Field(description="Backward-compatible alias for valid_from (ISO 8601 with timezone)."),
+    ] = None,
     access_end: Annotated[
-        str,
-        Field(description="End of access period as ISO 8601 timestamp (e.g., 2026-03-17T17:00:00Z)"),
-    ],
+        str | None,
+        Field(description="Backward-compatible alias for valid_until (ISO 8601 with timezone)."),
+    ] = None,
+    valid_from: Annotated[
+        str | None,
+        Field(description="Start of access period as ISO 8601 timestamp (e.g., 2026-03-17T09:00:00Z)."),
+    ] = None,
+    valid_until: Annotated[
+        str | None,
+        Field(description="End of access period as ISO 8601 timestamp (e.g., 2026-03-17T17:00:00Z)."),
+    ] = None,
+    first_name: Annotated[
+        str | None,
+        Field(description="Explicit first name. Provide together with last_name to override splitting name."),
+    ] = None,
+    last_name: Annotated[
+        str | None,
+        Field(description="Explicit last name. Provide together with first_name to override splitting name."),
+    ] = None,
     email: Annotated[
         str | None,
         Field(description="Visitor email address for notifications. Optional."),
     ] = None,
     phone: Annotated[
         str | None,
-        Field(description="Visitor phone number. Optional."),
+        Field(description="Visitor mobile phone number. Optional."),
+    ] = None,
+    company: Annotated[
+        str | None,
+        Field(description="Visitor company. Optional."),
+    ] = None,
+    visit_reason: Annotated[
+        str | None,
+        Field(description="Reason for the visit. Optional."),
+    ] = None,
+    remarks: Annotated[
+        str | None,
+        Field(description="Operator notes about the visit. Optional."),
     ] = None,
     confirm: Annotated[
         bool,
@@ -112,12 +148,25 @@ async def access_create_visitor(
     logger.info("access_create_visitor tool called (name=%s, confirm=%s)", name, confirm)
     try:
         try:
+            if access_start and valid_from and access_start != valid_from:
+                raise ValueError("access_start and valid_from must match when both are provided")
+            if access_end and valid_until and access_end != valid_until:
+                raise ValueError("access_end and valid_until must match when both are provided")
+            resolved_start = valid_from or access_start
+            resolved_end = valid_until or access_end
+            if not resolved_start or not resolved_end:
+                raise ValueError("valid_from and valid_until are required")
             model = Visitor(
                 name=name,
-                valid_from=access_start,
-                valid_until=access_end,
+                valid_from=resolved_start,
+                valid_until=resolved_end,
+                first_name=first_name,
+                last_name=last_name,
                 email=email,
                 phone=phone,
+                company=company,
+                visit_reason=visit_reason,
+                remarks=remarks,
             )
         except Exception as e:
             return {"success": False, "error": f"Invalid visitor input: {e}"}
@@ -144,16 +193,21 @@ async def access_create_visitor(
 @server.tool(
     name="access_delete_visitor",
     description=(
-        "Delete a visitor pass. This permanently removes the visitor's access. "
-        "Requires confirm=true to execute. Only available via local proxy session."
+        "Delete a visitor pass through the UniFi Access Developer API, revoking its access; the "
+        "controller retains a cancelled historical record. The UUID must come from "
+        "access_list_visitors and is scoped to this visitor tool family — do not pass IDs from "
+        "other Access user or credential tools. Requires an Access API token and confirm=true."
     ),
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, openWorldHint=False),
     permission_category="visitor",
     permission_action="delete",
-    auth="local_only",
+    auth="api_key_only",
 )
 async def access_delete_visitor(
-    visitor_id: Annotated[str, Field(description="Visitor UUID (from access_list_visitors)")],
+    visitor_id: Annotated[
+        str,
+        Field(description="Access Developer API visitor UUID from access_list_visitors; visitor-family scoped"),
+    ],
     confirm: Annotated[
         bool,
         Field(description="When true, deletes the visitor pass. When false (default), returns a preview."),
@@ -178,7 +232,9 @@ async def access_delete_visitor(
             resource_id=visitor_id,
             resource_data=preview_data["current_state"],
             resource_name=preview_data.get("visitor_name"),
-            warnings=["This will permanently remove the visitor pass and revoke all associated access."],
+            warnings=[
+                "This will revoke all associated access. The controller retains the visitor as cancelled history."
+            ],
         )
     except (UniFiNotFoundError, ValueError) as e:
         return {"success": False, "error": str(e)}

--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -270,7 +270,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a new visitor pass with a name and access time range. Optionally assign specific doors and contact information. Requires confirm=true to execute. Only available via local proxy session.",
+      "description": "Create a visitor pass in the UniFi Access Developer API. The returned UUID is scoped to the Access Developer API visitor tool family \u2014 use it only with access_get_visitor and access_delete_visitor. Requires a UniFi Access API token and confirm=true to execute.",
       "name": "access_create_visitor",
       "permission_action": "create",
       "permission_category": "visitor",
@@ -278,11 +278,15 @@
         "input": {
           "properties": {
             "access_end": {
-              "description": "End of access period as ISO 8601 timestamp (e.g., 2026-03-17T17:00:00Z)",
+              "description": "Backward-compatible alias for valid_until (ISO 8601 with timezone).",
               "type": "string"
             },
             "access_start": {
-              "description": "Start of access period as ISO 8601 timestamp (e.g., 2026-03-17T09:00:00Z)",
+              "description": "Backward-compatible alias for valid_from (ISO 8601 with timezone).",
+              "type": "string"
+            },
+            "company": {
+              "description": "Visitor company. Optional.",
               "type": "string"
             },
             "confirm": {
@@ -293,19 +297,41 @@
               "description": "Visitor email address for notifications. Optional.",
               "type": "string"
             },
+            "first_name": {
+              "description": "Explicit first name. Provide together with last_name to override splitting name.",
+              "type": "string"
+            },
+            "last_name": {
+              "description": "Explicit last name. Provide together with first_name to override splitting name.",
+              "type": "string"
+            },
             "name": {
               "description": "Visitor display name",
               "type": "string"
             },
             "phone": {
-              "description": "Visitor phone number. Optional.",
+              "description": "Visitor mobile phone number. Optional.",
+              "type": "string"
+            },
+            "remarks": {
+              "description": "Operator notes about the visit. Optional.",
+              "type": "string"
+            },
+            "valid_from": {
+              "description": "Start of access period as ISO 8601 timestamp (e.g., 2026-03-17T09:00:00Z).",
+              "type": "string"
+            },
+            "valid_until": {
+              "description": "End of access period as ISO 8601 timestamp (e.g., 2026-03-17T17:00:00Z).",
+              "type": "string"
+            },
+            "visit_reason": {
+              "description": "Reason for the visit. Optional.",
               "type": "string"
             }
           },
           "required": [
-            "name",
-            "access_start",
-            "access_end"
+            "name"
           ],
           "type": "object"
         },
@@ -387,7 +413,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Delete a visitor pass. This permanently removes the visitor's access. Requires confirm=true to execute. Only available via local proxy session.",
+      "description": "Delete a visitor pass through the UniFi Access Developer API, revoking its access; the controller retains a cancelled historical record. The UUID must come from access_list_visitors and is scoped to this visitor tool family \u2014 do not pass IDs from other Access user or credential tools. Requires an Access API token and confirm=true.",
       "name": "access_delete_visitor",
       "permission_action": "delete",
       "permission_category": "visitor",
@@ -399,7 +425,7 @@
               "type": "boolean"
             },
             "visitor_id": {
-              "description": "Visitor UUID (from access_list_visitors)",
+              "description": "Access Developer API visitor UUID from access_list_visitors; visitor-family scoped",
               "type": "string"
             }
           },
@@ -1443,7 +1469,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns detailed information for a single visitor pass including name, access time range, assigned doors, and status.",
+      "description": "Return one visitor pass from the UniFi Access Developer API. The visitor UUID must come from access_list_visitors and is scoped to this visitor tool family \u2014 do not pass IDs from other Access user or credential tools.",
       "name": "access_get_visitor",
       "permission_action": "read",
       "permission_category": "visitor",
@@ -1451,7 +1477,7 @@
         "input": {
           "properties": {
             "visitor_id": {
-              "description": "Visitor UUID (from access_list_visitors)",
+              "description": "Access Developer API visitor UUID from access_list_visitors; visitor-family scoped",
               "type": "string"
             }
           },
@@ -2269,7 +2295,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Lists all visitor passes with their name, status, valid time range, and assigned doors.",
+      "description": "List visitor passes from the UniFi Access Developer API. Returned UUIDs are scoped to the Access Developer API visitor tool family \u2014 pass them only to access_get_visitor and access_delete_visitor; do not pass them to other Access user or credential tools.",
       "name": "access_list_visitors",
       "permission_action": "read",
       "permission_category": "visitor",

--- a/apps/access/tests/unit/test_connection_manager.py
+++ b/apps/access/tests/unit/test_connection_manager.py
@@ -759,6 +759,86 @@ class TestClose:
 
 
 # ---------------------------------------------------------------------------
+# Access Developer API request tests
+# ---------------------------------------------------------------------------
+
+
+def _developer_response(status: int, payload: dict):
+    response = AsyncMock()
+    response.status = status
+    response.json = AsyncMock(return_value=payload)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
+
+
+class TestDeveloperRequest:
+    @pytest.mark.asyncio
+    async def test_success_uses_bearer_auth_on_api_port(self, cm_api_only):
+        response = _developer_response(200, {"code": "SUCCESS", "msg": "succ", "data": [{"id": "v1"}]})
+        session = MagicMock()
+        session.request = MagicMock(return_value=response)
+        cm_api_only._api_session = session
+        cm_api_only._api_client = MagicMock()
+        cm_api_only._api_client_available = True
+
+        result = await cm_api_only.developer_request(
+            "GET",
+            "visitors",
+            operation="List visitors",
+            params={"page_num": 1},
+        )
+
+        assert result == [{"id": "v1"}]
+        args, kwargs = session.request.call_args
+        assert args == ("GET", "https://192.168.1.1:12445/api/v1/developer/visitors")
+        assert kwargs["headers"]["Authorization"] == "Bearer test-api-key-123"
+        assert "X-API-Key" not in kwargs["headers"]
+        assert kwargs["params"] == {"page_num": 1}
+
+    @pytest.mark.asyncio
+    async def test_requires_configured_api_key(self, cm_proxy_only):
+        with pytest.raises(UniFiAuthError, match="UNIFI_ACCESS_API_KEY"):
+            await cm_proxy_only.developer_request("GET", "visitors", operation="List visitors")
+
+    @pytest.mark.asyncio
+    async def test_requires_authenticated_api_client(self, cm_api_only):
+        with pytest.raises(UniFiAuthError, match="did not authenticate on port 12445"):
+            await cm_api_only.developer_request("GET", "visitors", operation="List visitors")
+
+    @pytest.mark.asyncio
+    async def test_maps_unauthorized_to_actionable_auth_error(self, cm_api_only):
+        response = _developer_response(
+            401,
+            {"code": "CODE_UNAUTHORIZED", "msg": "You do not have permission to perform this action."},
+        )
+        session = MagicMock()
+        session.request = MagicMock(return_value=response)
+        cm_api_only._api_session = session
+        cm_api_only._api_client = MagicMock()
+        cm_api_only._api_client_available = True
+
+        with pytest.raises(UniFiAuthError, match="valid UniFi Access API token with visitor access"):
+            await cm_api_only.developer_request("GET", "visitors", operation="List visitors")
+
+    @pytest.mark.asyncio
+    async def test_rejects_application_error_envelope(self, cm_api_only):
+        response = _developer_response(200, {"code": "CODE_NOT_FOUND", "msg": "Visitor not found", "data": None})
+        session = MagicMock()
+        session.request = MagicMock(return_value=response)
+        cm_api_only._api_session = session
+        cm_api_only._api_client = MagicMock()
+        cm_api_only._api_client_available = True
+
+        with pytest.raises(UniFiConnectionError, match="Access API code CODE_NOT_FOUND"):
+            await cm_api_only.developer_request("GET", "visitors/missing", operation="Get visitor")
+
+    def test_has_api_key_reports_configuration(self, cm_api_only, cm_proxy_only):
+        assert cm_api_only.has_api_key is True
+        assert cm_proxy_only.has_api_key is False
+
+
+# ---------------------------------------------------------------------------
 # Websocket tests
 # ---------------------------------------------------------------------------
 

--- a/apps/access/tests/unit/test_delete_preview_contracts.py
+++ b/apps/access/tests/unit/test_delete_preview_contracts.py
@@ -40,7 +40,9 @@ async def test_delete_visitor_uses_standard_delete_preview() -> None:
         "name": "Smoke Visitor",
         "status": "active",
     }
-    assert result["warnings"] == ["This will permanently remove the visitor pass and revoke all associated access."]
+    assert result["warnings"] == [
+        "This will revoke all associated access. The controller retains the visitor as cancelled history."
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/access/tests/unit/test_visitor_tools.py
+++ b/apps/access/tests/unit/test_visitor_tools.py
@@ -1,0 +1,155 @@
+"""Tool-layer tests for the Access Developer API visitor family."""
+
+from __future__ import annotations
+
+import inspect
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unifi_core.access.models.visitors import MUTABLE_FIELDS
+
+os.environ.setdefault("UNIFI_ACCESS_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_ACCESS_USERNAME", "test")
+os.environ.setdefault("UNIFI_ACCESS_PASSWORD", "test")
+
+
+@pytest.mark.asyncio
+async def test_list_visitors_normalizes_developer_api_fields() -> None:
+    with patch("unifi_access_mcp.tools.visitors.visitor_manager") as manager:
+        manager.list_visitors = AsyncMock(
+            return_value=[
+                {
+                    "id": "visitor-uuid",
+                    "first_name": "Smoke",
+                    "last_name": "Visitor",
+                    "start_time": 1773738000,
+                    "end_time": 1773766800,
+                    "status": 6,
+                    "mobile_phone": "+15551234567",
+                    "company": "Example Co",
+                    "nfc_cards": [],
+                    "license_plates": [],
+                }
+            ]
+        )
+        from unifi_access_mcp.tools.visitors import access_list_visitors
+
+        result = await access_list_visitors()
+
+    assert result == {
+        "success": True,
+        "data": {
+            "visitors": [
+                {
+                    "id": "visitor-uuid",
+                    "status": "active",
+                    "credential_count": 0,
+                    "name": "Smoke Visitor",
+                    "first_name": "Smoke",
+                    "last_name": "Visitor",
+                    "valid_from": "2026-03-17T09:00:00Z",
+                    "valid_until": "2026-03-17T17:00:00Z",
+                    "phone": "+15551234567",
+                    "company": "Example Co",
+                }
+            ],
+            "count": 1,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_visitor_accepts_canonical_fields_and_previews() -> None:
+    with patch("unifi_access_mcp.tools.visitors.visitor_manager") as manager:
+        manager.create_visitor = AsyncMock(
+            return_value={
+                "proposed_changes": {
+                    "action": "create",
+                    "name": "Smoke Visitor",
+                    "access_start": "2026-03-17T09:00:00Z",
+                    "access_end": "2026-03-17T17:00:00Z",
+                    "company": "Example Co",
+                }
+            }
+        )
+        from unifi_access_mcp.tools.visitors import access_create_visitor
+
+        result = await access_create_visitor(
+            name="Smoke Visitor",
+            valid_from="2026-03-17T09:00:00Z",
+            valid_until="2026-03-17T17:00:00Z",
+            company="Example Co",
+            confirm=False,
+        )
+
+    assert result["success"] is True
+    assert result["requires_confirmation"] is True
+    assert result["action"] == "create"
+    manager.create_visitor.assert_awaited_once_with(
+        name="Smoke Visitor",
+        access_start="2026-03-17T09:00:00Z",
+        access_end="2026-03-17T17:00:00Z",
+        company="Example Co",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_visitor_confirm_forwards_developer_metadata() -> None:
+    with patch("unifi_access_mcp.tools.visitors.visitor_manager") as manager:
+        manager.apply_create_visitor = AsyncMock(
+            return_value={"action": "create", "result": "success", "data": {"id": "visitor-uuid"}}
+        )
+        from unifi_access_mcp.tools.visitors import access_create_visitor
+
+        result = await access_create_visitor(
+            name="Smoke Visitor",
+            access_start="2026-03-17T09:00:00Z",
+            access_end="2026-03-17T17:00:00Z",
+            first_name="Smoke",
+            last_name="Visitor",
+            email="smoke@example.com",
+            phone="+15551234567",
+            company="Example Co",
+            visit_reason="Business",
+            remarks="Disposable",
+            confirm=True,
+        )
+
+    assert result["success"] is True
+    assert result["data"]["data"]["id"] == "visitor-uuid"
+    manager.apply_create_visitor.assert_awaited_once_with(
+        name="Smoke Visitor",
+        access_start="2026-03-17T09:00:00Z",
+        access_end="2026-03-17T17:00:00Z",
+        first_name="Smoke",
+        last_name="Visitor",
+        email="smoke@example.com",
+        phone="+15551234567",
+        company="Example Co",
+        visit_reason="Business",
+        remarks="Disposable",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_visitor_rejects_conflicting_time_aliases() -> None:
+    from unifi_access_mcp.tools.visitors import access_create_visitor
+
+    result = await access_create_visitor(
+        name="Smoke Visitor",
+        access_start="2026-03-17T09:00:00Z",
+        valid_from="2026-03-17T10:00:00Z",
+        access_end="2026-03-17T17:00:00Z",
+    )
+
+    assert result["success"] is False
+    assert "must match" in result["error"]
+
+
+def test_every_mutable_visitor_field_is_a_create_parameter() -> None:
+    from unifi_access_mcp.tools.visitors import access_create_visitor
+
+    create_params = set(inspect.signature(access_create_visitor).parameters)
+    assert MUTABLE_FIELDS <= create_params

--- a/apps/access/tests/unit/test_visitors.py
+++ b/apps/access/tests/unit/test_visitors.py
@@ -1,76 +1,86 @@
-"""Tests for VisitorManager."""
+"""Tests for the Access Developer API VisitorManager."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
 from unifi_core.access.managers.connection_manager import AccessConnectionManager
 from unifi_core.access.managers.visitor_manager import VisitorManager
-from unifi_core.exceptions import UniFiConnectionError
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+from unifi_core.exceptions import UniFiAuthError, UniFiConnectionError, UniFiNotFoundError
 
 
 @pytest.fixture
-def cm_proxy():
-    cm = AccessConnectionManager(host="192.168.1.1", username="admin", password="secret")
-    cm._proxy_available = True
-    cm._proxy_session = MagicMock()
+def cm_api() -> MagicMock:
+    cm = MagicMock(spec=AccessConnectionManager)
+    cm.has_api_key = True
+    cm.has_api_client = True
+    cm.developer_request = AsyncMock()
     return cm
 
 
 @pytest.fixture
-def cm_none():
-    return AccessConnectionManager(host="192.168.1.1", username="", password="")
-
-
-@pytest.fixture
-def visitor_mgr(cm_proxy):
-    return VisitorManager(cm_proxy)
-
-
-@pytest.fixture
-def visitor_mgr_none(cm_none):
-    return VisitorManager(cm_none)
-
-
-# ---------------------------------------------------------------------------
-# list_visitors
-# ---------------------------------------------------------------------------
+def visitor_mgr(cm_api: MagicMock) -> VisitorManager:
+    return VisitorManager(cm_api)
 
 
 class TestListVisitors:
     @pytest.mark.asyncio
-    async def test_list_visitors_success(self, visitor_mgr, cm_proxy):
-        expected = [{"id": "vis-1", "name": "John Doe"}]
-        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
-            mock_req.return_value = {"data": expected}
-            result = await visitor_mgr.list_visitors()
-        assert result == expected
+    async def test_list_visitors_paginates_developer_api(self, visitor_mgr, cm_api):
+        first_page = [{"id": f"vis-{i}"} for i in range(100)]
+        cm_api.developer_request.side_effect = [first_page, [{"id": "vis-100"}]]
+
+        result = await visitor_mgr.list_visitors()
+
+        assert len(result) == 101
+        assert result[-1]["id"] == "vis-100"
+        assert cm_api.developer_request.await_args_list == [
+            call(
+                "GET",
+                "visitors",
+                operation="List visitors",
+                params={"page_num": 1, "page_size": 100},
+            ),
+            call(
+                "GET",
+                "visitors",
+                operation="List visitors",
+                params={"page_num": 2, "page_size": 100},
+            ),
+        ]
 
     @pytest.mark.asyncio
-    async def test_list_visitors_no_proxy(self, visitor_mgr_none):
-        with pytest.raises(UniFiConnectionError, match="No proxy session"):
-            await visitor_mgr_none.list_visitors()
+    async def test_list_visitors_requires_api_key_without_proxy_fallback(self, visitor_mgr, cm_api):
+        cm_api.has_api_key = False
 
+        with pytest.raises(UniFiAuthError, match="UNIFI_ACCESS_API_KEY"):
+            await visitor_mgr.list_visitors()
 
-# ---------------------------------------------------------------------------
-# get_visitor
-# ---------------------------------------------------------------------------
+        cm_api.developer_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_list_visitors_rejects_unexpected_shape(self, visitor_mgr, cm_api):
+        cm_api.developer_request.return_value = {"items": []}
+
+        with pytest.raises(UniFiConnectionError, match="unexpected Access API response shape"):
+            await visitor_mgr.list_visitors()
 
 
 class TestGetVisitor:
     @pytest.mark.asyncio
-    async def test_get_visitor_success(self, visitor_mgr, cm_proxy):
-        expected = {"id": "vis-1", "name": "John Doe", "status": "active"}
-        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
-            mock_req.return_value = {"data": expected}
-            result = await visitor_mgr.get_visitor("vis-1")
+    async def test_get_visitor_success(self, visitor_mgr, cm_api):
+        expected = {"id": "vis-1", "first_name": "John", "last_name": "Doe", "status": 6}
+        cm_api.developer_request.return_value = expected
+
+        result = await visitor_mgr.get_visitor("vis-1")
+
         assert result == expected
+        cm_api.developer_request.assert_awaited_once_with(
+            "GET",
+            "visitors/vis-1",
+            operation="Get visitor",
+        )
 
     @pytest.mark.asyncio
     async def test_get_visitor_empty_id(self, visitor_mgr):
@@ -78,97 +88,138 @@ class TestGetVisitor:
             await visitor_mgr.get_visitor("")
 
     @pytest.mark.asyncio
-    async def test_get_visitor_no_proxy(self, visitor_mgr_none):
-        with pytest.raises(UniFiConnectionError, match="No proxy session"):
-            await visitor_mgr_none.get_visitor("vis-1")
+    async def test_get_visitor_maps_developer_not_found(self, visitor_mgr, cm_api):
+        cm_api.developer_request.side_effect = UniFiConnectionError(
+            "Get visitor failed: HTTP 404 GET /api/v1/developer/visitors/missing"
+        )
 
-
-# ---------------------------------------------------------------------------
-# create_visitor (preview)
-# ---------------------------------------------------------------------------
+        with pytest.raises(UniFiNotFoundError, match="visitor 'missing' not found"):
+            await visitor_mgr.get_visitor("missing")
 
 
 class TestCreateVisitor:
     @pytest.mark.asyncio
-    async def test_create_visitor_preview(self, visitor_mgr):
-        preview = await visitor_mgr.create_visitor(
-            name="Jane Doe",
-            access_start="2026-03-17T09:00:00Z",
-            access_end="2026-03-17T17:00:00Z",
-        )
-        assert preview["visitor_data"]["name"] == "Jane Doe"
-        assert preview["proposed_changes"]["action"] == "create"
-
-    @pytest.mark.asyncio
-    async def test_create_visitor_with_extra(self, visitor_mgr):
+    async def test_create_visitor_preview_uses_stable_fields(self, visitor_mgr):
         preview = await visitor_mgr.create_visitor(
             name="Jane Doe",
             access_start="2026-03-17T09:00:00Z",
             access_end="2026-03-17T17:00:00Z",
             email="jane@example.com",
+            company="Example Co",
         )
-        assert preview["visitor_data"]["email"] == "jane@example.com"
+
+        assert preview["visitor_data"] == {
+            "name": "Jane Doe",
+            "access_start": "2026-03-17T09:00:00Z",
+            "access_end": "2026-03-17T17:00:00Z",
+            "email": "jane@example.com",
+            "company": "Example Co",
+        }
+        assert preview["proposed_changes"]["action"] == "create"
 
     @pytest.mark.asyncio
-    async def test_create_visitor_empty_name(self, visitor_mgr):
-        with pytest.raises(ValueError, match="name is required"):
+    async def test_create_visitor_rejects_partial_explicit_name(self, visitor_mgr):
+        with pytest.raises(ValueError, match="first_name and last_name must be provided together"):
             await visitor_mgr.create_visitor(
-                name="",
+                name="Jane Doe",
+                first_name="Jane",
                 access_start="2026-03-17T09:00:00Z",
                 access_end="2026-03-17T17:00:00Z",
             )
 
     @pytest.mark.asyncio
-    async def test_create_visitor_empty_times(self, visitor_mgr):
-        with pytest.raises(ValueError, match="access_start and access_end are required"):
+    async def test_create_visitor_requires_timezone(self, visitor_mgr):
+        with pytest.raises(ValueError, match="valid_from must include a timezone"):
             await visitor_mgr.create_visitor(
-                name="Jane",
-                access_start="",
-                access_end="",
+                name="Jane Doe",
+                access_start="2026-03-17T09:00:00",
+                access_end="2026-03-17T17:00:00Z",
             )
 
+    @pytest.mark.asyncio
+    async def test_create_visitor_accepts_canonical_time_fields(self, visitor_mgr):
+        preview = await visitor_mgr.create_visitor(
+            name="Jane Doe",
+            valid_from="2026-03-17T09:00:00Z",
+            valid_until="2026-03-17T17:00:00Z",
+        )
 
-# ---------------------------------------------------------------------------
-# apply_create_visitor
-# ---------------------------------------------------------------------------
+        assert preview["proposed_changes"]["valid_from"] == "2026-03-17T09:00:00Z"
+        assert preview["proposed_changes"]["valid_until"] == "2026-03-17T17:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_create_visitor_requires_end_after_start(self, visitor_mgr):
+        with pytest.raises(ValueError, match="access_end must be after access_start"):
+            await visitor_mgr.create_visitor(
+                name="Jane Doe",
+                access_start="2026-03-17T17:00:00Z",
+                access_end="2026-03-17T09:00:00Z",
+            )
 
 
 class TestApplyCreateVisitor:
     @pytest.mark.asyncio
-    async def test_apply_create_success(self, visitor_mgr, cm_proxy):
-        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
-            mock_req.return_value = {"data": {"id": "vis-new"}}
-            result = await visitor_mgr.apply_create_visitor(
-                name="Jane Doe",
-                access_start="2026-03-17T09:00:00Z",
-                access_end="2026-03-17T17:00:00Z",
-            )
+    async def test_apply_create_translates_to_developer_payload(self, visitor_mgr, cm_api):
+        cm_api.developer_request.return_value = {"id": "vis-new", "first_name": "Jane", "last_name": "Doe"}
+
+        result = await visitor_mgr.apply_create_visitor(
+            name="Display Name",
+            first_name="Jane",
+            last_name="Doe",
+            access_start="2026-03-17T09:00:00Z",
+            access_end="2026-03-17T17:00:00Z",
+            email="jane@example.com",
+            phone="+15551234567",
+            company="Example Co",
+            visit_reason="Business",
+            remarks="Disposable test",
+        )
+
         assert result["result"] == "success"
+        assert result["data"]["id"] == "vis-new"
+        cm_api.developer_request.assert_awaited_once_with(
+            "POST",
+            "visitors",
+            operation="Create visitor",
+            json={
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "start_time": 1773738000,
+                "end_time": 1773766800,
+                "email": "jane@example.com",
+                "mobile_phone": "+15551234567",
+                "company": "Example Co",
+                "visit_reason": "Business",
+                "remarks": "Disposable test",
+            },
+        )
 
     @pytest.mark.asyncio
-    async def test_apply_create_no_proxy(self, visitor_mgr_none):
-        with pytest.raises(UniFiConnectionError, match="No proxy session"):
-            await visitor_mgr_none.apply_create_visitor(
-                name="Jane",
-                access_start="2026-03-17T09:00:00Z",
-                access_end="2026-03-17T17:00:00Z",
-            )
+    async def test_apply_create_splits_display_name(self, visitor_mgr, cm_api):
+        cm_api.developer_request.return_value = {"id": "vis-new"}
 
+        await visitor_mgr.apply_create_visitor(
+            name="Jane Doe",
+            access_start="2026-03-17T09:00:00Z",
+            access_end="2026-03-17T17:00:00Z",
+        )
 
-# ---------------------------------------------------------------------------
-# delete_visitor (preview)
-# ---------------------------------------------------------------------------
+        payload = cm_api.developer_request.await_args.kwargs["json"]
+        assert payload["first_name"] == "Jane"
+        assert payload["last_name"] == "Doe"
 
 
 class TestDeleteVisitor:
     @pytest.mark.asyncio
-    async def test_delete_visitor_preview(self, visitor_mgr, cm_proxy):
-        current = {"id": "vis-1", "name": "John Doe", "status": "active"}
-        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
-            mock_req.return_value = {"data": current}
-            preview = await visitor_mgr.delete_visitor("vis-1")
+    async def test_delete_visitor_preview_composes_name(self, visitor_mgr, cm_api):
+        current = {"id": "vis-1", "first_name": "John", "last_name": "Doe", "status": 6}
+        cm_api.developer_request.return_value = current
+
+        preview = await visitor_mgr.delete_visitor("vis-1")
+
         assert preview["visitor_id"] == "vis-1"
         assert preview["visitor_name"] == "John Doe"
+        assert preview["current_state"] == current
         assert preview["proposed_changes"]["action"] == "delete"
 
     @pytest.mark.asyncio
@@ -177,21 +228,25 @@ class TestDeleteVisitor:
             await visitor_mgr.delete_visitor("")
 
 
-# ---------------------------------------------------------------------------
-# apply_delete_visitor
-# ---------------------------------------------------------------------------
-
-
 class TestApplyDeleteVisitor:
     @pytest.mark.asyncio
-    async def test_apply_delete_success(self, visitor_mgr, cm_proxy):
-        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
-            mock_req.return_value = {}
-            result = await visitor_mgr.apply_delete_visitor("vis-1")
-        assert result["result"] == "success"
-        assert result["action"] == "delete"
+    async def test_apply_delete_success(self, visitor_mgr, cm_api):
+        cm_api.developer_request.return_value = None
+
+        result = await visitor_mgr.apply_delete_visitor("vis-1")
+
+        assert result == {"visitor_id": "vis-1", "action": "delete", "result": "success"}
+        cm_api.developer_request.assert_awaited_once_with(
+            "DELETE",
+            "visitors/vis-1",
+            operation="Delete visitor",
+        )
 
     @pytest.mark.asyncio
-    async def test_apply_delete_no_proxy(self, visitor_mgr_none):
-        with pytest.raises(UniFiConnectionError, match="No proxy session"):
-            await visitor_mgr_none.apply_delete_visitor("vis-1")
+    async def test_apply_delete_maps_developer_not_found(self, visitor_mgr, cm_api):
+        cm_api.developer_request.side_effect = UniFiConnectionError(
+            "Delete visitor failed: Access API code CODE_NOT_FOUND"
+        )
+
+        with pytest.raises(UniFiNotFoundError, match="visitor 'missing' not found"):
+            await visitor_mgr.apply_delete_visitor("missing")

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -129,10 +129,14 @@ type AccessQuery {
   """List Access schedules (weekly access windows)."""
   schedules(controller: ID!, limit: Int! = 50, cursor: String = null): SchedulePage!
 
-  """List Access visitors (time-bounded guest passes)."""
+  """
+  List Access Developer API visitors. Returned UUIDs are scoped to the visitor family and must not be passed to other Access user or credential operations.
+  """
   visitors(controller: ID!, limit: Int! = 50, cursor: String = null): VisitorPage!
 
-  """Look up a single Access visitor by id."""
+  """
+  Look up one Access Developer API visitor using a UUID returned by the visitor family; IDs from other Access user or credential operations are not accepted.
+  """
   visitor(controller: ID!, id: ID!): Visitor
 
   """List Access events (paginated, most recent first)."""
@@ -2046,10 +2050,14 @@ type ViewerList {
   count: Int
 }
 
-"""A UniFi Access visitor (time-bounded guest pass)."""
+"""
+A time-bounded UniFi Access Developer API visitor pass. Its UUID is scoped to the Access Developer API visitor family and must not be passed to other Access user or credential operations.
+"""
 type Visitor {
   id: ID
   name: String
+  firstName: String
+  lastName: String
   hostUserId: String
   validFrom: String
   validUntil: String
@@ -2057,6 +2065,10 @@ type Visitor {
   credentialCount: Int
   email: String
   phone: String
+  company: String
+  visitReason: String
+  remarks: String
+  accessPolicyIds: [String!]
 }
 
 """Paginated page of UniFi Access visitors."""
@@ -2195,8 +2207,8 @@ Read-only access to UniFi Access resources.
 - `schedules: SchedulePage!`  — List Access schedules (weekly access windows).
 - `systemInfo: AccessSystemInfo`  — Get the Access application info (name + version + host).
 - `users: UserPage!`  — List Access users (employees / cardholders, paginated).
-- `visitor: Visitor`  — Look up a single Access visitor by id.
-- `visitors: VisitorPage!`  — List Access visitors (time-bounded guest passes).
+- `visitor: Visitor`  — Look up one Access Developer API visitor using a UUID returned by the visitor family; IDs from other Access user or credential operations are not accepted.
+- `visitors: VisitorPage!`  — List Access Developer API visitors. Returned UUIDs are scoped to the visitor family and must not be passed to other Access user or credential operations.
 
 
 ### `query.health`

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -300,6 +300,9 @@ Fetch a user by listing then filtering — no native get_user method.
 ### `GET /v1/sites/{site_id}/visitors` — List Visitors
 
 
+List UniFi Access Developer API visitors. Returned UUIDs are scoped to the Access Developer API visitor family and must not be passed to other Access user or credential operations.
+
+
 **Parameters:**
 
 - `site_id` (path) (required)
@@ -311,6 +314,9 @@ Fetch a user by listing then filtering — no native get_user method.
 **Returns:** `object`
 
 ### `GET /v1/sites/{site_id}/visitors/{visitor_id}` — Get Visitor
+
+
+Get a UniFi Access Developer API visitor by a UUID returned from the visitor family. Do not pass IDs from other Access user or credential operations.
 
 
 **Parameters:**

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -20158,6 +20158,7 @@
     },
     "/v1/sites/{site_id}/visitors": {
       "get": {
+        "description": "List UniFi Access Developer API visitors. Returned UUIDs are scoped to the Access Developer API visitor family and must not be passed to other Access user or credential operations.",
         "operationId": "list_visitors_v1_sites__site_id__visitors_get",
         "parameters": [
           {
@@ -20248,6 +20249,7 @@
     },
     "/v1/sites/{site_id}/visitors/{visitor_id}": {
       "get": {
+        "description": "Get a UniFi Access Developer API visitor by a UUID returned from the visitor family. Do not pass IDs from other Access user or credential operations.",
         "operationId": "get_visitor_v1_sites__site_id__visitors__visitor_id__get",
         "parameters": [
           {

--- a/apps/api/src/unifi_api/graphql/resolvers/access.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/access.py
@@ -834,7 +834,10 @@ class AccessQuery:
 
     @strawberry.field(
         permission_classes=[IsRead],
-        description="List Access visitors (time-bounded guest passes).",
+        description=(
+            "List Access Developer API visitors. Returned UUIDs are scoped to the visitor family "
+            "and must not be passed to other Access user or credential operations."
+        ),
     )
     async def visitors(
         self,
@@ -862,7 +865,10 @@ class AccessQuery:
 
     @strawberry.field(
         permission_classes=[IsRead],
-        description="Look up a single Access visitor by id.",
+        description=(
+            "Look up one Access Developer API visitor using a UUID returned by the visitor family; "
+            "IDs from other Access user or credential operations are not accepted."
+        ),
     )
     async def visitor(
         self,

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -118,10 +118,14 @@ type AccessQuery {
   """List Access schedules (weekly access windows)."""
   schedules(controller: ID!, limit: Int! = 50, cursor: String = null): SchedulePage!
 
-  """List Access visitors (time-bounded guest passes)."""
+  """
+  List Access Developer API visitors. Returned UUIDs are scoped to the visitor family and must not be passed to other Access user or credential operations.
+  """
   visitors(controller: ID!, limit: Int! = 50, cursor: String = null): VisitorPage!
 
-  """Look up a single Access visitor by id."""
+  """
+  Look up one Access Developer API visitor using a UUID returned by the visitor family; IDs from other Access user or credential operations are not accepted.
+  """
   visitor(controller: ID!, id: ID!): Visitor
 
   """List Access events (paginated, most recent first)."""
@@ -2035,10 +2039,14 @@ type ViewerList {
   count: Int
 }
 
-"""A UniFi Access visitor (time-bounded guest pass)."""
+"""
+A time-bounded UniFi Access Developer API visitor pass. Its UUID is scoped to the Access Developer API visitor family and must not be passed to other Access user or credential operations.
+"""
 type Visitor {
   id: ID
   name: String
+  firstName: String
+  lastName: String
   hostUserId: String
   validFrom: String
   validUntil: String
@@ -2046,6 +2054,10 @@ type Visitor {
   credentialCount: Int
   email: String
   phone: String
+  company: String
+  visitReason: String
+  remarks: String
+  accessPolicyIds: [String!]
 }
 
 """Paginated page of UniFi Access visitors."""

--- a/apps/api/src/unifi_api/graphql/types/access/visitors.py
+++ b/apps/api/src/unifi_api/graphql/types/access/visitors.py
@@ -1,18 +1,7 @@
-"""Strawberry types for access/visitors.
+"""Strawberry projection for the Access Developer API visitor family.
 
-Phase 6 PR4 Task B migration target. The single read serializer
-(``VisitorSerializer``) maps to one Strawberry class:
-
-- ``Visitor`` — access_list_visitors + access_get_visitor
-
-Resource-registered (LIST + DETAIL paths). Mutation acks
-(``access_create_visitor`` / ``access_delete_visitor``) stay in
-``serializers/access/visitors.py``; the API action path dispatches to
-the manager mutation methods and serializes their dict acknowledgements.
-
-VisitorManager surfaces ``valid_from`` / ``valid_until`` (with
-``access_start`` / ``access_end`` fallbacks). ``from_manager_output``
-normalizes across both, mirroring the old serializer byte-for-byte.
+Read tools use this type; create/delete acknowledgement dicts remain in
+``serializers/access/visitors.py``.
 """
 
 from __future__ import annotations
@@ -21,23 +10,22 @@ from dataclasses import asdict
 from typing import Any
 
 import strawberry
+from unifi_core.access.models.visitors import from_controller as visitor_from_controller
 
 
-def _get(obj: Any, key: str, default: Any = None) -> Any:
-    if isinstance(obj, dict):
-        return obj.get(key, default)
-    raw = getattr(obj, "raw", None)
-    if isinstance(raw, dict):
-        return raw.get(key, default)
-    return getattr(obj, key, default)
-
-
-@strawberry.type(description="A UniFi Access visitor (time-bounded guest pass).")
+@strawberry.type(
+    description=(
+        "A time-bounded UniFi Access Developer API visitor pass. Its UUID is scoped to the "
+        "Access Developer API visitor family and must not be passed to other Access user or credential operations."
+    )
+)
 class Visitor:
-    """Mirrors ``VisitorSerializer.serialize`` projection byte-for-byte."""
+    """Typed projection of the shared visitor field model."""
 
     id: strawberry.ID | None
     name: str | None
+    first_name: str | None
+    last_name: str | None
     host_user_id: str | None
     valid_from: str | None
     valid_until: str | None
@@ -45,6 +33,10 @@ class Visitor:
     credential_count: int | None
     email: str | None
     phone: str | None
+    company: str | None
+    visit_reason: str | None
+    remarks: str | None
+    access_policy_ids: list[str] | None
 
     @classmethod
     def render_hint(cls, kind: str) -> dict:
@@ -53,7 +45,7 @@ class Visitor:
             "primary_key": "id",
             "display_columns": [
                 "name",
-                "host_user_id",
+                "company",
                 "valid_from",
                 "valid_until",
                 "status",
@@ -62,17 +54,8 @@ class Visitor:
 
     @classmethod
     def from_manager_output(cls, obj: Any) -> "Visitor":
-        return cls(
-            id=_get(obj, "id"),
-            name=_get(obj, "name"),
-            host_user_id=_get(obj, "host_user_id"),
-            valid_from=_get(obj, "valid_from") or _get(obj, "access_start"),
-            valid_until=_get(obj, "valid_until") or _get(obj, "access_end"),
-            status=_get(obj, "status"),
-            credential_count=_get(obj, "credential_count"),
-            email=_get(obj, "email"),
-            phone=_get(obj, "phone"),
-        )
+        normalized = visitor_from_controller(obj)
+        return cls(**normalized.model_dump())
 
     def to_dict(self) -> dict:
         out = asdict(self)

--- a/apps/api/src/unifi_api/routes/resources/access/visitors.py
+++ b/apps/api/src/unifi_api/routes/resources/access/visitors.py
@@ -39,6 +39,10 @@ def _decode_cursor(cursor: str | None) -> Cursor | None:
     "/sites/{site_id}/visitors",
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["access/visitors"],
+    description=(
+        "List UniFi Access Developer API visitors. Returned UUIDs are scoped to the Access Developer API "
+        "visitor family and must not be passed to other Access user or credential operations."
+    ),
 )
 async def list_visitors(
     request: Request,
@@ -90,6 +94,10 @@ async def list_visitors(
     "/sites/{site_id}/visitors/{visitor_id}",
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["access/visitors"],
+    description=(
+        "Get a UniFi Access Developer API visitor by a UUID returned from the visitor family. "
+        "Do not pass IDs from other Access user or credential operations."
+    ),
 )
 async def get_visitor(
     request: Request,

--- a/apps/api/tests/graphql/fixtures/access/test_visitors.py
+++ b/apps/api/tests/graphql/fixtures/access/test_visitors.py
@@ -19,8 +19,15 @@ async def test_access_visitors_list(tmp_path, monkeypatch):
         monkeypatch,
         {
             ("access", "visitor_manager", "list_visitors"): [
-                {"id": "vis1", "name": "Alice Guest", "status": "active"},
-                {"id": "vis2", "name": "Bob Guest", "status": "expired"},
+                {
+                    "id": "vis1",
+                    "first_name": "Alice",
+                    "last_name": "Guest",
+                    "status": 6,
+                    "start_time": 1773738000,
+                    "end_time": 1773766800,
+                },
+                {"id": "vis2", "first_name": "Bob", "last_name": "Guest", "status": 2},
             ],
         },
     )
@@ -29,7 +36,7 @@ async def test_access_visitors_list(tmp_path, monkeypatch):
         key,
         f'''{{
         access {{ visitors(controller: "{cid}", limit: 10) {{
-            items {{ id name status }}
+            items {{ id name firstName lastName validFrom validUntil status }}
         }} }}
     }}''',
     )
@@ -37,6 +44,16 @@ async def test_access_visitors_list(tmp_path, monkeypatch):
     items = body["data"]["access"]["visitors"]["items"]
     assert len(items) == 2
     assert {it["id"] for it in items} == {"vis1", "vis2"}
+    first = next(item for item in items if item["id"] == "vis1")
+    assert first == {
+        "id": "vis1",
+        "name": "Alice Guest",
+        "firstName": "Alice",
+        "lastName": "Guest",
+        "validFrom": "2026-03-17T09:00:00Z",
+        "validUntil": "2026-03-17T17:00:00Z",
+        "status": "active",
+    }
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/routes/resources/test_access_doors_policies.py
+++ b/apps/api/tests/routes/resources/test_access_doors_policies.py
@@ -505,7 +505,7 @@ async def test_list_visitors_happy_path(tmp_path, monkeypatch) -> None:
     app, key, cid = await _bootstrap(tmp_path)
     _stub_connection(app, cid)
 
-    visitors = [{"id": f"vis-{i}", "name": f"Visitor {i}", "status": "active"} for i in range(3)]
+    visitors = [{"id": f"vis-{i}", "first_name": "Visitor", "last_name": str(i), "status": 6} for i in range(3)]
 
     async def fake_list(self):
         return visitors
@@ -522,6 +522,8 @@ async def test_list_visitors_happy_path(tmp_path, monkeypatch) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert len(body["items"]) == 3
+    assert {item["name"] for item in body["items"]} == {"Visitor 0", "Visitor 1", "Visitor 2"}
+    assert {item["status"] for item in body["items"]} == {"active"}
     assert body["render_hint"]["kind"] == "list"
 
 

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -650,6 +650,54 @@ async def test_dispatch_delete_actions_require_confirm(tool_name: str, product: 
 
 
 @pytest.mark.asyncio
+async def test_dispatch_access_create_visitor_preserves_developer_fields() -> None:
+    entry = ToolEntry(
+        name="access_create_visitor",
+        product="access",
+        category="visitor",
+        manager="",
+        method="",
+        permission_action="create",
+    )
+    registry = _registry_with(entry)
+    manager = MagicMock()
+    manager.apply_create_visitor = AsyncMock(
+        return_value={"action": "create", "result": "success", "data": {"id": "visitor-uuid"}}
+    )
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    args = {
+        "name": "Smoke Visitor",
+        "valid_from": "2026-03-17T09:00:00Z",
+        "valid_until": "2026-03-17T17:00:00Z",
+        "first_name": "Smoke",
+        "last_name": "Visitor",
+        "company": "Example Co",
+    }
+
+    result = await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="access_create_visitor",
+        controller_id="cid",
+        controller_products=["access"],
+        site="default",
+        args=args,
+        confirm=True,
+        dispatch_table={
+            "access_create_visitor": DispatchEntry(
+                manager_attr="visitor_manager",
+                method="apply_create_visitor",
+            )
+        },
+    )
+
+    assert result["data"]["id"] == "visitor-uuid"
+    manager.apply_create_visitor.assert_awaited_once_with(**args)
+
+
+@pytest.mark.asyncio
 async def test_dispatch_confirmed_delete_reaches_manager() -> None:
     entry = ToolEntry(
         name="access_delete_visitor",

--- a/apps/api/tests/test_live_api_smoke_harness.py
+++ b/apps/api/tests/test_live_api_smoke_harness.py
@@ -74,31 +74,6 @@ def test_live_smoke_known_controller_issue_matches_exact_error_code():
     )
 
 
-def test_live_smoke_known_visitor_endpoint_404_requires_full_signature():
-    import live_smoke
-
-    runner = live_smoke.LiveSmokeRunner.__new__(live_smoke.LiveSmokeRunner)
-
-    assert runner.expected_known_controller_issue(
-        "access_create_visitor",
-        (
-            "Failed to create visitor: Proxy request failed: HTTP 404 POST "
-            "https://127.0.0.1:11444/proxy/access/api/v2/visitors "
-            '{"code":404,"codeS":"CODE_NOT_FOUND","msg":"The API was not found.",'
-            '"error":"you entered no-man zone"}'
-        ),
-    )
-    assert not runner.expected_known_controller_issue(
-        "access_create_visitor",
-        (
-            "Failed to create visitor: Proxy request failed: HTTP 404 POST "
-            "https://127.0.0.1:11444/proxy/access/api/v2/visitor-groups "
-            '{"code":404,"codeS":"CODE_NOT_FOUND","msg":"The API was not found.",'
-            '"error":"you entered no-man zone"}'
-        ),
-    )
-
-
 def test_live_smoke_known_firewall_policy_rejection_requires_controller_code():
     import live_smoke
 

--- a/packages/unifi-core/src/unifi_core/access/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/connection_manager.py
@@ -233,6 +233,88 @@ class AccessConnectionManager:
             logger.debug("[access-cm] Proxy login successful, CSRF token obtained.")
 
     # ------------------------------------------------------------------
+    # Access Developer API request helper
+    # ------------------------------------------------------------------
+
+    async def developer_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        operation: str,
+        json: Any = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Request the official Access Developer API with Bearer auth.
+
+        The Access Developer API is served on ``api_port`` and uses
+        ``Authorization: Bearer``. This differs from Network's public
+        Integration API, which uses ``X-API-Key``.
+        """
+        remediation = (
+            "Create a UniFi Access API token and set UNIFI_ACCESS_API_KEY (or UNIFI_API_KEY) for the Access MCP server."
+        )
+        if not self._api_key:
+            raise UniFiAuthError(f"{operation} requires a UniFi Access API token. {remediation}")
+        if not self.has_api_client or self._api_session is None:
+            raise UniFiAuthError(
+                f"{operation} requires an authenticated UniFi Access Developer API session. "
+                f"The configured token did not authenticate on port {self._api_port}. {remediation}"
+            )
+
+        url = f"https://{self.host}:{self._api_port}/api/v1/developer/{path.lstrip('/')}"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._api_key}",
+        }
+        try:
+            async with self._api_session.request(
+                method,
+                url,
+                headers=headers,
+                json=json,
+                params=params,
+                ssl=self._ssl_context,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                try:
+                    payload = await resp.json(content_type=None)
+                except (ValueError, aiohttp.ContentTypeError) as exc:
+                    body = await resp.text()
+                    raise UniFiConnectionError(
+                        f"{operation} failed: HTTP {resp.status} {method} {url} — "
+                        f"invalid JSON response{(': ' + body[:200]) if body else ''}"
+                    ) from exc
+
+                message = ""
+                if isinstance(payload, dict):
+                    message = str(payload.get("msg") or payload.get("message") or payload.get("code") or "")
+                if resp.status in (401, 403):
+                    raise UniFiAuthError(
+                        f"{operation} requires a valid UniFi Access API token with visitor access: "
+                        f"HTTP {resp.status}{(' — ' + message) if message else ''}. {remediation}"
+                    )
+                if resp.status != 200:
+                    raise UniFiConnectionError(
+                        f"{operation} failed: HTTP {resp.status} {method} {url}{(' — ' + message) if message else ''}"
+                    )
+                if not isinstance(payload, dict):
+                    raise UniFiConnectionError(f"{operation} failed: unexpected Access API response shape")
+                if payload.get("code") != "SUCCESS":
+                    raise UniFiConnectionError(
+                        f"{operation} failed: Access API code {payload.get('code', 'UNKNOWN')}"
+                        f"{(' — ' + message) if message else ''}"
+                    )
+                if "data" not in payload:
+                    raise UniFiConnectionError(f"{operation} failed: Access API response is missing data")
+                return payload["data"]
+        except (UniFiAuthError, UniFiConnectionError):
+            raise
+        except (TimeoutError, aiohttp.ClientError, OSError) as exc:
+            raise UniFiConnectionError(f"{operation} failed: {exc}") from exc
+
+    # ------------------------------------------------------------------
     # Proxy request helpers
     # ------------------------------------------------------------------
 
@@ -425,6 +507,11 @@ class AccessConnectionManager:
     def api_client(self) -> Any | None:
         """Return the :class:`UnifiAccessApiClient` instance, or ``None``."""
         return self._api_client
+
+    @property
+    def has_api_key(self) -> bool:
+        """Return whether an Access Developer API token is configured."""
+        return bool(self._api_key)
 
     @property
     def has_api_client(self) -> bool:

--- a/packages/unifi-core/src/unifi_core/access/managers/visitor_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/visitor_manager.py
@@ -1,88 +1,215 @@
-"""Visitor management for UniFi Access.
+"""Visitor management through the official UniFi Access Developer API.
 
-Provides methods to query and manage visitor passes
-via the Access controller API.
-
-All methods use the proxy session path since visitor management is
-not exposed by the py-unifi-access API client.
-
-NOTE: Visitor endpoints were not directly visible in browser network
-traces (visitors may be part of the user system under ulp-go).  The
-paths below are best-effort guesses.  Each method includes graceful
-error handling that returns an empty result with a clear message when
-the endpoint returns 404.
+The visitor family is served at ``/api/v1/developer/visitors`` on the
+Access API port (default 12445) and requires Bearer-token authentication.
+Its UUIDs belong to this Developer API family and are not interchangeable
+with IDs from the legacy Access proxy/user surfaces.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from unifi_core.access.managers.connection_manager import AccessConnectionManager
-from unifi_core.exceptions import UniFiConnectionError, UniFiNotFoundError
+from unifi_core.exceptions import UniFiAuthError, UniFiConnectionError, UniFiNotFoundError
 
 logger = logging.getLogger(__name__)
 
+_VISITORS_PATH = "visitors"
+_PAGE_SIZE = 100
+_TOKEN_REMEDIATION = (
+    "Create a UniFi Access API token and set UNIFI_ACCESS_API_KEY (or UNIFI_API_KEY) for the Access MCP server."
+)
+
 
 class VisitorManager:
-    """Reads and mutates visitor data from the Access controller."""
+    """Reads and mutates the Access Developer API visitor family."""
 
     def __init__(self, connection_manager: AccessConnectionManager) -> None:
         self._cm = connection_manager
+
+    def _require_developer_api(self, operation: str) -> None:
+        """Fail before any proxy fallback when Developer API auth is unavailable."""
+        if not self._cm.has_api_key:
+            raise UniFiAuthError(f"{operation} requires a UniFi Access API token. {_TOKEN_REMEDIATION}")
+        if not self._cm.has_api_client:
+            raise UniFiAuthError(
+                f"{operation} requires an authenticated UniFi Access Developer API session. "
+                f"The configured token did not authenticate. {_TOKEN_REMEDIATION}"
+            )
+
+    async def _request(self, method: str, path: str, *, operation: str, **kwargs: Any) -> Any:
+        self._require_developer_api(operation)
+        return await self._cm.developer_request(method, path, operation=operation, **kwargs)
+
+    @staticmethod
+    def _is_not_found(exc: Exception) -> bool:
+        text = str(exc).upper()
+        return "HTTP 404" in text or "CODE_NOT_FOUND" in text
+
+    @staticmethod
+    def _resolve_names(name: str, first_name: str | None, last_name: str | None) -> tuple[str, str]:
+        display_name = name.strip()
+        if not display_name:
+            raise ValueError("name is required")
+        if (first_name is None) != (last_name is None):
+            raise ValueError("first_name and last_name must be provided together")
+        if first_name is not None and last_name is not None:
+            resolved_first = first_name.strip()
+            resolved_last = last_name.strip()
+            if not resolved_first or not resolved_last:
+                raise ValueError("first_name and last_name must not be empty")
+            return resolved_first, resolved_last
+
+        parts = display_name.split(maxsplit=1)
+        return parts[0], parts[1] if len(parts) == 2 else ""
+
+    @staticmethod
+    def _iso_to_epoch(value: str, field_name: str) -> int:
+        if not value:
+            raise ValueError(f"{field_name} is required")
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be a valid ISO 8601 timestamp") from exc
+        if parsed.tzinfo is None:
+            raise ValueError(f"{field_name} must include a timezone")
+        return int(parsed.astimezone(timezone.utc).timestamp())
+
+    @staticmethod
+    def _resolve_times(
+        access_start: str | None,
+        access_end: str | None,
+        valid_from: str | None,
+        valid_until: str | None,
+    ) -> tuple[str, str]:
+        if access_start and valid_from and access_start != valid_from:
+            raise ValueError("access_start and valid_from must match when both are provided")
+        if access_end and valid_until and access_end != valid_until:
+            raise ValueError("access_end and valid_until must match when both are provided")
+        resolved_start = valid_from or access_start
+        resolved_end = valid_until or access_end
+        if not resolved_start:
+            raise ValueError("valid_from (or access_start) is required")
+        if not resolved_end:
+            raise ValueError("valid_until (or access_end) is required")
+        return resolved_start, resolved_end
+
+    @classmethod
+    def _developer_create_payload(
+        cls,
+        name: str,
+        access_start: str | None = None,
+        access_end: str | None = None,
+        *,
+        valid_from: str | None = None,
+        valid_until: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        email: str | None = None,
+        phone: str | None = None,
+        company: str | None = None,
+        visit_reason: str | None = None,
+        remarks: str | None = None,
+    ) -> Dict[str, Any]:
+        resolved_first, resolved_last = cls._resolve_names(name, first_name, last_name)
+        resolved_start, resolved_end = cls._resolve_times(access_start, access_end, valid_from, valid_until)
+        start_time = cls._iso_to_epoch(resolved_start, "valid_from")
+        end_time = cls._iso_to_epoch(resolved_end, "valid_until")
+        if end_time <= start_time:
+            raise ValueError("access_end must be after access_start")
+
+        payload: Dict[str, Any] = {
+            "first_name": resolved_first,
+            "last_name": resolved_last,
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+        for key, value in (
+            ("email", email),
+            ("mobile_phone", phone),
+            ("company", company),
+            ("visit_reason", visit_reason),
+            ("remarks", remarks),
+        ):
+            if value is not None:
+                payload[key] = value
+        return payload
+
+    @staticmethod
+    def _preview_data(
+        name: str,
+        access_start: str | None,
+        access_end: str | None,
+        **extra: Any,
+    ) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "name": name,
+            "access_start": access_start,
+            "access_end": access_end,
+        }
+        data.update({key: value for key, value in extra.items() if value is not None})
+        return data
+
+    @staticmethod
+    def _visitor_name(visitor: Dict[str, Any]) -> str | None:
+        if visitor.get("name"):
+            return str(visitor["name"])
+        parts = [str(visitor.get(key, "")).strip() for key in ("first_name", "last_name")]
+        return " ".join(part for part in parts if part) or None
 
     # ------------------------------------------------------------------
     # Read-only methods
     # ------------------------------------------------------------------
 
     async def list_visitors(self) -> List[Dict[str, Any]]:
-        """Return all visitors as summary dicts.
-
-        Returns an empty list with a warning if the endpoint is not available
-        (404), since the exact visitor API path has not been confirmed.
-        """
-        if not self._cm.has_proxy:
-            raise UniFiConnectionError("No proxy session available for list_visitors")
+        """Return every visitor, following Developer API pagination."""
+        visitors: List[Dict[str, Any]] = []
+        page_num = 1
         try:
-            data = await self._cm.proxy_request("GET", "visitors")
-            return self._cm.extract_data(data)
-        except UniFiConnectionError as e:
-            if "HTTP 404" in str(e):
-                logger.warning(
-                    "[visitors] Visitor endpoint returned 404 — endpoint path may not be correct. Returning empty list."
+            while True:
+                page = await self._request(
+                    "GET",
+                    _VISITORS_PATH,
+                    operation="List visitors",
+                    params={"page_num": page_num, "page_size": _PAGE_SIZE},
                 )
-                return []
+                if not isinstance(page, list):
+                    raise UniFiConnectionError("List visitors failed: unexpected Access API response shape")
+                visitors.extend(item for item in page if isinstance(item, dict))
+                if len(page) < _PAGE_SIZE:
+                    return visitors
+                page_num += 1
+        except (UniFiAuthError, UniFiConnectionError):
             raise
-        except Exception as e:
-            logger.error("Failed to list visitors: %s", e, exc_info=True)
+        except Exception as exc:
+            logger.error("Failed to list visitors: %s", exc, exc_info=True)
             raise
 
     async def get_visitor(self, visitor_id: str) -> Dict[str, Any]:
-        """Return detailed information for a single visitor.
-
-        Returns an error if the endpoint is not available (404).
-        """
+        """Return one Developer API visitor by its family-scoped UUID."""
         if not visitor_id:
             raise ValueError("visitor_id is required")
-        if not self._cm.has_proxy:
-            raise UniFiConnectionError("No proxy session available for get_visitor")
         try:
-            data = await self._cm.proxy_request("GET", f"visitors/{visitor_id}")
-            return self._cm.extract_data(data)
-        except UniFiConnectionError as e:
-            if "HTTP 404" in str(e):
-                logger.warning(
-                    "[visitors] Visitor endpoint returned 404 for %s — endpoint path may not be correct.",
-                    visitor_id,
-                )
-                raise UniFiNotFoundError(
-                    "visitor",
-                    visitor_id,
-                    f"Visitor not found or endpoint not available: {visitor_id}. "
-                    "The visitor API path has not been confirmed via browser inspection.",
-                ) from e
+            visitor = await self._request(
+                "GET",
+                f"{_VISITORS_PATH}/{visitor_id}",
+                operation="Get visitor",
+            )
+            if not isinstance(visitor, dict):
+                raise UniFiConnectionError("Get visitor failed: unexpected Access API response shape")
+            return visitor
+        except UniFiConnectionError as exc:
+            if self._is_not_found(exc):
+                raise UniFiNotFoundError("visitor", visitor_id) from exc
             raise
-        except Exception as e:
-            logger.error("Failed to get visitor %s: %s", visitor_id, e, exc_info=True)
+        except (UniFiAuthError, UniFiNotFoundError, ValueError):
+            raise
+        except Exception as exc:
+            logger.error("Failed to get visitor %s: %s", visitor_id, exc, exc_info=True)
             raise
 
     # ------------------------------------------------------------------
@@ -92,99 +219,70 @@ class VisitorManager:
     async def create_visitor(
         self,
         name: str,
-        access_start: str,
-        access_end: str,
+        access_start: str | None = None,
+        access_end: str | None = None,
         **extra: Any,
     ) -> Dict[str, Any]:
-        """Preview a visitor creation. Returns preview data for confirmation.
-
-        Parameters
-        ----------
-        name:
-            Visitor display name.
-        access_start:
-            ISO 8601 start time for the visitor pass.
-        access_end:
-            ISO 8601 end time for the visitor pass.
-        **extra:
-            Additional fields (e.g., email, phone, doors).
-        """
-        if not name:
-            raise ValueError("name is required")
-        if not access_start or not access_end:
-            raise ValueError("access_start and access_end are required")
-
-        visitor_data = {
-            "name": name,
-            "access_start": access_start,
-            "access_end": access_end,
-            **extra,
-        }
+        """Validate and preview a Developer API visitor creation."""
+        self._developer_create_payload(name, access_start, access_end, **extra)
+        visitor_data = self._preview_data(name, access_start, access_end, **extra)
         return {
             "visitor_data": visitor_data,
-            "proposed_changes": {
-                "action": "create",
-                **visitor_data,
-            },
+            "proposed_changes": {"action": "create", **visitor_data},
         }
 
     async def apply_create_visitor(
         self,
         name: str,
-        access_start: str,
-        access_end: str,
+        access_start: str | None = None,
+        access_end: str | None = None,
         **extra: Any,
     ) -> Dict[str, Any]:
-        """Execute the visitor creation on the controller."""
-        if not self._cm.has_proxy:
-            raise UniFiConnectionError("No proxy session available for create_visitor")
+        """Create a visitor through the Access Developer API."""
+        payload = self._developer_create_payload(name, access_start, access_end, **extra)
         try:
-            payload = {
-                "name": name,
-                "access_start": access_start,
-                "access_end": access_end,
-                **extra,
-            }
-            result = await self._cm.proxy_request("POST", "visitors", json=payload)
-            return {
-                "action": "create",
-                "result": "success",
-                "data": self._cm.extract_data(result),
-            }
-        except UniFiConnectionError:
+            created = await self._request(
+                "POST",
+                _VISITORS_PATH,
+                operation="Create visitor",
+                json=payload,
+            )
+            return {"action": "create", "result": "success", "data": created}
+        except (UniFiAuthError, UniFiConnectionError, ValueError):
             raise
-        except Exception as e:
-            logger.error("Failed to create visitor: %s", e, exc_info=True)
+        except Exception as exc:
+            logger.error("Failed to create visitor: %s", exc, exc_info=True)
             raise
 
     async def delete_visitor(self, visitor_id: str) -> Dict[str, Any]:
-        """Preview a visitor deletion. Returns preview data for confirmation."""
+        """Fetch current state and preview a Developer API visitor deletion."""
         if not visitor_id:
             raise ValueError("visitor_id is required")
-
         current = await self.get_visitor(visitor_id)
         return {
             "visitor_id": visitor_id,
-            "visitor_name": current.get("name"),
+            "visitor_name": self._visitor_name(current),
             "current_state": current,
-            "proposed_changes": {
-                "action": "delete",
-            },
+            "proposed_changes": {"action": "delete"},
         }
 
     async def apply_delete_visitor(self, visitor_id: str) -> Dict[str, Any]:
-        """Execute the visitor deletion on the controller."""
-        if not self._cm.has_proxy:
-            raise UniFiConnectionError("No proxy session available for delete_visitor")
+        """Revoke a visitor through Developer API DELETE, leaving cancelled history."""
+        if not visitor_id:
+            raise ValueError("visitor_id is required")
         try:
-            await self._cm.proxy_request("DELETE", f"visitors/{visitor_id}")
-            return {
-                "visitor_id": visitor_id,
-                "action": "delete",
-                "result": "success",
-            }
-        except UniFiConnectionError:
+            await self._request(
+                "DELETE",
+                f"{_VISITORS_PATH}/{visitor_id}",
+                operation="Delete visitor",
+            )
+            return {"visitor_id": visitor_id, "action": "delete", "result": "success"}
+        except UniFiConnectionError as exc:
+            if self._is_not_found(exc):
+                raise UniFiNotFoundError("visitor", visitor_id) from exc
             raise
-        except Exception as e:
-            logger.error("Failed to delete visitor %s: %s", visitor_id, e, exc_info=True)
+        except (UniFiAuthError, UniFiNotFoundError, ValueError):
+            raise
+        except Exception as exc:
+            logger.error("Failed to delete visitor %s: %s", visitor_id, exc, exc_info=True)
             raise

--- a/packages/unifi-core/src/unifi_core/access/models/visitors.py
+++ b/packages/unifi-core/src/unifi_core/access/models/visitors.py
@@ -1,53 +1,45 @@
-"""Shared field model for Access visitors (read + create).
+"""Shared field model for the Access Developer API visitor family.
 
-Mirrors the Strawberry type in
-``unifi_api.graphql.types.access.visitors``.
-
-- ``Visitor`` — access_list_visitors + access_get_visitor +
-  access_create_visitor (mutable fields only)
-
-Factory helpers:
-- ``from_controller``      — normalise the raw manager dict → Visitor
-- ``to_controller_create`` — translate a Visitor → manager create payload
-
-``MUTABLE_FIELDS`` drives the cross-layer symmetry test: the Strawberry
-type must expose every field listed here.
-
-Naming note: the canonical model uses ``valid_from`` / ``valid_until``
-(read-shape names). The MCP tool accepts ``access_start`` / ``access_end``
-from callers and builds the model with ``valid_from=access_start``,
-``valid_until=access_end``. ``to_controller_create`` translates back to
-``access_start`` / ``access_end`` for the manager's expected signature.
+The controller uses separate ``first_name`` / ``last_name`` fields and epoch
+seconds for ``start_time`` / ``end_time``. MCP and API callers retain the
+stable ``name`` plus ISO-8601 ``valid_from`` / ``valid_until`` dialect; the
+helpers below translate at the boundary.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
-# ---------------------------------------------------------------------------
-# Pydantic domain model
-# ---------------------------------------------------------------------------
+_STATUS_NAMES = {
+    1: "upcoming",
+    2: "visited",
+    3: "visiting",
+    4: "cancelled",
+    5: "no_visit",
+    6: "active",
+}
 
 
 class Visitor(BaseModel):
-    """Canonical Access visitor model (read + mutable create fields)."""
+    """Canonical Access Developer API visitor model."""
 
     # --- read-only ---
     id: Optional[str] = Field(
         default=None,
-        description="Visitor UUID",
+        description="Access Developer API visitor UUID",
         json_schema_extra={"mutable": False},
     )
     host_user_id: Optional[str] = Field(
         default=None,
-        description="UUID of the host user who created the pass",
+        description="Legacy host-user UUID when supplied by the controller",
         json_schema_extra={"mutable": False},
     )
     status: Optional[str] = Field(
         default=None,
-        description="Visitor status (active, expired, etc.)",
+        description="Normalized visitor status",
         json_schema_extra={"mutable": False},
     )
     credential_count: Optional[int] = Field(
@@ -55,33 +47,30 @@ class Visitor(BaseModel):
         description="Number of credentials associated with this visitor",
         json_schema_extra={"mutable": False},
     )
+    access_policy_ids: Optional[list[str]] = Field(
+        default=None,
+        description="Developer API access-policy UUIDs currently assigned to the visitor",
+        json_schema_extra={"mutable": False},
+    )
 
     # --- mutable (accepted by create) ---
-    name: Optional[str] = Field(
+    name: Optional[str] = Field(default=None, description="Visitor display name")
+    first_name: Optional[str] = Field(
         default=None,
-        description="Visitor display name",
+        description="Explicit Developer API first name; provide with last_name to override name splitting",
     )
-    valid_from: Optional[str] = Field(
+    last_name: Optional[str] = Field(
         default=None,
-        description="Start of access period (ISO 8601)",
+        description="Explicit Developer API last name; provide with first_name to override name splitting",
     )
-    valid_until: Optional[str] = Field(
-        default=None,
-        description="End of access period (ISO 8601)",
-    )
-    email: Optional[str] = Field(
-        default=None,
-        description="Visitor email address for notifications",
-    )
-    phone: Optional[str] = Field(
-        default=None,
-        description="Visitor phone number",
-    )
+    valid_from: Optional[str] = Field(default=None, description="Start of access period (ISO 8601 with timezone)")
+    valid_until: Optional[str] = Field(default=None, description="End of access period (ISO 8601 with timezone)")
+    email: Optional[str] = Field(default=None, description="Visitor email address for notifications")
+    phone: Optional[str] = Field(default=None, description="Visitor mobile phone number")
+    company: Optional[str] = Field(default=None, description="Visitor company")
+    visit_reason: Optional[str] = Field(default=None, description="Reason for the visit")
+    remarks: Optional[str] = Field(default=None, description="Operator notes about the visit")
 
-
-# ---------------------------------------------------------------------------
-# Field sets
-# ---------------------------------------------------------------------------
 
 MUTABLE_FIELDS: frozenset[str] = frozenset(
     name for name, field in Visitor.model_fields.items() if (field.json_schema_extra or {}).get("mutable", True)
@@ -94,58 +83,93 @@ READ_ONLY_FIELDS: frozenset[str] = frozenset(
 )
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
 def _get(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
 
 
-# ---------------------------------------------------------------------------
-# Public factory helpers
-# ---------------------------------------------------------------------------
+def _epoch_to_iso(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        try:
+            value = int(value)
+        except ValueError:
+            return value
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _status_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return _STATUS_NAMES.get(value, str(value))
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError):
+        return str(value).lower()
+    return _STATUS_NAMES.get(numeric, str(value))
+
+
+def _credential_count(raw: Any) -> int | None:
+    existing = _get(raw, "credential_count")
+    if existing is not None:
+        return int(existing)
+
+    count = 0
+    present = False
+    for key in ("nfc_cards", "license_plates"):
+        values = _get(raw, key)
+        if isinstance(values, list):
+            count += len(values)
+            present = True
+    for key in ("pin_code", "qr_code"):
+        value = _get(raw, key)
+        if value:
+            count += 1
+            present = True
+    return count if present else None
 
 
 def from_controller(raw: Any) -> Visitor:
-    """Build a Visitor from a manager dict or object.
+    """Normalize a Developer API visitor dict or compatible legacy object."""
+    first_name = _get(raw, "first_name")
+    last_name = _get(raw, "last_name")
+    name = _get(raw, "name")
+    if not name:
+        name = " ".join(str(part).strip() for part in (first_name, last_name) if part and str(part).strip()) or None
 
-    Coalesces:
-    - ``valid_from`` / ``access_start`` → ``valid_from``
-    - ``valid_until`` / ``access_end``  → ``valid_until``
-    """
-    valid_from = _get(raw, "valid_from") or _get(raw, "access_start")
-    valid_until = _get(raw, "valid_until") or _get(raw, "access_end")
     return Visitor(
         id=_get(raw, "id"),
         host_user_id=_get(raw, "host_user_id"),
-        status=_get(raw, "status"),
-        credential_count=_get(raw, "credential_count"),
-        name=_get(raw, "name"),
-        valid_from=valid_from,
-        valid_until=valid_until,
+        status=_status_name(_get(raw, "status")),
+        credential_count=_credential_count(raw),
+        access_policy_ids=_get(raw, "access_policy_ids"),
+        name=name,
+        first_name=first_name,
+        last_name=last_name,
+        valid_from=_epoch_to_iso(_get(raw, "valid_from") or _get(raw, "access_start") or _get(raw, "start_time")),
+        valid_until=_epoch_to_iso(_get(raw, "valid_until") or _get(raw, "access_end") or _get(raw, "end_time")),
         email=_get(raw, "email"),
-        phone=_get(raw, "phone"),
+        phone=_get(raw, "phone") or _get(raw, "mobile_phone"),
+        company=_get(raw, "company"),
+        visit_reason=_get(raw, "visit_reason"),
+        remarks=_get(raw, "remarks"),
     )
 
 
 def to_controller_create(model: Visitor) -> Dict[str, Any]:
-    """Produce the payload for ``apply_create_visitor(name, access_start, access_end, **extra)``.
-
-    Translates ``valid_from`` → ``access_start`` and
-    ``valid_until`` → ``access_end`` to match the manager's expected
-    signature. ``email`` and ``phone`` are included only when not None.
-    """
+    """Produce the tool-facing arguments accepted by ``VisitorManager``."""
     payload: Dict[str, Any] = {
         "name": model.name,
         "access_start": model.valid_from,
         "access_end": model.valid_until,
     }
-    if model.email is not None:
-        payload["email"] = model.email
-    if model.phone is not None:
-        payload["phone"] = model.phone
+    for key in ("first_name", "last_name", "email", "phone", "company", "visit_reason", "remarks"):
+        value = getattr(model, key)
+        if value is not None:
+            payload[key] = value
     return payload

--- a/packages/unifi-core/tests/access/models/test_visitors.py
+++ b/packages/unifi-core/tests/access/models/test_visitors.py
@@ -13,15 +13,26 @@ from unifi_core.access.models.visitors import (
 
 class TestFieldSets:
     def test_mutable_fields_contains_expected(self) -> None:
-        for field in ("name", "valid_from", "valid_until", "email", "phone"):
+        for field in (
+            "name",
+            "first_name",
+            "last_name",
+            "valid_from",
+            "valid_until",
+            "email",
+            "phone",
+            "company",
+            "visit_reason",
+            "remarks",
+        ):
             assert field in MUTABLE_FIELDS, f"Expected {field!r} in MUTABLE_FIELDS"
 
     def test_mutable_fields_excludes_read_only(self) -> None:
-        for field in ("id", "host_user_id", "status", "credential_count"):
+        for field in ("id", "host_user_id", "status", "credential_count", "access_policy_ids"):
             assert field not in MUTABLE_FIELDS, f"{field!r} should NOT be in MUTABLE_FIELDS"
 
     def test_read_only_fields_contains_expected(self) -> None:
-        for field in ("id", "host_user_id", "status", "credential_count"):
+        for field in ("id", "host_user_id", "status", "credential_count", "access_policy_ids"):
             assert field in READ_ONLY_FIELDS, f"Expected {field!r} in READ_ONLY_FIELDS"
 
     def test_read_only_fields_excludes_mutable(self) -> None:
@@ -60,6 +71,40 @@ class TestFromController:
         assert v.credential_count == 2
         assert v.email == "jane@example.com"
         assert v.phone == "+15551234567"
+
+    def test_normalizes_developer_api_shape(self) -> None:
+        raw = {
+            "id": "dev-vis-1",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "start_time": 1773738000,
+            "end_time": 1773766800,
+            "status": 6,
+            "mobile_phone": "+15551234567",
+            "company": "Example Co",
+            "visit_reason": "Business",
+            "remarks": "Front desk",
+            "access_policy_ids": ["policy-uuid"],
+            "nfc_cards": [{"id": "nfc-1"}],
+            "pin_code": {"token": "secret"},
+            "qr_code": None,
+            "license_plates": [],
+        }
+
+        visitor = from_controller(raw)
+
+        assert visitor.name == "Jane Doe"
+        assert visitor.first_name == "Jane"
+        assert visitor.last_name == "Doe"
+        assert visitor.valid_from == "2026-03-17T09:00:00Z"
+        assert visitor.valid_until == "2026-03-17T17:00:00Z"
+        assert visitor.status == "active"
+        assert visitor.phone == "+15551234567"
+        assert visitor.company == "Example Co"
+        assert visitor.visit_reason == "Business"
+        assert visitor.remarks == "Front desk"
+        assert visitor.access_policy_ids == ["policy-uuid"]
+        assert visitor.credential_count == 2
 
     def test_coalesces_access_start_to_valid_from(self) -> None:
         raw = {"id": "vis-2", "access_start": "2026-04-01T08:00:00Z"}
@@ -118,15 +163,25 @@ class TestToControllerCreate:
             valid_from="2026-03-17T09:00:00Z",
             valid_until="2026-03-17T17:00:00Z",
             email="jane@example.com",
+            first_name="Jane",
+            last_name="Doe",
             phone="+15551234567",
+            company="Example Co",
+            visit_reason="Business",
+            remarks="Disposable",
         )
         payload = to_controller_create(model)
         assert payload == {
             "name": "Jane Doe",
             "access_start": "2026-03-17T09:00:00Z",
             "access_end": "2026-03-17T17:00:00Z",
+            "first_name": "Jane",
+            "last_name": "Doe",
             "email": "jane@example.com",
             "phone": "+15551234567",
+            "company": "Example Co",
+            "visit_reason": "Business",
+            "remarks": "Disposable",
         }
 
     def test_minimal_payload_excludes_email_and_phone(self) -> None:

--- a/plugins/unifi-access/skills/unifi-access/SKILL.md
+++ b/plugins/unifi-access/skills/unifi-access/SKILL.md
@@ -54,16 +54,16 @@ All tools return: `{"success": true, "data": ...}`, `{"success": false, "error":
 - **Historical events:** `access_list_events` with time/door/user filters. Topics: `admin` or `admin_activity`
 - **Activity summary:** `access_get_activity_summary` aggregates events over a time period — useful for security audits
 - **Credentials:** Create NFC (`{user_id, token}`), PIN (`{user_id, pin_code}`), or mobile (`{user_id}`) credentials
-- **Visitor passes:** Time-bounded with ISO 8601 start/end times, optional email/phone for notifications
+- **Visitor passes:** Developer API family with scoped UUIDs, ISO 8601 `valid_from`/`valid_until`, and optional contact/company metadata
 
 ## Dual Authentication
 
 Access has two independent auth paths:
 
-- **API key (port 12445)** — for read-only operations (listing doors, events, devices)
-- **Username + password (port 443)** — required for mutations (lock/unlock, credentials, visitors)
+- **API key (port 12445)** — official Developer API operations, including visitor list/get/create/delete
+- **Username + password (port 443)** — proxy-backed operations such as credentials and policies
 
-Either can work independently. For full functionality, configure both. If mutations fail with auth errors, the user needs username+password (API key alone is not enough for write operations).
+Either can work independently for its supported tools. For full functionality, configure both. Visitor auth failures require checking `UNIFI_ACCESS_API_KEY`; proxy-backed mutation failures require checking the local username/password.
 
 To configure, run `/unifi-access:unifi-access-setup` or set env vars manually:
 ```

--- a/plugins/unifi-access/skills/unifi-access/references/access-tools.md
+++ b/plugins/unifi-access/skills/unifi-access/references/access-tools.md
@@ -110,17 +110,19 @@ Always available, regardless of registration mode.
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `access_get_visitor` | Read | Returns detailed information for a single visitor pass including name, access time range, assigned doors, and status. |
-| `access_list_visitors` | Read | Lists all visitor passes with their name, status, valid time range, and assigned doors. |
-| `access_create_visitor` | Mutate | Create a new visitor pass with a name and access time range. |
-| `access_delete_visitor` | Mutate | Delete a visitor pass. |
+| `access_get_visitor` | Read | Return one visitor pass from the UniFi Access Developer API. |
+| `access_list_visitors` | Read | List visitor passes from the UniFi Access Developer API. |
+| `access_create_visitor` | Mutate | Create a visitor pass in the UniFi Access Developer API. |
+| `access_delete_visitor` | Mutate | Delete a visitor pass through the UniFi Access Developer API, revoking its access; the controller retains a cancelled historical record. |
 <!-- /AUTO:tools:visitors -->
 
 **Tips:**
-- Visitor passes are time-bounded — they automatically expire at `access_end`
-- Times use ISO 8601 format: `2026-03-17T09:00:00Z`
-- Include contact info (email/phone) for notification support
-- Both create and delete require the proxy session auth path
+- Visitor passes are time-bounded — they automatically expire at `valid_until` (`access_end` remains a compatibility alias)
+- Times use ISO 8601 with a timezone: `2026-03-17T09:00:00Z`
+- Include contact/company metadata when useful
+- All four visitor tools require `UNIFI_ACCESS_API_KEY` on port 12445
+- Developer API DELETE revokes access but retains the pass as cancelled history
+- Visitor UUIDs are scoped to this Developer API family; do not pass them to Access user or credential tools
 
 **Permission env vars:**
 - `UNIFI_POLICY_ACCESS_VISITORS_CREATE=true`
@@ -232,7 +234,7 @@ If mutations fail with auth errors, the user likely needs to set `UNIFI_ACCESS_U
 3. `access_unlock_door(door_id="...", duration=5)` → preview, then confirm
 
 ### "Create a visitor pass for tomorrow"
-1. `access_create_visitor(name="Jane Smith", access_start="2026-03-18T09:00:00Z", access_end="2026-03-18T17:00:00Z", email="jane@example.com")` → preview
+1. `access_create_visitor(name="Jane Smith", valid_from="2026-03-18T09:00:00Z", valid_until="2026-03-18T17:00:00Z", email="jane@example.com")` → preview
 2. Confirm after review
 
 ### "Issue a new PIN credential"

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -94,12 +94,6 @@ KNOWN_CONTROLLER_ISSUE_READS = {
 
 KNOWN_CONTROLLER_ISSUE_MARKERS = {
     "access_get_activity_summary": ("CODE_SYSTEM_ERROR", r"API code -3\b"),
-    "access_create_visitor": (
-        "HTTP 404",
-        "CODE_NOT_FOUND",
-        r"/proxy/access/api/v2/visitors\b",
-        "you entered no-man zone",
-    ),
     "unifi_create_firewall_policy": (
         "FirewallPolicyCreateRespondTrafficPolicyNotAllowed",
         "Firewall policy create respond traffic not allowed",
@@ -905,12 +899,12 @@ class LiveSmokeRunner:
         return self.args_for_tool(name, required_params(next(t for t in self.manifest["tools"] if t["name"] == name)))
 
     def visitor_args(self, stamp: str) -> dict[str, Any]:
-        start = datetime.now(UTC) + timedelta(minutes=5)
+        start = (datetime.now(UTC) + timedelta(minutes=5)).replace(microsecond=0)
         end = start + timedelta(minutes=30)
         return {
             "name": f"{RUN_PREFIX}-{stamp}",
-            "access_start": start.isoformat().replace("+00:00", "Z"),
-            "access_end": end.isoformat().replace("+00:00", "Z"),
+            "valid_from": start.isoformat().replace("+00:00", "Z"),
+            "valid_until": end.isoformat().replace("+00:00", "Z"),
         }
 
     def protect_camera_id(self, prefer_ptz: bool = False) -> str | None:
@@ -1752,6 +1746,37 @@ class LiveSmokeRunner:
             self.skip("access_delete_visitor", "lifecycle", "visitor create did not return an id")
             return
         self.report.created_resources.append({"type": "visitor", "id": visitor_id, "name": args["name"]})
+        await self.call("access_list_visitors", {}, "lifecycle:list")
+        listed = any(
+            str(visitor.get("id")) == visitor_id
+            for visitor in self.cache.items_from_tool("access_list_visitors", "visitors")
+        )
+        self.record_check(
+            "access_list_visitors",
+            "lifecycle:verify-list",
+            listed,
+            "disposable visitor is visible in the Developer API family",
+        )
+        detail_call = await self.call(
+            "access_get_visitor",
+            {"visitor_id": visitor_id},
+            "lifecycle:get",
+        )
+        detail_payload = self.cache.by_tool.get("access_get_visitor", {})
+        detail = detail_payload.get("data", {}) if isinstance(detail_payload, dict) else {}
+        fields_match = (
+            detail_call.success is True
+            and detail.get("id") == visitor_id
+            and detail.get("name") == args["name"]
+            and detail.get("valid_from") == args["valid_from"]
+            and detail.get("valid_until") == args["valid_until"]
+        )
+        self.record_check(
+            "access_get_visitor",
+            "lifecycle:verify-fields",
+            fields_match,
+            "name and ISO-8601 validity fields round-trip through the Developer API",
+        )
         preview = await self.call(
             "access_delete_visitor",
             {"visitor_id": visitor_id, "confirm": False},
@@ -1772,7 +1797,20 @@ class LiveSmokeRunner:
             "lifecycle:delete",
         )
         if delete.success:
-            self.report.cleaned_resources.append({"type": "visitor", "id": visitor_id, "name": args["name"]})
+            after = await self.call(
+                "access_get_visitor",
+                {"visitor_id": visitor_id},
+                "lifecycle:verify-cleanup",
+            )
+            cancelled = after.success is True and after.summary.get("resource_status") == "cancelled"
+            self.record_check(
+                "access_delete_visitor",
+                "lifecycle:verify-cleanup-status",
+                cancelled,
+                "Developer API DELETE revokes access and retains the visitor as cancelled history",
+            )
+            if cancelled:
+                self.report.cleaned_resources.append({"type": "visitor", "id": visitor_id, "name": args["name"]})
 
 
 def summarize_payload(data: dict[str, Any]) -> dict[str, Any]:
@@ -1801,6 +1839,9 @@ def summarize_payload(data: dict[str, Any]) -> dict[str, Any]:
     resource_id = find_resource_id(data)
     if resource_id:
         summary["resource_id"] = resource_id
+    resource_status = find_resource_status(data)
+    if resource_status:
+        summary["resource_status"] = resource_status
     for collection, items in collection_items(data).items():
         summary[f"{collection}_count"] = len(items)
     preview = data.get("preview")
@@ -1811,6 +1852,19 @@ def summarize_payload(data: dict[str, Any]) -> dict[str, Any]:
     if "_meta" in data:
         summary["_meta"] = data["_meta"]
     return summary
+
+
+def find_resource_status(data: Any) -> str | None:
+    """Find a bounded scalar resource status in a nested tool response."""
+    if isinstance(data, dict):
+        status = data.get("status")
+        if isinstance(status, (str, int)):
+            return str(status).lower()
+        for key in ("details", "data", "result"):
+            value = find_resource_status(data.get(key))
+            if value:
+                return value
+    return None
 
 
 def find_resource_id(data: Any) -> str | None:
@@ -1886,6 +1940,7 @@ API_ACTIONS_SAMPLE: list[tuple[str, str, dict[str, Any]]] = [
     ("protect", "protect_list_lights", {}),
     ("access", "access_list_doors", {}),
     ("access", "access_list_users", {}),
+    ("access", "access_list_visitors", {}),
 ]
 
 
@@ -2315,7 +2370,7 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
 # Manual-only phase. Same bootstrap as api-actions (spins up unifi-api-server locally,
 # registers .env-configured controllers), then exercises the GET resource
 # endpoints (clients, devices, networks, wlans, firewall rules, cameras,
-# recordings, events, doors, users, credentials). For each resource that has a
+# recordings, events, doors, users, credentials, visitors). For each resource that has a
 # tool equivalent, also calls the matching action endpoint and compares the
 # data payloads — the resource version wraps in {items, next_cursor,
 # render_hint} and the action version wraps in {success: true, data,
@@ -2346,6 +2401,14 @@ API_RESOURCES_SAMPLE: list[tuple[str, str, dict[str, Any], str | None, dict[str,
     ("protect", "/v1/sites/{site}/cameras", {"limit": 10}, "protect_list_cameras", {}, ("cameras", "items")),
     ("access", "/v1/sites/{site}/doors", {"limit": 10}, "access_list_doors", {}, ("doors", "items")),
     ("access", "/v1/sites/{site}/users", {"limit": 10}, "access_list_users", {}, ("users", "items")),
+    (
+        "access",
+        "/v1/sites/{site}/visitors",
+        {"limit": 10},
+        "access_list_visitors",
+        {},
+        ("visitors", "items"),
+    ),
 ]
 
 

--- a/tests/test_live_smoke_response_sizes.py
+++ b/tests/test_live_smoke_response_sizes.py
@@ -148,3 +148,22 @@ def test_summarize_payload_preserves_only_safe_bounded_response_metadata():
         "rogue_aps_count": 1,
     }
     assert "rogue_aps" not in summary
+
+
+def test_summarize_payload_extracts_nested_resource_status():
+    summary = summarize_payload(
+        {
+            "success": True,
+            "data": {
+                "id": "visitor-1",
+                "status": "cancelled",
+                "remarks": "not retained in the report",
+            },
+        }
+    )
+
+    assert summary == {
+        "success": True,
+        "resource_id": "visitor-1",
+        "resource_status": "cancelled",
+    }


### PR DESCRIPTION
## Summary

- Replace the explicitly guessed `/proxy/access/api/v2/visitors` implementation with the supported Access Developer API family on port 12445:
  - `GET/POST /api/v1/developer/visitors`
  - `GET/DELETE /api/v1/developer/visitors/{visitor_id}`
- Add an `AccessConnectionManager.developer_request` boundary using the Access-specific `Authorization: Bearer` contract, actionable token errors, and no proxy fallback.
- Move list/get/create/delete together so every visitor UUID stays inside one documented Developer-API family.
- Normalize Developer API fields through the shared visitor model:
  - `first_name` + `last_name` → stable `name`
  - epoch `start_time` / `end_time` → ISO-8601 `valid_from` / `valid_until`
  - integer status values → stable status names
  - `mobile_phone` → `phone`
  - optional company/reason/remarks metadata
  - derived credential count without exposing credential values
- Preserve `access_start` / `access_end` as compatibility aliases while adding canonical create parameters matching list output.
- Keep `access_policy_ids` read-only until a verified Developer-API policy source or explicit cross-family bridge exists.
- Change all four visitor tools from `local_only` to `api_key_only`, scope IDs in MCP/REST/GraphQL descriptions, and regenerate manifests/API artifacts/docs.
- Extend permanent smoke coverage across MCP lifecycle, API action, and REST resource paths.

Closes #488.

## Why

The old manager documented its visitor paths as best-effort guesses. Unit tests mocked those paths successfully, but live POST consistently returned 404 / `CODE_NOT_FOUND`, so visitor mutations had never completed against hardware.

A protocol-accurate probe also corrected the initial auth diagnosis: unlike Network's public Integration API, Access on port 12445 uses `Authorization: Bearer`. The configured token returns HTTP 200 / `SUCCESS` for visitors; `X-API-Key` returns 401.

## Compatibility and safety

- Existing `name`, `access_start`, `access_end`, `email`, and `phone` callers remain supported.
- Canonical `valid_from` / `valid_until` are now accepted so mutable list fields can round-trip into create.
- Callers may optionally supply explicit `first_name` + `last_name`; otherwise `name` is split for the controller payload.
- Naive timestamps, mismatched aliases, partial explicit names, and end-before-start ranges are rejected before mutation.
- Missing or failed Access API-key auth fails clearly and never falls back to the guessed proxy family.
- Visitor UUIDs are scoped in MCP tool, REST route, GraphQL field, and GraphQL type descriptions.
- Existing response redaction remains at the egress boundaries.

## DELETE semantics discovered live

Access Developer API `DELETE` is a soft cancellation: it revokes access but retains the visitor as historical `status=cancelled`. The tool and docs now state this explicitly. The permanent lifecycle only records cleanup after a post-delete GET verifies `cancelled`.

Three disposable validation records remain as cancelled history by controller design; **active smoke-marker orphans are zero**. No pre-existing visitor was changed.

## Tests

- `make pre-commit` — passed, including **951 API tests** and every repository gate
- Full Access suite — **206 passed**
- Full unifi-core suite — **1439 passed**
- Focused API + generated-artifact drift suite — **167 passed**
- Live-smoke harness tests — **17 passed**
- Ruff check/format — passed
- Manifest/reference drift — passed

## Live verification

Readonly ran before any mutation. The only Access readonly skip remained the unrelated controller-specific activity histogram `CODE_SYSTEM_ERROR`; visitor list succeeded in seed and readonly phases.

<details>
<summary>Protocol auth probe</summary>

```text
GET https://<access-host>:12445/api/v1/developer/visitors?page_num=1&page_size=1
Bearer:    HTTP 200, code='SUCCESS', msg='succ', data_kind='list'
X-API-Key: HTTP 401, code='CODE_UNAUTHORIZED'
```
</details>

<details>
<summary>Final disposable MCP lifecycle</summary>

```text
access lifecycle:create ok: access_create_visitor
access lifecycle:list ok: access_list_visitors
access lifecycle:verify-list ok: disposable visitor is visible in the Developer API family
access lifecycle:get ok: access_get_visitor
access lifecycle:verify-fields ok: name and ISO-8601 validity fields round-trip through the Developer API
access lifecycle:preview-delete ok: access_delete_visitor
access lifecycle:verify-preview ok: delete preview identifies the disposable visitor
access lifecycle:delete ok: access_delete_visitor
access lifecycle:verify-cleanup ok: access_get_visitor
access lifecycle:verify-cleanup-status ok: Developer API DELETE revokes access and retains the visitor as cancelled history
created=1 cleaned=1 failures=0
smoke_history_records=3 statuses={'cancelled': 3} active_orphans=0
```

The preview asserted `action=delete`, the exact disposable UUID, and `preview.will_delete` before confirmation.
</details>

<details>
<summary>Live API action and REST parity</summary>

```text
api-actions pass: access_list_visitors http=200 success=True live_count=2
api-resources pass: /v1/sites/default/visitors http=200 items=2 parity=ok (r=2 a=2)
```
</details>

## Generated artifacts

Updated and drift-checked:

- `apps/access/src/unifi_access_mcp/tools_manifest.json`
- Access plugin skill/reference
- GraphQL SDL and GraphQL reference
- OpenAPI JSON and OpenAPI reference

## Release sequencing

This PR adds new `unifi-core` behavior consumed by Access and API. Per the repository's PyPI floor-bump sequencing rule, after merge publish the next core patch first, then raise the Access/API `unifi-core` minimum floors in release preparation before tagging those downstream packages. Workspace overrides intentionally cannot validate published-wheel floor metadata.
