### PR TITLE
chore(deps): raise unifi-core floor to 0.4.26 for network and api

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.24,<0.5",
+    "unifi-core[network,protect,access]>=0.4.26,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.51.0",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/tests/test_action_catalog_packaging.py
+++ b/apps/api/tests/test_action_catalog_packaging.py
@@ -16,7 +16,7 @@ def test_api_declares_only_core_as_an_internal_runtime_dependency() -> None:
     dependencies = pyproject["project"]["dependencies"]
     internal = [dependency for dependency in dependencies if dependency.startswith("unifi-")]
 
-    assert internal == ["unifi-core[network,protect,access]>=0.4.24,<0.5"]
+    assert internal == ["unifi-core[network,protect,access]>=0.4.26,<0.5"]
 
 
 def test_built_wheel_contains_and_loads_catalog_without_sibling_apps(tmp_path: Path) -> None:

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.24,<0.5",
+    "unifi-core[network]>=0.4.26,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1443,7 +1443,6 @@ class LiveSmokeRunner:
             self.skip("unifi_create_wlan/unifi_delete_wlan", "approved", "could not discover AP group id")
             return
 
-        stamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
         # SSIDs are capped at 32 bytes; use a compact stamp so the disposable
         # name stays inside the limit while remaining unique and recognizable.
         name = f"{RUN_PREFIX}-ssid-{datetime.now(UTC).strftime('%H%M%S')}-{secrets.token_hex(3)}"


### PR DESCRIPTION
Both packages import APIs introduced in core 0.4.26 (write-verification envelope, centralized network/WLAN validation, deletable-purpose guard), so published wheels must require it. Wheel-metadata verified locally: both wheels now declare `unifi-core>=0.4.26,<0.5`. `check_pin_alignment.py` (standard and `--api-core-floor-only`) passes against the published 0.4.26.

Precedes the `network/v0.26.0` and `api/v0.12.0` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUW6ZPPJkaWLTbmaXa8B9R