### PR TITLE
chore(release): require unifi-core 0.4.22

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.
-    "unifi-core[access]>=0.4.17,<0.5",
+    "unifi-core[access]>=0.4.22,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "pyyaml>=6.0",

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.21,<0.5",
+    "unifi-core[network,protect,access]>=0.4.22,<0.5",
     # services/manifest.py imports unifi_mcp_shared.meta_tools. unifi-core does not
     # depend on shared (import direction is app -> shared -> core), so this must be
     # declared directly or a PyPI install has no unifi_mcp_shared.

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.21,<0.5",
+    "unifi-core[network]>=0.4.22,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "pyyaml>=6.0",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "unifi-mcp-shared>=0.6.6,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.17,<0.5",
+    "unifi-core[protect]>=0.4.22,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "pyyaml>=6.0",

--- a/packages/unifi-mcp-shared/pyproject.toml
+++ b/packages/unifi-mcp-shared/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "Shared MCP server patterns: permissions, confirmation, lazy loading, config"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-core>=0.4.9,<0.5",
+    "unifi-core>=0.4.22,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "omegaconf>=2.3.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

- raise `unifi-mcp-shared`'s `unifi-core` floor to 0.4.22 for the public `delete_preview` re-export
- raise Network and Protect floors for their new direct `delete_preview` imports
- raise Access and API floors for the Access Developer API visitor manager/model/connection contract

## Release sequencing

`core/v0.4.22` has already published successfully to PyPI and passed an isolated install/import smoke test. This PR must merge before tagging shared or downstream applications so their wheel metadata cannot resolve an older core lacking the APIs merged in #487 and #490.

## Verification

- `make pre-commit` — passed, including 951 API tests
- `python3 scripts/check_pin_alignment.py` — all downstream wheels passed clean-PyPI install/import validation
- wheel METADATA inspection — all five changed packages declare `unifi-core>=0.4.22,<0.5`
- architecture import-direction greps — passed
