### PR TITLE
API actions: preview unconfirmed catalog mutations

### DIFF
--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1978,7 +1978,10 @@ No native ``protect_get_sensor`` tool exists — filter from LIST.
 
 ## untagged
 
-### `POST /v1/actions/{tool_name}` — Post Action
+### `POST /v1/actions/{tool_name}` — Preview or execute a catalog action
+
+
+Read actions execute immediately. Mutations with `confirm=false` validate the request and return a non-mutating preview with `requires_confirmation=true`; no mutation manager is invoked. Send the same request with `confirm=true` to execute it. Capability and argument checks apply to both paths.
 
 
 **Parameters:**

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -151,20 +151,23 @@
         "properties": {
           "args": {
             "additionalProperties": true,
-            "default": {},
+            "description": "Arguments from the catalog entry's input schema.",
             "title": "Args",
             "type": "object"
           },
           "confirm": {
             "default": false,
+            "description": "For mutations, false validates and returns a non-mutating preview; true executes the action. Read actions execute regardless of this value.",
             "title": "Confirm",
             "type": "boolean"
           },
           "controller": {
+            "description": "Registered controller identifier.",
             "title": "Controller",
             "type": "string"
           },
           "site": {
+            "description": "Controller site to use for this action.",
             "title": "Site",
             "type": "string"
           }
@@ -8439,6 +8442,7 @@
   "paths": {
     "/v1/actions/{tool_name}": {
       "post": {
+        "description": "Read actions execute immediately. Mutations with `confirm=false` validate the request and return a non-mutating preview with `requires_confirmation=true`; no mutation manager is invoked. Send the same request with `confirm=true` to execute it. Capability and argument checks apply to both paths.",
         "operationId": "post_action_v1_actions__tool_name__post",
         "parameters": [
           {
@@ -8485,7 +8489,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Post Action"
+        "summary": "Preview or execute a catalog action"
       }
     },
     "/v1/audit": {

--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -6,7 +6,8 @@ import inspect
 from functools import lru_cache
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from unifi_core.redaction import redact_sensitive_fields
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
@@ -56,15 +57,27 @@ def _coerce_list_result(result: object, tool_name: str, kind: str) -> list:
 
 
 class ActionIn(BaseModel):
-    site: str
-    controller: str
-    args: dict = {}
-    confirm: bool = False
+    site: str = Field(description="Controller site to use for this action.")
+    controller: str = Field(description="Registered controller identifier.")
+    args: dict = Field(default_factory=dict, description="Arguments from the catalog entry's input schema.")
+    confirm: bool = Field(
+        default=False,
+        description=(
+            "For mutations, false validates and returns a non-mutating preview; true executes the action. "
+            "Read actions execute regardless of this value."
+        ),
+    )
 
 
 @router.post(
     "/actions/{tool_name}",
     dependencies=[Depends(require_scope(Scope.WRITE))],
+    summary="Preview or execute a catalog action",
+    description=(
+        "Read actions execute immediately. Mutations with `confirm=false` validate the request and return a "
+        "non-mutating preview with `requires_confirmation=true`; no mutation manager is invoked. Send the same "
+        "request with `confirm=true` to execute it. Capability and argument checks apply to both paths."
+    ),
 )
 async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
     sm = request.app.state.sessionmaker
@@ -106,8 +119,9 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 confirm=body.confirm,
             )
             redact_sensitive = request.app.state.config.policy.response.redact_sensitive_fields
-            tool_type = type_registry.lookup_tool(tool_name)
-            if tool_type is not None:
+            if isinstance(result, actions_svc.MutationPreview):
+                shaped = redact_sensitive_fields(result.payload, redact_sensitive=redact_sensitive)
+            elif (tool_type := type_registry.lookup_tool(tool_name)) is not None:
                 # Phase 6 PR2 — read tool migrated to a Strawberry type. Shape
                 # the manager output through Type.from_manager_output().to_dict()
                 # and wrap with the same {"success", "data", "render_hint"}

--- a/apps/api/src/unifi_api/services/actions.py
+++ b/apps/api/src/unifi_api/services/actions.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable
 
 from jsonschema import Draft202012Validator
 from sqlalchemy.ext.asyncio import AsyncSession
+from unifi_core.confirmation import create_preview, delete_preview, preview_response
 from unifi_core.redaction import redaction_marker_paths
 
 from unifi_api.services.dispatch_overrides import (
@@ -33,6 +34,13 @@ class CapabilityMismatch(Exception):
 
 class DispatchEntryMissing(Exception):
     """Raised when a catalog entry has no callable Core manager binding."""
+
+
+@dataclass(frozen=True)
+class MutationPreview:
+    """Validated, non-executed mutation intent for the API response layer."""
+
+    payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -68,6 +76,53 @@ def _classify_action(entry: ToolEntry) -> str:
 
 async def _resolve_result(result: Any) -> Any:
     return await result if inspect.isawaitable(result) else result
+
+
+def _preview_resource_id(args: dict[str, Any]) -> str:
+    """Return the first public resource identifier in stable argument order."""
+    for name, value in args.items():
+        if (name in {"id", "mac", "mac_address"} or name.endswith("_id")) and value not in (None, ""):
+            return str(value)
+    return "(not yet assigned)"
+
+
+def _build_mutation_preview(entry: ToolEntry, site: str, args: dict[str, Any]) -> MutationPreview:
+    """Build a Core-standard preview without resolving or invoking a manager."""
+    resource_name = args.get("name")
+    if not isinstance(resource_name, str):
+        resource_name = None
+
+    if entry.permission_action == "create":
+        payload = create_preview(
+            resource_type=entry.category,
+            resource_data=dict(args),
+            resource_name=resource_name,
+        )
+    elif entry.permission_action == "delete":
+        payload = delete_preview(
+            resource_type=entry.category,
+            resource_id=_preview_resource_id(args),
+            resource_name=resource_name,
+            resource_data=dict(args),
+        )
+    else:
+        payload = preview_response(
+            action=entry.permission_action,
+            resource_type=entry.category,
+            resource_id=_preview_resource_id(args),
+            resource_name=resource_name,
+            current_state={},
+            proposed_changes=dict(args),
+        )
+
+    payload.update(
+        {
+            "tool": entry.name,
+            "product": entry.product,
+            "site": site,
+        }
+    )
+    return MutationPreview(payload)
 
 
 def _validate_action_args(entry: ToolEntry, args: dict[str, Any]) -> None:
@@ -110,8 +165,6 @@ async def dispatch_action(
         )
 
     action_kind = _classify_action(entry)
-    if not confirm and action_kind == "mutation":
-        raise ValueError(f"tool '{tool_name}' requires confirm=true")
 
     if dispatch_table is None:
         binding = DispatchEntry(entry.manager_attr, entry.manager_method)
@@ -139,18 +192,21 @@ async def dispatch_action(
             "omit them or use the dedicated resource endpoint."
         )
 
-    direct_adapter = DISPATCH_DIRECT_RESULT_ADAPTERS.get(tool_name)
-    if direct_adapter is not None:
-        handled, direct_result = direct_adapter(dict(args))
-        if handled:
-            return direct_result
-
     manager_args = dict(args)
     translator = DISPATCH_ARG_TRANSLATORS.get(tool_name)
     if translator is not None:
         positional, keyword = translator(manager_args)
     else:
         positional, keyword = (), manager_args
+
+    if action_kind == "mutation" and not confirm:
+        return _build_mutation_preview(entry, site, args)
+
+    direct_adapter = DISPATCH_DIRECT_RESULT_ADAPTERS.get(tool_name)
+    if direct_adapter is not None:
+        handled, direct_result = direct_adapter(dict(args))
+        if handled:
+            return direct_result
 
     manager = await factory.get_domain_manager(
         session=session,

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -108,7 +108,14 @@ async def test_action_endpoint_enforces_confirmation_before_manager_interaction(
             },
         )
         assert unconfirmed_response.status_code == 200
-        assert "requires confirm=true" in unconfirmed_response.json()["error"]
+        preview = unconfirmed_response.json()
+        assert preview["success"] is True
+        assert preview["requires_confirmation"] is True
+        assert preview["tool"] == "access_unlock_door"
+        assert preview["product"] == "access"
+        assert preview["action"] == "update"
+        assert preview["resource_id"] == "door-1"
+        assert preview["preview"]["proposed"] == {"door_id": "door-1", "duration": 2}
         factory.get_domain_manager.assert_not_awaited()
         manager.apply_unlock_door.assert_not_awaited()
 
@@ -125,6 +132,85 @@ async def test_action_endpoint_enforces_confirmation_before_manager_interaction(
         assert confirmed_response.status_code == 200
         assert confirmed_response.json()["success"] is True
         manager.apply_unlock_door.assert_awaited_once_with(door_id="door-1", duration=2)
+
+
+@pytest.mark.parametrize(
+    ("product", "tool_name", "args", "manager_method"),
+    [
+        ("network", "unifi_reboot_device", {"mac_address": "aa:bb:cc:dd:ee:ff"}, "reboot_device"),
+        ("protect", "protect_reboot_camera", {"camera_id": "camera-1"}, "apply_reboot_camera"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_action_endpoint_previews_network_and_protect_without_manager_interaction(
+    tmp_path,
+    monkeypatch,
+    product,
+    tool_name,
+    args,
+    manager_method,
+) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, product_kinds=product)
+    manager = MagicMock()
+    setattr(manager, manager_method, AsyncMock(return_value=True))
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    app.state.manager_factory = factory
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            f"/v1/actions/{tool_name}",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": args, "confirm": False},
+        )
+
+    assert response.status_code == 200
+    preview = response.json()
+    assert preview["success"] is True
+    assert preview["requires_confirmation"] is True
+    assert preview["tool"] == tool_name
+    assert preview["product"] == product
+    assert preview["preview"]["proposed"] == args
+    if product == "network":
+        assert preview["resource_id"] == args["mac_address"]
+    factory.get_domain_manager.assert_not_awaited()
+    getattr(manager, manager_method).assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_action_endpoint_redacts_sensitive_preview_fields(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock()
+    app.state.manager_factory = factory
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/actions/unifi_create_wlan",
+            headers={"Authorization": f"Bearer {key}"},
+            json={
+                "site": "default",
+                "controller": cid,
+                "args": {
+                    "wlan_data": {
+                        "name": "Preview only",
+                        "security": "wpa2-psk",
+                        "x_passphrase": "do-not-return-this",
+                    }
+                },
+                "confirm": False,
+            },
+        )
+
+    assert response.status_code == 200
+    preview = response.json()
+    assert preview["success"] is True
+    assert preview["requires_confirmation"] is True
+    assert preview["preview"]["will_create"]["wlan_data"]["x_passphrase"] == "***REDACTED***"
+    assert "do-not-return-this" not in response.text
+    factory.get_domain_manager.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -11,6 +11,7 @@ from unifi_api.services.actions import (
     CapabilityMismatch,
     DispatchEntry,
     DispatchEntryMissing,
+    MutationPreview,
     build_dispatch_table,
     dispatch_action,
 )
@@ -123,14 +124,14 @@ def test_dispatchable_mutations_include_high_impact_sentinels() -> None:
     DISPATCHABLE_MUTATIONS,
     ids=[tool_name for tool_name, _entry in DISPATCHABLE_MUTATIONS],
 )
-async def test_every_dispatchable_mutation_requires_confirm(
+async def test_every_dispatchable_mutation_preview_never_resolves_manager(
     tool_name: str,
     entry: ToolEntry,
 ) -> None:
     factory = MagicMock()
 
-    with pytest.raises(ValueError, match=rf"tool '{tool_name}' requires confirm=true"):
-        await dispatch_action(
+    try:
+        result = await dispatch_action(
             registry=_registry_with(entry),
             factory=factory,
             session=MagicMock(),
@@ -140,8 +141,14 @@ async def test_every_dispatchable_mutation_requires_confirm(
             site="default",
             args={},
             confirm=False,
-            dispatch_table={},
         )
+    except ValueError:
+        # Most production mutations require arguments. Validation may reject
+        # this deliberately minimal probe, but it must still fail before a
+        # controller manager is resolved.
+        pass
+    else:
+        assert isinstance(result, MutationPreview)
 
     factory.get_domain_manager.assert_not_called()
 
@@ -456,19 +463,19 @@ async def test_capability_mismatch_precedes_safety_metadata_validation() -> None
 
 
 @pytest.mark.asyncio
-async def test_confirmation_precedes_argument_validation() -> None:
+async def test_preview_argument_validation_precedes_preview_response() -> None:
     entry = ToolEntry(
         name="access_update_test_resource",
         product="access",
         category="test",
-        manager="",
-        method="",
+        manager="test_manager",
+        method="update_test_resource",
         permission_action="update",
         read_only_hint=False,
     )
     factory = MagicMock()
 
-    with pytest.raises(ValueError, match="requires confirm=true"):
+    with pytest.raises(ValueError, match="include_sensitive is not supported"):
         await dispatch_action(
             registry=_registry_with(entry),
             factory=factory,
@@ -479,7 +486,6 @@ async def test_confirmation_precedes_argument_validation() -> None:
             site="default",
             args={"include_sensitive": True},
             confirm=False,
-            dispatch_table={},
         )
 
     factory.get_domain_manager.assert_not_called()
@@ -956,40 +962,45 @@ async def test_dispatch_protect_update_viewer_routes_to_apply_viewer_update() ->
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("tool_name", "product"),
+    ("tool_name", "product", "args"),
     [
-        ("unifi_delete_dns_record", "network"),
-        ("protect_alarm_delete_rule", "protect"),
-        ("access_delete_visitor", "access"),
+        ("unifi_delete_dns_record", "network", {"dns_record_id": "dns-1"}),
+        ("protect_alarm_delete_rule", "protect", {"rule_id": "rule-1"}),
+        ("access_delete_visitor", "access", {"visitor_id": "visitor-1"}),
     ],
 )
-async def test_dispatch_delete_actions_require_confirm(tool_name: str, product: str) -> None:
+async def test_dispatch_delete_actions_return_preview_without_manager(
+    tool_name: str,
+    product: str,
+    args: dict,
+) -> None:
     entry = ToolEntry(
         name=tool_name,
         product=product,
         category="test",
-        manager="",
-        method="",
+        manager="test_manager",
+        method="delete_resource",
         permission_action="delete",
         read_only_hint=False,
     )
     registry = _registry_with(entry)
     factory = MagicMock()
 
-    with pytest.raises(ValueError, match="requires confirm=true"):
-        await dispatch_action(
-            registry=registry,
-            factory=factory,
-            session=MagicMock(),
-            tool_name=tool_name,
-            controller_id="cid",
-            controller_products=[product],
-            site="default",
-            args={},
-            confirm=False,
-            dispatch_table={},
-        )
+    result = await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name=tool_name,
+        controller_id="cid",
+        controller_products=[product],
+        site="default",
+        args=args,
+        confirm=False,
+    )
 
+    assert isinstance(result, MutationPreview)
+    assert result.payload["action"] == "delete"
+    assert result.payload["tool"] == tool_name
     factory.get_domain_manager.assert_not_called()
 
 
@@ -1090,7 +1101,7 @@ async def test_dispatch_confirmed_delete_reaches_manager() -> None:
         ("protect_update_viewer", {"viewer_id": "viewer-1", "settings": {"name": "Lobby"}}),
     ],
 )
-async def test_dispatch_protect_capability_actions_require_confirm(tool_name: str, args: dict) -> None:
+async def test_dispatch_protect_capability_actions_return_preview(tool_name: str, args: dict) -> None:
     entry = ToolEntry(
         name=tool_name,
         product="protect",
@@ -1103,25 +1114,27 @@ async def test_dispatch_protect_capability_actions_require_confirm(tool_name: st
     registry = _registry_with(entry)
     factory = MagicMock()
 
-    with pytest.raises(ValueError, match="requires confirm=true"):
-        await dispatch_action(
-            registry=registry,
-            factory=factory,
-            session=MagicMock(),
-            tool_name=tool_name,
-            controller_id="cid",
-            controller_products=["protect"],
-            site="default",
-            args=args,
-            confirm=False,
-            dispatch_table=build_dispatch_table(),
-        )
+    result = await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name=tool_name,
+        controller_id="cid",
+        controller_products=["protect"],
+        site="default",
+        args=args,
+        confirm=False,
+        dispatch_table=build_dispatch_table(),
+    )
 
+    assert isinstance(result, MutationPreview)
+    assert result.payload["product"] == "protect"
+    assert result.payload["preview"]["proposed"] == args
     factory.get_domain_manager.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_dispatch_reorder_firewall_policies_requires_confirm() -> None:
+async def test_dispatch_reorder_firewall_policies_returns_preview() -> None:
     entry = ToolEntry(
         name="unifi_reorder_firewall_policies",
         product="network",
@@ -1134,32 +1147,35 @@ async def test_dispatch_reorder_firewall_policies_requires_confirm() -> None:
     registry = _registry_with(entry)
     factory = MagicMock()
 
-    with pytest.raises(ValueError, match="requires confirm=true"):
-        await dispatch_action(
-            registry=registry,
-            factory=factory,
-            session=MagicMock(),
-            tool_name="unifi_reorder_firewall_policies",
-            controller_id="cid",
-            controller_products=["network"],
-            site="default",
-            args={
-                "source_firewall_zone_id": "zone-src",
-                "destination_firewall_zone_id": "zone-dst",
-                "ordered_firewall_policy_ids": {
-                    "beforeSystemDefined": ["allow-1"],
-                    "afterSystemDefined": ["block-1"],
-                },
-            },
-            confirm=False,
-            dispatch_table={
-                "unifi_reorder_firewall_policies": DispatchEntry(
-                    manager_attr="firewall_manager",
-                    method="reorder_firewall_policies",
-                ),
-            },
-        )
+    args = {
+        "source_firewall_zone_id": "zone-src",
+        "destination_firewall_zone_id": "zone-dst",
+        "ordered_firewall_policy_ids": {
+            "beforeSystemDefined": ["allow-1"],
+            "afterSystemDefined": ["block-1"],
+        },
+    }
+    result = await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_reorder_firewall_policies",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args=args,
+        confirm=False,
+        dispatch_table={
+            "unifi_reorder_firewall_policies": DispatchEntry(
+                manager_attr="firewall_manager",
+                method="reorder_firewall_policies",
+            ),
+        },
+    )
 
+    assert isinstance(result, MutationPreview)
+    assert result.payload["preview"]["proposed"] == args
+    assert result.payload["resource_id"] == "zone-src"
     factory.get_domain_manager.assert_not_called()
 
 

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1950,10 +1950,10 @@ API_ACTION_SENTINELS: dict[str, str] = {
     "access": "access_list_doors",
 }
 
-API_CONFIRMATION_NEGATIVE_CONTROLS: dict[str, tuple[str, dict[str, Any]]] = {
+API_CONFIRMATION_PREVIEW_CONTROLS: dict[str, tuple[str, dict[str, Any]]] = {
     "network": ("unifi_reboot_device", {"mac_address": "00:00:00:00:00:00"}),
     "protect": ("protect_reboot_camera", {"camera_id": "__confirmation_probe__"}),
-    "access": ("access_unlock_door", {"door_id": "__confirmation_probe__"}),
+    "access": ("access_unlock_door", {"door_id": "__confirmation_probe__", "duration": 2}),
 }
 
 
@@ -1976,15 +1976,23 @@ def _validate_api_action_catalog(response: object) -> dict[str, Any]:
     }
 
 
-def _classify_confirmation_negative_control(status: int, response: object) -> dict[str, Any]:
-    error = str(response.get("error") or "") if isinstance(response, dict) else f"HTTP {status}: {response!r}"
+def _classify_confirmation_preview_control(
+    status: int,
+    response: object,
+    *,
+    expected_tool: str,
+) -> dict[str, Any]:
+    tool = str(response.get("tool") or "") if isinstance(response, dict) else ""
     passed = (
         status == 200
         and isinstance(response, dict)
-        and response.get("success") is False
-        and "requires confirm=true" in error
+        and response.get("success") is True
+        and response.get("requires_confirmation") is True
+        and response.get("action") in {"create", "update", "delete"}
+        and isinstance(response.get("preview"), dict)
+        and tool == expected_tool
     )
-    return {"passed": passed, "error": error}
+    return {"passed": passed, "tool_returned": tool, "response": response}
 
 
 def _classify_api_action_result(success: bool | None, shape_match: bool) -> str:
@@ -2207,9 +2215,11 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
         "db_path": str(db_path),
         "controllers": [],
         "catalog_probe": None,
-        "confirmation_negative_controls": [],
+        "confirmation_preview_controls": [],
         "results": [],
         "summary": {
+            "preview_controls_exercised": 0,
+            "preview_controls_passed": 0,
             "tools_exercised": 0,
             "passed": 0,
             "regressions": 0,
@@ -2310,8 +2320,10 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
             controller_id = product_to_controller_id.get(product)
             if controller_id is None:
                 continue
-            tool_name, tool_args = API_CONFIRMATION_NEGATIVE_CONTROLS[product]
-            negative_status, negative_response = _http_request(
+            tool_name, tool_args = API_CONFIRMATION_PREVIEW_CONTROLS[product]
+            if args.tool and tool_name not in args.tool:
+                continue
+            preview_status, preview_response = _http_request(
                 "POST",
                 f"{base_url}/v1/actions/{tool_name}",
                 headers=auth_headers,
@@ -2322,20 +2334,27 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
                     "confirm": False,
                 },
             )
-            negative_result = _classify_confirmation_negative_control(negative_status, negative_response)
-            artifact["confirmation_negative_controls"].append(
+            preview_result = _classify_confirmation_preview_control(
+                preview_status,
+                preview_response,
+                expected_tool=tool_name,
+            )
+            artifact["confirmation_preview_controls"].append(
                 {
                     "product": product,
                     "tool": tool_name,
-                    "http_status": negative_status,
-                    **negative_result,
+                    "http_status": preview_status,
+                    **preview_result,
                 }
             )
             print(
-                f"  confirmation negative control: {tool_name} passed={negative_result['passed']}",
+                f"  confirmation preview control: {tool_name} passed={preview_result['passed']}",
                 flush=True,
             )
-            if not negative_result["passed"]:
+            artifact["summary"]["preview_controls_exercised"] += 1
+            if preview_result["passed"]:
+                artifact["summary"]["preview_controls_passed"] += 1
+            else:
                 artifact["summary"]["regressions"] += 1
 
         # Step 2: exercise the sample, comparing to baselines
@@ -2348,6 +2367,8 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
 
         for product, tool_name, tool_args in API_ACTIONS_SAMPLE:
             if product not in product_to_controller_id:
+                continue
+            if args.tool and tool_name not in args.tool:
                 continue
             controller_id = product_to_controller_id[product]
             site = site_for_product[product]

--- a/tests/test_live_smoke_harness.py
+++ b/tests/test_live_smoke_harness.py
@@ -33,18 +33,43 @@ def test_live_api_catalog_probe_reports_exact_parity(monkeypatch, tmp_path):
     assert all(result["sentinels"].values())
 
 
-def test_live_api_confirmation_negative_control_requires_interlock_error():
+def test_live_api_confirmation_preview_control_requires_safe_preview():
     import live_smoke
 
-    assert live_smoke._classify_confirmation_negative_control(
+    response = {
+        "success": True,
+        "requires_confirmation": True,
+        "tool": "unifi_reboot_device",
+        "action": "update",
+        "preview": {"proposed": {"mac_address": "00:00:00:00:00:00"}},
+    }
+    assert live_smoke._classify_confirmation_preview_control(
         200,
-        {"success": False, "error": "tool 'unifi_reboot_device' requires confirm=true"},
-    ) == {"passed": True, "error": "tool 'unifi_reboot_device' requires confirm=true"}
-    assert live_smoke._classify_confirmation_negative_control(200, {"success": True})["passed"] is False
+        response,
+        expected_tool="unifi_reboot_device",
+    ) == {"passed": True, "tool_returned": "unifi_reboot_device", "response": response}
     assert (
-        live_smoke._classify_confirmation_negative_control(200, {"success": False, "error": "device not found"})[
-            "passed"
-        ]
+        live_smoke._classify_confirmation_preview_control(
+            200,
+            {"success": True},
+            expected_tool="unifi_reboot_device",
+        )["passed"]
+        is False
+    )
+    assert (
+        live_smoke._classify_confirmation_preview_control(
+            200,
+            {"success": False, "error": "tool 'unifi_reboot_device' requires confirm=true"},
+            expected_tool="unifi_reboot_device",
+        )["passed"]
+        is False
+    )
+    assert (
+        live_smoke._classify_confirmation_preview_control(
+            200,
+            {**response, "tool": "protect_reboot_camera"},
+            expected_tool="unifi_reboot_device",
+        )["passed"]
         is False
     )
 


### PR DESCRIPTION
Closes #503.

## Summary

- return Core-standard mutation previews from `POST /v1/actions/{tool}` when `confirm=false`
- validate capability, safety metadata, catalog arguments, unsupported fields, redaction markers, and action translators before previewing
- stop before manager resolution so preview requests cannot reach a controller or invoke a mutation
- preserve the existing `confirm=true` execution path and redact sensitive preview fields at the API boundary
- document both paths in OpenAPI/reference docs
- update the live harness to verify exact Network, Protect, and Access preview responses and honor API action `--tool` filters

## Verification

- `make pre-commit`
- API suite: 1,176 passed
- focused dispatcher/endpoint tests: 275 passed
- live API harness: catalog 266/266; 3/3 product preview controls passed; 0 regressions

Live artifact: `live-smoke-results/phase2-api-actions/api-actions-2026-08-07T144406.461065Z.json` (gitignored operator evidence).