### PR TITLE
fix(core): bound background job retention

### DIFF
--- a/packages/unifi-core/src/unifi_core/jobs.py
+++ b/packages/unifi-core/src/unifi_core/jobs.py
@@ -10,11 +10,15 @@ Example:
 
 import asyncio
 import logging
+import math
 import secrets
 import time
 from typing import Any, Callable, Coroutine, Dict
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_JOB_RETENTION_SECONDS = 60 * 60
+DEFAULT_MAX_COMPLETED_JOBS = 1_000
 
 
 class JobStore:
@@ -29,10 +33,55 @@ class JobStore:
         _lock: Asyncio lock for thread-safe access to the job store
     """
 
-    def __init__(self) -> None:
-        """Initialize an empty job store with a lock for concurrent access."""
+    def __init__(
+        self,
+        *,
+        retention_seconds: float = DEFAULT_JOB_RETENTION_SECONDS,
+        max_completed_jobs: int = DEFAULT_MAX_COMPLETED_JOBS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        """Initialize an empty job store with bounded terminal-job retention.
+
+        Completed and failed jobs remain queryable for at most
+        ``retention_seconds`` and are additionally capped at
+        ``max_completed_jobs``. Running jobs are never evicted. The clock is
+        injectable so retention behavior can be tested without sleeping.
+        """
+        if not math.isfinite(retention_seconds) or retention_seconds < 0:
+            raise ValueError("retention_seconds must be finite and non-negative")
+        if isinstance(max_completed_jobs, bool) or not isinstance(max_completed_jobs, int) or max_completed_jobs < 0:
+            raise ValueError("max_completed_jobs must be a non-negative integer")
+
         self._jobs: Dict[str, Dict[str, Any]] = {}
         self._lock: asyncio.Lock = asyncio.Lock()
+        self._retention_seconds = retention_seconds
+        self._max_completed_jobs = max_completed_jobs
+        self._clock = clock
+
+    def _prune_locked(self, now: float) -> None:
+        """Evict expired and excess terminal jobs while ``_lock`` is held."""
+        terminal = [(job_id, job) for job_id, job in self._jobs.items() if job["status"] in {"done", "error"}]
+
+        expired_ids = {job_id for job_id, job in terminal if now - job["completed"] >= self._retention_seconds}
+        for job_id in expired_ids:
+            del self._jobs[job_id]
+
+        retained_terminal = [(job_id, job) for job_id, job in terminal if job_id not in expired_ids]
+        excess = len(retained_terminal) - self._max_completed_jobs
+        if excess > 0:
+            retained_terminal.sort(
+                key=lambda item: (
+                    item[1]["completed"],
+                    item[1]["started"],
+                    item[0],
+                )
+            )
+            for job_id, _job in retained_terminal[:excess]:
+                del self._jobs[job_id]
+
+        removed = len(expired_ids) + max(excess, 0)
+        if removed:
+            logger.debug("Pruned %s completed background jobs", removed)
 
     async def start(self, coro: Coroutine[Any, Any, Any]) -> str:
         """Start a background job and return its unique identifier.
@@ -50,9 +99,11 @@ class JobStore:
         job_id = secrets.token_hex(8)
 
         async with self._lock:
+            now = self._clock()
+            self._prune_locked(now)
             self._jobs[job_id] = {
                 "status": "running",
-                "started": time.time(),
+                "started": now,
                 "result": None,
                 "error": None,
             }
@@ -65,16 +116,20 @@ class JobStore:
                 result = await coro
                 async with self._lock:
                     if job_id in self._jobs:
+                        completed = self._clock()
                         self._jobs[job_id]["status"] = "done"
                         self._jobs[job_id]["result"] = result
-                        self._jobs[job_id]["completed"] = time.time()
+                        self._jobs[job_id]["completed"] = completed
+                        self._prune_locked(completed)
                 logger.info("Background job %s completed successfully", job_id)
             except Exception as e:
                 async with self._lock:
                     if job_id in self._jobs:
+                        completed = self._clock()
                         self._jobs[job_id]["status"] = "error"
                         self._jobs[job_id]["error"] = str(e)
-                        self._jobs[job_id]["completed"] = time.time()
+                        self._jobs[job_id]["completed"] = completed
+                        self._prune_locked(completed)
                 logger.error("Background job %s failed with error: %s", job_id, e, exc_info=True)
 
         # Launch the runner as a background task
@@ -97,6 +152,7 @@ class JobStore:
             - error: Error message (if failed)
         """
         async with self._lock:
+            self._prune_locked(self._clock())
             if job_id not in self._jobs:
                 logger.warning("Status requested for unknown job ID: %s", job_id)
                 return {"status": "unknown"}

--- a/packages/unifi-core/tests/test_jobs.py
+++ b/packages/unifi-core/tests/test_jobs.py
@@ -1,0 +1,130 @@
+"""Bounded-retention contracts for the shared background job store."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from unifi_core.jobs import JobStore
+
+
+class _Clock:
+    def __init__(self, value: float = 1_000.0) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+async def _wait_for_terminal(store: JobStore, job_id: str) -> dict:
+    for _ in range(20):
+        status = await store.status(job_id)
+        if status["status"] != "running":
+            return status
+        await asyncio.sleep(0)
+    raise AssertionError(f"job {job_id} did not finish")
+
+
+@pytest.mark.asyncio
+async def test_completed_and_failed_jobs_expire_after_retention_window() -> None:
+    clock = _Clock()
+    store = JobStore(retention_seconds=60, max_completed_jobs=10, clock=clock)
+
+    async def succeed() -> str:
+        return "ok"
+
+    async def fail() -> None:
+        raise RuntimeError("expected")
+
+    done_id = await store.start(succeed())
+    error_id = await store.start(fail())
+    assert (await _wait_for_terminal(store, done_id))["status"] == "done"
+    assert (await _wait_for_terminal(store, error_id))["status"] == "error"
+
+    clock.advance(60)
+
+    assert await store.status(done_id) == {"status": "unknown"}
+    assert await store.status(error_id) == {"status": "unknown"}
+
+
+@pytest.mark.asyncio
+async def test_completed_job_limit_evicts_oldest_terminal_jobs() -> None:
+    clock = _Clock()
+    store = JobStore(retention_seconds=3_600, max_completed_jobs=2, clock=clock)
+    job_ids: list[str] = []
+
+    for index in range(3):
+
+        async def complete(value: int = index) -> int:
+            return value
+
+        job_id = await store.start(complete())
+        job_ids.append(job_id)
+        assert (await _wait_for_terminal(store, job_id))["status"] == "done"
+        clock.advance(1)
+
+    assert await store.status(job_ids[0]) == {"status": "unknown"}
+    assert (await store.status(job_ids[1]))["status"] == "done"
+    assert (await store.status(job_ids[2]))["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_running_jobs_are_never_evicted_by_ttl_or_completed_limit() -> None:
+    clock = _Clock()
+    store = JobStore(retention_seconds=10, max_completed_jobs=1, clock=clock)
+    release = asyncio.Event()
+
+    async def remain_running() -> str:
+        await release.wait()
+        return "released"
+
+    running_id = await store.start(remain_running())
+
+    for value in range(3):
+
+        async def complete(result: int = value) -> int:
+            return result
+
+        completed_id = await store.start(complete())
+        await _wait_for_terminal(store, completed_id)
+        clock.advance(20)
+
+    assert (await store.status(running_id))["status"] == "running"
+
+    release.set()
+    assert (await _wait_for_terminal(store, running_id))["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_completions_keep_store_bounded() -> None:
+    clock = _Clock()
+    store = JobStore(retention_seconds=3_600, max_completed_jobs=5, clock=clock)
+
+    async def complete(value: int) -> int:
+        await asyncio.sleep(0)
+        return value
+
+    await asyncio.gather(*(store.start(complete(index)) for index in range(40)))
+    for _ in range(20):
+        if not any(job["status"] == "running" for job in store._jobs.values()):
+            break
+        await asyncio.sleep(0)
+    else:
+        raise AssertionError("concurrent jobs did not finish")
+
+    terminal_jobs = [job for job in store._jobs.values() if job["status"] != "running"]
+    assert len(terminal_jobs) <= 5
+
+
+def test_retention_policy_rejects_unbounded_or_invalid_values() -> None:
+    with pytest.raises(ValueError, match="retention_seconds"):
+        JobStore(retention_seconds=-1)
+    with pytest.raises(ValueError, match="retention_seconds"):
+        JobStore(retention_seconds=float("inf"))
+    with pytest.raises(ValueError, match="max_completed_jobs"):
+        JobStore(max_completed_jobs=-1)
+    with pytest.raises(ValueError, match="max_completed_jobs"):
+        JobStore(max_completed_jobs=1.5)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- expire completed and failed jobs after a documented one-hour default retention window
- cap retained terminal jobs at 1,000 by default while never evicting running jobs
- prune atomically on start, completion, and status without a permanent cleanup task
- add controllable-clock coverage for TTL, count eviction, running-job preservation, invalid policy values, and concurrent completion

## Verification

- `make pre-commit`
- Core suite: 1,478 passed
- shared jobs suite: 9 passed
- Network async jobs suite: 6 passed
- focused retention suite: 5 passed

Closes #502