### PR TITLE
feat(api): complete read action parity

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.23,<0.5",
+    "unifi-core[network,protect,access]>=0.4.24,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -14,6 +14,7 @@ from unifi_api.auth.scopes import Scope
 from unifi_api.serializers._base import SerializerContractError
 from unifi_api.serializers._registry import SerializerRegistryError
 from unifi_api.services import actions as actions_svc
+from unifi_api.services.action_results import ShapedReadResult
 from unifi_api.services.audit import write_audit
 from unifi_api.services.controllers import ControllerNotFound, get_controller
 from unifi_api.services.manifest import ToolNotFound
@@ -54,6 +55,69 @@ def _coerce_list_result(result: object, tool_name: str, kind: str) -> list:
     raise SerializerContractError(
         f"tool '{tool_name}' declared kind={kind} but manager returned {type(result).__name__}"
     )
+
+
+def _shape_shared_read_result(
+    result: ShapedReadResult,
+    *,
+    tool_name: str,
+    type_registry: object,
+    redact_sensitive: bool,
+) -> dict:
+    """Preserve the action envelope while returning a Core-shaped read view."""
+    payload = redact_sensitive_fields(result.payload, redact_sensitive=redact_sensitive)
+    if payload.get("success") is False:
+        return payload
+    if result.data_key not in payload:
+        raise SerializerContractError(f"tool '{tool_name}' shared read view omitted primary field '{result.data_key}'")
+    tool_type = type_registry.lookup_tool(tool_name)
+    if tool_type is None:
+        raise SerializerContractError(f"tool '{tool_name}' shared read view has no registered render type")
+    _, kind = tool_type
+    data = payload[result.data_key]
+    if kind in ("list", "timeseries", "event_log"):
+        if not isinstance(data, list):
+            raise SerializerContractError(
+                f"tool '{tool_name}' declared kind={kind} but shared read view returned {type(data).__name__}"
+            )
+    elif not isinstance(data, dict):
+        raise SerializerContractError(
+            f"tool '{tool_name}' declared kind={kind} but shared read view returned {type(data).__name__}"
+        )
+
+    hint = {"kind": kind, **result.render_hint}
+    projected_fields = payload.get("fields")
+    if isinstance(projected_fields, str) and projected_fields.strip():
+        selected = {field.strip() for field in projected_fields.split(",")}
+        if hint.get("primary_key") not in selected:
+            hint.pop("primary_key", None)
+        if isinstance(hint.get("display_columns"), list):
+            hint["display_columns"] = [field for field in hint["display_columns"] if field in selected]
+        sort_field = str(hint.get("sort_default", "")).partition(":")[0]
+        if sort_field and sort_field not in selected:
+            hint.pop("sort_default", None)
+
+    if isinstance(data, list):
+        item_fields = [set(item) for item in data if isinstance(item, dict)]
+        available = set().union(*item_fields) if item_fields else set()
+        guaranteed = set.intersection(*item_fields) if item_fields else set()
+        if hint.get("primary_key") not in guaranteed:
+            hint.pop("primary_key", None)
+        if isinstance(hint.get("display_columns"), list):
+            hint["display_columns"] = [field for field in hint["display_columns"] if field in available]
+        sort_field = str(hint.get("sort_default", "")).partition(":")[0]
+        if sort_field and sort_field not in available:
+            hint.pop("sort_default", None)
+
+    metadata = {key: value for key, value in payload.items() if key not in {"success", result.data_key}}
+    shaped = {
+        "success": True,
+        "data": data,
+        "render_hint": hint,
+    }
+    if metadata:
+        shaped["meta"] = metadata
+    return shaped
 
 
 class ActionIn(BaseModel):
@@ -121,6 +185,13 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
             redact_sensitive = request.app.state.config.policy.response.redact_sensitive_fields
             if isinstance(result, actions_svc.MutationPreview):
                 shaped = redact_sensitive_fields(result.payload, redact_sensitive=redact_sensitive)
+            elif isinstance(result, ShapedReadResult):
+                shaped = _shape_shared_read_result(
+                    result,
+                    tool_name=tool_name,
+                    type_registry=type_registry,
+                    redact_sensitive=redact_sensitive,
+                )
             elif (tool_type := type_registry.lookup_tool(tool_name)) is not None:
                 # Phase 6 PR2 — read tool migrated to a Strawberry type. Shape
                 # the manager output through Type.from_manager_output().to_dict()

--- a/apps/api/src/unifi_api/services/action_results.py
+++ b/apps/api/src/unifi_api/services/action_results.py
@@ -1,0 +1,15 @@
+"""Marker result types shared by action dispatch and response routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ShapedReadResult:
+    """A Core-shaped read result with its primary public data field."""
+
+    payload: dict[str, Any]
+    data_key: str
+    render_hint: dict[str, Any] = field(default_factory=dict)

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -44,6 +44,22 @@ import base64
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from unifi_core.network.read_views import (
+    shape_alerts,
+    shape_client_details,
+    shape_client_list,
+    shape_dashboard,
+    shape_device_details,
+    shape_device_list,
+    shape_firewall_policy_list,
+    shape_network_details,
+    shape_network_list,
+    shape_rogue_ap_list,
+    shape_wlan_list,
+)
+
+from unifi_api.services.action_results import ShapedReadResult
+
 # Format: tool_name -> (manager_attr, method_name)
 DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     # =========================================================================
@@ -602,15 +618,13 @@ def _rename_mac_address_to_client_mac(args: dict[str, Any]) -> tuple[tuple[Any, 
 # ---------------------------------------------------------------------------
 # Network — list_clients
 # ---------------------------------------------------------------------------
-# ``get_clients()`` takes no arguments.  The tool exposes ``filter_type``,
-# ``include_offline``, and ``limit`` to the LLM for its own filtering logic,
-# but since the dispatcher bypasses the tool body we must strip those kwargs
-# before invoking the no-arg manager method.
+# Core owns the online-vs-historical selection; the remaining public options
+# are applied by the shared result view after the manager returns.
 
 
 def _translate_list_clients(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    """Strip tool-only filter kwargs; ``get_clients()`` accepts no arguments."""
-    return (), {}
+    """Pass only the Core client-source selector to ``get_clients``."""
+    return (), {"include_offline": args.get("include_offline", False)}
 
 
 # ---------------------------------------------------------------------------
@@ -1168,19 +1182,200 @@ def _recent_events_result(result: Any, args: dict[str, Any], manager: Any) -> di
     }
 
 
-UNSUPPORTED_ACTION_PARAMETERS: dict[str, frozenset[str]] = {
-    "unifi_list_clients": frozenset({"filter_type", "include_offline", "search", "limit", "fields"}),
-    "unifi_get_alerts": frozenset({"limit"}),
-    "unifi_get_client_details": frozenset({"include", "summary"}),
-    "unifi_get_dashboard": frozenset({"summary"}),
-    "unifi_get_device_details": frozenset({"include", "summary"}),
-    "unifi_get_network_details": frozenset({"include", "summary"}),
-    "unifi_list_devices": frozenset({"device_type", "status", "search", "limit", "include_details", "summary"}),
-    "unifi_list_firewall_policies": frozenset({"search", "action", "enabled_only", "limit", "summary"}),
-    "unifi_list_networks": frozenset({"fields", "limit", "purpose", "search"}),
-    "unifi_list_rogue_aps": frozenset({"channel", "limit", "min_signal", "offset", "summary"}),
-    "unifi_list_wlans": frozenset({"enabled_only", "limit", "search"}),
-}
+def _manager_site(manager: Any) -> str:
+    return str(manager._connection.site)
+
+
+def _list_clients_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_client_list(
+        result,
+        site=_manager_site(manager),
+        filter_type=args.get("filter_type", "all"),
+        search=args.get("search"),
+        limit=args.get("limit", 100),
+        fields=args.get("fields"),
+    )
+    return ShapedReadResult(
+        payload,
+        "clients",
+        {
+            "primary_key": "mac",
+            "display_columns": ["name", "ip", "connection_type", "status"],
+            "sort_default": "name:asc",
+        },
+    )
+
+
+def _alerts_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_alerts(
+        result,
+        site=_manager_site(manager),
+        limit=args.get("limit", 10),
+        include_archived=args.get("include_archived", False),
+    )
+    return ShapedReadResult(
+        payload,
+        "alerts",
+        {
+            "primary_key": "_id",
+            "display_columns": ["timestamp", "key", "msg", "mac"],
+            "sort_default": "timestamp:desc",
+        },
+    )
+
+
+def _client_details_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_client_details(
+        result,
+        site=_manager_site(manager),
+        mac_address=args["mac_address"],
+        include=args.get("include", "basic"),
+        summary=args.get("summary", False),
+    )
+    return ShapedReadResult(payload, "client")
+
+
+def _dashboard_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_dashboard(
+        result,
+        site=_manager_site(manager),
+        summary=args.get("summary", True),
+        history_seconds=args.get("history_seconds", 86400),
+    )
+    return ShapedReadResult(payload, "dashboard", {"sort_default": "time:desc"})
+
+
+def _device_details_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_device_details(
+        result,
+        site=_manager_site(manager),
+        mac_address=args["mac_address"],
+        include=args.get("include", "basic,ports"),
+        summary=args.get("summary", False),
+    )
+    return ShapedReadResult(payload, "device")
+
+
+def _network_details_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_network_details(
+        result,
+        site=_manager_site(manager),
+        network_id=args["network_id"],
+        include=args.get("include", "basic"),
+        summary=args.get("summary", False),
+    )
+    return ShapedReadResult(payload, "details")
+
+
+def _list_devices_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_device_list(
+        result,
+        site=_manager_site(manager),
+        device_type=args.get("device_type", "all"),
+        status=args.get("status", "all"),
+        search=args.get("search"),
+        limit=args.get("limit"),
+        include_details=args.get("include_details", False),
+        summary=args.get("summary", True),
+    )
+    return ShapedReadResult(
+        payload,
+        "devices",
+        {
+            "primary_key": "mac",
+            "display_columns": ["name", "model", "type", "status", "ip"],
+            "sort_default": "name:asc",
+        },
+    )
+
+
+def _firewall_policies_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    summary = args.get("summary", True)
+    payload = shape_firewall_policy_list(
+        result,
+        site=_manager_site(manager),
+        search=args.get("search"),
+        action=args.get("action"),
+        enabled_only=args.get("enabled_only", False),
+        limit=args.get("limit", 50),
+        summary=summary,
+    )
+    index_field = "rule_index" if summary else "index"
+    return ShapedReadResult(
+        payload,
+        "policies",
+        {
+            "primary_key": "id",
+            "display_columns": ["name", "action", "enabled", index_field],
+            "sort_default": f"{index_field}:asc",
+        },
+    )
+
+
+def _list_networks_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_network_list(
+        result,
+        site=_manager_site(manager),
+        search=args.get("search"),
+        purpose=args.get("purpose"),
+        limit=args.get("limit", 25),
+        fields=args.get("fields"),
+    )
+    return ShapedReadResult(
+        payload,
+        "networks",
+        {
+            "primary_key": "_id",
+            "display_columns": ["name", "purpose", "vlan", "ip_subnet", "enabled"],
+            "sort_default": "name:asc",
+        },
+    )
+
+
+def _rogue_aps_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    summary = args.get("summary", True)
+    payload = shape_rogue_ap_list(
+        result,
+        site=_manager_site(manager),
+        within_hours=args.get("within_hours", 24),
+        channel=args.get("channel"),
+        min_signal=args.get("min_signal"),
+        limit=args.get("limit", 100),
+        offset=args.get("offset", 0),
+        summary=summary,
+    )
+    ssid_field = "ssid" if summary else "essid"
+    return ShapedReadResult(
+        payload,
+        "rogue_aps",
+        {
+            "primary_key": "bssid",
+            "display_columns": ["bssid", ssid_field, "channel", "signal", "last_seen"],
+            "sort_default": "signal:desc",
+        },
+    )
+
+
+def _wlans_result(result: Any, args: dict[str, Any], manager: Any) -> ShapedReadResult:
+    payload = shape_wlan_list(
+        result,
+        site=_manager_site(manager),
+        search=args.get("search"),
+        enabled_only=args.get("enabled_only", False),
+        limit=args.get("limit", 25),
+    )
+    return ShapedReadResult(
+        payload,
+        "wlans",
+        {
+            "primary_key": "id",
+            "display_columns": ["name", "security", "enabled", "network_id"],
+            "sort_default": "name:asc",
+        },
+    )
+
+
+UNSUPPORTED_ACTION_PARAMETERS: dict[str, frozenset[str]] = {}
 
 DirectResultAdapter = Callable[[dict[str, Any]], tuple[bool, Any]]
 ResultAdapter = Callable[[Any, dict[str, Any], Any], Any]
@@ -1196,6 +1391,17 @@ DISPATCH_RESULT_ADAPTERS: dict[str, ResultAdapter] = {
     "protect_alarm_update_rule": _alarm_facade_result,
     "protect_alarm_delete_rule": _alarm_facade_result,
     "protect_delete_recording": _delete_recording_result,
+    "unifi_list_clients": _list_clients_result,
+    "unifi_get_alerts": _alerts_result,
+    "unifi_get_client_details": _client_details_result,
+    "unifi_get_dashboard": _dashboard_result,
+    "unifi_get_device_details": _device_details_result,
+    "unifi_get_network_details": _network_details_result,
+    "unifi_list_devices": _list_devices_result,
+    "unifi_list_firewall_policies": _firewall_policies_result,
+    "unifi_list_networks": _list_networks_result,
+    "unifi_list_rogue_aps": _rogue_aps_result,
+    "unifi_list_wlans": _wlans_result,
 }
 
 
@@ -1266,8 +1472,8 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslatorSpec] = {
         "local_dns_record",
     ),
     "unifi_forget_client": _spec(_rename_mac_address_to_client_mac, "client_mac"),
-    # Network — list clients: manager get_clients() takes no args
-    "unifi_list_clients": _spec(_translate_list_clients),
+    # Network — list clients: Core selects online or all/historical clients.
+    "unifi_list_clients": _spec(_translate_list_clients, "include_offline"),
     # Network — firewall: kwarg rename
     "unifi_update_firewall_policy": _spec(_translate_update_firewall_policy, "policy_id", "updates"),
     # Network — port forward toggle/delete: kwarg rename (port_forward_id → rule_id)

--- a/apps/api/tests/test_action_catalog_packaging.py
+++ b/apps/api/tests/test_action_catalog_packaging.py
@@ -16,7 +16,7 @@ def test_api_declares_only_core_as_an_internal_runtime_dependency() -> None:
     dependencies = pyproject["project"]["dependencies"]
     internal = [dependency for dependency in dependencies if dependency.startswith("unifi-")]
 
-    assert internal == ["unifi-core[network,protect,access]>=0.4.23,<0.5"]
+    assert internal == ["unifi-core[network,protect,access]>=0.4.24,<0.5"]
 
 
 def test_built_wheel_contains_and_loads_catalog_without_sibling_apps(tmp_path: Path) -> None:

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -267,6 +267,98 @@ async def test_action_endpoint_dispatches_and_audits(tmp_path, monkeypatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_action_endpoint_preserves_shared_read_view_metadata(tmp_path, monkeypatch) -> None:
+    """Shared read views keep the typed action envelope and expose their metadata."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    from unifi_api.services import actions as actions_svc
+    from unifi_api.services.action_results import ShapedReadResult
+
+    shaped = ShapedReadResult(
+        payload={
+            "success": True,
+            "site": "default",
+            "filter_type": "wired",
+            "fields": "mac,connection_type",
+            "total_count": 2,
+            "returned_count": 1,
+            "limit": 1,
+            "clients": [{"mac": "aa:bb", "connection_type": "Wired"}],
+        },
+        data_key="clients",
+        render_hint={
+            "primary_key": "mac",
+            "display_columns": ["name", "connection_type"],
+            "sort_default": "name:asc",
+        },
+    )
+    monkeypatch.setattr(actions_svc, "dispatch_action", AsyncMock(return_value=shaped))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.post(
+            "/v1/actions/unifi_list_clients",
+            headers={"Authorization": f"Bearer {key}"},
+            json={
+                "site": "default",
+                "controller": cid,
+                "args": {"filter_type": "wired", "limit": 1, "fields": "mac,connection_type"},
+                "confirm": False,
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["success"] is True
+    assert body["data"] == [{"mac": "aa:bb", "connection_type": "Wired"}]
+    assert body["render_hint"] == {
+        "kind": "list",
+        "primary_key": "mac",
+        "display_columns": ["connection_type"],
+    }
+    assert body["meta"] == {
+        "site": "default",
+        "filter_type": "wired",
+        "fields": "mac,connection_type",
+        "total_count": 2,
+        "returned_count": 1,
+        "limit": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_action_endpoint_rejects_malformed_shared_read_shape(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    from unifi_api.services import actions as actions_svc
+    from unifi_api.services.action_results import ShapedReadResult
+
+    monkeypatch.setattr(
+        actions_svc,
+        "dispatch_action",
+        AsyncMock(
+            return_value=ShapedReadResult(
+                payload={"success": True, "clients": {"mac": "aa:bb"}},
+                data_key="clients",
+                render_hint={"primary_key": "mac"},
+            )
+        ),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.post(
+            "/v1/actions/unifi_list_clients",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {}, "confirm": False},
+        )
+
+    assert response.status_code == 500
+    assert response.json()["detail"]["kind"] == "serializer_contract_error"
+    assert "shared read view returned dict" in response.json()["detail"]["detail"]
+
+
+@pytest.mark.asyncio
 async def test_action_endpoint_serializer_contract_error(tmp_path, monkeypatch) -> None:
     """When manager returns wrong type for declared kind, endpoint returns 500."""
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from unifi_api.services.action_results import ShapedReadResult
 from unifi_api.services.actions import (
     CapabilityMismatch,
     DispatchEntry,
@@ -241,9 +242,10 @@ async def test_dispatch_happy_path_invokes_manager() -> None:
     )
     registry = _registry_with(entry)
 
-    # Mock domain manager whose `get_clients` returns a sentinel response.
-    expected_response = {"success": True, "data": {"clients": []}}
+    # Mock domain manager whose `get_clients` returns controller rows.
+    expected_response: list[dict[str, object]] = []
     domain_manager = MagicMock()
+    domain_manager._connection.site = "default"
     domain_manager.get_clients = AsyncMock(return_value=expected_response)
 
     # Mock connection manager — supports site updates.
@@ -272,7 +274,26 @@ async def test_dispatch_happy_path_invokes_manager() -> None:
         },
     )
 
-    assert result is expected_response
+    assert result == ShapedReadResult(
+        payload={
+            "success": True,
+            "site": "default",
+            "filter_type": "all",
+            "search": None,
+            "fields": None,
+            "total_count": 0,
+            "returned_count": 0,
+            "count": 0,
+            "limit": 100,
+            "clients": [],
+        },
+        data_key="clients",
+        render_hint={
+            "primary_key": "mac",
+            "display_columns": ["name", "ip", "connection_type", "status"],
+            "sort_default": "name:asc",
+        },
+    )
     factory.get_domain_manager.assert_awaited_once_with(
         session=session,
         controller_id="cid",
@@ -280,7 +301,7 @@ async def test_dispatch_happy_path_invokes_manager() -> None:
         attr_name="client_manager",
         site="default",
     )
-    domain_manager.get_clients.assert_awaited_once_with()
+    domain_manager.get_clients.assert_awaited_once_with(include_offline=False)
     factory.get_connection_manager.assert_not_awaited()
 
 
@@ -545,7 +566,7 @@ async def test_dispatch_scopes_manager_to_requested_site_without_mutating_connec
     registry = _registry_with(entry)
 
     domain_manager = MagicMock()
-    domain_manager.get_clients = AsyncMock(return_value={"ok": True})
+    domain_manager.get_clients = AsyncMock(return_value=[])
 
     factory = MagicMock()
     factory.get_domain_manager = AsyncMock(return_value=domain_manager)
@@ -575,8 +596,7 @@ async def test_dispatch_scopes_manager_to_requested_site_without_mutating_connec
         site="upstairs",
     )
     factory.get_connection_manager.assert_not_awaited()
-    # The list_clients translator strips filter kwargs; get_clients() takes no args.
-    domain_manager.get_clients.assert_awaited_once_with()
+    domain_manager.get_clients.assert_awaited_once_with(include_offline=False)
 
 
 def test_build_dispatch_table_finds_real_tools() -> None:
@@ -2165,53 +2185,6 @@ async def test_dispatch_translates_set_client_ip_settings_mac_address_to_client_
 
 
 # ---------------------------------------------------------------------------
-# Network — list_clients: manager get_clients() takes no arguments
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_dispatch_rejects_list_clients_wrapper_only_kwargs() -> None:
-    """The typed action endpoint must not silently discard MCP-only filters."""
-    entry = ToolEntry(
-        name="unifi_list_clients",
-        product="network",
-        category="clients",
-        manager="",
-        method="",
-    )
-    registry = _registry_with(entry)
-
-    domain_manager = MagicMock()
-    domain_manager.get_clients = AsyncMock(return_value=[])
-
-    conn_manager = MagicMock()
-    conn_manager.site = "default"
-    conn_manager.set_site = AsyncMock()
-
-    factory = MagicMock()
-    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
-    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
-
-    with pytest.raises(ValueError, match="filter_type.*include_offline.*limit.*not supported"):
-        await dispatch_action(
-            registry=registry,
-            factory=factory,
-            session=MagicMock(),
-            tool_name="unifi_list_clients",
-            controller_id="cid",
-            controller_products=["network"],
-            site="default",
-            args={"filter_type": "wireless", "include_offline": False, "limit": 50},
-            confirm=False,
-            dispatch_table={
-                "unifi_list_clients": DispatchEntry(manager_attr="client_manager", method="get_clients"),
-            },
-        )
-
-    domain_manager.get_clients.assert_not_awaited()
-
-
-# ---------------------------------------------------------------------------
 # Network — update_firewall_policy: update_data → updates rename
 # ---------------------------------------------------------------------------
 
@@ -2687,37 +2660,188 @@ async def test_reviewed_catalog_mutations_preserve_wrapper_semantics(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("tool_name", "args", "parameter"),
+    (
+        "tool_name",
+        "args",
+        "method_name",
+        "manager_result",
+        "expected_manager_kwargs",
+        "data_key",
+        "expected_payload",
+    ),
     [
-        ("unifi_list_clients", {"include_offline": True}, "include_offline"),
-        ("unifi_list_devices", {"limit": 5}, "limit"),
-        ("unifi_get_client_details", {"mac_address": "aa:bb:cc:dd:ee:ff", "summary": True}, "summary"),
-        ("unifi_list_firewall_policies", {"search": "guest"}, "search"),
-        ("unifi_list_networks", {"fields": "id,name"}, "fields"),
+        (
+            "unifi_list_clients",
+            {
+                "filter_type": "wireless",
+                "include_offline": True,
+                "search": "phone",
+                "limit": 1,
+                "fields": "mac,connection_type",
+            },
+            "get_clients",
+            [{"mac": "aa", "name": "Phone", "is_wired": False}],
+            {"include_offline": True},
+            "clients",
+            {"filter_type": "wireless", "search": "phone", "limit": 1, "returned_count": 1},
+        ),
+        (
+            "unifi_get_alerts",
+            {"limit": 1, "include_archived": True},
+            "get_alerts",
+            [{"id": "a1"}, {"id": "a2"}],
+            {"include_archived": True},
+            "alerts",
+            {"limit": 1, "include_archived": True},
+        ),
+        (
+            "unifi_get_client_details",
+            {"mac_address": "aa", "include": "wireless", "summary": True},
+            "get_client_details",
+            {"mac": "aa", "is_wired": False, "signal": -42},
+            {"client_mac": "aa"},
+            "client",
+            {"include": "wireless", "summary_mode": True},
+        ),
+        (
+            "unifi_get_dashboard",
+            {"history_seconds": 3600, "summary": False},
+            "get_dashboard",
+            [{"wan_activity": [1], "num_sta": 2}],
+            {"history_seconds": 3600},
+            "dashboard",
+            {"history_seconds": 3600, "summary_mode": False, "omitted_sections": []},
+        ),
+        (
+            "unifi_get_device_details",
+            {"mac_address": "bb", "include": "ports", "summary": True},
+            "get_device_details",
+            {"mac": "bb", "type": "usw", "port_table": []},
+            {"device_mac": "bb"},
+            "device",
+            {"include": "ports", "summary_mode": True},
+        ),
+        (
+            "unifi_get_network_details",
+            {"network_id": "n1", "include": "dhcp", "summary": True},
+            "get_network_details",
+            {"_id": "n1", "name": "LAN", "dhcpd_enabled": True},
+            {"network_id": "n1"},
+            "details",
+            {"network_id": "n1", "include": "dhcp", "summary_mode": True},
+        ),
+        (
+            "unifi_list_devices",
+            {
+                "device_type": "switch",
+                "status": "online",
+                "search": "office",
+                "limit": 1,
+                "include_details": True,
+                "summary": False,
+            },
+            "get_devices",
+            [{"mac": "cc", "name": "Office", "type": "usw", "state": 1, "port_table": []}],
+            {},
+            "devices",
+            {
+                "filter_type": "switch",
+                "filter_status": "online",
+                "search": "office",
+                "limit": 1,
+                "returned_count": 1,
+            },
+        ),
+        (
+            "unifi_list_firewall_policies",
+            {
+                "search": "guest",
+                "action": "allow",
+                "enabled_only": True,
+                "limit": 1,
+                "summary": False,
+                "include_predefined": True,
+            },
+            "get_firewall_policies",
+            [{"_id": "p1", "name": "Guest", "enabled": True, "action": "ALLOW", "index": 1}],
+            {"include_predefined": True},
+            "policies",
+            {"search": "guest", "action_filter": "allow", "enabled_only": True, "limit": 1},
+        ),
+        (
+            "unifi_list_networks",
+            {"search": "20", "purpose": "guest", "limit": 1, "fields": "_id,name"},
+            "get_networks",
+            [{"_id": "n1", "name": "Guest", "purpose": "guest", "vlan": 20}],
+            {},
+            "networks",
+            {"search": "20", "purpose_filter": "guest", "fields": "_id,name", "limit": 1},
+        ),
+        (
+            "unifi_list_rogue_aps",
+            {"within_hours": 12, "channel": 36, "min_signal": -70, "limit": 1, "offset": 1, "summary": False},
+            "list_rogue_aps",
+            [
+                {"bssid": "one", "channel": 36, "signal": -60},
+                {"bssid": "two", "channel": 36, "signal": -50},
+            ],
+            {"within_hours": 12},
+            "rogue_aps",
+            {"within_hours": 12, "summary_mode": False, "limit": 1, "offset": 1},
+        ),
+        (
+            "unifi_list_wlans",
+            {"search": "guest", "enabled_only": True, "limit": 1},
+            "get_wlans",
+            [{"_id": "w1", "name": "Guest", "enabled": True}],
+            {},
+            "wlans",
+            {"search": "guest", "enabled_only": True, "limit": 1, "returned_count": 1},
+        ),
     ],
 )
-async def test_wrapper_only_action_parameters_fail_explicitly(
+async def test_read_action_non_default_parameters_share_core_view_contract(
     tool_name: str,
     args: dict,
-    parameter: str,
+    method_name: str,
+    manager_result: object,
+    expected_manager_kwargs: dict,
+    data_key: str,
+    expected_payload: dict,
 ) -> None:
     entry = PRODUCTION_REGISTRY.resolve(tool_name)
+    manager = MagicMock()
+    manager._connection.site = "default"
+    method = AsyncMock(return_value=manager_result)
+    setattr(manager, method_name, method)
     factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
 
-    with pytest.raises(ValueError, match=rf"{parameter}.*not supported"):
-        await dispatch_action(
-            registry=PRODUCTION_REGISTRY,
-            factory=factory,
-            session=MagicMock(),
-            tool_name=tool_name,
-            controller_id="cid",
-            controller_products=[entry.product],
-            site="default",
-            args=args,
-            confirm=False,
-        )
+    result = await dispatch_action(
+        registry=PRODUCTION_REGISTRY,
+        factory=factory,
+        session=MagicMock(),
+        tool_name=tool_name,
+        controller_id="cid",
+        controller_products=[entry.product],
+        site="default",
+        args=args,
+        confirm=False,
+    )
 
-    factory.get_domain_manager.assert_not_called()
+    assert isinstance(result, ShapedReadResult)
+    assert result.data_key == data_key
+    assert result.payload["success"] is True
+    assert data_key in result.payload
+    for key, value in expected_payload.items():
+        assert result.payload[key] == value
+    if tool_name == "unifi_list_firewall_policies":
+        assert result.render_hint["display_columns"][-1] == "index"
+        assert result.render_hint["sort_default"] == "index:asc"
+    if tool_name == "unifi_list_rogue_aps":
+        assert "essid" in result.render_hint["display_columns"]
+        assert "ssid" not in result.render_hint["display_columns"]
+    method.assert_awaited_once_with(**expected_manager_kwargs)
 
 
 @pytest.mark.asyncio

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.22,<0.5",
+    "unifi-core[network]>=0.4.24,<0.5",
     "mcp[cli]>=1.28.1,<2",
     "aiohttp>=3.14.3",
     "pyyaml>=6.0",

--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -21,12 +21,8 @@ from unifi_core.network.models._actions import (
     UnauthorizeGuestInput,
     UnblockClientInput,
 )
-from unifi_core.network.models.clients import (
-    _is_online,
-    blocked_client_from_controller,
-    client_from_controller,
-    client_lookup_from_controller,
-)
+from unifi_core.network.models.clients import blocked_client_from_controller, client_lookup_from_controller
+from unifi_core.network.read_views import shape_client_details, shape_client_list
 
 # Import the global FastMCP server instance, config, and managers
 from unifi_network_mcp.runtime import client_manager, server
@@ -106,90 +102,15 @@ async def list_clients(
 ) -> Dict[str, Any]:
     """Implementation for listing clients."""
     try:
-        clients = await client_manager.get_all_clients() if include_offline else await client_manager.get_clients()
-
-        def _raw(c):
-            return c.raw if hasattr(c, "raw") else c  # c might already be a dict
-
-        clients_raw = [_raw(c) for c in clients]
-
-        if filter_type == "wireless":
-            clients_raw = [c for c in clients_raw if not c.get("is_wired", False)]
-        elif filter_type == "wired":
-            clients_raw = [c for c in clients_raw if c.get("is_wired", False)]
-
-        # Filter by search term (name, hostname, IP, or MAC)
-        if search and search.strip():
-            search_lower = search.strip().lower()
-            clients_raw = [
-                c
-                for c in clients_raw
-                if search_lower in (c.get("name") or "").lower()
-                or search_lower in (c.get("hostname") or "").lower()
-                or search_lower in (c.get("ip") or "").lower()
-                or search_lower in (c.get("mac") or "").lower()
-            ]
-
-        total_count = len(clients_raw)
-        clients_raw = clients_raw[:limit]
-
-        # Parse requested fields for selective return + surface unknown tokens
-        # so LLM callers can self-correct typos (e.g. fields="mac,naame").
-        known_fields = {
-            "mac",
-            "name",
-            "hostname",
-            "ip",
-            "connection_type",
-            "status",
-            "last_seen",
-            "_id",
-            "essid",
-            "signal_dbm",
-            "channel",
-            "radio",
-        }
-        requested_fields = None
-        unknown_fields: list[str] = []
-        if fields and fields.strip():
-            requested_fields = set(f.strip() for f in fields.split(","))
-            unknown_fields = sorted(requested_fields - known_fields)
-
-        formatted_clients = []
-        for client in clients_raw:
-            shaped = client_from_controller(client)
-            full_data = shaped.model_dump(exclude_none=True)
-            # Preserve wired/wireless display fields not in the base model
-            full_data["connection_type"] = "Wired" if client.get("is_wired", False) else "Wireless"
-            full_data["_id"] = client.get("_id")
-            if not client.get("is_wired", False):
-                full_data["essid"] = client.get("essid", "Unknown")
-                full_data["signal_dbm"] = client.get("signal")
-                full_data["channel"] = client.get("channel", "Unknown")
-                full_data["radio"] = client.get("radio", "Unknown")
-
-            if requested_fields:
-                formatted = {k: v for k, v in full_data.items() if k in requested_fields}
-            else:
-                formatted = full_data
-
-            formatted_clients.append(formatted)
-
-        response = {
-            "success": True,
-            "site": client_manager._connection.site,
-            "filter_type": filter_type,
-            "search": search,
-            "fields": fields,
-            "total_count": total_count,
-            "returned_count": len(formatted_clients),
-            "count": len(formatted_clients),  # back-compat alias for returned_count
-            "limit": limit,
-            "clients": formatted_clients,
-        }
-        if unknown_fields:
-            response["unknown_fields"] = unknown_fields
-        return response
+        clients = await client_manager.get_clients(include_offline=include_offline)
+        return shape_client_list(
+            clients,
+            site=client_manager._connection.site,
+            filter_type=filter_type,
+            search=search,
+            limit=limit,
+            fields=fields,
+        )
     except Exception as e:
         logger.error("Error listing clients: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list clients: {e}"}
@@ -233,120 +154,13 @@ async def get_client_details(
     """Implementation for getting client details."""
     try:
         client_obj = await client_manager.get_client_details(mac_address)
-        if client_obj:
-            raw = (
-                client_obj.raw
-                if hasattr(client_obj, "raw") and isinstance(client_obj.raw, dict)
-                else (client_obj if isinstance(client_obj, dict) else {})
-            )
-
-            if not summary:
-                shaped = client_from_controller(client_obj).model_dump(exclude_none=True)
-                # Honor the "full raw client object" promise: deliver all controller-reported
-                # fields. Selectively layer the typed/normalized shape on top only for fields
-                # where the shape adds value (ISO timestamps, derived status, null-safe alias).
-                # Leave raw fields like `ip`/`last_ip` distinct so the current-vs-historical
-                # distinction is preserved.
-                merged: Dict[str, Any] = dict(raw)
-                for key in ("last_seen", "first_seen", "status", "name", "hostname"):
-                    if key in shaped:
-                        merged[key] = shaped[key]
-                return {
-                    "success": True,
-                    "site": client_manager._connection.site,
-                    "client": merged,
-                }
-
-            # summary=true: opt-in section-trimmed view. The default path above is the
-            # full raw object; this branch only runs when the caller explicitly asks to trim.
-            known_sections = {"basic", "network", "wireless", "traffic", "fingerprint", "all"}
-            sections = set(s.strip().lower() for s in include.split(","))
-            unknown_sections = sorted(sections - known_sections)
-            include_all = "all" in sections
-            client_data: Dict[str, Any] = {}
-
-            if include_all or "basic" in sections:
-                client_data.update(
-                    {
-                        "mac": raw.get("mac"),
-                        "name": raw.get("name") or raw.get("hostname", "Unknown"),
-                        "hostname": raw.get("hostname"),
-                        "ip": raw.get("ip"),
-                        "connection_type": "Wired" if raw.get("is_wired", False) else "Wireless",
-                        "status": "Online" if _is_online(raw) else "Offline",
-                        "last_seen": raw.get("last_seen"),
-                        "uptime": raw.get("uptime"),
-                        "first_seen": raw.get("first_seen"),
-                    }
-                )
-
-            if include_all or "network" in sections:
-                client_data.update(
-                    {
-                        "network_id": raw.get("network_id"),
-                        "network": raw.get("network"),
-                        "vlan": raw.get("vlan"),
-                        "use_fixedip": raw.get("use_fixedip", False),
-                        "fixed_ip": raw.get("fixed_ip"),
-                        "local_dns_record": raw.get("local_dns_record"),
-                    }
-                )
-
-            if (include_all or "wireless" in sections) and not raw.get("is_wired", False):
-                client_data.update(
-                    {
-                        "essid": raw.get("essid"),
-                        "bssid": raw.get("bssid"),
-                        "channel": raw.get("channel"),
-                        "radio": raw.get("radio"),
-                        "radio_proto": raw.get("radio_proto"),
-                        "signal": raw.get("signal"),
-                        "rssi": raw.get("rssi"),
-                        "noise": raw.get("noise"),
-                        "satisfaction": raw.get("satisfaction"),
-                        "ap_mac": raw.get("ap_mac"),
-                    }
-                )
-
-            if include_all or "traffic" in sections:
-                client_data.update(
-                    {
-                        "tx_bytes": raw.get("tx_bytes"),
-                        "rx_bytes": raw.get("rx_bytes"),
-                        "tx_packets": raw.get("tx_packets"),
-                        "rx_packets": raw.get("rx_packets"),
-                        "tx_rate": raw.get("tx_rate"),
-                        "rx_rate": raw.get("rx_rate"),
-                    }
-                )
-
-            if include_all or "fingerprint" in sections:
-                client_data.update(
-                    {
-                        "oui": raw.get("oui"),
-                        "os_name": raw.get("os_name"),
-                        "dev_cat": raw.get("dev_cat"),
-                        "dev_family": raw.get("dev_family"),
-                        "dev_vendor": raw.get("dev_vendor"),
-                        "dev_id": raw.get("dev_id"),
-                        "fingerprint_source": raw.get("fingerprint_source"),
-                    }
-                )
-
-            response = {
-                "success": True,
-                "site": client_manager._connection.site,
-                "include": include,
-                "summary_mode": True,
-                "client": client_data,
-            }
-            if unknown_sections:
-                response["unknown_sections"] = unknown_sections
-            return response
-        return {
-            "success": False,
-            "error": f"Client not found with MAC address: {mac_address}",
-        }
+        return shape_client_details(
+            client_obj,
+            site=client_manager._connection.site,
+            mac_address=mac_address,
+            include=include,
+            summary=summary,
+        )
     except Exception as e:
         logger.error("Error getting client details for %s: %s", mac_address, e, exc_info=True)
         return {"success": False, "error": f"Failed to get client details for {mac_address}: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -5,7 +5,6 @@ This module provides MCP tools to manage devices in a Unifi Network Controller.
 """
 
 import logging
-from datetime import datetime, timedelta
 from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
@@ -25,84 +24,12 @@ from unifi_core.network.models._actions import (
     UpgradeDeviceInput,
 )
 from unifi_core.network.models.devices import validate_radio_update
+from unifi_core.network.read_views import shape_device_details, shape_device_list, shape_rogue_ap_list
 
 # Import the global FastMCP server instance, config, and managers
 from unifi_network_mcp.runtime import device_manager, server
 
 logger = logging.getLogger(__name__)
-
-
-# Model prefixes for USP Smart Power devices that may report as 'uap' type
-_POWER_DEVICE_MODELS = {"UP1", "UP6", "USP"}
-
-
-def _rogue_ap_summary(ap: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "bssid": ap.get("bssid"),
-        "ssid": ap.get("essid"),
-        "channel": ap.get("channel"),
-        "signal": ap.get("signal"),
-        "rssi": ap.get("rssi"),
-        "band": ap.get("band"),
-        "bandwidth": ap.get("bw"),
-        "security": ap.get("security"),
-        "ap_mac": ap.get("ap_mac"),
-        "ap_name": ap.get("ap_name"),
-        "last_seen": ap.get("last_seen"),
-        "is_rogue": ap.get("is_rogue"),
-    }
-
-
-def classify_device(device: Dict[str, Any]) -> str:
-    """Classify a device into a semantic category.
-
-    Uses the controller's ``is_access_point`` flag as the primary signal
-    for distinguishing real APs from other ``uap``-typed devices (e.g.,
-    USP Smart Power strips that connect via wireless mesh).  Falls back
-    to model-prefix matching when the flag is absent.
-
-    Returns one of: 'ap', 'switch', 'gateway', 'pdu', 'unknown'
-    """
-    device_type = device.get("type", "")
-    model = device.get("model", "")
-
-    # Explicit power device types
-    if device_type.startswith("usp"):
-        return "pdu"
-
-    # For uap-typed devices, use the controller's is_access_point flag
-    if device_type.startswith("uap"):
-        is_ap = device.get("is_access_point")
-        if is_ap is not None:
-            if not is_ap:
-                return "pdu"
-            return "ap"
-        # Fallback: check model prefix when flag is missing (older firmware)
-        if any(model.upper().startswith(prefix) for prefix in _POWER_DEVICE_MODELS):
-            return "pdu"
-        return "ap"
-
-    if device_type[:3] in ("usw", "usk"):
-        return "switch"
-    if device_type[:3] in ("ugw", "udm", "uxg"):
-        return "gateway"
-    if device_type == "uci":
-        return "wan"
-
-    return "unknown"
-
-
-def get_wifi_bands(device: Dict[str, Any]) -> List[str]:
-    """Extract active WiFi bands from device radio table."""
-    bands = set()
-    for radio in device.get("radio_table", []):
-        if radio.get("radio") == "na":
-            bands.add("5GHz")
-        elif radio.get("radio") == "ng":
-            bands.add("2.4GHz")
-        elif radio.get("radio") == "wifi6e":
-            bands.add("6GHz")
-    return sorted(list(bands))
 
 
 @server.tool(
@@ -162,213 +89,16 @@ async def list_devices(
     """Implementation for listing devices."""
     try:
         devices = await device_manager.get_devices()
-
-        # Convert Device objects to plain dictionaries for easier filtering
-        devices_raw = [d.raw if hasattr(d, "raw") else d for d in devices]
-
-        # Filter by device type using semantic classification
-        if device_type != "all":
-            devices_raw = [d for d in devices_raw if classify_device(d) == device_type]
-
-        # Filter by status
-        if status != "all":
-            status_map = {
-                "online": 1,
-                "offline": 0,
-                "pending": 2,
-                "adopting": 4,
-                "provisioning": 5,
-                "upgrading": 6,
-            }
-            target_state = status_map.get(status)
-            if target_state is not None:
-                devices_raw = [d for d in devices_raw if d.get("state") == target_state]
-            else:
-                logger.warning("Unknown status filter: %s", status)
-
-        # Filter by search term (name, IP, or MAC)
-        if search and search.strip():
-            search_lower = search.strip().lower()
-            devices_raw = [
-                d
-                for d in devices_raw
-                if search_lower in (d.get("name") or "").lower()
-                or search_lower in (d.get("ip") or "").lower()
-                or search_lower in (d.get("mac") or "").lower()
-            ]
-
-        # Capture total before applying limit
-        total_count = len(devices_raw)
-        if limit is not None:
-            devices_raw = devices_raw[:limit]
-
-        formatted_devices = []
-        state_map = {
-            0: "offline",
-            1: "online",
-            2: "pending_adoption",
-            4: "managed_by_other/adopting",
-            5: "provisioning",
-            6: "upgrading",
-            11: "error/heartbeat_missed",
-        }
-
-        for device in devices_raw:
-            device_state = device.get("state", 0)
-            device_status_str = state_map.get(device_state, f"unknown_state ({device_state})")
-
-            category = classify_device(device)
-
-            # Extract per-device resource stats (available on all device types)
-            sys_stats = device.get("sys_stats", {})
-            mem_total = sys_stats.get("mem_total", 0)
-            mem_used = sys_stats.get("mem_used", 0)
-            mem_pct = round((mem_used / mem_total) * 100, 1) if mem_total else None
-
-            # Uplink topology
-            uplink = device.get("uplink", device.get("last_uplink", {}))
-            uplink_info = None
-            if uplink:
-                uplink_info = {
-                    "type": uplink.get("type", "unknown"),
-                    "speed": uplink.get("speed", 0),
-                    "uplink_device": uplink.get("uplink_device_name"),
-                    "uplink_port": uplink.get("uplink_remote_port"),
-                }
-
-            device_info = {
-                "mac": device.get("mac", ""),
-                "name": device.get("name", device.get("model", "Unknown")),
-                "model": device.get("model", ""),
-                "type": device.get("type", ""),
-                "device_category": category,
-                "ip": device.get("ip", ""),
-                "status": device_status_str,
-                "uptime": str(timedelta(seconds=device.get("uptime", 0))) if device.get("uptime") else "N/A",
-                "last_seen": (
-                    datetime.fromtimestamp(device.get("last_seen", 0)).isoformat() if device.get("last_seen") else "N/A"
-                ),
-                "firmware": device.get("version", ""),
-                "upgradable": device.get("upgradable", False),
-                "adopted": device.get("adopted", False),
-                "connection_network": device.get("connection_network_name", ""),
-                "uplink": uplink_info,
-                "load_avg_1": sys_stats.get("loadavg_1"),
-                "mem_pct": mem_pct,
-                "model_eol": device.get("model_in_eol", False),
-                "_id": device.get("_id", ""),
-            }
-
-            if include_details:
-                details_to_add = {
-                    "serial": device.get("serial", ""),
-                    "hw_revision": device.get("hw_rev", ""),
-                    "model_display": device.get("model_display", device.get("model")),
-                    "clients": device.get("num_sta", 0),
-                }
-
-                if summary:
-                    # Compressed shape (default): summaries + counts, no raw tables.
-                    if category == "ap":
-                        radio_table = device.get("radio_table", [])
-                        vap_table = device.get("vap_table", [])
-                        details_to_add.update(
-                            {
-                                "radio_count": len(radio_table),
-                                "radios": [
-                                    {"band": r.get("radio"), "channel": r.get("channel"), "tx_power": r.get("tx_power")}
-                                    for r in radio_table
-                                ],
-                                "vap_count": len(vap_table),
-                                "wifi_bands": get_wifi_bands(device),
-                                "experience_score": device.get("satisfaction", 0),
-                                "num_clients": device.get("num_sta", 0),
-                            }
-                        )
-                    elif category == "switch":
-                        port_table = device.get("port_table", [])
-                        ports_up = sum(1 for p in port_table if p.get("up", False))
-                        ports_poe = sum(1 for p in port_table if p.get("poe_enable", False))
-                        details_to_add.update(
-                            {
-                                "total_ports": len(port_table),
-                                "ports_up": ports_up,
-                                "ports_poe_enabled": ports_poe,
-                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                                "poe_power": device.get("poe_power"),
-                                "poe_voltage": device.get("poe_voltage"),
-                            }
-                        )
-                    elif category == "gateway":
-                        network_table = device.get("network_table", [])
-                        wan1 = device.get("wan1", {})
-                        wan2 = device.get("wan2", {})
-                        system_stats = device.get("system-stats", {})
-                        details_to_add.update(
-                            {
-                                "wan1_ip": wan1.get("ip") if wan1 else None,
-                                "wan1_up": wan1.get("up", False) if wan1 else None,
-                                "wan2_ip": wan2.get("ip") if wan2 else None,
-                                "wan2_up": wan2.get("up", False) if wan2 else None,
-                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                                "network_count": len(network_table),
-                                "cpu_usage": system_stats.get("cpu"),
-                                "mem_usage": system_stats.get("mem"),
-                            }
-                        )
-                else:
-                    # Legacy raw shape (pre-PR upstream): full tables passthrough.
-                    if category == "ap":
-                        details_to_add.update(
-                            {
-                                "radio_table": device.get("radio_table", []),
-                                "vap_table": device.get("vap_table", []),
-                                "wifi_bands": get_wifi_bands(device),
-                                "experience_score": device.get("satisfaction", 0),
-                                "num_clients": device.get("num_sta", 0),
-                            }
-                        )
-                    elif category == "switch":
-                        details_to_add.update(
-                            {
-                                "ports": device.get("port_table", []),
-                                "total_ports": len(device.get("port_table", [])),
-                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                                "poe_info": {
-                                    "poe_current": device.get("poe_current"),
-                                    "poe_power": device.get("poe_power"),
-                                    "poe_voltage": device.get("poe_voltage"),
-                                },
-                            }
-                        )
-                    elif category == "gateway":
-                        details_to_add.update(
-                            {
-                                "wan1": device.get("wan1", {}),
-                                "wan2": device.get("wan2", {}),
-                                "num_clients": device.get("user-num_sta", 0) + device.get("guest-num_sta", 0),
-                                "network_table": device.get("network_table", []),
-                                "system_stats": device.get("system-stats", {}),
-                                "speedtest_status": device.get("speedtest-status", {}),
-                            }
-                        )
-
-                device_info.update(details_to_add)
-
-            formatted_devices.append(device_info)
-
-        return {
-            "success": True,
-            "site": device_manager._connection.site,
-            "filter_type": device_type,
-            "filter_status": status,
-            "search": search,
-            "total_count": total_count,
-            "returned_count": len(formatted_devices),
-            "count": len(formatted_devices),  # back-compat alias for returned_count
-            "limit": limit,
-            "devices": formatted_devices,
-        }
+        return shape_device_list(
+            devices,
+            site=device_manager._connection.site,
+            device_type=device_type,
+            status=status,
+            search=search,
+            limit=limit,
+            include_details=include_details,
+            summary=summary,
+        )
     except Exception as e:
         logger.error("Error listing devices: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list devices: {e}"}
@@ -416,131 +146,13 @@ async def get_device_details(
     """Implementation for getting device details."""
     try:
         device = await device_manager.get_device_details(mac_address)
-        if device:
-            device_raw = device.raw if hasattr(device, "raw") else device
-
-            if not summary:
-                return {
-                    "success": True,
-                    "site": device_manager._connection.site,
-                    "include": "all",
-                    "summary_mode": False,
-                    "device": device_raw,
-                }
-
-            known_sections = {"basic", "ports", "radios", "stats", "uplink", "lldp", "all"}
-            sections = set(s.strip().lower() for s in include.split(","))
-            unknown_sections = sorted(sections - known_sections)
-            include_all = "all" in sections
-
-            device_data: Dict[str, Any] = {}
-
-            # Basic — essential device info
-            if include_all or "basic" in sections:
-                state_map = {
-                    0: "offline",
-                    1: "online",
-                    2: "pending_adoption",
-                    4: "managed_by_other/adopting",
-                    5: "provisioning",
-                    6: "upgrading",
-                    11: "error/heartbeat_missed",
-                }
-                device_state = device_raw.get("state", 0)
-                device_data.update(
-                    {
-                        "mac": device_raw.get("mac"),
-                        "name": device_raw.get("name", device_raw.get("model", "Unknown")),
-                        "model": device_raw.get("model"),
-                        "type": device_raw.get("type"),
-                        "ip": device_raw.get("ip"),
-                        "status": state_map.get(device_state, f"unknown ({device_state})"),
-                        "uptime": str(timedelta(seconds=device_raw.get("uptime", 0)))
-                        if device_raw.get("uptime")
-                        else None,
-                        "firmware": device_raw.get("version"),
-                        "adopted": device_raw.get("adopted", False),
-                    }
-                )
-
-            # Ports — compressed port table (switches)
-            if (include_all or "ports" in sections) and "port_table" in device_raw:
-                # Build LLDP lookup by local port for accurate neighbor detection
-                lldp_by_port: Dict[int, Dict[str, Any]] = {}
-                for lldp_entry in device_raw.get("lldp_table", []):
-                    local_port = lldp_entry.get("local_port_idx")
-                    if local_port is not None:
-                        lldp_by_port[local_port] = {
-                            "mac": lldp_entry.get("chassis_id"),
-                            "name": lldp_entry.get("chassis_name"),
-                            "port": lldp_entry.get("port_id"),
-                        }
-
-                device_data["port_summary"] = [
-                    {
-                        "port_idx": p.get("port_idx"),
-                        "name": p.get("name"),
-                        "up": p.get("up"),
-                        "speed": p.get("speed"),
-                        "poe_enable": p.get("poe_enable"),
-                        "poe_power": p.get("poe_power"),
-                        # last_seen_mac: last MAC that sent traffic on this port (may be wireless client traffic)
-                        "last_seen_mac": p.get("last_connection", {}).get("mac"),
-                        # lldp_neighbor: actual directly connected device (infrastructure only)
-                        "lldp_neighbor": lldp_by_port.get(p.get("port_idx")),
-                    }
-                    for p in device_raw["port_table"]
-                ]
-                device_data["port_count"] = len(device_raw["port_table"])
-
-            # Radios — compressed radio table (APs)
-            if (include_all or "radios" in sections) and "radio_table" in device_raw:
-                device_data["radio_summary"] = [
-                    {
-                        "radio": r.get("radio"),
-                        "channel": r.get("channel"),
-                        "tx_power": r.get("tx_power"),
-                    }
-                    for r in device_raw["radio_table"]
-                ]
-                device_data["radio_count"] = len(device_raw["radio_table"])
-                if "vap_table" in device_raw:
-                    device_data["vap_count"] = len(device_raw["vap_table"])
-
-            if include_all or "stats" in sections:
-                if "system-stats" in device_raw:
-                    device_data["system_stats"] = device_raw["system-stats"]
-
-            if include_all or "uplink" in sections:
-                if "uplink" in device_raw:
-                    uplink = device_raw["uplink"]
-                    device_data["uplink"] = {
-                        "type": uplink.get("type"),
-                        "uplink_mac": uplink.get("uplink_mac"),
-                        "uplink_device_name": uplink.get("uplink_device_name"),
-                        "uplink_remote_port": uplink.get("uplink_remote_port"),
-                        "speed": uplink.get("speed"),
-                        "ip": uplink.get("ip"),
-                    }
-
-            if include_all or "lldp" in sections:
-                if "lldp_table" in device_raw:
-                    device_data["lldp_table"] = device_raw["lldp_table"]
-
-            response = {
-                "success": True,
-                "site": device_manager._connection.site,
-                "include": include,
-                "summary_mode": True,
-                "device": device_data,
-            }
-            if unknown_sections:
-                response["unknown_sections"] = unknown_sections
-            return response
-        return {
-            "success": False,
-            "error": f"Device not found with MAC address: {mac_address}",
-        }
+        return shape_device_details(
+            device,
+            site=device_manager._connection.site,
+            mac_address=mac_address,
+            include=include,
+            summary=summary,
+        )
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
@@ -1137,33 +749,16 @@ async def list_rogue_aps(
     """List neighboring/rogue APs detected by your access points."""
     try:
         rogue_aps = await device_manager.list_rogue_aps(within_hours)
-
-        # Apply client-side filters
-        if channel is not None:
-            rogue_aps = [ap for ap in rogue_aps if ap.get("channel") == channel]
-        if min_signal is not None:
-            rogue_aps = [ap for ap in rogue_aps if ap.get("signal", -100) >= min_signal]
-
-        total_count = len(rogue_aps)
-        page = rogue_aps[offset : offset + limit]
-        formatted = [_rogue_ap_summary(ap) for ap in page] if summary else page
-        next_offset = offset + len(page) if offset + len(page) < total_count else None
-
-        return {
-            "success": True,
-            "site": device_manager._connection.site,
-            "within_hours": within_hours,
-            "filters": {"channel": channel, "min_signal": min_signal},
-            "summary_mode": summary,
-            "total_count": total_count,
-            "returned_count": len(formatted),
-            "count": len(formatted),
-            "limit": limit,
-            "offset": offset,
-            "next_offset": next_offset,
-            "has_more": next_offset is not None,
-            "rogue_aps": formatted,
-        }
+        return shape_rogue_ap_list(
+            rogue_aps,
+            site=device_manager._connection.site,
+            within_hours=within_hours,
+            channel=channel,
+            min_signal=min_signal,
+            limit=limit,
+            offset=offset,
+            summary=summary,
+        )
     except Exception as e:
         logger.error("Error listing rogue APs: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list rogue APs: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -19,20 +19,9 @@ from unifi_core.network.models.firewall import (
     normalize_policy_enums,
     normalize_policy_update,
 )
-from unifi_core.network.models.firewall import (
-    from_controller as fw_from_controller,
-)
+from unifi_core.network.read_views import LEGACY_ENGINE_HINT, shape_firewall_policy_list
 from unifi_core.redaction import redact_sensitive_fields
 from unifi_network_mcp.runtime import firewall_manager, server, should_redact_sensitive_fields
-
-#: Emitted when the V2 zone-based endpoints report nothing. On a site still running
-#: the pre-zone-based engine those endpoints are empty rather than absent, which is
-#: indistinguishable from "no rules configured" unless the caller is told otherwise.
-LEGACY_ENGINE_HINT = (
-    "No zone-based firewall configuration was returned. This site may still be running the "
-    "legacy (pre-zone-based) firewall engine, whose rules are not visible here. Call "
-    "unifi_list_legacy_firewall_rules before concluding that no firewall rules are configured."
-)
 
 logger = logging.getLogger(__name__)
 
@@ -90,75 +79,15 @@ async def list_firewall_policies(
     """
     try:
         policies = await firewall_manager.get_firewall_policies(include_predefined=include_predefined)
-        policies_raw = [p.raw if hasattr(p, "raw") else p for p in policies]
-        # Captured before filtering: "the controller returned nothing" is the legacy-engine
-        # signal, whereas "a filter matched nothing" says nothing about the engine.
-        controller_policy_count = len(policies_raw)
-
-        if enabled_only:
-            policies_raw = [p for p in policies_raw if p.get("enabled", False)]
-
-        if action and action.strip():
-            policies_raw = [p for p in policies_raw if p.get("action") == action.strip().upper()]
-
-        if search and search.strip():
-            search_lower = search.strip().lower()
-            policies_raw = [p for p in policies_raw if search_lower in (p.get("name") or "").lower()]
-
-        total_count = len(policies_raw)
-        policies_raw = policies_raw[:limit]
-
-        formatted_policies = []
-        for p in policies_raw:
-            shaped = fw_from_controller(p)
-            if not summary:
-                # Legacy/full shape: complete model dump (protocol, schedule, logging, ip_version,
-                # index, full source/destination dicts).
-                formatted_policies.append(shaped.model_dump(exclude_none=True))
-                continue
-            # Curated shape (default): narrow to the 6 most useful keys plus targeting subset.
-            # `description` is not a model field, so it stays read from raw.
-            entry = {
-                "id": shaped.id,
-                "name": shaped.name,
-                "enabled": shaped.enabled,
-                "action": shaped.action,
-                "rule_index": shaped.index,
-                "description": p.get("description", p.get("desc", "")),
-            }
-            for direction in ("source", "destination"):
-                ep = getattr(shaped, direction)
-                if ep and isinstance(ep, dict):
-                    targeting = {
-                        "zone_id": ep.get("zone_id"),
-                        "matching_target": ep.get("matching_target"),
-                    }
-                    if ep.get("matching_target_type"):
-                        targeting["matching_target_type"] = ep["matching_target_type"]
-                    if ep.get("ips"):
-                        targeting["ips"] = ep["ips"]
-                    if ep.get("network_ids"):
-                        targeting["network_ids"] = ep["network_ids"]
-                    if ep.get("client_macs"):
-                        targeting["client_macs"] = ep["client_macs"]
-                    entry[direction] = targeting
-            formatted_policies.append(entry)
-
-        result = {
-            "success": True,
-            "site": firewall_manager._connection.site,
-            "search": search,
-            "action_filter": action,
-            "enabled_only": enabled_only,
-            "total_count": total_count,
-            "returned_count": len(formatted_policies),
-            "count": len(formatted_policies),  # back-compat alias for returned_count
-            "limit": limit,
-            "policies": formatted_policies,
-        }
-        if controller_policy_count == 0:
-            result["note"] = LEGACY_ENGINE_HINT
-        return result
+        return shape_firewall_policy_list(
+            policies,
+            site=firewall_manager._connection.site,
+            search=search,
+            action=action,
+            enabled_only=enabled_only,
+            limit=limit,
+            summary=summary,
+        )
     except Exception as e:
         logger.error("Error listing firewall policies: %s", e, exc_info=True)
         return {"success": False, "error": "Failed to list firewall policies: %s" % e}

--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -26,9 +26,6 @@ from unifi_core.network.models.networks import (
     READ_ONLY_FIELDS as NETWORK_READ_ONLY_FIELDS,
 )
 from unifi_core.network.models.networks import (
-    from_controller as network_from_controller,
-)
-from unifi_core.network.models.networks import (
     to_controller_update as network_to_update,
 )
 from unifi_core.network.models.wlans import (
@@ -40,6 +37,7 @@ from unifi_core.network.models.wlans import (
 from unifi_core.network.models.wlans import (
     to_controller_update as wlan_to_update,
 )
+from unifi_core.network.read_views import shape_network_details, shape_network_list, shape_wlan_list
 from unifi_core.redaction import redact_sensitive_fields
 from unifi_network_mcp.runtime import network_manager, server, should_redact_sensitive_fields
 
@@ -140,78 +138,14 @@ async def list_networks(
     """
     try:
         networks_data = await network_manager.get_networks()
-        if purpose and purpose.strip():
-            networks_data = [n for n in networks_data if n.get("purpose") == purpose.strip().lower()]
-
-        if search and search.strip():
-            search_lower = search.strip().lower()
-            networks_data = [
-                n
-                for n in networks_data
-                if search_lower in (n.get("name") or "").lower() or search_lower == str(n.get("vlan") or "")
-            ]
-
-        total_count = len(networks_data)
-        networks_data = networks_data[:limit]
-
-        known_fields = {
-            "_id",
-            "name",
-            "enabled",
-            "purpose",
-            "ip_subnet",
-            "vlan_enabled",
-            "vlan",
-            "dhcpd_enabled",
-            "dhcpd_start",
-            "dhcpd_stop",
-        }
-        requested_fields = None
-        unknown_fields: list[str] = []
-        if fields and fields.strip():
-            requested_fields = set(f.strip() for f in fields.split(","))
-            unknown_fields = sorted(requested_fields - known_fields)
-
-        formatted_networks = []
-        for network in networks_data:
-            # Source values through the typed model (validation/coercion); the list view
-            # then narrows to a curated subset and honors the optional `fields` selector.
-            shaped = network_from_controller(network)
-            full_data = {
-                "_id": shaped.id,
-                "name": shaped.name,
-                "enabled": shaped.enabled,
-                "purpose": shaped.purpose,
-                "ip_subnet": shaped.ip_subnet,
-                "vlan_enabled": shaped.vlan_enabled,
-                "vlan": shaped.vlan,
-                "dhcpd_enabled": shaped.dhcpd_enabled,
-                "dhcpd_start": shaped.dhcpd_start,
-                "dhcpd_stop": shaped.dhcpd_stop,
-            }
-
-            if requested_fields:
-                formatted = {k: v for k, v in full_data.items() if k in requested_fields}
-            else:
-                formatted = full_data
-
-            formatted_networks.append(formatted)
-
-        response = {
-            "success": True,
-            "site": network_manager._connection.site,
-            "search": search,
-            "purpose_filter": purpose,
-            "fields": fields,
-            "total_count": total_count,
-            "returned_count": len(formatted_networks),
-            "count": len(formatted_networks),  # back-compat alias for returned_count
-            "limit": limit,
-            "networks": formatted_networks,
-        }
-        if unknown_fields:
-            response["unknown_fields"] = unknown_fields
-        return response
+        return shape_network_list(
+            networks_data,
+            site=network_manager._connection.site,
+            search=search,
+            purpose=purpose,
+            limit=limit,
+            fields=fields,
+        )
     except Exception as e:
         logger.error("Error listing networks in tool: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list networks: {e}"}
@@ -289,118 +223,14 @@ async def get_network_details(
         if not network_id:
             return {"success": False, "error": "network_id is required"}
         network = await network_manager.get_network_details(network_id)
-        if network:
-            if not summary:
-                return redact_sensitive_fields(
-                    {
-                        "success": True,
-                        "site": network_manager._connection.site,
-                        "network_id": network_id,
-                        "include": "all",
-                        "summary_mode": False,
-                        "details": json.loads(json.dumps(network, default=str)),
-                    },
-                    redact_sensitive=redact_sensitive,
-                )
-
-            known_sections = {"basic", "dhcp", "ipv6", "vpn", "wan", "all"}
-            sections = set(s.strip().lower() for s in include.split(","))
-            unknown_sections = sorted(sections - known_sections)
-            include_all = "all" in sections
-
-            network_data: Dict[str, Any] = {}
-
-            if include_all or "basic" in sections:
-                network_data.update(
-                    {
-                        "_id": network.get("_id"),
-                        "name": network.get("name"),
-                        "enabled": network.get("enabled"),
-                        "purpose": network.get("purpose"),
-                        "ip_subnet": network.get("ip_subnet"),
-                        "vlan_enabled": network.get("vlan_enabled"),
-                        "vlan": network.get("vlan"),
-                        "domain_name": network.get("domain_name"),
-                        "is_nat": network.get("is_nat"),
-                        "network_isolation_enabled": network.get("network_isolation_enabled"),
-                    }
-                )
-
-            if include_all or "dhcp" in sections:
-                network_data.update(
-                    {
-                        "dhcpd_enabled": network.get("dhcpd_enabled"),
-                        "dhcpd_start": network.get("dhcpd_start"),
-                        "dhcpd_stop": network.get("dhcpd_stop"),
-                        "dhcpd_leasetime": network.get("dhcpd_leasetime"),
-                        "dhcpd_dns_enabled": network.get("dhcpd_dns_enabled"),
-                        "dhcpd_gateway_enabled": network.get("dhcpd_gateway_enabled"),
-                        "dhcpd_unifi_controller": network.get("dhcpd_unifi_controller"),
-                    }
-                )
-
-            if include_all or "ipv6" in sections:
-                network_data.update(
-                    {
-                        "ipv6_interface_type": network.get("ipv6_interface_type"),
-                        "ipv6_pd_start": network.get("ipv6_pd_start"),
-                        "ipv6_pd_stop": network.get("ipv6_pd_stop"),
-                        "ipv6_ra_enabled": network.get("ipv6_ra_enabled"),
-                    }
-                )
-
-            if include_all or "vpn" in sections:
-                network_data.update(
-                    {
-                        "vpn_type": network.get("vpn_type"),
-                        "remote_site_id": network.get("remote_site_id"),
-                        "remote_site_subnets": network.get("remote_site_subnets"),
-                    }
-                )
-
-            if include_all or "wan" in sections:
-                network_data.update(
-                    {
-                        "wan_networkgroup": network.get("wan_networkgroup"),
-                        "wan_type": network.get("wan_type"),
-                        "wan_dns_preference": network.get("wan_dns_preference"),
-                        "wan_load_balance_type": network.get("wan_load_balance_type"),
-                        "wan_load_balance_weight": network.get("wan_load_balance_weight"),
-                        "wan_failover_priority": network.get("wan_failover_priority"),
-                        "wan_smartq_enabled": network.get("wan_smartq_enabled"),
-                        "wan_vlan_enabled": network.get("wan_vlan_enabled"),
-                        "igmp_proxy_upstream": network.get("igmp_proxy_upstream"),
-                        "igmp_proxy_for": network.get("igmp_proxy_for"),
-                        "mac_override_enabled": network.get("mac_override_enabled"),
-                        "wan_ip_aliases": network.get("wan_ip_aliases"),
-                        "ipv6_enabled": network.get("ipv6_enabled"),
-                        "wan_type_v6": network.get("wan_type_v6"),
-                        "ipv6_setting_preference": network.get("ipv6_setting_preference"),
-                        "ipv6_wan_delegation_type": network.get("ipv6_wan_delegation_type"),
-                        "wan_dhcpv6_pd_size": network.get("wan_dhcpv6_pd_size"),
-                        "wan_dhcpv6_pd_size_auto": network.get("wan_dhcpv6_pd_size_auto"),
-                        "wan_ipv6_dns_preference": network.get("wan_ipv6_dns_preference"),
-                        "wan_ipv6_dns1": network.get("wan_ipv6_dns1"),
-                        "wan_ipv6_dns2": network.get("wan_ipv6_dns2"),
-                    }
-                )
-
-            response = {
-                "success": True,
-                "site": network_manager._connection.site,
-                "network_id": network_id,
-                "include": include,
-                "summary_mode": True,
-                "details": network_data,
-            }
-            if unknown_sections:
-                response["unknown_sections"] = unknown_sections
-            return redact_sensitive_fields(response, redact_sensitive=redact_sensitive)
-        else:
-            return {
-                "success": False,
-                "error": f"Network with ID '{network_id}' not found.",
-            }
+        response = shape_network_details(
+            network,
+            site=network_manager._connection.site,
+            network_id=network_id,
+            include=include,
+            summary=summary,
+        )
+        return redact_sensitive_fields(response, redact_sensitive=redact_sensitive)
     except Exception as e:
         logger.error("Error getting network details for %s: %s", network_id, e, exc_info=True)
         return {"success": False, "error": f"Failed to get network details for {network_id}: {e}"}
@@ -912,43 +742,13 @@ async def list_wlans(
     """
     try:
         wlans = await network_manager.get_wlans()
-        # Ensure wlans are dictionaries
-        wlans_raw = [w.raw if hasattr(w, "raw") else w for w in wlans]
-
-        # Filter by enabled_only
-        if enabled_only:
-            wlans_raw = [w for w in wlans_raw if w.get("enabled", False)]
-
-        # Filter by search term (SSID name)
-        if search and search.strip():
-            search_lower = search.strip().lower()
-            wlans_raw = [w for w in wlans_raw if search_lower in (w.get("name") or "").lower()]
-
-        total_count = len(wlans_raw)
-        wlans_raw = wlans_raw[:limit]
-
-        formatted_wlans = [
-            {
-                "id": w.get("_id"),
-                "name": w.get("name"),
-                "enabled": w.get("enabled"),
-                "security": w.get("security"),
-                "network_id": w.get("networkconf_id"),  # Map internal key
-                "usergroup_id": w.get("usergroup_id"),
-            }
-            for w in wlans_raw
-        ]
-        return {
-            "success": True,
-            "site": network_manager._connection.site,
-            "search": search,
-            "enabled_only": enabled_only,
-            "total_count": total_count,
-            "returned_count": len(formatted_wlans),
-            "count": len(formatted_wlans),  # back-compat alias for returned_count
-            "limit": limit,
-            "wlans": formatted_wlans,
-        }
+        return shape_wlan_list(
+            wlans,
+            site=network_manager._connection.site,
+            search=search,
+            enabled_only=enabled_only,
+            limit=limit,
+        )
     except Exception as e:
         logger.error("Error listing WLANs: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list WLANs: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/stats.py
+++ b/apps/network/src/unifi_network_mcp/tools/stats.py
@@ -16,26 +16,10 @@ from unifi_core.network.models.sessions import (
 )
 from unifi_core.network.models.stats import dpi_stats_from_controller
 from unifi_core.network.models.system import speedtest_result_from_controller, top_client_from_controller
+from unifi_core.network.read_views import shape_alerts, shape_dashboard
 from unifi_network_mcp.runtime import client_manager, device_manager, server, stats_manager
 
 logger = logging.getLogger(__name__)
-
-_DASHBOARD_TIMESERIES_SECTIONS = frozenset(
-    {
-        "radio_activity",
-        "wan_activity",
-        "wan_history",
-        "wifi_activity",
-    }
-)
-
-
-def _dashboard_summary(entries: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
-    omitted = sorted({key for entry in entries for key in _DASHBOARD_TIMESERIES_SECTIONS if key in entry})
-    summarized = [
-        {key: value for key, value in entry.items() if key not in _DASHBOARD_TIMESERIES_SECTIONS} for entry in entries
-    ]
-    return summarized, omitted
 
 
 @server.tool(
@@ -312,14 +296,12 @@ async def get_alerts(
     """Implementation for getting alerts."""
     try:
         alerts = await stats_manager.get_alerts(include_archived=include_archived)
-        alerts = alerts[:limit]
-        return {
-            "success": True,
-            "site": stats_manager._connection.site,
-            "limit": limit,
-            "include_archived": include_archived,
-            "alerts": alerts,
-        }
+        return shape_alerts(
+            alerts,
+            site=stats_manager._connection.site,
+            limit=limit,
+            include_archived=include_archived,
+        )
     except Exception as e:
         logger.error("Error getting alerts: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to get alerts: {e}"}
@@ -564,15 +546,12 @@ async def get_dashboard(
     """Implementation for getting the site dashboard summary."""
     try:
         dashboard = await stats_manager.get_dashboard(history_seconds=history_seconds)
-        formatted, omitted_sections = _dashboard_summary(dashboard) if summary else (dashboard, [])
-        return {
-            "success": True,
-            "site": stats_manager._connection.site,
-            "summary_mode": summary,
-            "history_seconds": history_seconds,
-            "omitted_sections": omitted_sections,
-            "dashboard": formatted,
-        }
+        return shape_dashboard(
+            dashboard,
+            site=stats_manager._connection.site,
+            summary=summary,
+            history_seconds=history_seconds,
+        )
     except Exception as e:
         logger.error("Error getting dashboard: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to get dashboard: {e}"}

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1944,6 +1944,13 @@ API_ACTIONS_SAMPLE: list[tuple[str, str, dict[str, Any]]] = [
     ("access", "access_list_visitors", {}),
 ]
 
+# Non-default, read-only probes derive a guaranteed match from the corresponding
+# default read. A missing seed is inconclusive and therefore cannot make this
+# release-readiness phase green.
+API_ACTION_READ_CONTRACT_PROBES: list[tuple[str, str]] = [
+    ("network", "unifi_list_clients"),
+]
+
 API_ACTION_SENTINELS: dict[str, str] = {
     "network": "unifi_list_clients",
     "protect": "protect_list_cameras",
@@ -1998,6 +2005,66 @@ def _classify_confirmation_preview_control(
 def _classify_api_action_result(success: bool | None, shape_match: bool) -> str:
     """Require current live success; historical baselines are diagnostic only."""
     return "pass" if success is True and shape_match else "regression"
+
+
+def _validate_api_read_contract_probe(
+    response: object,
+    *,
+    expected_meta: dict[str, Any],
+    projected_fields: set[str] | None,
+    require_non_empty: bool = False,
+    expected_empty: bool = False,
+    expected_item_values: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate a non-default read response without assuming live inventory."""
+    errors: list[str] = []
+    if not isinstance(response, dict) or response.get("success") is not True:
+        return {"passed": False, "errors": ["response was not a successful action envelope"]}
+
+    data = response.get("data")
+    meta = response.get("meta")
+    if not isinstance(data, list):
+        errors.append("response data was not a list")
+    if not isinstance(meta, dict):
+        errors.append("response meta was not an object")
+        meta = {}
+
+    for key, expected in expected_meta.items():
+        actual = meta.get(key)
+        if actual != expected:
+            errors.append(f"meta.{key} expected {expected!r}, got {actual!r}")
+
+    limit = expected_meta.get("limit")
+    if isinstance(data, list) and isinstance(limit, int) and len(data) > limit:
+        errors.append(f"data length {len(data)} exceeds limit {limit}")
+
+    if isinstance(data, list):
+        if require_non_empty and not data:
+            errors.append("positive control returned no rows")
+        if expected_empty and data:
+            errors.append(f"negative control returned {len(data)} rows")
+        returned_count = meta.get("returned_count")
+        if returned_count != len(data):
+            errors.append(f"meta.returned_count expected {len(data)}, got {returned_count!r}")
+        if "count" in meta and meta["count"] != len(data):
+            errors.append(f"meta.count expected {len(data)}, got {meta['count']!r}")
+        total_count = meta.get("total_count")
+        if not isinstance(total_count, int) or total_count < len(data):
+            errors.append(f"meta.total_count must be an integer >= {len(data)}, got {total_count!r}")
+
+    if isinstance(data, list) and projected_fields is not None:
+        for index, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"data[{index}] was not an object")
+                continue
+            unexpected = sorted(set(item) - projected_fields)
+            if unexpected:
+                errors.append(f"data[{index}] contains fields outside projection: {', '.join(unexpected)}")
+            for key, expected in (expected_item_values or {}).items():
+                if item.get(key) != expected:
+                    errors.append(f"data[{index}].{key} expected {expected!r}, got {item.get(key)!r}")
+
+    return {"passed": not errors, "errors": errors}
 
 
 def _api_actions_baseline_dirs() -> dict[str, str]:
@@ -2216,10 +2283,13 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
         "controllers": [],
         "catalog_probe": None,
         "confirmation_preview_controls": [],
+        "read_contract_probes": [],
         "results": [],
         "summary": {
             "preview_controls_exercised": 0,
             "preview_controls_passed": 0,
+            "read_contract_probes_exercised": 0,
+            "read_contract_probes_passed": 0,
             "tools_exercised": 0,
             "passed": 0,
             "regressions": 0,
@@ -2364,6 +2434,7 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
             "protect": "default",
             "access": "default",
         }
+        live_action_responses: dict[str, dict[str, Any]] = {}
 
         for product, tool_name, tool_args in API_ACTIONS_SAMPLE:
             if product not in product_to_controller_id:
@@ -2400,6 +2471,8 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
                 if success is False:
                     error = str(response.get("error") or "")
                 summary = _summarize_action_response(response)
+                if success is True:
+                    live_action_responses[tool_name] = response
             else:
                 success = False
                 error = f"HTTP {status}: {response!r}"
@@ -2452,6 +2525,129 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
             )
             if args.delay:
                 time.sleep(args.delay)
+
+        # Step 3: prove representative non-default read behavior through the
+        # running action endpoint. The positive control derives an exact search
+        # key from the default read; the negative control proves filtering is
+        # actually applied. Neither call mutates controller state.
+        for product, tool_name in API_ACTION_READ_CONTRACT_PROBES:
+            if product not in product_to_controller_id:
+                continue
+            if args.tool and tool_name not in args.tool:
+                continue
+            controller_id = product_to_controller_id[product]
+            site = site_for_product[product]
+            seed = live_action_responses.get(tool_name, {})
+            seed_rows = seed.get("data") if isinstance(seed, dict) else None
+            candidate = next(
+                (
+                    row
+                    for row in seed_rows or []
+                    if isinstance(row, dict) and isinstance(row.get("mac"), str) and row["mac"]
+                ),
+                None,
+            )
+            if candidate is None:
+                error = "default live read returned no client with a MAC; contract probe is inconclusive"
+                artifact["read_contract_probes"].append(
+                    {
+                        "product": product,
+                        "tool": tool_name,
+                        "controller_id": controller_id,
+                        "site": site,
+                        "control": "seed",
+                        "passed": False,
+                        "errors": [error],
+                    }
+                )
+                artifact["summary"]["read_contract_probes_exercised"] += 1
+                artifact["summary"]["regressions"] += 1
+                print(f"  api-actions read contract: {tool_name} inconclusive ({error})", flush=True)
+                continue
+
+            mac = candidate["mac"]
+            connection_type = str(candidate.get("connection_type") or "Wireless")
+            filter_type = "wired" if connection_type.lower() == "wired" else "wireless"
+            common_args = {
+                "filter_type": filter_type,
+                "include_offline": True,
+                "limit": 1,
+                "fields": "mac,connection_type",
+            }
+            controls = [
+                (
+                    "positive",
+                    {**common_args, "search": mac},
+                    {**common_args, "search": mac},
+                    True,
+                    False,
+                    {"mac": mac, "connection_type": connection_type},
+                ),
+                (
+                    "negative",
+                    {**common_args, "search": "__unifi_live_smoke_no_match__"},
+                    {**common_args, "search": "__unifi_live_smoke_no_match__"},
+                    False,
+                    True,
+                    None,
+                ),
+            ]
+            for control, tool_args, expected_meta, require_non_empty, expected_empty, item_values in controls:
+                expected_meta.pop("include_offline")
+                t0 = time.perf_counter()
+                try:
+                    status, response = _http_request(
+                        "POST",
+                        f"{base_url}/v1/actions/{tool_name}",
+                        headers=auth_headers,
+                        body={
+                            "site": site,
+                            "controller": controller_id,
+                            "args": tool_args,
+                            "confirm": False,
+                        },
+                        timeout=120.0,
+                    )
+                except Exception as exc:
+                    status = 0
+                    response = f"{type(exc).__name__}: {exc}"
+                duration_ms = int((time.perf_counter() - t0) * 1000)
+                validation = _validate_api_read_contract_probe(
+                    response,
+                    expected_meta=expected_meta,
+                    projected_fields={"mac", "connection_type"},
+                    require_non_empty=require_non_empty,
+                    expected_empty=expected_empty,
+                    expected_item_values=item_values,
+                )
+                passed = status == 200 and validation["passed"]
+                artifact["read_contract_probes"].append(
+                    {
+                        "product": product,
+                        "tool": tool_name,
+                        "controller_id": controller_id,
+                        "site": site,
+                        "control": control,
+                        "args": tool_args,
+                        "http_status": status,
+                        "passed": passed,
+                        "errors": validation["errors"],
+                        "duration_ms": duration_ms,
+                        "summary": _summarize_action_response(response),
+                    }
+                )
+                artifact["summary"]["read_contract_probes_exercised"] += 1
+                if passed:
+                    artifact["summary"]["read_contract_probes_passed"] += 1
+                else:
+                    artifact["summary"]["regressions"] += 1
+                print(
+                    f"  api-actions read contract {control}: {tool_name} "
+                    f"passed={passed} http={status} ({duration_ms}ms)",
+                    flush=True,
+                )
+                if args.delay:
+                    time.sleep(args.delay)
 
     finally:
         artifact["finished_at"] = datetime.now(UTC).isoformat()

--- a/tests/test_live_smoke_harness.py
+++ b/tests/test_live_smoke_harness.py
@@ -83,6 +83,63 @@ def test_api_actions_have_no_baseline_failure_exemption():
     assert live_smoke._classify_api_action_result(True, False) == "regression"
 
 
+def test_live_api_non_default_read_contract_requires_projection_limit_and_metadata():
+    import live_smoke
+
+    response = {
+        "success": True,
+        "data": [{"mac": "aa:bb", "connection_type": "Wireless"}],
+        "meta": {
+            "filter_type": "wireless",
+            "search": "phone",
+            "fields": "mac,connection_type",
+            "limit": 1,
+            "total_count": 2,
+            "returned_count": 1,
+        },
+    }
+    assert live_smoke._validate_api_read_contract_probe(
+        response,
+        expected_meta={
+            "filter_type": "wireless",
+            "search": "phone",
+            "fields": "mac,connection_type",
+            "limit": 1,
+        },
+        projected_fields={"mac", "connection_type"},
+    ) == {"passed": True, "errors": []}
+
+    broken = {
+        **response,
+        "data": [{"mac": "aa:bb", "name": "Phone"}, {"mac": "cc:dd"}],
+        "meta": {**response["meta"], "limit": 100},
+    }
+    result = live_smoke._validate_api_read_contract_probe(
+        broken,
+        expected_meta={"limit": 1},
+        projected_fields={"mac", "connection_type"},
+    )
+    assert result["passed"] is False
+    assert result["errors"] == [
+        "meta.limit expected 1, got 100",
+        "data length 2 exceeds limit 1",
+        "meta.returned_count expected 2, got 1",
+        "data[0] contains fields outside projection: name",
+    ]
+
+    empty_positive = live_smoke._validate_api_read_contract_probe(
+        {
+            "success": True,
+            "data": [],
+            "meta": {"limit": 1, "returned_count": 0, "total_count": 0},
+        },
+        expected_meta={"limit": 1},
+        projected_fields={"mac"},
+        require_non_empty=True,
+    )
+    assert empty_positive == {"passed": False, "errors": ["positive control returned no rows"]}
+
+
 def test_live_smoke_known_controller_issue_matches_exact_error_code():
     import live_smoke
 


### PR DESCRIPTION
## Summary

- route all 11 deferred Network read actions through the shared Core 0.4.24 view contracts
- honor filters, search, limits, projections, detail/include switches, summaries, and offline-client selection without cross-app dependencies
- preserve API response metadata with field-accurate, projection-aware render hints and strict result-shape validation
- add exhaustive non-default dispatch contracts and a positive/negative live API read probe that cannot false-green on empty inventory
- raise the Network and API minimum Core dependency to the independently released 0.4.24 bridge

Closes #504.

## Verification

- `make pre-commit` (green; API 1183, Network 936, Core 1489, plus Protect, Access, relay, worker, generated-artifact, and registration-mode gates)
- exact published Core floor check: 266/266 catalog bindings against `unifi-core==0.4.24`
- full clean-wheel pin alignment: all downstream packages install and import cleanly
- focused API shared-read/endpoint contracts: 282 passed
- live harness: API boot and 266/266 catalog parity passed; controller-backed reads timed out because the configured Network controller was unreachable, and the harness correctly recorded regressions rather than granting a false green
- final independent adversarial review: READY, no findings or residual risks