### PR TITLE
test(api): make packaging dependency assertion version-agnostic

### DIFF
--- a/apps/api/tests/test_action_catalog_packaging.py
+++ b/apps/api/tests/test_action_catalog_packaging.py
@@ -16,7 +16,11 @@ def test_api_declares_only_core_as_an_internal_runtime_dependency() -> None:
     dependencies = pyproject["project"]["dependencies"]
     internal = [dependency for dependency in dependencies if dependency.startswith("unifi-")]
 
-    assert internal == ["unifi-core[network,protect,access]>=0.4.26,<0.5"]
+    # The floor version moves with routine core releases; assert the
+    # dependency set and bound shape, not the exact floor.
+    assert len(internal) == 1
+    assert internal[0].startswith("unifi-core[network,protect,access]>=")
+    assert internal[0].endswith(",<0.5")
 
 
 def test_built_wheel_contains_and_loads_catalog_without_sibling_apps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes the red `Test on Python 3.13` job on `main`: `test_api_declares_only_core_as_an_internal_runtime_dependency` hardcoded the exact core floor string and broke when #519 bumped it to 0.4.27 (my miss — I merged #519 on the pin-alignment gate without catching this job).

The test's intent is that `unifi-core` is the **only** internal runtime dependency with a bounded range — not what the floor happens to be this week. The assertion now checks the dependency set and bound shape, so routine floor bumps can't break it again.

## Testing

```
apps/api tests/test_action_catalog_packaging.py    2 passed
ruff check / format                                clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYkkppusnWbMdbw6hdd1fu