### PR TITLE
chore(release): require unifi-mcp-shared 0.6.7

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Access MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.6,<0.7",
+    "unifi-mcp-shared>=0.6.7,<0.7",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     # services/manifest.py imports unifi_mcp_shared.meta_tools. unifi-core does not
     # depend on shared (import direction is app -> shared -> core), so this must be
     # declared directly or a PyPI install has no unifi_mcp_shared.
-    "unifi-mcp-shared>=0.6.6,<0.7",
+    "unifi-mcp-shared>=0.6.7,<0.7",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -5,7 +5,7 @@ description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.6,<0.7",
+    "unifi-mcp-shared>=0.6.7,<0.7",
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Protect MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.6,<0.7",
+    "unifi-mcp-shared>=0.6.7,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly.
     "unifi-core[protect]>=0.4.22,<0.5",

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "python-dotenv>=1.2.2",
-    "unifi-mcp-shared>=0.6.6,<0.7",
+    "unifi-mcp-shared>=0.6.7,<0.7",
     # location_timeline.py imports unifi_core.event_timeline directly. This resolves
     # today only as a transitive of unifi-mcp-shared; declare it so it does not.
     "unifi-core>=0.4.21,<0.5",


### PR DESCRIPTION
## Summary

Raise the Network, Protect, Access, API, and Relay wheel floors to `unifi-mcp-shared>=0.6.7,<0.7` before their coordinated patch releases.

## Release sequencing

`shared/v0.6.7` is published on PyPI and has passed an isolated install/import smoke test together with `unifi-core==0.4.22`. This floor ensures downstream users receive the release containing the public standardized `delete_preview` contract.

## Verification

- `make pre-commit` — passed, including 951 API tests
- `python3 scripts/check_pin_alignment.py` — all downstream wheels passed clean-PyPI install/import validation
- wheel METADATA inspection — all five downstream packages declare `unifi-mcp-shared>=0.6.7,<0.7`; direct feature consumers also declare `unifi-core>=0.4.22,<0.5`
