### PR TITLE
fix(api): isolate Network site manager state

### DIFF
--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -115,14 +115,8 @@ async def _fetch_clients(ctx: GraphQLContext, controller: str, site: str) -> lis
                 controller,
                 "network",
                 "client_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_clients())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -138,14 +132,8 @@ async def _fetch_devices(ctx: GraphQLContext, controller: str, site: str) -> lis
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_devices())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -161,14 +149,8 @@ async def _fetch_networks(ctx: GraphQLContext, controller: str, site: str) -> li
                 controller,
                 "network",
                 "network_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_networks())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -188,14 +170,8 @@ async def _fetch_blocked_clients(
                 controller,
                 "network",
                 "client_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_blocked_clients())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -216,14 +192,8 @@ async def _fetch_client_by_ip(
                 controller,
                 "network",
                 "client_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_client_by_ip(ip)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -244,14 +214,8 @@ async def _fetch_device_radio(
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_device_radio(mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -272,14 +236,8 @@ async def _fetch_lldp_neighbors(
                 controller,
                 "network",
                 "switch_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_lldp_neighbors(device_mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -300,14 +258,8 @@ async def _fetch_pdu_outlets(
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_pdu_outlets(mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -328,14 +280,8 @@ async def _fetch_rogue_aps(
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.list_rogue_aps(within_hours))
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -356,14 +302,8 @@ async def _fetch_rf_scan_results(
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_rf_scan_results(ap_mac) or [])
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -383,14 +323,8 @@ async def _fetch_available_channels(
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.list_available_channels() or [])
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -411,14 +345,8 @@ async def _fetch_speedtest_status(
                 controller,
                 "network",
                 "device_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_speedtest_status(gateway_mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -438,14 +366,8 @@ async def _fetch_network_health(
                 controller,
                 "network",
                 "system_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_network_health() or [])
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -464,14 +386,8 @@ async def _fetch_wlans(ctx: GraphQLContext, controller: str, site: str) -> list:
                 controller,
                 "network",
                 "network_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_wlans())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -491,14 +407,8 @@ async def _fetch_vpn_clients(
                 controller,
                 "network",
                 "vpn_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_vpn_clients())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -518,14 +428,8 @@ async def _fetch_vpn_servers(
                 controller,
                 "network",
                 "vpn_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_vpn_servers())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -545,14 +449,8 @@ async def _fetch_dns_records(
                 controller,
                 "network",
                 "dns_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.list_dns_records())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -572,14 +470,8 @@ async def _fetch_dynamic_dns(
                 controller,
                 "network",
                 "dynamic_dns_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.list_dynamic_dns())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -595,14 +487,8 @@ async def _fetch_routes(ctx: GraphQLContext, controller: str, site: str) -> list
                 controller,
                 "network",
                 "routing_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_routes())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -622,14 +508,8 @@ async def _fetch_active_routes(
                 controller,
                 "network",
                 "routing_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_active_routes())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -649,14 +529,8 @@ async def _fetch_traffic_routes(
                 controller,
                 "network",
                 "traffic_route_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_traffic_routes())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -677,14 +551,8 @@ async def _fetch_traffic_flows(
             controller,
             "network",
             "traffic_flow_manager",
+            site=site,
         )
-        cm = await ctx.manager_factory.get_connection_manager(
-            session,
-            controller,
-            "network",
-        )
-        if cm.site != site:
-            await cm.set_site(site)
         return await mgr.get_traffic_flows(query)
 
 
@@ -701,14 +569,8 @@ async def _fetch_traffic_flow_statistics(
             controller,
             "network",
             "traffic_flow_manager",
+            site=site,
         )
-        cm = await ctx.manager_factory.get_connection_manager(
-            session,
-            controller,
-            "network",
-        )
-        if cm.site != site:
-            await cm.set_site(site)
         return await mgr.get_traffic_flow_statistics(period=period, top=top)
 
 
@@ -729,14 +591,8 @@ async def _fetch_firewall_policies(
                 controller,
                 "network",
                 "firewall_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_firewall_policies(include_predefined=True))
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -756,14 +612,8 @@ async def _fetch_firewall_groups(
                 controller,
                 "network",
                 "firewall_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_firewall_groups())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -783,14 +633,8 @@ async def _fetch_firewall_zones(
                 controller,
                 "network",
                 "firewall_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_firewall_zones())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -810,14 +654,8 @@ async def _fetch_legacy_firewall_rules(
                 controller,
                 "network",
                 "firewall_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_legacy_firewall_rules())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -841,14 +679,8 @@ async def _fetch_firewall_policy_ordering(
                 controller,
                 "network",
                 "firewall_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return dict(
                 await mgr.get_firewall_policy_ordering(
                     source_firewall_zone_id,
@@ -873,14 +705,8 @@ async def _fetch_qos_rules(
                 controller,
                 "network",
                 "qos_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_qos_rules())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -910,14 +736,8 @@ async def _fetch_dpi_applications(
                 controller,
                 "network",
                 "dpi_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             result = await mgr.get_dpi_applications(limit=2500, offset=0)
             return _unwrap_dpi(result)
 
@@ -938,14 +758,8 @@ async def _fetch_dpi_categories(
                 controller,
                 "network",
                 "dpi_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             result = await mgr.get_dpi_categories(limit=500, offset=0)
             return _unwrap_dpi(result)
 
@@ -966,14 +780,8 @@ async def _fetch_content_filters(
                 controller,
                 "network",
                 "content_filter_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_content_filters())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -993,14 +801,8 @@ async def _fetch_acl_rules(
                 controller,
                 "network",
                 "acl_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_acl_rules())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1020,14 +822,8 @@ async def _fetch_oon_policies(
                 controller,
                 "network",
                 "oon_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_oon_policies())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1047,14 +843,8 @@ async def _fetch_port_forwards(
                 controller,
                 "network",
                 "firewall_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_port_forwards())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1078,14 +868,8 @@ async def _stats_mgr_fetch(
                 controller,
                 "network",
                 "stats_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await getattr(mgr, method)(*args)
 
     return await ctx.cache.get_or_fetch(cache_key, _do)
@@ -1327,14 +1111,8 @@ async def _event_mgr_fetch(
                 controller,
                 "network",
                 "event_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await getattr(mgr, method)(*args)
 
     return await ctx.cache.get_or_fetch(cache_key, _do)
@@ -1355,14 +1133,8 @@ async def _fetch_event_log(
                 controller,
                 "network",
                 "event_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_events(limit=fetch_limit))
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1391,14 +1163,8 @@ async def _fetch_event_types(
                 controller,
                 "network",
                 "event_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             import inspect as _inspect
 
             result = mgr.get_event_type_prefixes()
@@ -1424,14 +1190,8 @@ async def _system_mgr_fetch(
                 controller,
                 "network",
                 "system_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await getattr(mgr, method)(*args)
 
     return await ctx.cache.get_or_fetch(cache_key, _do)
@@ -1500,14 +1260,8 @@ async def _fetch_gateway_settings(
                 controller,
                 "network",
                 "gateway_settings_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_gateway_settings()
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1537,14 +1291,8 @@ async def _hotspot_mgr_fetch(
                 controller,
                 "network",
                 "hotspot_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await getattr(mgr, method)(*args)
 
     return await ctx.cache.get_or_fetch(cache_key, _do)
@@ -1564,14 +1312,8 @@ async def _fetch_vouchers(
                 controller,
                 "network",
                 "hotspot_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_vouchers())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1611,14 +1353,8 @@ async def _fetch_port_profiles(
                 controller,
                 "network",
                 "switch_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_port_profiles())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1639,14 +1375,8 @@ async def _fetch_switch_ports(
                 controller,
                 "network",
                 "switch_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_switch_ports(device_mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1667,14 +1397,8 @@ async def _fetch_port_stats(
                 controller,
                 "network",
                 "switch_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_port_stats(device_mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1695,14 +1419,8 @@ async def _fetch_switch_capabilities(
                 controller,
                 "network",
                 "switch_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return await mgr.get_switch_capabilities(device_mac)
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1722,14 +1440,8 @@ async def _fetch_ap_groups(
                 controller,
                 "network",
                 "network_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.list_ap_groups())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1749,14 +1461,8 @@ async def _fetch_client_groups(
                 controller,
                 "network",
                 "client_group_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_client_groups())
 
     return await ctx.cache.get_or_fetch(key, _do)
@@ -1776,14 +1482,8 @@ async def _fetch_user_groups(
                 controller,
                 "network",
                 "usergroup_manager",
+                site=site,
             )
-            cm = await ctx.manager_factory.get_connection_manager(
-                session,
-                controller,
-                "network",
-            )
-            if cm.site != site:
-                await cm.set_site(site)
             return list(await mgr.get_usergroups())
 
     return await ctx.cache.get_or_fetch(key, _do)

--- a/apps/api/src/unifi_api/routes/resources/network/acl.py
+++ b/apps/api/src/unifi_api/routes/resources/network/acl.py
@@ -58,10 +58,8 @@ async def list_acl_rules(
             controller.id,
             "network",
             "acl_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_acl_rules()
 
     cursor_obj = _decode_cursor(cursor)
@@ -111,10 +109,8 @@ async def get_acl_rule_details(
                 controller.id,
                 "network",
                 "acl_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_acl_rule_by_id(rule_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/ap_groups.py
@@ -60,10 +60,8 @@ async def list_ap_groups(
             controller.id,
             "network",
             "network_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.list_ap_groups()
 
     cursor_obj = _decode_cursor(cursor)
@@ -113,10 +111,8 @@ async def get_ap_group_details(
                 controller.id,
                 "network",
                 "network_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_ap_group_details(group_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/blocked_clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/blocked_clients.py
@@ -57,10 +57,8 @@ async def list_blocked_clients(
             controller.id,
             "network",
             "client_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_blocked = await mgr.get_blocked_clients()
 
     cursor_obj = _decode_cursor(cursor)

--- a/apps/api/src/unifi_api/routes/resources/network/client_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/client_groups.py
@@ -58,10 +58,8 @@ async def list_client_groups(
             controller.id,
             "network",
             "client_group_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_groups = await mgr.get_client_groups()
 
     cursor_obj = _decode_cursor(cursor)
@@ -112,10 +110,8 @@ async def get_client_group_details(
                 controller.id,
                 "network",
                 "client_group_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             group = await mgr.get_client_group_by_id(group_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/clients.py
@@ -53,10 +53,8 @@ async def list_clients(
             controller.id,
             "network",
             "client_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_clients = await mgr.get_clients()
 
     cursor_obj = None
@@ -106,10 +104,8 @@ async def get_client(
                 controller.id,
                 "network",
                 "client_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             client = await mgr.get_client_details(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/content_filters.py
+++ b/apps/api/src/unifi_api/routes/resources/network/content_filters.py
@@ -58,10 +58,8 @@ async def list_content_filters(
             controller.id,
             "network",
             "content_filter_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_content_filters()
 
     cursor_obj = _decode_cursor(cursor)
@@ -111,10 +109,8 @@ async def get_content_filter_details(
                 controller.id,
                 "network",
                 "content_filter_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_content_filter_by_id(filter_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/devices.py
+++ b/apps/api/src/unifi_api/routes/resources/network/devices.py
@@ -47,10 +47,8 @@ async def list_devices(
             controller.id,
             "network",
             "device_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_devices = await mgr.get_devices()
 
     cursor_obj = None
@@ -100,10 +98,8 @@ async def get_device(
                 controller.id,
                 "network",
                 "device_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             device = await mgr.get_device_details(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
@@ -137,10 +133,8 @@ async def get_device_radio(
                 controller.id,
                 "network",
                 "device_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             radio = await mgr.get_device_radio(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
@@ -185,10 +179,8 @@ async def get_pdu_outlets(
                 controller.id,
                 "network",
                 "device_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             outlets = await mgr.get_pdu_outlets(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dns.py
@@ -58,10 +58,8 @@ async def list_dns_records(
             controller.id,
             "network",
             "dns_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.list_dns_records()
 
     cursor_obj = _decode_cursor(cursor)
@@ -111,10 +109,8 @@ async def get_dns_record_details(
                 controller.id,
                 "network",
                 "dns_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             # dns_manager exposes get_dns_record (no `_by_id` suffix); the manifest
             # tool name is unifi_get_dns_record_details.
             item = await mgr.get_dns_record(record_id)

--- a/apps/api/src/unifi_api/routes/resources/network/dpi.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dpi.py
@@ -112,11 +112,10 @@ async def list_dpi_applications(
             controller.id,
             "network",
             "dpi_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
+        cm = await factory.get_connection_manager(session, controller.id, "network", site=site_id)
         _require_dpi_auth(cm, controller.id)
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         # Manager returns the integration-API wrapper. Ask for a wide page so
         # cursor-based pagination on the client side has the full set.
         result = await mgr.get_dpi_applications(limit=2500, offset=0)
@@ -169,11 +168,10 @@ async def list_dpi_categories(
             controller.id,
             "network",
             "dpi_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
+        cm = await factory.get_connection_manager(session, controller.id, "network", site=site_id)
         _require_dpi_auth(cm, controller.id)
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         result = await mgr.get_dpi_categories(limit=500, offset=0)
 
     items_raw = _unwrap(result)

--- a/apps/api/src/unifi_api/routes/resources/network/dynamic_dns.py
+++ b/apps/api/src/unifi_api/routes/resources/network/dynamic_dns.py
@@ -59,10 +59,8 @@ async def list_dynamic_dns(
             controller.id,
             "network",
             "dynamic_dns_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.list_dynamic_dns()
 
     cursor_obj = _decode_cursor(cursor)
@@ -113,10 +111,8 @@ async def get_dynamic_dns_entry_details(
                 controller.id,
                 "network",
                 "dynamic_dns_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_dynamic_dns(entry_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/events.py
+++ b/apps/api/src/unifi_api/routes/resources/network/events.py
@@ -40,11 +40,6 @@ def _event_key(obj) -> tuple:
     return (ts, eid)
 
 
-async def _maybe_set_site(cm, site_id: str) -> None:
-    if getattr(cm, "site", None) != site_id:
-        await cm.set_site(site_id)
-
-
 def _list_response(request, items, tool_name, *, limit, cursor):
     cursor_obj = _decode_cursor(cursor)
     page, next_cursor = paginate(
@@ -134,9 +129,8 @@ async def _list_network_events(
             controller.id,
             "network",
             "event_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         events = await mgr.get_events(limit=max(limit, 100))
     return _list_response(
         request,
@@ -211,9 +205,8 @@ async def get_alerts(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         events = await mgr.get_alerts()
     return _list_response(
         request,
@@ -245,9 +238,8 @@ async def get_anomalies(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         events = await mgr.get_anomalies()
     return _list_response(
         request,
@@ -279,9 +271,8 @@ async def get_ips_events(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         events = await mgr.get_ips_events()
     return _list_response(
         request,

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_groups.py
@@ -58,10 +58,8 @@ async def list_firewall_groups(
             controller.id,
             "network",
             "firewall_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_firewall_groups()
 
     cursor_obj = _decode_cursor(cursor)
@@ -111,10 +109,8 @@ async def get_firewall_group_details(
                 controller.id,
                 "network",
                 "firewall_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_firewall_group_by_id(group_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_rules.py
@@ -47,10 +47,8 @@ async def list_firewall_rules(
             controller.id,
             "network",
             "firewall_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_rules = await mgr.get_firewall_policies()
 
     cursor_obj = None
@@ -100,10 +98,8 @@ async def get_firewall_rule(
                 controller.id,
                 "network",
                 "firewall_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             # firewall_manager exposes get_firewall_policies (list) but not a
             # singular get_firewall_policy_details. Fetch the list and filter
             # by id; the manager already caches/normalizes the response.
@@ -161,10 +157,8 @@ async def get_firewall_policy_ordering(
             controller.id,
             "network",
             "firewall_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         ordering = await mgr.get_firewall_policy_ordering(
             source_firewall_zone_id,
             destination_firewall_zone_id,

--- a/apps/api/src/unifi_api/routes/resources/network/firewall_zones.py
+++ b/apps/api/src/unifi_api/routes/resources/network/firewall_zones.py
@@ -60,10 +60,8 @@ async def list_firewall_zones(
             controller.id,
             "network",
             "firewall_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_firewall_zones()
 
     cursor_obj = _decode_cursor(cursor)

--- a/apps/api/src/unifi_api/routes/resources/network/gateway_settings.py
+++ b/apps/api/src/unifi_api/routes/resources/network/gateway_settings.py
@@ -37,10 +37,8 @@ async def get_gateway_settings(
             controller.id,
             "network",
             "gateway_settings_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         settings = await mgr.get_gateway_settings()
 
     type_class = request.app.state.type_registry.lookup("network", "gateway_settings")

--- a/apps/api/src/unifi_api/routes/resources/network/legacy_firewall_rules.py
+++ b/apps/api/src/unifi_api/routes/resources/network/legacy_firewall_rules.py
@@ -65,10 +65,8 @@ async def list_legacy_firewall_rules(
             controller.id,
             "network",
             "firewall_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_legacy_firewall_rules()
 
     cursor_obj = _decode_cursor(cursor)

--- a/apps/api/src/unifi_api/routes/resources/network/lldp.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lldp.py
@@ -57,10 +57,8 @@ async def list_lldp_neighbors(
             controller.id,
             "network",
             "switch_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         wrapper = await mgr.get_lldp_neighbors(device_mac)
     if wrapper is None:
         raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")

--- a/apps/api/src/unifi_api/routes/resources/network/lookup.py
+++ b/apps/api/src/unifi_api/routes/resources/network/lookup.py
@@ -41,10 +41,8 @@ async def lookup_client_by_ip(
                 controller.id,
                 "network",
                 "client_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             client = await mgr.get_client_by_ip(ip)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/networks.py
+++ b/apps/api/src/unifi_api/routes/resources/network/networks.py
@@ -47,10 +47,8 @@ async def list_networks(
             controller.id,
             "network",
             "network_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_networks = await mgr.get_networks()
 
     cursor_obj = None
@@ -100,10 +98,8 @@ async def get_network(
                 controller.id,
                 "network",
                 "network_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             network = await mgr.get_network_details(network_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/oon.py
+++ b/apps/api/src/unifi_api/routes/resources/network/oon.py
@@ -58,10 +58,8 @@ async def list_oon_policies(
             controller.id,
             "network",
             "oon_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_oon_policies()
 
     cursor_obj = _decode_cursor(cursor)
@@ -111,10 +109,8 @@ async def get_oon_policy_details(
                 controller.id,
                 "network",
                 "oon_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_oon_policy_by_id(policy_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
+++ b/apps/api/src/unifi_api/routes/resources/network/port_forwards.py
@@ -59,10 +59,8 @@ async def list_port_forwards(
             controller.id,
             "network",
             "firewall_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_port_forwards()
 
     cursor_obj = _decode_cursor(cursor)
@@ -112,10 +110,8 @@ async def get_port_forward(
                 controller.id,
                 "network",
                 "firewall_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_port_forward_by_id(port_forward_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/qos.py
+++ b/apps/api/src/unifi_api/routes/resources/network/qos.py
@@ -58,10 +58,8 @@ async def list_qos_rules(
             controller.id,
             "network",
             "qos_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_qos_rules()
 
     cursor_obj = _decode_cursor(cursor)
@@ -111,10 +109,8 @@ async def get_qos_rule_details(
                 controller.id,
                 "network",
                 "qos_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_qos_rule_details(rule_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/rogue_aps.py
+++ b/apps/api/src/unifi_api/routes/resources/network/rogue_aps.py
@@ -76,10 +76,8 @@ async def list_rogue_aps(
             controller.id,
             "network",
             "device_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         rows = await mgr.list_rogue_aps(within_hours)
 
     cursor_obj = _decode_cursor(cursor)
@@ -129,10 +127,8 @@ async def list_rf_scan_results(
             controller.id,
             "network",
             "device_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         rows = await mgr.get_rf_scan_results(ap_mac)
 
     cursor_obj = _decode_cursor(cursor)

--- a/apps/api/src/unifi_api/routes/resources/network/routes.py
+++ b/apps/api/src/unifi_api/routes/resources/network/routes.py
@@ -62,10 +62,8 @@ async def list_active_routes(
             controller.id,
             "network",
             "routing_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_active_routes()
 
     cursor_obj = _decode_cursor(cursor)
@@ -118,10 +116,8 @@ async def list_routes(
             controller.id,
             "network",
             "routing_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_routes()
 
     cursor_obj = _decode_cursor(cursor)
@@ -171,10 +167,8 @@ async def get_route_details(
                 controller.id,
                 "network",
                 "routing_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_route_details(route_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
@@ -219,10 +213,8 @@ async def list_traffic_routes(
             controller.id,
             "network",
             "traffic_route_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_traffic_routes()
 
     cursor_obj = _decode_cursor(cursor)
@@ -272,10 +264,8 @@ async def get_traffic_route_details(
                 controller.id,
                 "network",
                 "traffic_route_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_traffic_route_details(route_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/snmp.py
+++ b/apps/api/src/unifi_api/routes/resources/network/snmp.py
@@ -38,10 +38,8 @@ async def get_snmp_settings(
             controller.id,
             "network",
             "system_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         settings = await mgr.get_settings("snmp")
     type_registry = request.app.state.type_registry
     tool_type = type_registry.lookup_tool("unifi_get_snmp_settings")

--- a/apps/api/src/unifi_api/routes/resources/network/speedtest.py
+++ b/apps/api/src/unifi_api/routes/resources/network/speedtest.py
@@ -34,10 +34,8 @@ async def get_speedtest_status(
             controller.id,
             "network",
             "device_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         status = await mgr.get_speedtest_status(gateway_mac)
 
     type_registry = request.app.state.type_registry

--- a/apps/api/src/unifi_api/routes/resources/network/stats.py
+++ b/apps/api/src/unifi_api/routes/resources/network/stats.py
@@ -102,11 +102,6 @@ def _stats_response(
     return {"data": serializer.serialize(payload), "render_hint": hint}
 
 
-async def _maybe_set_site(cm, site_id: str) -> None:
-    if getattr(cm, "site", None) != site_id:
-        await cm.set_site(site_id)
-
-
 # ---------- TIMESERIES — flat /stats/* paths ----------
 
 
@@ -131,9 +126,8 @@ async def get_dashboard_stats(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_dashboard()
     return _stats_response(
         request,
@@ -165,9 +159,8 @@ async def get_network_stats(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_network_stats()
     return _stats_response(
         request,
@@ -199,9 +192,8 @@ async def get_gateway_stats(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_gateway_stats()
     return _stats_response(
         request,
@@ -233,9 +225,8 @@ async def get_site_dpi_traffic(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_site_dpi_traffic()
     return _stats_response(
         request,
@@ -268,9 +259,8 @@ async def get_client_dpi_traffic(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_client_dpi_traffic(mac)
     return _stats_response(
         request,
@@ -306,9 +296,8 @@ async def get_dpi_stats(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_dpi_stats()
     return _stats_response(
         request,
@@ -343,9 +332,8 @@ async def get_device_stats(
                 controller.id,
                 "network",
                 "stats_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            await _maybe_set_site(cm, site_id)
             payload = await mgr.get_device_stats(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
@@ -382,9 +370,8 @@ async def get_client_stats(
                 controller.id,
                 "network",
                 "stats_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            await _maybe_set_site(cm, site_id)
             payload = await mgr.get_client_stats(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/switch.py
+++ b/apps/api/src/unifi_api/routes/resources/network/switch.py
@@ -73,10 +73,8 @@ async def list_port_profiles(
             controller.id,
             "network",
             "switch_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_profiles = await mgr.get_port_profiles()
 
     cursor_obj = _decode_cursor(cursor)
@@ -127,10 +125,8 @@ async def get_port_profile_details(
                 controller.id,
                 "network",
                 "switch_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             profile = await mgr.get_port_profile_by_id(profile_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
@@ -186,10 +182,8 @@ async def list_switch_ports(
             controller.id,
             "network",
             "switch_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         wrapper = await mgr.get_switch_ports(device_mac)
     if wrapper is None:
         raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")
@@ -266,10 +260,8 @@ async def list_port_stats(
             controller.id,
             "network",
             "switch_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         wrapper = await mgr.get_port_stats(device_mac)
     if wrapper is None:
         raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")
@@ -324,10 +316,8 @@ async def get_switch_capabilities(
             controller.id,
             "network",
             "switch_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         caps = await mgr.get_switch_capabilities(device_mac)
     if caps is None:
         raise HTTPException(status_code=404, detail=f"switch '{device_mac}' not found")

--- a/apps/api/src/unifi_api/routes/resources/network/system.py
+++ b/apps/api/src/unifi_api/routes/resources/network/system.py
@@ -41,11 +41,6 @@ def _id_key(obj) -> tuple:
     return (ts, eid)
 
 
-async def _maybe_set_site(cm, site_id: str) -> None:
-    if getattr(cm, "site", None) != site_id:
-        await cm.set_site(site_id)
-
-
 def _list_response(request, items, tool_name, *, limit, cursor):
     cursor_obj = _decode_cursor(cursor)
     page, next_cursor = paginate(
@@ -111,9 +106,8 @@ async def list_alarms(
             controller.id,
             "network",
             "event_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         items = await mgr.get_alarms()
     return _list_response(
         request,
@@ -145,9 +139,8 @@ async def list_backups(
             controller.id,
             "network",
             "system_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         items = await mgr.list_backups()
     return _list_response(
         request,
@@ -179,9 +172,8 @@ async def get_top_clients(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         items = await mgr.get_top_clients()
     return _list_response(
         request,
@@ -213,9 +205,8 @@ async def get_client_sessions(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         items = await mgr.get_client_sessions()
     return _list_response(
         request,
@@ -248,9 +239,8 @@ async def get_network_health(
             controller.id,
             "network",
             "system_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         items = await mgr.get_network_health()
     return _list_response(
         request,
@@ -282,9 +272,8 @@ async def get_speedtest_results(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         items = await mgr.get_speedtest_results()
     return _list_response(
         request,
@@ -318,9 +307,8 @@ async def get_event_types(
             controller.id,
             "network",
             "event_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         result = mgr.get_event_type_prefixes()
         if inspect.isawaitable(result):
             result = await result
@@ -346,9 +334,8 @@ async def get_autobackup_settings(
             controller.id,
             "network",
             "system_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_autobackup_settings()
     return _detail_response(request, payload, "unifi_get_autobackup_settings")
 
@@ -372,9 +359,8 @@ async def get_site_settings(
             controller.id,
             "network",
             "system_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_site_settings()
     return _detail_response(request, payload, "unifi_get_site_settings")
 
@@ -398,9 +384,8 @@ async def get_system_info(
             controller.id,
             "network",
             "system_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_system_info()
     return _detail_response(request, payload, "unifi_get_system_info")
 
@@ -425,9 +410,8 @@ async def get_client_wifi_details(
             controller.id,
             "network",
             "stats_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        await _maybe_set_site(cm, site_id)
         payload = await mgr.get_client_wifi_details(mac)
     if payload is None:
         raise HTTPException(

--- a/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
+++ b/apps/api/src/unifi_api/routes/resources/network/traffic_flows.py
@@ -85,10 +85,8 @@ async def get_traffic_flows(
             controller.id,
             "network",
             "traffic_flow_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         result = await mgr.get_traffic_flows(query)
 
     type_registry = request.app.state.type_registry
@@ -131,10 +129,8 @@ async def get_traffic_flow_statistics(
             controller.id,
             "network",
             "traffic_flow_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         try:
             result = await mgr.get_traffic_flow_statistics(period=period, top=top)
         except ValueError as exc:

--- a/apps/api/src/unifi_api/routes/resources/network/user_groups.py
+++ b/apps/api/src/unifi_api/routes/resources/network/user_groups.py
@@ -60,10 +60,8 @@ async def list_user_groups(
             controller.id,
             "network",
             "usergroup_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_groups = await mgr.get_usergroups()
 
     cursor_obj = _decode_cursor(cursor)
@@ -114,10 +112,8 @@ async def get_user_group_details(
                 controller.id,
                 "network",
                 "usergroup_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             group = await mgr.get_usergroup_details(group_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/vouchers.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vouchers.py
@@ -62,10 +62,8 @@ async def list_vouchers(
             controller.id,
             "network",
             "hotspot_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_vouchers()
 
     cursor_obj = _decode_cursor(cursor)
@@ -115,10 +113,8 @@ async def get_voucher_details(
                 controller.id,
                 "network",
                 "hotspot_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             voucher = await mgr.get_voucher_details(voucher_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/vpn.py
+++ b/apps/api/src/unifi_api/routes/resources/network/vpn.py
@@ -61,10 +61,8 @@ async def list_vpn_clients(
             controller.id,
             "network",
             "vpn_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_vpn_clients()
 
     cursor_obj = _decode_cursor(cursor)
@@ -114,10 +112,8 @@ async def get_vpn_client_details(
                 controller.id,
                 "network",
                 "vpn_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_vpn_client_details(client_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
@@ -165,10 +161,8 @@ async def list_vpn_servers(
             controller.id,
             "network",
             "vpn_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         items = await mgr.get_vpn_servers()
 
     cursor_obj = _decode_cursor(cursor)
@@ -218,10 +212,8 @@ async def get_vpn_server_details(
                 controller.id,
                 "network",
                 "vpn_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             item = await mgr.get_vpn_server_details(server_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/routes/resources/network/wireless.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wireless.py
@@ -46,10 +46,8 @@ async def list_available_channels(
             controller.id,
             "network",
             "device_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         rows = await mgr.list_available_channels()
 
     cursor_obj: Cursor | None = None

--- a/apps/api/src/unifi_api/routes/resources/network/wlans.py
+++ b/apps/api/src/unifi_api/routes/resources/network/wlans.py
@@ -52,10 +52,8 @@ async def list_wlans(
             controller.id,
             "network",
             "network_manager",
+            site=site_id,
         )
-        cm = await factory.get_connection_manager(session, controller.id, "network")
-        if cm.site != site_id:
-            await cm.set_site(site_id)
         all_wlans = await mgr.get_wlans()
 
     cursor_obj = None
@@ -106,10 +104,8 @@ async def get_wlan(
                 controller.id,
                 "network",
                 "network_manager",
+                site=site_id,
             )
-            cm = await factory.get_connection_manager(session, controller.id, "network")
-            if cm.site != site_id:
-                await cm.set_site(site_id)
             wlan = await mgr.get_wlan_details(wlan_id)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/api/src/unifi_api/services/actions.py
+++ b/apps/api/src/unifi_api/services/actions.py
@@ -157,15 +157,8 @@ async def dispatch_action(
         controller_id=controller_id,
         product=entry.product,
         attr_name=binding.manager_attr,
+        site=site,
     )
-
-    if entry.product == "network":
-        connection_manager = await factory.get_connection_manager(session, controller_id, "network")
-        current_site = getattr(connection_manager, "site", None)
-        if site and current_site != site:
-            set_site = getattr(connection_manager, "set_site", None)
-            if callable(set_site):
-                await _resolve_result(set_site(site))
 
     method = getattr(manager, binding.method, None)
     if method is None or not callable(method):

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -6,9 +6,15 @@ construction prevents concurrent-cache-miss races.
 
 Public surface:
 - ManagerFactory(sessionmaker, cipher)
-- get_connection_manager(session, controller_id, product) -> ConnectionManager
-- get_domain_manager(session, controller_id, product, attr_name) -> domain manager
+- get_connection_manager(session, controller_id, product, site=...) -> ConnectionManager
+- get_domain_manager(session, controller_id, product, attr_name, site=...) -> domain manager
 - invalidate_controller(controller_id)
+
+Network connection and domain-manager caches include the site. A cached
+Network manager therefore never changes site after construction, so
+concurrent requests for different sites cannot race through mutable shared
+ConnectionManager state. Protect and Access have no Network site namespace;
+their cache identity remains controller + product.
 """
 
 from __future__ import annotations
@@ -172,13 +178,34 @@ class ManagerFactory:
     ) -> None:
         self._sm = sessionmaker
         self._cipher = cipher
-        self._connection_cache: dict[tuple[str, str], Any] = {}
-        self._domain_cache: dict[tuple[str, str, str], Any] = {}
+        self._connection_cache: dict[tuple[str, str, str | None], Any] = {}
+        self._domain_cache: dict[tuple[str, str, str, str | None], Any] = {}
         self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._builder_cache: dict[str, dict[str, Callable[[Any], Any]]] = {}
 
-    async def get_connection_manager(self, session: AsyncSession, controller_id: str, product: str) -> Any:
-        key = (controller_id, product)
+    @staticmethod
+    def _site_scope(product: str, site: str | None) -> str | None:
+        """Return the cache scope for a product.
+
+        Only Network has a controller-side site namespace. Treat an omitted
+        Network site as ``default`` so existing non-site-specific control
+        paths keep their historical behavior without sharing an instance
+        with an explicitly selected site.
+        """
+        if product == "network":
+            return site or "default"
+        return None
+
+    async def get_connection_manager(
+        self,
+        session: AsyncSession,
+        controller_id: str,
+        product: str,
+        *,
+        site: str | None = None,
+    ) -> Any:
+        site_scope = self._site_scope(product, site)
+        key = (controller_id, product, site_scope)
         cm = self._connection_cache.get(key)
         if cm is not None:
             return cm
@@ -186,11 +213,23 @@ class ManagerFactory:
             cm = self._connection_cache.get(key)
             if cm is not None:
                 return cm
-            cm = await self._construct_connection_manager(session, controller_id, product)
+            cm = await self._construct_connection_manager(
+                session,
+                controller_id,
+                product,
+                site=site_scope,
+            )
             self._connection_cache[key] = cm
             return cm
 
-    async def _construct_connection_manager(self, session: AsyncSession, controller_id: str, product: str) -> Any:
+    async def _construct_connection_manager(
+        self,
+        session: AsyncSession,
+        controller_id: str,
+        product: str,
+        *,
+        site: str | None = None,
+    ) -> Any:
         controller = await session.get(Controller, controller_id)
         if controller is None:
             raise ValueError(f"controller {controller_id} not found")
@@ -222,6 +261,7 @@ class ManagerFactory:
                 username=creds["username"],
                 password=creds["password"],
                 port=port,
+                site=site or "default",
                 verify_ssl=controller.verify_tls,
             )
             # Stash a UniFiAuth carrying the controller's API token (if any)
@@ -282,23 +322,28 @@ class ManagerFactory:
         controller_id: str,
         product: str,
         attr_name: str,
+        *,
+        site: str | None = None,
     ) -> Any:
         """Resolve a per-controller domain manager by its runtime attribute name.
 
         ``attr_name`` matches the singleton attribute used by the MCP runtime
         modules (e.g. ``client_manager`` from ``unifi_network_mcp.runtime``).
 
-        Cached on (controller_id, product, attr_name). Does NOT take the
-        per-controller lock here — get_connection_manager already serializes
-        the slow path (initialize()), and the rest of this function is a
-        synchronous builder call where a brief race on first-use produces
-        last-writer-wins on the cache, which is harmless because builders
-        are pure and share the cached connection manager.
+        Network managers are cached on
+        (controller_id, product, attr_name, site). Other products use a null
+        site scope. Does NOT take the per-controller lock here —
+        get_connection_manager already serializes the slow path
+        (initialize()), and the rest of this function is a synchronous builder
+        call where a brief race on first-use produces last-writer-wins on the
+        cache, which is harmless because builders are pure and share the
+        cached connection manager for the same site.
 
         Acquiring the lock here would deadlock — it's non-reentrant and
         get_connection_manager acquires the same lock.
         """
-        key = (controller_id, product, attr_name)
+        site_scope = self._site_scope(product, site)
+        key = (controller_id, product, attr_name, site_scope)
         cached = self._domain_cache.get(key)
         if cached is not None:
             return cached
@@ -306,7 +351,12 @@ class ManagerFactory:
         builder = builders.get(attr_name)
         if builder is None:
             raise UnknownManager(f"product '{product}' has no domain manager named '{attr_name}'")
-        cm = await self.get_connection_manager(session, controller_id, product)
+        cm = await self.get_connection_manager(
+            session,
+            controller_id,
+            product,
+            site=site_scope,
+        )
         instance = builder(cm)
         self._domain_cache[key] = instance
         return instance

--- a/apps/api/tests/graphql/fixtures/_helpers.py
+++ b/apps/api/tests/graphql/fixtures/_helpers.py
@@ -110,14 +110,14 @@ def stub_managers(
 
         setattr(mgr, method_name, _bound)
 
-    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name, *, site=None):
         return domain_mgrs.get((product, attr_name), MagicMock())
 
     fake_cm = MagicMock()
     fake_cm.site = "default"
     fake_cm.set_site = AsyncMock()
 
-    async def _fake_get_connection_manager(self, session, controller_id, product):
+    async def _fake_get_connection_manager(self, session, controller_id, product, *, site=None):
         return fake_cm
 
     monkeypatch.setattr(

--- a/apps/api/tests/graphql/test_n1_regression.py
+++ b/apps/api/tests/graphql/test_n1_regression.py
@@ -120,14 +120,14 @@ async def test_deep_network_query_makes_constant_manager_calls(
     fake_cm.site = "default"
     fake_cm.set_site = AsyncMock()
 
-    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name, *, site=None):
         if attr_name == "client_manager":
             return fake_client_mgr
         if attr_name == "device_manager":
             return fake_device_mgr
         return MagicMock()
 
-    async def _fake_get_connection_manager(self, session, controller_id, product):
+    async def _fake_get_connection_manager(self, session, controller_id, product, *, site=None):
         return fake_cm
 
     monkeypatch.setattr(

--- a/apps/api/tests/graphql/test_query_e2e_access.py
+++ b/apps/api/tests/graphql/test_query_e2e_access.py
@@ -168,14 +168,14 @@ def _stub_access_managers(
         ("access", "system_manager"): fake_system_mgr,
     }
 
-    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name, *, site=None):
         return domain_mgrs.get((product, attr_name), MagicMock())
 
     fake_cm = MagicMock()
     fake_cm.site = "default"
     fake_cm.set_site = AsyncMock()
 
-    async def _fake_get_connection_manager(self, session, controller_id, product):
+    async def _fake_get_connection_manager(self, session, controller_id, product, *, site=None):
         return fake_cm
 
     monkeypatch.setattr(

--- a/apps/api/tests/graphql/test_query_e2e_network.py
+++ b/apps/api/tests/graphql/test_query_e2e_network.py
@@ -112,14 +112,14 @@ def _stub_managers(
         ("network", "network_manager"): fake_network_mgr,
     }
 
-    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name, *, site=None):
         return domain_mgrs[(product, attr_name)]
 
     fake_cm = MagicMock()
     fake_cm.site = "default"
     fake_cm.set_site = AsyncMock()
 
-    async def _fake_get_connection_manager(self, session, controller_id, product):
+    async def _fake_get_connection_manager(self, session, controller_id, product, *, site=None):
         return fake_cm
 
     monkeypatch.setattr(

--- a/apps/api/tests/graphql/test_query_e2e_protect.py
+++ b/apps/api/tests/graphql/test_query_e2e_protect.py
@@ -148,14 +148,14 @@ def _stub_protect_managers(
         ("protect", "recording_manager"): fake_recording_mgr,
     }
 
-    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name):
+    async def _fake_get_domain_manager(self, session, controller_id, product, attr_name, *, site=None):
         return domain_mgrs.get((product, attr_name), MagicMock())
 
     fake_cm = MagicMock()
     fake_cm.site = "default"
     fake_cm.set_site = AsyncMock()
 
-    async def _fake_get_connection_manager(self, session, controller_id, product):
+    async def _fake_get_connection_manager(self, session, controller_id, product, *, site=None):
         return fake_cm
 
     monkeypatch.setattr(

--- a/apps/api/tests/routes/resources/test_access_doors_policies.py
+++ b/apps/api/tests/routes/resources/test_access_doors_policies.py
@@ -82,7 +82,7 @@ class _FakeAccessCM:
 
 def _stub_connection(app, cid: str) -> _FakeAccessCM:
     fake = _FakeAccessCM()
-    app.state.manager_factory._connection_cache[(cid, "access")] = fake
+    app.state.manager_factory._connection_cache[(cid, "access", None)] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_access_events_system.py
+++ b/apps/api/tests/routes/resources/test_access_events_system.py
@@ -74,7 +74,7 @@ class _FakeAccessCM:
 
 def _stub_connection(app, cid: str) -> _FakeAccessCM:
     fake = _FakeAccessCM()
-    app.state.manager_factory._connection_cache[(cid, "access")] = fake
+    app.state.manager_factory._connection_cache[(cid, "access", None)] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_access_resources.py
+++ b/apps/api/tests/routes/resources/test_access_resources.py
@@ -67,7 +67,7 @@ class _FakeAccessCM:
 
 def _stub_connection(app, cid: str) -> _FakeAccessCM:
     fake = _FakeAccessCM()
-    app.state.manager_factory._connection_cache[(cid, "access")] = fake
+    app.state.manager_factory._connection_cache[(cid, "access", None)] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_clients_groups.py
+++ b/apps/api/tests/routes/resources/test_network_clients_groups.py
@@ -69,7 +69,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_config.py
+++ b/apps/api/tests/routes/resources/test_network_config.py
@@ -73,7 +73,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_devices_switches.py
+++ b/apps/api/tests/routes/resources/test_network_devices_switches.py
@@ -69,7 +69,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_filtering.py
+++ b/apps/api/tests/routes/resources/test_network_filtering.py
@@ -73,7 +73,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_misc.py
+++ b/apps/api/tests/routes/resources/test_network_misc.py
@@ -70,7 +70,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_resources.py
+++ b/apps/api/tests/routes/resources/test_network_resources.py
@@ -73,7 +73,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_network_stats_events_system.py
+++ b/apps/api/tests/routes/resources/test_network_stats_events_system.py
@@ -69,7 +69,7 @@ class _FakeCM:
 
 def _stub_connection(app, cid: str) -> _FakeCM:
     fake = _FakeCM()
-    app.state.manager_factory._connection_cache[(cid, "network")] = fake
+    app.state.manager_factory._connection_cache[(cid, "network", "default")] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_protect_cameras_lights_sensors.py
+++ b/apps/api/tests/routes/resources/test_protect_cameras_lights_sensors.py
@@ -74,7 +74,7 @@ class _FakeProtectCM:
 
 def _stub_connection(app, cid: str) -> _FakeProtectCM:
     fake = _FakeProtectCM()
-    app.state.manager_factory._connection_cache[(cid, "protect")] = fake
+    app.state.manager_factory._connection_cache[(cid, "protect", None)] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_protect_events_system.py
+++ b/apps/api/tests/routes/resources/test_protect_events_system.py
@@ -74,7 +74,7 @@ class _FakeProtectCM:
 
 def _stub_connection(app, cid: str) -> _FakeProtectCM:
     fake = _FakeProtectCM()
-    app.state.manager_factory._connection_cache[(cid, "protect")] = fake
+    app.state.manager_factory._connection_cache[(cid, "protect", None)] = fake
     return fake
 
 

--- a/apps/api/tests/routes/resources/test_protect_resources.py
+++ b/apps/api/tests/routes/resources/test_protect_resources.py
@@ -65,7 +65,7 @@ class _FakeProtectCM:
 
 def _stub_connection(app, cid: str) -> _FakeProtectCM:
     fake = _FakeProtectCM()
-    app.state.manager_factory._connection_cache[(cid, "protect")] = fake
+    app.state.manager_factory._connection_cache[(cid, "protect", None)] = fake
     return fake
 
 

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -71,6 +71,7 @@ async def test_catalog_binding_is_authoritative_and_accepts_sync_result() -> Non
         controller_id="cid",
         product="network",
         attr_name="event_manager",
+        site="default",
     )
     manager.get_event_type_prefixes.assert_called_once_with()
 
@@ -270,10 +271,10 @@ async def test_dispatch_happy_path_invokes_manager() -> None:
         controller_id="cid",
         product="network",
         attr_name="client_manager",
+        site="default",
     )
     domain_manager.get_clients.assert_awaited_once_with()
-    # Same site -> no set_site call.
-    conn_manager.set_site.assert_not_awaited()
+    factory.get_connection_manager.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -527,7 +528,7 @@ async def test_dispatch_rejects_include_sensitive_arg_before_manager_invocation(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_updates_site_when_changed() -> None:
+async def test_dispatch_scopes_manager_to_requested_site_without_mutating_connection() -> None:
     entry = ToolEntry(
         name="unifi_list_clients",
         product="network",
@@ -540,18 +541,15 @@ async def test_dispatch_updates_site_when_changed() -> None:
     domain_manager = MagicMock()
     domain_manager.get_clients = AsyncMock(return_value={"ok": True})
 
-    conn_manager = MagicMock()
-    conn_manager.site = "default"
-    conn_manager.set_site = AsyncMock()
-
     factory = MagicMock()
     factory.get_domain_manager = AsyncMock(return_value=domain_manager)
-    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+    factory.get_connection_manager = AsyncMock()
+    session = MagicMock()
 
     await dispatch_action(
         registry=registry,
         factory=factory,
-        session=MagicMock(),
+        session=session,
         tool_name="unifi_list_clients",
         controller_id="cid",
         controller_products=["network"],
@@ -563,7 +561,14 @@ async def test_dispatch_updates_site_when_changed() -> None:
         },
     )
 
-    conn_manager.set_site.assert_awaited_once_with("upstairs")
+    factory.get_domain_manager.assert_awaited_once_with(
+        session=session,
+        controller_id="cid",
+        product="network",
+        attr_name="client_manager",
+        site="upstairs",
+    )
+    factory.get_connection_manager.assert_not_awaited()
     # The list_clients translator strips filter kwargs; get_clients() takes no args.
     domain_manager.get_clients.assert_awaited_once_with()
 
@@ -720,6 +725,7 @@ async def test_dispatch_update_traffic_route_routes_to_mutation_with_widened_fie
         controller_id="cid",
         product="network",
         attr_name="traffic_route_manager",
+        site="default",
     )
     # The widened match field is forwarded to update_traffic_route as a kwarg
     # (no arg translator — the manager takes **kwargs; confirm is a separate arg).

--- a/apps/api/tests/test_managers_factory.py
+++ b/apps/api/tests/test_managers_factory.py
@@ -1,5 +1,6 @@
 """Manager factory tests — caching + invalidation."""
 
+import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
@@ -22,10 +23,14 @@ class _FakeCM:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.init_calls = 0
+        self.close_calls = 0
 
     async def initialize(self) -> bool:
         self.init_calls += 1
         return True
+
+    async def close(self) -> None:
+        self.close_calls += 1
 
 
 def _patch_network_cm(monkeypatch) -> list[_FakeCM]:
@@ -128,4 +133,78 @@ async def test_factory_calls_initialize_on_construction(tmp_path: Path, monkeypa
         cm2 = await factory.get_connection_manager(session, cid, "network")
     assert cm2 is cm
     assert instances[0].init_calls == 1
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_network_connection_cache_is_scoped_by_site(tmp_path: Path, monkeypatch) -> None:
+    instances = _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    factory = ManagerFactory(sm, cipher)
+
+    async with sm() as session:
+        site_a = await factory.get_connection_manager(session, cid, "network", site="site-a")
+        site_b = await factory.get_connection_manager(session, cid, "network", site="site-b")
+        site_a_again = await factory.get_connection_manager(session, cid, "network", site="site-a")
+
+    assert site_a is site_a_again
+    assert site_a is not site_b
+    assert [cm.kwargs["site"] for cm in instances] == ["site-a", "site-b"]
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_network_domain_managers_remain_isolated_under_forced_interleaving(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    factory = ManagerFactory(sm, cipher)
+    both_started = asyncio.Event()
+    started: list[str] = []
+
+    class _SiteManager:
+        def __init__(self, cm: _FakeCM) -> None:
+            self.cm = cm
+
+        async def observe_site(self) -> str:
+            started.append(self.cm.kwargs["site"])
+            if len(started) == 2:
+                both_started.set()
+            await both_started.wait()
+            await asyncio.sleep(0)
+            return self.cm.kwargs["site"]
+
+    factory._builder_cache["network"] = {"site_manager": _SiteManager}
+
+    async def _call(site: str) -> str:
+        async with sm() as session:
+            manager = await factory.get_domain_manager(
+                session,
+                cid,
+                "network",
+                "site_manager",
+                site=site,
+            )
+        return await manager.observe_site()
+
+    assert await asyncio.gather(_call("site-a"), _call("site-b")) == ["site-a", "site-b"]
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_closes_every_site_connection(tmp_path: Path, monkeypatch) -> None:
+    instances = _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    factory = ManagerFactory(sm, cipher)
+
+    async with sm() as session:
+        await factory.get_connection_manager(session, cid, "network", site="site-a")
+        await factory.get_connection_manager(session, cid, "network", site="site-b")
+
+    await factory.invalidate_controller(cid)
+
+    assert len(instances) == 2
+    assert [cm.close_calls for cm in instances] == [1, 1]
     await engine.dispose()

--- a/apps/api/tests/test_network_site_isolation_contract.py
+++ b/apps/api/tests/test_network_site_isolation_contract.py
@@ -1,0 +1,55 @@
+"""Structural guards for request-scoped Network site selection."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+API_ROOT = Path(__file__).resolve().parents[1] / "src" / "unifi_api"
+NETWORK_SURFACES = [
+    *sorted((API_ROOT / "routes" / "resources" / "network").glob("*.py")),
+    API_ROOT / "graphql" / "resolvers" / "network.py",
+]
+
+
+def _manager_factory_calls(path: Path) -> list[ast.Call]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"get_connection_manager", "get_domain_manager"}
+    ]
+
+
+def _targets_network(call: ast.Call) -> bool:
+    values = [*call.args, *(keyword.value for keyword in call.keywords)]
+    return any(isinstance(value, ast.Constant) and value.value == "network" for value in values)
+
+
+def _has_site_scope(call: ast.Call) -> bool:
+    return any(keyword.arg == "site" for keyword in call.keywords)
+
+
+def test_every_network_rest_and_graphql_manager_resolution_is_site_scoped() -> None:
+    unscoped: list[str] = []
+    network_calls = 0
+    for path in NETWORK_SURFACES:
+        for call in _manager_factory_calls(path):
+            if not _targets_network(call):
+                continue
+            network_calls += 1
+            if not _has_site_scope(call):
+                unscoped.append(f"{path.relative_to(API_ROOT)}:{call.lineno}")
+
+    assert network_calls > 0
+    assert unscoped == [], f"Network manager resolution must pass site=: {unscoped}"
+
+
+def test_action_dispatch_forwards_site_to_manager_factory() -> None:
+    path = API_ROOT / "services" / "actions.py"
+    calls = [call for call in _manager_factory_calls(path) if call.func.attr == "get_domain_manager"]
+
+    assert len(calls) == 1
+    assert _has_site_scope(calls[0])


### PR DESCRIPTION
## Summary

- scope API Network connection and domain-manager caches by controller and site
- pass the requested site through Action, REST, and GraphQL request paths
- remove request-time mutation of shared Network connection state
- add forced-interleaving, invalidation, and structural coverage

## Verification

- `make pre-commit`
- API suite: 1,173 passed
- focused REST + GraphQL suite: 400 passed
- worker typecheck
- generated artifacts drift check

Closes #501