### PR TITLE
fix(network): populate event mac/ip/msg from v2 system-log records

### DIFF
--- a/apps/network/tests/unit/test_event_tools.py
+++ b/apps/network/tests/unit/test_event_tools.py
@@ -33,3 +33,85 @@ async def test_archive_all_alarms_preview_requires_confirmation():
     assert result["resource_type"] == "alarm_collection"
     assert result["resource_id"] == "all_active_alarms"
     assert result["preview"]["proposed"]["archived"] is True
+
+
+class _StubConnection:
+    site = "default"
+
+
+class _StubEventManager:
+    """Minimal stand-in for EventManager returning canned records."""
+
+    _connection = _StubConnection()
+
+    def __init__(self, records):
+        self._records = records
+
+    async def get_events(self, **_kwargs):
+        return self._records
+
+
+_V2_RECORD = {
+    "id": "evt-0001",
+    "key": "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT",
+    "severity": "MEDIUM",
+    "timestamp": 1786225096952,
+    "message_raw": "{SRC_CLIENT} was blocked from accessing {DST_IP} by the {TRIGGER} Firewall Policy.",
+    "parameters": {
+        "SRC_CLIENT": {"id": "aa:bb:cc:00:00:01", "ip": "192.0.2.11", "name": "Lab-Camera"},
+        "DST_IP": {"id": "198.51.100.24", "name": "198.51.100.24"},
+        "TRIGGER": {"id": "trigger-0001", "name": "block cameras to external"},
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_list_events_surfaces_mac_ip_and_msg_for_v2_records(monkeypatch):
+    """End-to-end through the tool: v2 records must not come back anonymous.
+
+    ``model_dump(exclude_none=True)`` drops unresolved fields, so a mapping
+    gap shows up as missing keys rather than nulls.
+    """
+    from unifi_network_mcp.tools import events as events_module
+
+    monkeypatch.setattr(
+        events_module,
+        "_get_event_manager",
+        lambda: _StubEventManager([_V2_RECORD]),
+    )
+
+    result = await events_module.list_events(within_hours=1, limit=10)
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    event = result["events"][0]
+    assert event["mac"] == "aa:bb:cc:00:00:01"
+    assert event["ip"] == "192.0.2.11"
+    assert event["msg"] == (
+        "Lab-Camera was blocked from accessing 198.51.100.24 by the block cameras to external Firewall Policy."
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_events_still_maps_legacy_records(monkeypatch):
+    from unifi_network_mcp.tools import events as events_module
+
+    legacy = {
+        "_id": "legacy-1",
+        "key": "EVT_WU_Disconnected",
+        "msg": "Client disconnected",
+        "time": 1700000000000,
+        "user": "aa:bb:cc:00:00:09",
+        "ip": "192.0.2.50",
+    }
+    monkeypatch.setattr(
+        events_module,
+        "_get_event_manager",
+        lambda: _StubEventManager([legacy]),
+    )
+
+    event = (await events_module.list_events())["events"][0]
+
+    assert event["mac"] == "aa:bb:cc:00:00:09"
+    assert event["ip"] == "192.0.2.50"
+    assert event["msg"] == "Client disconnected"

--- a/packages/unifi-core/src/unifi_core/network/models/events.py
+++ b/packages/unifi-core/src/unifi_core/network/models/events.py
@@ -15,7 +15,8 @@ MUTABLE_FIELDS = frozenset() (all fields are read-only).
 
 from __future__ import annotations
 
-from typing import Any, Optional
+import re
+from typing import Any, Iterator, Optional
 
 from pydantic import BaseModel, Field
 
@@ -85,20 +86,154 @@ def _get(obj: Any, *keys: str) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# v2 ``/system-log/all`` support
+# ---------------------------------------------------------------------------
+#
+# Modern controllers (Network 9.x+) serve events from the v2 system-log API,
+# which does not carry the flat ``user``/``msg``/``ip`` keys the legacy
+# ``/stat/event`` API used. Instead each event has a ``parameters`` map keyed
+# by the actor's *role*, and a ``message_raw`` template referencing those roles:
+#
+#     {
+#       "key": "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT",
+#       "message_raw": "{SRC_CLIENT} was blocked from accessing {DST_IP} ...",
+#       "parameters": {
+#         "SRC_CLIENT": {"id": "aa:bb:...", "ip": "10.0.0.5", "name": "camera"},
+#         "DST_IP":     {"id": "52.70.82.252", "name": "52.70.82.252"},
+#         "TRIGGER":    {"id": "...", "name": "block cameras to external"}
+#       }
+#     }
+#
+# ``id`` holds a MAC for client/device roles but an IP for address roles such
+# as ``DST_IP``, so MAC extraction is both role-scoped and shape-validated.
+
+#: Actor roles that carry a MAC in ``id``, most-specific first.
+_MAC_ACTOR_ROLES: tuple[str, ...] = (
+    "SRC_CLIENT",
+    "CLIENT",
+    "DST_CLIENT",
+    "SRC_DEVICE",
+    "DEVICE",
+    "AP",
+    "GATEWAY",
+)
+
+_MAC_RE = re.compile(r"^(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+_PLACEHOLDER_RE = re.compile(r"\{([A-Z0-9_]+)\}")
+
+
+def _parameters(record: Any) -> dict[str, Any]:
+    """Return the v2 ``parameters`` map, or an empty dict."""
+    if not isinstance(record, dict):
+        return {}
+    params = record.get("parameters")
+    return params if isinstance(params, dict) else {}
+
+
+def _actors(record: Any) -> Iterator[dict[str, Any]]:
+    """Yield MAC-bearing actor dicts in role-priority order."""
+    params = _parameters(record)
+    for role in _MAC_ACTOR_ROLES:
+        actor = params.get(role)
+        if isinstance(actor, dict):
+            yield actor
+
+
+def _primary_actor(record: Any) -> Optional[dict[str, Any]]:
+    """Return the highest-priority actor whose ``id`` is shaped like a MAC.
+
+    ``mac`` and ``ip`` are both read from this single actor so they always
+    describe the *same* device. Reading them independently would happily
+    pair a client's MAC with the reporting console's IP — e.g. a
+    ``THREAT_DETECTED`` event, where ``SRC_CLIENT`` is the offender but only
+    the ``DEVICE`` (gateway) carries an ``ip``.
+    """
+    for actor in _actors(record):
+        candidate = actor.get("id")
+        if isinstance(candidate, str) and _MAC_RE.match(candidate):
+            return actor
+    return None
+
+
+def _actor_mac(record: Any) -> Optional[str]:
+    """Return the primary actor's MAC."""
+    actor = _primary_actor(record)
+    return actor.get("id") if actor else None
+
+
+def _actor_ip(record: Any) -> Optional[str]:
+    """Return the primary actor's IP.
+
+    Falls back to the first actor carrying an IP only when no MAC-bearing
+    actor exists, since with no MAC there is no pairing to get wrong.
+    """
+    actor = _primary_actor(record)
+    if actor is not None:
+        candidate = actor.get("ip")
+        return candidate if isinstance(candidate, str) and candidate else None
+
+    for other in _actors(record):
+        candidate = other.get("ip")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _actor_label(actor: Any) -> Optional[str]:
+    """Best human-readable label for an actor dict."""
+    if not isinstance(actor, dict):
+        return None
+    for key in ("name", "hostname", "id"):
+        value = actor.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _render_message(record: Any) -> Optional[str]:
+    """Interpolate a v2 ``message_raw`` template against ``parameters``.
+
+    Unknown placeholders are left intact rather than blanked, so an
+    unrecognised role degrades to the raw template instead of a sentence
+    with holes in it. Falls back to ``title_raw`` when no template exists.
+    """
+    if not isinstance(record, dict):
+        return None
+
+    template = _get(record, "message_raw", "messageRaw")
+    if not isinstance(template, str) or not template:
+        title = _get(record, "title_raw", "titleRaw")
+        return title if isinstance(title, str) and title else None
+
+    params = _parameters(record)
+
+    def _substitute(match: re.Match[str]) -> str:
+        label = _actor_label(params.get(match.group(1)))
+        return label if label is not None else match.group(0)
+
+    return _PLACEHOLDER_RE.sub(_substitute, template)
+
+
+# ---------------------------------------------------------------------------
 # Factory helper
 # ---------------------------------------------------------------------------
 
 
 def event_log_from_controller(record: Any) -> EventLog:
-    """Build an EventLog from a controller API response dict."""
+    """Build an EventLog from a controller API response dict.
+
+    Handles both the legacy ``/stat/event`` flat shape and the v2
+    ``/system-log/all`` nested shape. Legacy keys win when present so
+    older controllers are unaffected.
+    """
     if not isinstance(record, dict):
         return EventLog()
     return EventLog(
         id=_get(record, "_id", "id"),
         key=_get(record, "key", "event_type", "type"),
-        msg=_get(record, "msg", "message", "description"),
+        msg=_get(record, "msg", "message", "description") or _render_message(record),
         time=_get(record, "time", "timestamp", "ts"),
-        mac=_get(record, "user", "mac", "ap", "ap_mac", "device_mac"),
-        ip=_get(record, "ip", "src_ip"),
+        mac=_get(record, "user", "mac", "ap", "ap_mac", "device_mac") or _actor_mac(record),
+        ip=_get(record, "ip", "src_ip") or _actor_ip(record),
         severity=_get(record, "severity", "level"),
     )

--- a/packages/unifi-core/tests/network/fixtures/system_log_events_response.json
+++ b/packages/unifi-core/tests/network/fixtures/system_log_events_response.json
@@ -1,0 +1,110 @@
+{
+  "data": [
+    {
+      "category": "SECURITY",
+      "event": "BLOCKED_BY_FIREWALL",
+      "id": "evt-0001",
+      "key": "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT",
+      "message_raw": "{SRC_CLIENT} was blocked from accessing {DST_IP} by the {TRIGGER} Firewall Policy.",
+      "parameters": {
+        "SRC_CLIENT": {
+          "device_fingerprint_id": 4607,
+          "fingerprint_source": 0,
+          "hostname": "lab-cam",
+          "id": "aa:bb:cc:00:00:01",
+          "ip": "192.0.2.11",
+          "name": "Lab-Camera"
+        },
+        "CONSOLE_NAME": {
+          "id": "Lab-Gateway",
+          "name": "Lab-Gateway"
+        },
+        "DST_IP": {
+          "id": "198.51.100.24",
+          "name": "198.51.100.24",
+          "not_actionable": true
+        },
+        "TRIGGER": {
+          "id": "trigger-0001",
+          "name": "block cameras to external"
+        }
+      },
+      "severity": "MEDIUM",
+      "subcategory": "SECURITY_FIREWALL",
+      "target": "TRIGGER",
+      "timestamp": 1786225096952,
+      "title_raw": "Blocked by Firewall",
+      "type": "CONTENT_FILTERING_AND_RESTRICTIONS"
+    },
+    {
+      "category": "SECURITY",
+      "event": "THREAT_DETECTED",
+      "id": "evt-0002",
+      "key": "THREAT_DETECTED_KNOWN_SOURCE_CLIENT",
+      "message_raw": "A network intrusion attempt from {SRC_CLIENT} to {DST_IP} has been detected.",
+      "parameters": {
+        "SRC_CLIENT": {
+          "hostname": "lab-host",
+          "id": "aa:bb:cc:00:00:02",
+          "name": "Lab-Host"
+        },
+        "DEVICE": {
+          "id": "aa:bb:cc:ff:ff:fe",
+          "ip": "192.0.2.1",
+          "model": "UDM-Pro",
+          "name": "Lab-Gateway"
+        },
+        "DST_IP": {
+          "id": "198.51.100.99",
+          "name": "198.51.100.99",
+          "not_actionable": true
+        }
+      },
+      "severity": "HIGH",
+      "subcategory": "SECURITY_INTRUSION_PREVENTION",
+      "target": "DEVICE",
+      "timestamp": 1786225099647,
+      "title_raw": "Threat Detected",
+      "type": "THREAT_DETECTION_AND_PREVENTION"
+    },
+    {
+      "category": "CLIENT_DEVICES",
+      "event": "CLIENT_CONNECTED",
+      "id": "evt-0003",
+      "key": "CLIENT_CONNECTED_WIRELESS_2",
+      "message_raw": "{CLIENT} has connected to {AP}.",
+      "parameters": {
+        "CLIENT": {
+          "hostname": "lab-phone",
+          "id": "aa:bb:cc:00:00:03",
+          "name": "Lab-Phone"
+        },
+        "AP": {
+          "id": "aa:bb:cc:ff:ff:fd",
+          "name": "Lab-AP"
+        }
+      },
+      "severity": "LOW",
+      "subcategory": "CLIENT_CONNECTIVITY",
+      "timestamp": 1786225100000,
+      "title_raw": "Client Connected",
+      "type": "CLIENT_ACTIVITY"
+    },
+    {
+      "category": "SECURITY",
+      "event": "UNKNOWN_ROLE",
+      "id": "evt-0004",
+      "key": "EVENT_WITH_UNKNOWN_PLACEHOLDER",
+      "message_raw": "{MYSTERY_ROLE} did something to {DST_IP}.",
+      "parameters": {
+        "DST_IP": {
+          "id": "198.51.100.7",
+          "name": "198.51.100.7"
+        }
+      },
+      "severity": "LOW",
+      "timestamp": 1786225101000,
+      "title_raw": "Unknown Role"
+    }
+  ]
+}

--- a/packages/unifi-core/tests/network/models/test_events.py
+++ b/packages/unifi-core/tests/network/models/test_events.py
@@ -1,0 +1,177 @@
+"""Tests for Network EventLog model + serializer.
+
+Covers both controller shapes:
+- legacy ``/stat/event`` (flat ``user``/``msg``/``ip`` keys)
+- v2 ``/system-log/all`` (nested ``parameters`` + ``message_raw`` template)
+"""
+
+import json
+from pathlib import Path
+
+from unifi_core.network.models.events import (
+    MUTABLE_FIELDS,
+    EventLog,
+    event_log_from_controller,
+)
+
+# package-local fixture: models -> network (parents[1]) -> fixtures/
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "system_log_events_response.json"
+
+
+def _records():
+    return json.loads(_FIXTURE.read_text())["data"]
+
+
+def _by_key(key: str):
+    return next(r for r in _records() if r["key"] == key)
+
+
+# ---------------------------------------------------------------------------
+# v2 /system-log/all
+# ---------------------------------------------------------------------------
+
+
+def test_v2_firewall_event_populates_mac_ip_and_message():
+    event = event_log_from_controller(_by_key("TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT"))
+
+    assert event.id == "evt-0001"
+    assert event.key == "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT"
+    assert event.severity == "MEDIUM"
+    assert event.time == 1786225096952
+    assert event.mac == "aa:bb:cc:00:00:01"
+    assert event.ip == "192.0.2.11"
+    assert event.msg == (
+        "Lab-Camera was blocked from accessing 198.51.100.24 by the block cameras to external Firewall Policy."
+    )
+
+
+def test_v2_threat_event_prefers_src_client_over_device():
+    """DEVICE is the reporting console, not the offender — SRC_CLIENT wins."""
+    event = event_log_from_controller(_by_key("THREAT_DETECTED_KNOWN_SOURCE_CLIENT"))
+
+    assert event.mac == "aa:bb:cc:00:00:02"
+    assert event.msg == ("A network intrusion attempt from Lab-Host to 198.51.100.99 has been detected.")
+
+
+def test_v2_mac_and_ip_always_describe_the_same_actor():
+    """SRC_CLIENT (the offender) has no ip; DEVICE (the console) has 192.0.2.1.
+
+    Reading the two fields independently would report the offender's MAC
+    alongside the gateway's IP, which reads as a single device and is wrong.
+    """
+    event = event_log_from_controller(_by_key("THREAT_DETECTED_KNOWN_SOURCE_CLIENT"))
+
+    assert event.mac == "aa:bb:cc:00:00:02"
+    assert event.ip is None
+
+
+def test_v2_ip_falls_back_across_actors_only_without_a_mac():
+    record = {
+        "key": "K",
+        "parameters": {"DEVICE": {"id": "console-name-not-a-mac", "ip": "192.0.2.1"}},
+    }
+    event = event_log_from_controller(record)
+
+    assert event.mac is None
+    assert event.ip == "192.0.2.1"
+
+
+def test_v2_client_event_uses_client_role():
+    event = event_log_from_controller(_by_key("CLIENT_CONNECTED_WIRELESS_2"))
+
+    assert event.mac == "aa:bb:cc:00:00:03"
+    assert event.msg == "Lab-Phone has connected to Lab-AP."
+
+
+def test_v2_address_role_id_is_not_mistaken_for_a_mac():
+    """``DST_IP.id`` is an IP string; it must never land in ``mac``."""
+    event = event_log_from_controller(_by_key("EVENT_WITH_UNKNOWN_PLACEHOLDER"))
+
+    assert event.mac is None
+    assert event.ip is None
+
+
+def test_v2_unknown_placeholder_is_left_intact():
+    event = event_log_from_controller(_by_key("EVENT_WITH_UNKNOWN_PLACEHOLDER"))
+
+    assert event.msg == "{MYSTERY_ROLE} did something to 198.51.100.7."
+
+
+def test_v2_falls_back_to_title_when_no_template():
+    event = event_log_from_controller({"id": "e", "key": "K", "title_raw": "Threat Detected", "timestamp": 1})
+
+    assert event.msg == "Threat Detected"
+
+
+def test_every_fixture_record_yields_a_message():
+    for record in _records():
+        assert event_log_from_controller(record).msg, record["key"]
+
+
+# ---------------------------------------------------------------------------
+# legacy /stat/event — must be unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_flat_shape_still_maps():
+    event = event_log_from_controller(
+        {
+            "_id": "legacy-1",
+            "key": "EVT_WU_Disconnected",
+            "msg": "Client disconnected",
+            "time": 1700000000000,
+            "user": "aa:bb:cc:00:00:09",
+            "ip": "192.0.2.50",
+        }
+    )
+
+    assert event.id == "legacy-1"
+    assert event.mac == "aa:bb:cc:00:00:09"
+    assert event.ip == "192.0.2.50"
+    assert event.msg == "Client disconnected"
+
+
+def test_legacy_keys_win_over_v2_parameters():
+    event = event_log_from_controller(
+        {
+            "key": "EVT_WU_Connected",
+            "msg": "legacy message",
+            "user": "aa:bb:cc:00:00:0a",
+            "ip": "192.0.2.60",
+            "message_raw": "{SRC_CLIENT} connected.",
+            "parameters": {"SRC_CLIENT": {"id": "aa:bb:cc:00:00:0b", "ip": "192.0.2.61"}},
+        }
+    )
+
+    assert event.mac == "aa:bb:cc:00:00:0a"
+    assert event.ip == "192.0.2.60"
+    assert event.msg == "legacy message"
+
+
+def test_ap_mac_fallback_preserved():
+    event = event_log_from_controller({"key": "EVT_AP_Lost_Contact", "ap": "aa:bb:cc:00:00:0c"})
+
+    assert event.mac == "aa:bb:cc:00:00:0c"
+
+
+# ---------------------------------------------------------------------------
+# defensive
+# ---------------------------------------------------------------------------
+
+
+def test_non_dict_record_yields_empty_model():
+    for value in (None, [], "event", 7):
+        assert event_log_from_controller(value) == EventLog()
+
+
+def test_malformed_parameters_are_ignored():
+    for params in ("not-a-dict", [], None, {"SRC_CLIENT": "not-a-dict"}):
+        event = event_log_from_controller({"key": "K", "parameters": params})
+        assert event.mac is None
+        assert event.ip is None
+
+
+def test_eventlog_fields_marked_immutable():
+    assert MUTABLE_FIELDS == frozenset()
+    for field in EventLog.model_fields.values():
+        assert (field.json_schema_extra or {}).get("mutable") is False


### PR DESCRIPTION
## Summary

`unifi_list_events` and `unifi_recent_events` return events with no `mac`, no `ip`, and no `msg` on modern controllers:

```json
{ "id": "…", "key": "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT", "time": 1786224188475, "severity": "MEDIUM" }
```

Every event is anonymous, so there is no way to tell *which* client connected, disconnected, was blocked by a firewall policy, or tripped IPS. For security events in particular that removes the entire point of the record.

**`EventLog` already declares `mac`, `ip` and `msg`** — they resolve to `None` and `model_dump(exclude_none=True)` strips them. This is a serializer gap, not a model or endpoint limitation.

`get_events` gained a v2 branch (`_get_events_v2` → `/system-log/all`) but `event_log_from_controller` was never taught the v2 record shape. It still looks only for the legacy `/stat/event` flat keys:

| Field | Factory looks for | v2 actually provides |
|---|---|---|
| `mac` | `user`, `mac`, `ap`, `ap_mac`, `device_mac` | `parameters.SRC_CLIENT.id` |
| `ip` | `ip`, `src_ip` | `parameters.SRC_CLIENT.ip` |
| `msg` | `msg`, `message`, `description` | `message_raw` + `parameters` |
| `time` | `time`, `timestamp`, `ts` | `timestamp` ✅ — the only one that matched |

## Type of change

- [x] `fix:` bug fix
- [ ] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [ ] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [x] Network MCP server
- [ ] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [ ] API server
- [x] Shared packages
- [ ] Plugin packaging
- [ ] Documentation

## Change

v2 nests each actor under `parameters`, keyed by its **role**, and ships a template instead of a rendered message:

```json
{
  "key": "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT",
  "message_raw": "{SRC_CLIENT} was blocked from accessing {DST_IP} by the {TRIGGER} Firewall Policy.",
  "parameters": {
    "SRC_CLIENT": { "id": "aa:bb:cc:00:00:01", "ip": "192.0.2.11", "name": "Lab-Camera" },
    "DST_IP":     { "id": "198.51.100.24", "name": "198.51.100.24" },
    "TRIGGER":    { "id": "trigger-0001", "name": "block cameras to external" }
  }
}
```

Three behaviours in `models/events.py`:

1. **Role-scoped, shape-validated MAC.** `id` holds a MAC for client/device roles but an **IP** for address roles like `DST_IP`, so a naive scan would put `198.51.100.24` in `mac`. Extraction walks a fixed role priority (`SRC_CLIENT`, `CLIENT`, `DST_CLIENT`, `SRC_DEVICE`, `DEVICE`, `AP`, `GATEWAY`) and requires a MAC-shaped value.

2. **`mac` and `ip` come from one actor.** Resolving them independently pairs fields from different devices: on `THREAT_DETECTED_KNOWN_SOURCE_CLIENT`, `SRC_CLIENT` is the offender but carries no `ip`, while `DEVICE` (the reporting console) does — yielding the client's MAC beside the *gateway's* IP, which reads as one device and is wrong. Both are now read from a single primary actor; `ip` falls back across actors only when no MAC-bearing actor exists, where there is no pairing to get wrong.

3. **`message_raw` rendered against `parameters`**, preferring `name` → `hostname` → `id`. Unknown placeholders are left intact so an unrecognised role degrades to the raw template rather than a sentence with holes in it. Falls back to `title_raw`.

Legacy keys are still checked first, so `/stat/event` controllers are unaffected — covered by a test asserting legacy wins when both shapes are present.

No tool signature, field, or description change, so no manifest / GraphQL / OpenAPI regeneration.

### Result

```json
{
  "id": "evt-0001",
  "key": "TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT",
  "time": 1786225096952,
  "severity": "MEDIUM",
  "mac": "aa:bb:cc:00:00:01",
  "ip": "192.0.2.11",
  "msg": "Lab-Camera was blocked from accessing 198.51.100.24 by the block cameras to external Firewall Policy."
}
```

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. *(n/a — no tool surface change; drift check clean.)*
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. *(n/a — no doc-visible surface change.)*
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

Field names and nesting were read from a **live UDM Pro running Network 5.1.26**,
not inferred — a `POST /v2/api/site/<site>/system-log/all` capture using the same
payload `_get_events_v2` builds.

Replaying 100 consecutive live records through the factory, before vs after:

| | before | after |
|---|---|---|
| `mac` populated | 0 / 100 | **100 / 100** |
| `msg` populated | 0 / 100 | **100 / 100** |
| malformed MACs | — | **0** |

Spanning 7 distinct event keys (`CLIENT_CONNECTED_WIRELESS_2`,
`CLIENT_DISCONNECTED_WIRELESS_2`, `CLIENT_CONNECTED_WIRED_2`,
`CLIENT_DISCONNECTED_WIRED_2`, `THREAT_DETECTED_KNOWN_SOURCE_CLIENT`,
`TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT`, `CLIENT_ROAMED_2`).

### New tests

| Layer | File | Cases |
|---|---|---|
| `unifi-core` model | `packages/unifi-core/tests/network/models/test_events.py` *(new)* | 15 |
| Network tool | `apps/network/tests/unit/test_event_tools.py` | +2 |

Core cases run off a sanitised `system_log_events_response.json` fixture and cover
both v2 and legacy shapes, the address-role-is-not-a-MAC guard, the same-actor
`mac`/`ip` pairing guarantee, unknown-placeholder passthrough, `title_raw`
fallback, and malformed `parameters`. The tool-layer cases go end-to-end through
`unifi_list_events` so the assertion is on real tool output, not just the model —
`model_dump(exclude_none=True)` drops unresolved fields, so a mapping gap surfaces
as missing keys rather than nulls.

**Verified the new tests fail without the fix.** Checking `upstream/main`'s
`events.py` into the working tree and re-running:

```
packages/unifi-core/.../test_events.py     8 failed, 7 passed
apps/network/.../test_event_tools.py       1 failed  (KeyError: 'mac')
```

The cases that still pass under the old code are the legacy-shape and defensive
ones, which is the intended result — they assert behaviour this PR preserves.

### Suites

```
core-test (packages/unifi-core)      1504 passed
apps/api                             1185 passed
apps/network                          935 passed
shared-test                           359 passed
relay-test                            111 passed
ruff check / format                  All checks passed!
make pre-commit                      rc=0
check-generated                      "Checked 39 sections; no drift."
```

## Notes for reviewers

**The API layer carries a second copy of this bug — deliberately left alone.**
`unifi_api.graphql.types.network.event.EventLog.from_manager_output` duplicates
the same legacy-only field mapping, so it is blind to v2 in exactly the same way.
Its `render_hint` lists `mac` in `display_columns`, so on a modern controller that
rendered table has a permanently empty column.

I kept it out of this PR to keep the change reviewable and scoped to one
behaviour. The obvious fix is to delegate that method to
`event_log_from_controller` rather than patch the duplicate — `types/network/firewall.py`
already sets that precedent by importing its factory from `unifi-core` — but that
touches all seven fields on a type this PR otherwise doesn't need to change, and
removing the duplication is a maintainer call. Happy to follow up in a separate PR
if that's the direction you want.

**Test path quirk, pre-existing.** `apps/network/tests/unit/test_tool_map_sync.py`
errors with `FileNotFoundError` when pytest runs from `apps/network/` rather than
the repo root — it resolves `apps/network/src/.../tools_manifest.json` relative to
cwd. Unrelated to this PR; passes from the root, which is how `make` invokes it.

**No manifest / GraphQL / OpenAPI regeneration:** no tool signature, field, or
description changed. `check-generated` confirms no drift.
