### PR TITLE
chore(deps): raise unifi-core floor to 0.4.27 for network and api

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.26,<0.5",
+    "unifi-core[network,protect,access]>=0.4.27,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.26,<0.5",
+    "unifi-core[network]>=0.4.27,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
## Summary

Raises the `unifi-core` floor to `>=0.4.27` for `unifi-network-mcp` and `unifi-api-server` ahead of their release tags.

Both packages ship behavior that depends on core 0.4.27's v2 system-log event field mapping (#516, #518): the network server's event tools and the API server's delegated `EventLog` projection. An older core wheel resolves and imports cleanly but leaves events anonymous — the floor bump makes the behavioral dependency explicit in wheel metadata.

Protect, access, relay, and shared floors are untouched: their code doesn't use the changed core surface and their existing bounds already admit 0.4.27.

## Testing

Pin-alignment CI gate validates the floor resolves against PyPI (0.4.27 confirmed live before this PR was opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYkkppusnWbMdbw6hdd1fu