### PR TITLE
feat(core): add shared action bridge contracts

### DIFF
--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -583,6 +583,8 @@ class DeviceManager:
         Raises:
             UniFiNotFoundError: If the device does not exist.
         """
+        if outlet_index < 1:
+            raise ValueError("outlet_index must be >= 1.")
         device = await self.get_device_details(device_mac)  # raises on miss
         if not self._is_pdu(device.raw):
             return None
@@ -599,6 +601,11 @@ class DeviceManager:
         if sensed is None:
             logger.error("Outlet index %s not found on PDU %s.", outlet_index, device_mac)
             return None
+        if sensed.get("has_relay") is False:
+            raise ValueError(
+                f"Outlet {outlet_index} ('{sensed.get('name')}') on PDU {device_mac} "
+                "does not have a controllable relay (has_relay=false)."
+            )
 
         overrides: List[Dict[str, Any]] = copy.deepcopy(device.raw.get("outlet_overrides", []))
 

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -39,6 +39,21 @@ class FirewallManager:
         self._connection = connection_manager
         self._auth = auth
 
+    async def get_firewall_policy_by_id(self, policy_id: str) -> FirewallPolicy:
+        """Return one V2 firewall policy from the complete policy inventory."""
+        policies = await self.get_firewall_policies(include_predefined=True)
+        match = next(
+            (
+                policy
+                for policy in policies
+                if isinstance(getattr(policy, "raw", None), dict) and policy.raw.get("_id") == policy_id
+            ),
+            None,
+        )
+        if match is None:
+            raise UniFiNotFoundError("firewall_policy", policy_id)
+        return match
+
     @staticmethod
     def _requested_firewall_policy_ids(ordered_firewall_policy_ids: Any) -> list[str]:
         if not isinstance(ordered_firewall_policy_ids, dict):

--- a/packages/unifi-core/src/unifi_core/network/managers/qos_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/qos_manager.py
@@ -84,6 +84,11 @@ class QosManager:
         self._connection._invalidate_cache(f"{CACHE_PREFIX_QOS}_{self._connection.site}")
         return merged_data
 
+    async def toggle_qos_rule_enabled(self, rule_id: str) -> Dict[str, Any]:
+        """Invert a QoS rule's enabled state using the shared fetch-merge-put path."""
+        existing_rule = await self.get_qos_rule_details(rule_id)
+        return await self.update_qos_rule(rule_id, {"enabled": not existing_rule.get("enabled", False)})
+
     async def create_qos_rule(self, rule_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Create a new QoS rule.
 

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -10,6 +10,7 @@ from aiounifi.models.dpi_restriction_group import (
 
 from unifi_core.network.managers.client_manager import ClientManager  # Needed for get_top_clients
 from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.device_manager import DeviceManager
 
 logger = logging.getLogger("unifi-network-mcp")
 
@@ -144,6 +145,22 @@ class StatsManager:
             logger.error("Error getting stats for client %s: %s", client_mac, e)
             raise
 
+    async def get_client_stats_for_identifier(
+        self,
+        client_id: str,
+        duration_hours: int = 1,
+        granularity: str = "hourly",
+    ) -> List[Dict[str, Any]]:
+        """Resolve a public MAC-or-id client identifier before fetching stats."""
+        client = await self._client_manager.get_client_details(client_id)
+        raw = client.raw if hasattr(client, "raw") else client
+        client_mac = raw.get("mac", client_id)
+        return await self.get_client_stats(
+            client_mac,
+            duration_hours=duration_hours,
+            granularity=granularity,
+        )
+
     async def get_device_stats(
         self,
         device_mac: str,
@@ -222,6 +239,25 @@ class StatsManager:
         except Exception as e:
             logger.error("Error getting stats for device %s: %s", device_mac, e)
             raise
+
+    async def get_device_stats_for_identifier(
+        self,
+        device_id: str,
+        duration_hours: int = 1,
+        granularity: str = "hourly",
+    ) -> List[Dict[str, Any]]:
+        """Resolve a public MAC-or-id device identifier and select its report family."""
+        device = await DeviceManager(self._connection).get_device_details(device_id)
+        raw = device.raw if hasattr(device, "raw") else device
+        device_mac = raw.get("mac", device_id)
+        device_type = raw.get("type", "unknown")
+        report_type = {"uap": "ap", "ugw": "gw", "udm": "gw"}.get(device_type, "dev")
+        return await self.get_device_stats(
+            device_mac,
+            duration_hours=duration_hours,
+            granularity=granularity,
+            device_type=report_type,
+        )
 
     async def get_top_clients(self, duration_hours: int = 24, limit: int = 10) -> List[Dict[str, Any]]:
         """Get top clients by usage.

--- a/packages/unifi-core/src/unifi_core/network/models/_actions.py
+++ b/packages/unifi-core/src/unifi_core/network/models/_actions.py
@@ -246,6 +246,20 @@ class SetSiteLedsInput(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class CreateVoucherInput(BaseModel):
+    """Input for ``unifi_create_voucher`` with shared defaults and bounds."""
+
+    __action_input__: ClassVar[bool] = True
+
+    expire_minutes: int = Field(default=1440, ge=1, description="Voucher validity after activation")
+    count: int = Field(default=1, ge=1, le=10000, description="Number of vouchers to create")
+    quota: int = Field(default=1, description="Usage quota per voucher")
+    note: Optional[str] = None
+    up_limit_kbps: Optional[int] = None
+    down_limit_kbps: Optional[int] = None
+    bytes_limit_mb: Optional[int] = None
+
+
 class RevokeVoucherInput(BaseModel):
     """Input for ``unifi_revoke_voucher``."""
 

--- a/packages/unifi-core/src/unifi_core/network/models/devices.py
+++ b/packages/unifi-core/src/unifi_core/network/models/devices.py
@@ -256,3 +256,36 @@ def radio_to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     ``None`` values are dropped; boolean ``False`` is preserved.
     """
     return {k: v for k, v in fields.items() if k in DEVICERADIO_MUTABLE_FIELDS and v is not None}
+
+
+VALID_RADIOS: frozenset[str] = frozenset({"na", "ng", "6e", "wifi6e"})
+VALID_TX_POWER_MODES: frozenset[str] = frozenset({"auto", "high", "medium", "low", "custom"})
+VALID_HT_VALUES: frozenset[str] = frozenset({"20", "40", "80", "160", "320"})
+
+
+def validate_radio_update(radio: str, fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate cross-field radio rules and return the controller update payload."""
+    if radio not in VALID_RADIOS and not radio.startswith("wifi"):
+        raise ValueError(
+            f"Invalid radio '{radio}'. Must be a band code ({', '.join(sorted(VALID_RADIOS))}) "
+            "or an internal radio name (e.g. 'wifi0', 'wifi1')."
+        )
+    tx_power_mode = fields.get("tx_power_mode")
+    if tx_power_mode is not None and tx_power_mode not in VALID_TX_POWER_MODES:
+        raise ValueError(
+            f"Invalid tx_power_mode '{tx_power_mode}'. Must be one of: {', '.join(sorted(VALID_TX_POWER_MODES))}"
+        )
+    if fields.get("tx_power") is not None and tx_power_mode != "custom":
+        raise ValueError("tx_power can only be set when tx_power_mode is 'custom'.")
+    ht = fields.get("ht")
+    if ht is not None and ht not in VALID_HT_VALUES:
+        raise ValueError(f"Invalid ht '{ht}'. Must be one of: {', '.join(sorted(VALID_HT_VALUES))}")
+    if fields.get("min_rssi") is not None and fields.get("min_rssi_enabled") is not True:
+        raise ValueError("min_rssi can only be set when min_rssi_enabled is true.")
+    if fields.get("sens_level") is not None and fields.get("sens_level_enabled") is not True:
+        raise ValueError("sens_level can only be set when sens_level_enabled is true.")
+
+    updates = radio_to_controller_update(fields)
+    if not updates:
+        raise ValueError("No radio settings provided to update.")
+    return updates

--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -137,6 +137,15 @@ READ_ONLY_FIELDS: frozenset[str] = frozenset(
     if (field.json_schema_extra or {}).get("mutable", True) is False
 )
 
+_LEGACY_V1_FIREWALL_FIELDS = frozenset({"ruleset", "rule_index", "src_address", "dst_address", "src_port", "dst_port"})
+_LEGACY_V1_ACTIONS = frozenset({"accept", "drop", "reject"})
+_LEGACY_MIGRATION_ERROR = (
+    "Legacy V1 firewall fields are no longer supported (#210). "
+    "Use V2 zone-based fields: action (ALLOW/BLOCK/REJECT), source "
+    "(zone_id + matching_target), destination (zone_id + matching_target). "
+    "See unifi_list_firewall_policies for examples of valid V2 shape."
+)
+
 
 # ---------------------------------------------------------------------------
 # FirewallGroup pydantic model
@@ -503,6 +512,51 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     ``None`` values are dropped; boolean ``False`` is preserved.
     """
     return {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
+
+
+def legacy_policy_error(fields: Dict[str, Any]) -> str | None:
+    """Return the actionable V1-to-V2 migration error when legacy input is detected."""
+    if _LEGACY_V1_FIREWALL_FIELDS & set(fields):
+        return _LEGACY_MIGRATION_ERROR
+    action = fields.get("action")
+    if isinstance(action, str) and action in _LEGACY_V1_ACTIONS:
+        return _LEGACY_MIGRATION_ERROR
+    return None
+
+
+def normalize_policy_enums(fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Upper-case the controller's V2 firewall enum values."""
+    normalized = dict(fields)
+    action = normalized.get("action")
+    if isinstance(action, str):
+        upper_action = action.upper()
+        if upper_action not in {"ALLOW", "BLOCK", "REJECT"}:
+            raise ValueError(f"Invalid action '{action}'.")
+        normalized["action"] = upper_action
+    for key in ("ip_version", "connection_state_type"):
+        if isinstance(normalized.get(key), str):
+            normalized[key] = normalized[key].upper()
+    states = normalized.get("connection_states")
+    if isinstance(states, list):
+        normalized["connection_states"] = [state.upper() if isinstance(state, str) else state for state in states]
+    return normalized
+
+
+def normalize_policy_update(fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and normalize a public V2 firewall-policy partial update.
+
+    This is the shared mutation boundary for MCP and API callers. It rejects
+    retired V1 fields, normalizes the controller's upper-case enums, and drops
+    unknown/read-only fields through :func:`to_controller_update`.
+    """
+    if error := legacy_policy_error(fields):
+        raise ValueError(error)
+    normalized = normalize_policy_enums(fields)
+
+    payload = to_controller_update(normalized)
+    if not payload:
+        raise ValueError("Update data is effectively empty or invalid.")
+    return payload
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/src/unifi_core/network/models/route.py
+++ b/packages/unifi-core/src/unifi_core/network/models/route.py
@@ -19,6 +19,7 @@ Per-class MUTABLE_FIELDS constants drive the cross-layer symmetry test.
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
@@ -113,6 +114,51 @@ def route_from_controller(raw: Any) -> Route:
         distance=_get(raw, "static-route_distance", "distance"),
         enabled=bool(_get(raw, "enabled", default=True)),
     )
+
+
+def validate_static_route_fields(fields: dict[str, Any], *, require_complete: bool) -> dict[str, Any]:
+    """Validate and normalize public static-route create/update fields."""
+    allowed = {"name", "network", "nexthop", "distance", "enabled"}
+    provided = {key: value for key, value in fields.items() if key in allowed and value is not None}
+    if require_complete:
+        missing = [key for key in ("name", "network", "nexthop") if key not in provided]
+        if missing:
+            raise ValueError(f"Missing required route fields: {', '.join(missing)}")
+        provided.setdefault("distance", 1)
+        provided.setdefault("enabled", True)
+    elif not provided:
+        raise ValueError("At least one field must be provided.")
+
+    if "name" in provided:
+        name = str(provided["name"]).strip()
+        if not name:
+            raise ValueError("Name is required.")
+        provided["name"] = name
+
+    network = provided.get("network")
+    if network is not None:
+        try:
+            parsed_network = ipaddress.ip_network(network, strict=False)
+        except ValueError as exc:
+            raise ValueError(f"Invalid network format: {network}. Use CIDR notation.") from exc
+        if parsed_network.version != 4 or "/" not in str(network):
+            raise ValueError(f"Invalid network format: {network}. Use IPv4 CIDR notation.")
+
+    nexthop = provided.get("nexthop")
+    if nexthop is not None:
+        try:
+            parsed_nexthop = ipaddress.ip_address(nexthop)
+        except ValueError as exc:
+            raise ValueError(f"Invalid nexthop IP: {nexthop}.") from exc
+        if parsed_nexthop.version != 4:
+            raise ValueError(f"Invalid nexthop IP: {nexthop}. Use a valid IPv4 address.")
+
+    distance = provided.get("distance")
+    if distance is not None and (
+        not isinstance(distance, int) or isinstance(distance, bool) or not 1 <= distance <= 255
+    ):
+        raise ValueError("Distance must be between 1 and 255.")
+    return provided
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
@@ -95,6 +95,8 @@ class AlarmRulesFacade:
 
     async def update_rule(self, rule_id: str, fields: dict[str, Any]) -> tuple[dict[str, Any], bool]:
         """Update a rule, routing by id family."""
+        if not fields:
+            raise ValueError("No fields provided. Specify at least one field to update.")
         family = self._id_family(rule_id)
         if "actions" in fields:
             self._require_non_empty_canonical_actions(fields)

--- a/packages/unifi-core/src/unifi_core/protect/managers/chime_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/chime_manager.py
@@ -340,6 +340,12 @@ class ChimeManager:
 
         Uses the Chime.play() API to trigger the sound.
         """
+        from unifi_core.protect.models._actions import TriggerChimeInput
+
+        validated = TriggerChimeInput(chime_id=chime_id, volume=volume, repeat_times=repeat_times)
+        chime_id = validated.chime_id
+        volume = validated.volume
+        repeat_times = validated.repeat_times
         chime = self._get_chime(chime_id)
 
         kwargs: Dict[str, Any] = {}

--- a/packages/unifi-core/tests/network/managers/test_catalog_bridge_methods.py
+++ b/packages/unifi-core/tests/network/managers/test_catalog_bridge_methods.py
@@ -1,0 +1,124 @@
+"""Focused tests for Core methods exposed by the generated API action catalog."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.network.managers.device_manager import DeviceManager
+from unifi_core.network.managers.firewall_manager import FirewallManager
+from unifi_core.network.managers.qos_manager import QosManager
+from unifi_core.network.managers.stats_manager import StatsManager
+
+
+@pytest.mark.asyncio
+async def test_get_firewall_policy_by_id_returns_matching_policy() -> None:
+    manager = FirewallManager(MagicMock())
+    wanted = MagicMock(raw={"_id": "policy-2"})
+    manager.get_firewall_policies = AsyncMock(return_value=[MagicMock(raw={"_id": "policy-1"}), wanted])
+
+    assert await manager.get_firewall_policy_by_id("policy-2") is wanted
+    manager.get_firewall_policies.assert_awaited_once_with(include_predefined=True)
+
+
+@pytest.mark.asyncio
+async def test_get_firewall_policy_by_id_raises_for_missing_policy() -> None:
+    manager = FirewallManager(MagicMock())
+    manager.get_firewall_policies = AsyncMock(return_value=[])
+
+    with pytest.raises(UniFiNotFoundError):
+        await manager.get_firewall_policy_by_id("missing")
+
+
+@pytest.mark.asyncio
+async def test_toggle_qos_rule_enabled_inverts_current_state_through_update_path() -> None:
+    manager = QosManager(MagicMock())
+    manager.get_qos_rule_details = AsyncMock(return_value={"_id": "qos-1", "enabled": False})
+    manager.update_qos_rule = AsyncMock(return_value={"_id": "qos-1", "enabled": True})
+
+    result = await manager.toggle_qos_rule_enabled("qos-1")
+
+    assert result == {"_id": "qos-1", "enabled": True}
+    manager.get_qos_rule_details.assert_awaited_once_with("qos-1")
+    manager.update_qos_rule.assert_awaited_once_with("qos-1", {"enabled": True})
+
+
+@pytest.mark.asyncio
+async def test_toggle_qos_rule_enabled_defaults_missing_state_to_enabled() -> None:
+    manager = QosManager(MagicMock())
+    manager.get_qos_rule_details = AsyncMock(return_value={"_id": "qos-1"})
+    manager.update_qos_rule = AsyncMock(return_value={"_id": "qos-1", "enabled": True})
+
+    await manager.toggle_qos_rule_enabled("qos-1")
+
+    manager.update_qos_rule.assert_awaited_once_with("qos-1", {"enabled": True})
+
+
+@pytest.mark.asyncio
+async def test_client_stats_bridge_resolves_controller_id_to_mac() -> None:
+    client_manager = MagicMock()
+    client_manager.get_client_details = AsyncMock(return_value=MagicMock(raw={"mac": "aa:bb:cc:dd:ee:ff"}))
+    manager = StatsManager(MagicMock(), client_manager)
+    manager.get_client_stats = AsyncMock(return_value=[{"rx_bytes": 1}])
+
+    result = await manager.get_client_stats_for_identifier("client-object-id", duration_hours=24)
+
+    assert result == [{"rx_bytes": 1}]
+    client_manager.get_client_details.assert_awaited_once_with("client-object-id")
+    manager.get_client_stats.assert_awaited_once_with("aa:bb:cc:dd:ee:ff", duration_hours=24, granularity="hourly")
+
+
+@pytest.mark.asyncio
+async def test_device_stats_bridge_resolves_identifier_and_report_family(monkeypatch) -> None:
+    device_manager = MagicMock()
+    device_manager.get_device_details = AsyncMock(
+        return_value=MagicMock(raw={"mac": "11:22:33:44:55:66", "type": "uap"})
+    )
+    monkeypatch.setattr(
+        "unifi_core.network.managers.stats_manager.DeviceManager",
+        MagicMock(return_value=device_manager),
+    )
+    manager = StatsManager(MagicMock(), MagicMock())
+    manager.get_device_stats = AsyncMock(return_value=[{"num_sta": 2}])
+
+    result = await manager.get_device_stats_for_identifier("device-object-id", duration_hours=168)
+
+    assert result == [{"num_sta": 2}]
+    device_manager.get_device_details.assert_awaited_once_with("device-object-id")
+    manager.get_device_stats.assert_awaited_once_with(
+        "11:22:33:44:55:66",
+        duration_hours=168,
+        granularity="hourly",
+        device_type="ap",
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_outlet_state_rejects_non_relay_before_controller_write() -> None:
+    connection = MagicMock()
+    connection.request = AsyncMock()
+    manager = DeviceManager(connection)
+    manager.get_device_details = AsyncMock(
+        return_value=MagicMock(
+            raw={
+                "_id": "pdu-1",
+                "type": "usp",
+                "outlet_table": [{"index": 1, "name": "USB", "has_relay": False}],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="does not have a controllable relay"):
+        await manager.set_outlet_state("aa:bb:cc:dd:ee:ff", 1, False)
+
+    connection.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_outlet_state_rejects_nonpositive_index_before_lookup() -> None:
+    manager = DeviceManager(MagicMock())
+    manager.get_device_details = AsyncMock()
+
+    with pytest.raises(ValueError, match="outlet_index must be >= 1"):
+        await manager.set_outlet_state("aa:bb:cc:dd:ee:ff", 0, True)
+
+    manager.get_device_details.assert_not_awaited()

--- a/packages/unifi-core/tests/network/models/test_actions.py
+++ b/packages/unifi-core/tests/network/models/test_actions.py
@@ -8,6 +8,7 @@ from unifi_core.network.models._actions import (
     BlockClientInput,
     ConfigurePortAggregationInput,
     ConfigurePortMirrorInput,
+    CreateVoucherInput,
     ForceProvisionDeviceInput,
     ForceReconnectClientInput,
     ForgetClientInput,
@@ -515,6 +516,32 @@ class TestSetSiteLedsInput:
     def test_valid_disable(self):
         m = SetSiteLedsInput(enabled=False)
         assert m.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# CreateVoucherInput
+# ---------------------------------------------------------------------------
+
+
+class TestCreateVoucherInput:
+    def test_defaults_match_public_action_contract(self):
+        model = CreateVoucherInput()
+
+        assert model.expire_minutes == 1440
+        assert model.count == 1
+        assert model.quota == 1
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            {"expire_minutes": 0},
+            {"count": 0},
+            {"count": 10001},
+        ],
+    )
+    def test_rejects_values_outside_controller_safe_bounds(self, fields):
+        with pytest.raises(ValidationError):
+            CreateVoucherInput(**fields)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/tests/network/models/test_devices.py
+++ b/packages/unifi-core/tests/network/models/test_devices.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from unifi_core.network.models.devices import (
     DEVICE_MUTABLE_FIELDS,
     DEVICE_READ_ONLY_FIELDS,
@@ -13,6 +14,7 @@ from unifi_core.network.models.devices import (
     radio_from_controller,
     radio_to_controller_update,
     to_controller_update,
+    validate_radio_update,
 )
 
 
@@ -183,3 +185,29 @@ class TestRadioToControllerUpdate:
         # since False is not None, it should be kept
         assert "min_rssi_enabled" in result
         assert result["min_rssi_enabled"] is False
+
+
+class TestValidateRadioUpdate:
+    def test_accepts_controller_safe_cross_field_values(self) -> None:
+        result = validate_radio_update(
+            "na",
+            {"tx_power_mode": "custom", "tx_power": 20, "channel": 36, "ht": "80"},
+        )
+
+        assert result == {"tx_power_mode": "custom", "tx_power": 20, "channel": 36, "ht": "80"}
+
+    @pytest.mark.parametrize(
+        ("radio", "fields", "message"),
+        [
+            ("invalid", {"channel": 36}, "Invalid radio"),
+            ("na", {"tx_power_mode": "invalid"}, "Invalid tx_power_mode"),
+            ("na", {"tx_power_mode": "auto", "tx_power": 20}, "tx_power can only"),
+            ("na", {"ht": "10"}, "Invalid ht"),
+            ("na", {"min_rssi": -70}, "min_rssi can only"),
+            ("na", {"sens_level": -70}, "sens_level can only"),
+            ("na", {}, "No radio settings"),
+        ],
+    )
+    def test_rejects_invalid_or_incomplete_updates(self, radio: str, fields: dict, message: str) -> None:
+        with pytest.raises(ValueError, match=message):
+            validate_radio_update(radio, fields)

--- a/packages/unifi-core/tests/network/models/test_firewall.py
+++ b/packages/unifi-core/tests/network/models/test_firewall.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from unifi_core.network.models.firewall import (
     FIREWALLGROUP_MUTABLE_FIELDS,
     FIREWALLGROUP_READ_ONLY_FIELDS,
@@ -21,6 +22,7 @@ from unifi_core.network.models.firewall import (
     firewall_zone_from_controller,
     from_controller,
     legacy_firewall_rule_from_controller,
+    normalize_policy_update,
     to_controller_update,
     to_group_create,
 )
@@ -160,6 +162,37 @@ class TestToControllerUpdate:
     def test_returns_empty_dict_when_no_mutable_fields(self) -> None:
         result = to_controller_update({"id": "read-only"})
         assert result == {}
+
+
+class TestNormalizePolicyUpdate:
+    def test_normalizes_public_enum_values_and_filters_unknown_fields(self) -> None:
+        result = normalize_policy_update(
+            {
+                "action": "allow",
+                "ip_version": "ipv4",
+                "connection_states": ["established", "related"],
+                "unknown": "drop-me",
+            }
+        )
+
+        assert result == {
+            "action": "ALLOW",
+            "ip_version": "IPV4",
+            "connection_states": ["ESTABLISHED", "RELATED"],
+        }
+
+    @pytest.mark.parametrize(
+        ("fields", "message"),
+        [
+            ({"ruleset": "WAN_IN"}, "Legacy V1 firewall fields"),
+            ({"action": "accept"}, "Legacy V1 firewall fields"),
+            ({"action": "invalid"}, "Invalid action"),
+            ({"id": "read-only"}, "effectively empty"),
+        ],
+    )
+    def test_rejects_legacy_invalid_or_empty_updates(self, fields: dict, message: str) -> None:
+        with pytest.raises(ValueError, match=message):
+            normalize_policy_update(fields)
 
 
 class TestFirewallGroupFieldSets:

--- a/packages/unifi-core/tests/network/models/test_routes.py
+++ b/packages/unifi-core/tests/network/models/test_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from unifi_core.network.models.route import (
     ACTIVEROUTE_MUTABLE_FIELDS,
     ACTIVEROUTE_READ_ONLY_FIELDS,
@@ -12,6 +13,7 @@ from unifi_core.network.models.route import (
     Route,
     active_route_from_controller,
     route_from_controller,
+    validate_static_route_fields,
 )
 
 # ---------------------------------------------------------------------------
@@ -109,6 +111,37 @@ class TestRouteFromController:
         for name, field in Route.model_fields.items():
             extra = field.json_schema_extra or {}
             assert extra.get("mutable") is False, f"Field {name!r} is not tagged mutable=False"
+
+
+class TestStaticRouteValidation:
+    def test_create_normalizes_name_and_defaults(self) -> None:
+        assert validate_static_route_fields(
+            {"name": " Office ", "network": "10.0.0.0/24", "nexthop": "192.168.1.1"},
+            require_complete=True,
+        ) == {
+            "name": "Office",
+            "network": "10.0.0.0/24",
+            "nexthop": "192.168.1.1",
+            "distance": 1,
+            "enabled": True,
+        }
+
+    @pytest.mark.parametrize(
+        ("fields", "message"),
+        [
+            ({"name": " ", "network": "10.0.0.0/24", "nexthop": "192.168.1.1"}, "Name is required"),
+            ({"name": "x", "network": "not-cidr", "nexthop": "192.168.1.1"}, "Invalid network"),
+            ({"name": "x", "network": "10.0.0.0/24", "nexthop": "not-ip"}, "Invalid nexthop"),
+            ({"name": "x", "network": "10.0.0.0/24", "nexthop": "192.168.1.1", "distance": 0}, "Distance"),
+        ],
+    )
+    def test_create_rejects_invalid_fields(self, fields: dict, message: str) -> None:
+        with pytest.raises(ValueError, match=message):
+            validate_static_route_fields(fields, require_complete=True)
+
+    def test_update_requires_a_field(self) -> None:
+        with pytest.raises(ValueError, match="At least one field"):
+            validate_static_route_fields({}, require_complete=False)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
@@ -197,6 +197,17 @@ async def test_update_rule_routes_uuid_to_v2_with_full_editable_body():
 
 
 @pytest.mark.asyncio
+async def test_update_rule_rejects_empty_fields_before_backend_access():
+    facade = _facade(service_get=_RAW_V2)
+
+    with pytest.raises(ValueError, match="No fields provided"):
+        await facade.update_rule("019e9f9d-59a1-7ee3-8921-27f84a0086ea", {})
+
+    facade._service.get_rule_raw.assert_not_called()
+    facade._legacy.get_rule.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_update_rule_routes_object_id_to_legacy_with_translated_body():
     facade = _facade(legacy_get=_RAW_LEGACY)
 

--- a/packages/unifi-core/tests/protect/managers/test_chime_manager.py
+++ b/packages/unifi-core/tests/protect/managers/test_chime_manager.py
@@ -1,0 +1,38 @@
+"""Tests for controller-safe chime mutations."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+from unifi_core.protect.managers.chime_manager import ChimeManager
+
+
+@pytest.mark.asyncio
+async def test_trigger_chime_validates_before_device_lookup() -> None:
+    manager = ChimeManager(MagicMock())
+    manager._get_chime = MagicMock()
+
+    with pytest.raises(ValidationError):
+        await manager.trigger_chime("chime-1", volume=101, repeat_times=1)
+
+    manager._get_chime.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_trigger_chime_plays_with_validated_values() -> None:
+    chime = MagicMock(name="Entry Chime", volume=50, repeat_times=1)
+    chime.name = "Entry Chime"
+    chime.play = AsyncMock()
+    manager = ChimeManager(MagicMock())
+    manager._get_chime = MagicMock(return_value=chime)
+
+    result = await manager.trigger_chime("chime-1", volume=80, repeat_times=3)
+
+    chime.play.assert_awaited_once_with(volume=80, repeat_times=3)
+    assert result == {
+        "chime_id": "chime-1",
+        "chime_name": "Entry Chime",
+        "triggered": True,
+        "volume": 80,
+        "repeat_times": 3,
+    }


### PR DESCRIPTION
## Summary

- add Core manager bridges needed by non-MCP callers without introducing cross-app dependencies
- centralize reusable validation for routes, firewall policy updates, device radios, vouchers, PDU outlets, chimes, and alarm updates
- add focused Core tests for bridge resolution, mutation safety, validation defaults, and controller-write interlocks

## Why Core first

The downstream API catalog depends on these shared contracts. Publishing Core first keeps the dependency direction app to Core and lets the API declare an honest published minimum version rather than relying on workspace-only resolution.

## Verification

- make pre-commit
- 1,473 Core tests passed
- Ruff format and lint passed
- standalone wheel installed with Network, Protect, and Access extras; all manager families imported successfully
- reverse-import scan passed; only packages/unifi-core is changed

## Release sequence

After merge, publish core/v0.4.23 and verify PyPI before opening the downstream API floor-bump/catalog PR.