### PR TITLE
fix(network): make port profiles able to express an access port

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1491,12 +1491,17 @@ type PortProfile {
   id: ID
   name: String
   forward: String
+  taggedVlanMgmt: String
   nativeNetworkconfId: String
   taggedNetworkconfIds: [String!]!
+  excludedNetworkconfIds: [String!]
   voiceNetworkconfId: String
   poeMode: String
   isolation: Boolean
   stpPortMode: Boolean
+  stpEdgeState: String
+  stpBpduGuardEnabled: Boolean
+  stpUplink: Boolean
   dot1xCtrl: String
 }
 

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6512,6 +6512,20 @@
             ],
             "title": "Dot1X Ctrl"
           },
+          "excluded_networkconf_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Excluded Networkconf Ids"
+          },
           "forward": {
             "anyOf": [
               {
@@ -6578,6 +6592,28 @@
             ],
             "title": "Poe Mode"
           },
+          "stp_bpdu_guard_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stp Bpdu Guard Enabled"
+          },
+          "stp_edge_state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stp Edge State"
+          },
           "stp_port_mode": {
             "anyOf": [
               {
@@ -6589,12 +6625,34 @@
             ],
             "title": "Stp Port Mode"
           },
+          "stp_uplink": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stp Uplink"
+          },
           "tagged_networkconf_ids": {
             "items": {
               "type": "string"
             },
             "title": "Tagged Networkconf Ids",
             "type": "array"
+          },
+          "tagged_vlan_mgmt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tagged Vlan Mgmt"
           },
           "voice_networkconf_id": {
             "anyOf": [

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -2643,6 +2643,10 @@
             "description": "802.1X control: 'force_authorized', 'auto', 'force_unauthorized'",
             "type": "string"
           },
+          "excluded_networkconf_ids": {
+            "description": "Network IDs excluded when tagged_vlan_mgmt is 'custom'",
+            "type": "array"
+          },
           "forward": {
             "description": "Forward mode: 'native' (access), 'all' (trunk), 'customize', or 'disabled'",
             "type": "string"
@@ -2663,9 +2667,29 @@
             "description": "PoE mode: 'auto' or 'off'",
             "type": "string"
           },
+          "stp_bpdu_guard_enabled": {
+            "description": "Shut the port if it receives a BPDU (Edge ports)",
+            "type": "boolean"
+          },
+          "stp_edge_state": {
+            "description": "STP edge state: 'enabled' for end-device (Edge) ports, 'disabled' for uplinks. The UI's Port Mode control sets this with stp_bpdu_guard_enabled and stp_uplink",
+            "type": "string"
+          },
           "stp_port_mode": {
             "description": "Enable STP on this port",
             "type": "boolean"
+          },
+          "stp_uplink": {
+            "description": "Treat the port as an STP uplink (Infrastructure ports)",
+            "type": "boolean"
+          },
+          "tagged_networkconf_ids": {
+            "description": "Network IDs carried tagged when tagged_vlan_mgmt is 'custom'",
+            "type": "array"
+          },
+          "tagged_vlan_mgmt": {
+            "description": "Tagged VLAN Management \u2014 the access-vs-trunk control: 'auto' (allow all), 'block_all' (access port), 'custom'. An access port needs forward='native' with 'block_all'",
+            "type": "string"
           },
           "voice_networkconf_id": {
             "description": "Network/VLAN ID for voice traffic",
@@ -6277,7 +6301,7 @@
       "input_schema": {
         "properties": {
           "profile_data": {
-            "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), native_networkconf_id, voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host')",
+            "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, tagged_networkconf_ids (list), excluded_networkconf_ids (list), voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together",
             "type": "object"
           },
           "profile_id": {

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -2648,7 +2648,7 @@
             "type": "array"
           },
           "forward": {
-            "description": "Forward mode: 'native' (access), 'all' (trunk), 'customize', or 'disabled'",
+            "description": "Forward mode: 'native' (access), 'all' (trunk), or 'customize'",
             "type": "string"
           },
           "isolation": {
@@ -6301,7 +6301,7 @@
       "input_schema": {
         "properties": {
           "profile_data": {
-            "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, tagged_networkconf_ids (list), excluded_networkconf_ids (list), voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together",
+            "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'), tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, tagged_networkconf_ids (list), excluded_networkconf_ids (list), voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together. Port State (Active/Disabled) is a separate controller setting that this tool does not expose",
             "type": "object"
           },
           "profile_id": {

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1480,12 +1480,17 @@ type PortProfile {
   id: ID
   name: String
   forward: String
+  taggedVlanMgmt: String
   nativeNetworkconfId: String
   taggedNetworkconfIds: [String!]!
+  excludedNetworkconfIds: [String!]
   voiceNetworkconfId: String
   poeMode: String
   isolation: Boolean
   stpPortMode: Boolean
+  stpEdgeState: String
+  stpBpduGuardEnabled: Boolean
+  stpUplink: Boolean
   dot1xCtrl: String
 }
 

--- a/apps/api/src/unifi_api/graphql/types/network/switch.py
+++ b/apps/api/src/unifi_api/graphql/types/network/switch.py
@@ -45,12 +45,17 @@ class PortProfile:
     id: strawberry.ID | None
     name: str | None
     forward: str | None
+    tagged_vlan_mgmt: str | None
     native_networkconf_id: str | None
     tagged_networkconf_ids: list[str]
+    excluded_networkconf_ids: list[str] | None
     voice_networkconf_id: str | None
     poe_mode: str | None
     isolation: bool | None
     stp_port_mode: bool | None
+    stp_edge_state: str | None
+    stp_bpdu_guard_enabled: bool | None
+    stp_uplink: bool | None
     dot1x_ctrl: str | None
 
     @classmethod
@@ -66,16 +71,22 @@ class PortProfile:
         tagged = _get(obj, "tagged_networkconf_ids", []) or []
         if not isinstance(tagged, list):
             tagged = []
+        excluded = _get(obj, "excluded_networkconf_ids")
         return cls(
             id=_get(obj, "_id") or _get(obj, "id"),
             name=_get(obj, "name"),
             forward=_get(obj, "forward"),
+            tagged_vlan_mgmt=_get(obj, "tagged_vlan_mgmt"),
             native_networkconf_id=_get(obj, "native_networkconf_id"),
             tagged_networkconf_ids=list(tagged),
+            excluded_networkconf_ids=list(excluded) if isinstance(excluded, list) else None,
             voice_networkconf_id=_get(obj, "voice_networkconf_id"),
             poe_mode=_get(obj, "poe_mode"),
             isolation=_get(obj, "isolation"),
             stp_port_mode=_get(obj, "stp_port_mode"),
+            stp_edge_state=_get(obj, "stp_edge_state"),
+            stp_bpdu_guard_enabled=_get(obj, "stp_bpdu_guard_enabled"),
+            stp_uplink=_get(obj, "stp_uplink"),
             dot1x_ctrl=_get(obj, "dot1x_ctrl"),
         )
 

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -1130,6 +1130,40 @@ def _translate_port_profile_update(args: dict[str, Any]) -> tuple[tuple[Any, ...
     )
 
 
+def _translate_port_profile_create(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Build the port-profile create payload the way the MCP tool does.
+
+    Packing only the supplied keys is not equivalent here: ``poe_mode``,
+    ``stp_port_mode`` and ``isolation`` must be sent even when the caller takes
+    the documented default, or the controller applies its own — for ``poe_mode``
+    that means the profile is created with PoE off. Shares
+    ``build_create_payload`` with
+    ``apps/network/src/unifi_network_mcp/tools/switch.py:create_port_profile``.
+    """
+    from unifi_core.network.models.switch import build_create_payload
+
+    accepted = {
+        "name",
+        "forward",
+        "native_networkconf_id",
+        "tagged_vlan_mgmt",
+        "tagged_networkconf_ids",
+        "excluded_networkconf_ids",
+        "voice_networkconf_id",
+        "isolation",
+        "poe_mode",
+        "stp_port_mode",
+        "stp_edge_state",
+        "stp_bpdu_guard_enabled",
+        "stp_uplink",
+        "dot1x_ctrl",
+    }
+    supplied = {key: value for key, value in args.items() if key in accepted and value is not None}
+    if not supplied.get("name") or not supplied.get("forward"):
+        raise ValueError("name and forward are required to create a port profile.")
+    return (), {"profile_data": build_create_payload(**supplied)}
+
+
 def _translate_autobackup_update(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
     from unifi_core.network.models.system import autobackup_to_controller_update
 
@@ -1549,24 +1583,7 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslatorSpec] = {
     "unifi_create_simple_port_forward": _spec(_translate_create_simple_port_forward, "rule_data"),
     "unifi_create_qos_rule": _spec(_translate_create_qos_rule, "rule_data"),
     "unifi_create_simple_qos_rule": _spec(_translate_create_simple_qos_rule, "rule_data"),
-    "unifi_create_port_profile": _spec(
-        _pack_fields(
-            "profile_data",
-            frozenset(
-                {
-                    "name",
-                    "forward",
-                    "native_networkconf_id",
-                    "voice_networkconf_id",
-                    "poe_mode",
-                    "dot1x_ctrl",
-                    "isolation",
-                    "stp_port_mode",
-                }
-            ),
-        ),
-        "profile_data",
-    ),
+    "unifi_create_port_profile": _spec(_translate_port_profile_create, "profile_data"),
     "unifi_create_route": _spec(
         _translate_route_args,
         "name",

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -3406,3 +3406,51 @@ def test_delete_recording_result_adapter_rejects_unsupported_operation() -> None
             {},
             MagicMock(),
         )
+
+
+def test_create_port_profile_translator_sends_defaults_that_keep_poe_on() -> None:
+    """Packing only the supplied keys is not equivalent for this tool.
+
+    poe_mode, stp_port_mode and isolation must reach the controller even when
+    the caller takes the documented default, or the controller applies its own —
+    for poe_mode that creates the profile with PoE off, de-energising anything
+    wired through a port using it.
+    """
+    translator = DISPATCH_ARG_TRANSLATORS["unifi_create_port_profile"]
+
+    _, kwargs = translator({"name": "Access", "forward": "native", "tagged_vlan_mgmt": "block_all"})
+
+    payload = kwargs["profile_data"]
+    assert payload["poe_mode"] == "auto"
+    assert payload["stp_port_mode"] is True
+    assert payload["isolation"] is False
+    assert payload["tagged_vlan_mgmt"] == "block_all"
+
+
+def test_create_port_profile_translator_forwards_new_access_port_fields() -> None:
+    translator = DISPATCH_ARG_TRANSLATORS["unifi_create_port_profile"]
+
+    _, kwargs = translator(
+        {
+            "name": "Access",
+            "forward": "native",
+            "tagged_vlan_mgmt": "block_all",
+            "excluded_networkconf_ids": ["net-9"],
+            "stp_edge_state": "enabled",
+            "stp_bpdu_guard_enabled": True,
+            "stp_uplink": False,
+        }
+    )
+
+    payload = kwargs["profile_data"]
+    assert payload["excluded_networkconf_ids"] == ["net-9"]
+    assert payload["stp_edge_state"] == "enabled"
+    assert payload["stp_bpdu_guard_enabled"] is True
+    assert payload["stp_uplink"] is False
+
+
+def test_create_port_profile_translator_requires_name_and_forward() -> None:
+    translator = DISPATCH_ARG_TRANSLATORS["unifi_create_port_profile"]
+
+    with pytest.raises(ValueError):
+        translator({"name": "Access"})

--- a/apps/network/src/unifi_network_mcp/tools/switch.py
+++ b/apps/network/src/unifi_network_mcp/tools/switch.py
@@ -9,18 +9,25 @@ and device management commands.
 
 import json
 import logging
-from typing import Annotated, Any, Dict, List
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError
 
 from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.network.managers.switch_manager import coerced_fields
 from unifi_core.network.models._actions import (
     ConfigurePortAggregationInput,
     ConfigurePortMirrorInput,
     SetJumboFramesInput,
     SetSwitchPortProfileInput,
+)
+from unifi_core.network.models.switch import (
+    MUTABLE_FIELDS as PP_MUTABLE_FIELDS,
+)
+from unifi_core.network.models.switch import (
+    build_create_payload as pp_build_create_payload,
 )
 from unifi_core.network.models.switch import (
     from_controller as pp_from_controller,
@@ -89,7 +96,11 @@ async def get_port_profile_details(
 @server.tool(
     name="unifi_create_port_profile",
     description="Create a new port profile. forward values: 'native' (access port), 'all' (trunk), "
-    "'customize' (selective trunk), 'disabled'. Requires confirmation.",
+    "'customize' (selective trunk), 'disabled'. "
+    "tagged_vlan_mgmt is the access-vs-trunk control ('auto'/'block_all'/'custom'): the controller "
+    "rewrites forward to agree with it, so an access port needs forward='native' with "
+    "tagged_vlan_mgmt='block_all'. Port Mode in the UI maps to stp_edge_state + "
+    "stp_bpdu_guard_enabled + stp_uplink (Edge = 'enabled'/true/false). Requires confirmation.",
     permission_category="switch",
     permission_action="create",
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
@@ -100,10 +111,41 @@ async def create_port_profile(
         str, Field(description="Forward mode: 'native' (access), 'all' (trunk), 'customize', or 'disabled'")
     ],
     native_networkconf_id: Annotated[str, Field(description="Network/VLAN ID for native (untagged) traffic")] = "",
+    tagged_vlan_mgmt: Annotated[
+        str,
+        Field(
+            description="Tagged VLAN Management — the access-vs-trunk control: "
+            "'auto' (allow all), 'block_all' (access port), 'custom'. "
+            "An access port needs forward='native' with 'block_all'"
+        ),
+    ] = "",
+    tagged_networkconf_ids: Annotated[
+        Optional[List[str]],
+        Field(description="Network IDs carried tagged when tagged_vlan_mgmt is 'custom'"),
+    ] = None,
+    excluded_networkconf_ids: Annotated[
+        Optional[List[str]],
+        Field(description="Network IDs excluded when tagged_vlan_mgmt is 'custom'"),
+    ] = None,
     voice_networkconf_id: Annotated[str, Field(description="Network/VLAN ID for voice traffic")] = "",
     isolation: Annotated[bool, Field(description="Enable port isolation (block inter-client traffic)")] = False,
     poe_mode: Annotated[str, Field(description="PoE mode: 'auto' or 'off'")] = "auto",
     stp_port_mode: Annotated[bool, Field(description="Enable STP on this port")] = True,
+    stp_edge_state: Annotated[
+        str,
+        Field(
+            description="STP edge state: 'enabled' for end-device (Edge) ports, 'disabled' for uplinks. "
+            "The UI's Port Mode control sets this with stp_bpdu_guard_enabled and stp_uplink"
+        ),
+    ] = "",
+    stp_bpdu_guard_enabled: Annotated[
+        Optional[bool],
+        Field(description="Shut the port if it receives a BPDU (Edge ports)"),
+    ] = None,
+    stp_uplink: Annotated[
+        Optional[bool],
+        Field(description="Treat the port as an STP uplink (Infrastructure ports)"),
+    ] = None,
     dot1x_ctrl: Annotated[
         str, Field(description="802.1X control: 'force_authorized', 'auto', 'force_unauthorized'")
     ] = "",
@@ -113,19 +155,22 @@ async def create_port_profile(
     ] = False,
 ) -> Dict[str, Any]:
     """Creates a new port profile."""
-    profile_data: Dict[str, Any] = {"name": name, "forward": forward}
-    if native_networkconf_id:
-        profile_data["native_networkconf_id"] = native_networkconf_id
-    if voice_networkconf_id:
-        profile_data["voice_networkconf_id"] = voice_networkconf_id
-    if isolation:
-        profile_data["isolation"] = isolation
-    if poe_mode != "auto":
-        profile_data["poe_mode"] = poe_mode
-    if not stp_port_mode:
-        profile_data["stp_port_mode"] = stp_port_mode
-    if dot1x_ctrl:
-        profile_data["dot1x_ctrl"] = dot1x_ctrl
+    profile_data = pp_build_create_payload(
+        name=name,
+        forward=forward,
+        native_networkconf_id=native_networkconf_id,
+        tagged_vlan_mgmt=tagged_vlan_mgmt,
+        tagged_networkconf_ids=tagged_networkconf_ids,
+        excluded_networkconf_ids=excluded_networkconf_ids,
+        voice_networkconf_id=voice_networkconf_id,
+        isolation=isolation,
+        poe_mode=poe_mode,
+        stp_port_mode=stp_port_mode,
+        stp_edge_state=stp_edge_state,
+        stp_bpdu_guard_enabled=stp_bpdu_guard_enabled,
+        stp_uplink=stp_uplink,
+        dot1x_ctrl=dot1x_ctrl,
+    )
 
     if not confirm:
         return create_preview(
@@ -137,6 +182,19 @@ async def create_port_profile(
     try:
         result = await switch_manager.create_port_profile(profile_data)
         if result:
+            coerced = coerced_fields(profile_data, result)
+            if coerced:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Port profile '{name}' was created, but the controller stored different "
+                        f"values than requested for: {', '.join(sorted(coerced))}. "
+                        "forward is rewritten to agree with tagged_vlan_mgmt — an access port needs "
+                        "forward='native' with tagged_vlan_mgmt='block_all'."
+                    ),
+                    "coerced_fields": coerced,
+                    "profile": json.loads(json.dumps(result, default=str)),
+                }
             return {
                 "success": True,
                 "message": f"Port profile '{name}' created successfully.",
@@ -165,9 +223,13 @@ async def update_port_profile(
             description="Dictionary of fields to update. Pass only the fields you want to change — "
             "current values are automatically preserved. "
             "Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), "
-            "native_networkconf_id, voice_networkconf_id, isolation (bool), "
+            "tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, "
+            "tagged_networkconf_ids (list), excluded_networkconf_ids (list), "
+            "voice_networkconf_id, isolation (bool), "
             "poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), "
-            "dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host')"
+            "stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), "
+            "dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). "
+            "The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together"
         ),
     ],
     confirm: Annotated[
@@ -182,7 +244,21 @@ async def update_port_profile(
         return {"success": False, "error": "profile_data cannot be empty"}
 
     validated_data = pp_to_update(profile_data)
+    # unifi_get_port_profile_details returns the controller's full raw object, so
+    # callers routinely round-trip keys this tool cannot write. Name them rather
+    # than dropping them silently.
+    ignored_fields = sorted(k for k in profile_data if k not in PP_MUTABLE_FIELDS)
     if not validated_data:
+        if ignored_fields:
+            return {
+                "success": False,
+                "error": (
+                    f"The following fields are not supported by unifi_update_port_profile: "
+                    f"{', '.join(ignored_fields)}. "
+                    "unifi_get_port_profile_details returns the controller's full raw object, "
+                    "which includes fields this tool cannot write."
+                ),
+            }
         return {"success": False, "error": "No valid mutable fields provided for update."}
 
     if not confirm:
@@ -192,14 +268,28 @@ async def update_port_profile(
             resource_name=profile_id,
             current_state={},
             updates=validated_data,
+            warnings=(
+                [
+                    "The following fields are not writable through this tool and will be ignored: "
+                    + ", ".join(ignored_fields)
+                    + "."
+                ]
+                if ignored_fields
+                else None
+            ),
         )
 
     try:
-        merged = await switch_manager.update_port_profile(profile_id, validated_data)
-        return {
+        success, error = await switch_manager.update_port_profile(profile_id, validated_data)
+        if not success:
+            return {"success": False, "error": error}
+        result: Dict[str, Any] = {
             "success": True,
-            "message": f"Port profile '{merged.get('name', profile_id)}' updated successfully.",
+            "message": f"Port profile '{profile_id}' updated successfully.",
         }
+        if ignored_fields:
+            result["ignored_fields"] = ignored_fields
+        return result
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:

--- a/apps/network/src/unifi_network_mcp/tools/switch.py
+++ b/apps/network/src/unifi_network_mcp/tools/switch.py
@@ -16,7 +16,6 @@ from pydantic import Field, ValidationError
 
 from unifi_core.confirmation import create_preview, delete_preview, update_preview
 from unifi_core.exceptions import UniFiNotFoundError
-from unifi_core.network.managers.switch_manager import coerced_fields
 from unifi_core.network.models._actions import (
     ConfigurePortAggregationInput,
     ConfigurePortMirrorInput,
@@ -35,6 +34,7 @@ from unifi_core.network.models.switch import (
 from unifi_core.network.models.switch import (
     to_controller_update as pp_to_update,
 )
+from unifi_core.write_verification import format_tool_payload
 from unifi_network_mcp.runtime import server, switch_manager
 
 logger = logging.getLogger(__name__)
@@ -96,7 +96,8 @@ async def get_port_profile_details(
 @server.tool(
     name="unifi_create_port_profile",
     description="Create a new port profile. forward values: 'native' (access port), 'all' (trunk), "
-    "'customize' (selective trunk), 'disabled'. "
+    "or 'customize' (selective trunk). Port State (Active/Disabled) is a separate controller setting "
+    "that these port-profile tools do not currently expose. "
     "tagged_vlan_mgmt is the access-vs-trunk control ('auto'/'block_all'/'custom'): the controller "
     "rewrites forward to agree with it, so an access port needs forward='native' with "
     "tagged_vlan_mgmt='block_all'. Port Mode in the UI maps to stp_edge_state + "
@@ -107,9 +108,7 @@ async def get_port_profile_details(
 )
 async def create_port_profile(
     name: Annotated[str, Field(description="Profile name")],
-    forward: Annotated[
-        str, Field(description="Forward mode: 'native' (access), 'all' (trunk), 'customize', or 'disabled'")
-    ],
+    forward: Annotated[str, Field(description="Forward mode: 'native' (access), 'all' (trunk), or 'customize'")],
     native_networkconf_id: Annotated[str, Field(description="Network/VLAN ID for native (untagged) traffic")] = "",
     tagged_vlan_mgmt: Annotated[
         str,
@@ -180,27 +179,12 @@ async def create_port_profile(
         )
 
     try:
-        result = await switch_manager.create_port_profile(profile_data)
-        if result:
-            coerced = coerced_fields(profile_data, result)
-            if coerced:
-                return {
-                    "success": False,
-                    "error": (
-                        f"Port profile '{name}' was created, but the controller stored different "
-                        f"values than requested for: {', '.join(sorted(coerced))}. "
-                        "forward is rewritten to agree with tagged_vlan_mgmt — an access port needs "
-                        "forward='native' with tagged_vlan_mgmt='block_all'."
-                    ),
-                    "coerced_fields": coerced,
-                    "profile": json.loads(json.dumps(result, default=str)),
-                }
-            return {
-                "success": True,
-                "message": f"Port profile '{name}' created successfully.",
-                "profile": json.loads(json.dumps(result, default=str)),
-            }
-        return {"success": False, "error": f"Failed to create port profile '{name}'."}
+        write_result = await switch_manager.create_port_profile(profile_data)
+        return format_tool_payload(
+            write_result,
+            site=switch_manager._connection.site,
+            success_message=f"Port profile '{name}' created successfully.",
+        )
     except Exception as e:
         logger.error("Error creating port profile: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to create port profile: {e}"}
@@ -222,14 +206,15 @@ async def update_port_profile(
         Field(
             description="Dictionary of fields to update. Pass only the fields you want to change — "
             "current values are automatically preserved. "
-            "Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), "
+            "Allowed keys: name, forward ('all'/'native'/'customize'), "
             "tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, "
             "tagged_networkconf_ids (list), excluded_networkconf_ids (list), "
             "voice_networkconf_id, isolation (bool), "
             "poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), "
             "stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), "
             "dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). "
-            "The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together"
+            "The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together. "
+            "Port State (Active/Disabled) is a separate controller setting that this tool does not expose"
         ),
     ],
     confirm: Annotated[
@@ -280,13 +265,13 @@ async def update_port_profile(
         )
 
     try:
-        success, error = await switch_manager.update_port_profile(profile_id, validated_data)
-        if not success:
-            return {"success": False, "error": error}
-        result: Dict[str, Any] = {
-            "success": True,
-            "message": f"Port profile '{profile_id}' updated successfully.",
-        }
+        write_result = await switch_manager.update_port_profile(profile_id, validated_data)
+        result = format_tool_payload(
+            write_result,
+            site=switch_manager._connection.site,
+            success_message=f"Port profile '{profile_id}' updated successfully.",
+        )
+        result["profile_id"] = profile_id
         if ignored_fields:
             result["ignored_fields"] = ignored_fields
         return result

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -2210,7 +2210,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a new port profile. forward values: 'native' (access port), 'all' (trunk), 'customize' (selective trunk), 'disabled'. Requires confirmation.",
+      "description": "Create a new port profile. forward values: 'native' (access port), 'all' (trunk), 'customize' (selective trunk), 'disabled'. tagged_vlan_mgmt is the access-vs-trunk control ('auto'/'block_all'/'custom'): the controller rewrites forward to agree with it, so an access port needs forward='native' with tagged_vlan_mgmt='block_all'. Port Mode in the UI maps to stp_edge_state + stp_bpdu_guard_enabled + stp_uplink (Edge = 'enabled'/true/false). Requires confirmation.",
       "name": "unifi_create_port_profile",
       "permission_action": "create",
       "permission_category": "switch",
@@ -2224,6 +2224,10 @@
             "dot1x_ctrl": {
               "description": "802.1X control: 'force_authorized', 'auto', 'force_unauthorized'",
               "type": "string"
+            },
+            "excluded_networkconf_ids": {
+              "description": "Network IDs excluded when tagged_vlan_mgmt is 'custom'",
+              "type": "array"
             },
             "forward": {
               "description": "Forward mode: 'native' (access), 'all' (trunk), 'customize', or 'disabled'",
@@ -2245,9 +2249,29 @@
               "description": "PoE mode: 'auto' or 'off'",
               "type": "string"
             },
+            "stp_bpdu_guard_enabled": {
+              "description": "Shut the port if it receives a BPDU (Edge ports)",
+              "type": "boolean"
+            },
+            "stp_edge_state": {
+              "description": "STP edge state: 'enabled' for end-device (Edge) ports, 'disabled' for uplinks. The UI's Port Mode control sets this with stp_bpdu_guard_enabled and stp_uplink",
+              "type": "string"
+            },
             "stp_port_mode": {
               "description": "Enable STP on this port",
               "type": "boolean"
+            },
+            "stp_uplink": {
+              "description": "Treat the port as an STP uplink (Infrastructure ports)",
+              "type": "boolean"
+            },
+            "tagged_networkconf_ids": {
+              "description": "Network IDs carried tagged when tagged_vlan_mgmt is 'custom'",
+              "type": "array"
+            },
+            "tagged_vlan_mgmt": {
+              "description": "Tagged VLAN Management \u2014 the access-vs-trunk control: 'auto' (allow all), 'block_all' (access port), 'custom'. An access port needs forward='native' with 'block_all'",
+              "type": "string"
             },
             "voice_networkconf_id": {
               "description": "Network/VLAN ID for voice traffic",
@@ -17371,7 +17395,7 @@
               "type": "boolean"
             },
             "profile_data": {
-              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), native_networkconf_id, voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host')",
+              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, tagged_networkconf_ids (list), excluded_networkconf_ids (list), voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together",
               "type": "object"
             },
             "profile_id": {

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -2210,7 +2210,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a new port profile. forward values: 'native' (access port), 'all' (trunk), 'customize' (selective trunk), 'disabled'. tagged_vlan_mgmt is the access-vs-trunk control ('auto'/'block_all'/'custom'): the controller rewrites forward to agree with it, so an access port needs forward='native' with tagged_vlan_mgmt='block_all'. Port Mode in the UI maps to stp_edge_state + stp_bpdu_guard_enabled + stp_uplink (Edge = 'enabled'/true/false). Requires confirmation.",
+      "description": "Create a new port profile. forward values: 'native' (access port), 'all' (trunk), or 'customize' (selective trunk). Port State (Active/Disabled) is a separate controller setting that these port-profile tools do not currently expose. tagged_vlan_mgmt is the access-vs-trunk control ('auto'/'block_all'/'custom'): the controller rewrites forward to agree with it, so an access port needs forward='native' with tagged_vlan_mgmt='block_all'. Port Mode in the UI maps to stp_edge_state + stp_bpdu_guard_enabled + stp_uplink (Edge = 'enabled'/true/false). Requires confirmation.",
       "name": "unifi_create_port_profile",
       "permission_action": "create",
       "permission_category": "switch",
@@ -2230,7 +2230,7 @@
               "type": "array"
             },
             "forward": {
-              "description": "Forward mode: 'native' (access), 'all' (trunk), 'customize', or 'disabled'",
+              "description": "Forward mode: 'native' (access), 'all' (trunk), or 'customize'",
               "type": "string"
             },
             "isolation": {
@@ -17395,7 +17395,7 @@
               "type": "boolean"
             },
             "profile_data": {
-              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'/'disabled'), tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, tagged_networkconf_ids (list), excluded_networkconf_ids (list), voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together",
+              "description": "Dictionary of fields to update. Pass only the fields you want to change \u2014 current values are automatically preserved. Allowed keys: name, forward ('all'/'native'/'customize'), tagged_vlan_mgmt ('auto'/'block_all'/'custom'), native_networkconf_id, tagged_networkconf_ids (list), excluded_networkconf_ids (list), voice_networkconf_id, isolation (bool), poe_mode ('auto'/'off'/'pasv24'/'passthrough'), stp_port_mode (bool), stp_edge_state ('enabled'/'disabled'), stp_bpdu_guard_enabled (bool), stp_uplink (bool), dot1x_ctrl ('force_authorized'/'auto'/'force_unauthorized'/'mac_based'/'multi_host'). The controller rewrites forward to agree with tagged_vlan_mgmt, so change them together. Port State (Active/Disabled) is a separate controller setting that this tool does not expose",
               "type": "object"
             },
             "profile_id": {

--- a/apps/network/tests/unit/test_switch_manager.py
+++ b/apps/network/tests/unit/test_switch_manager.py
@@ -100,16 +100,33 @@ class TestSwitchManager:
 
         result = await switch_manager.create_port_profile({"name": "Test", "forward": "native"})
 
-        assert result is not None
-        assert result["_id"] == "new1"
+        assert result.success is True
+        assert result.resource["_id"] == "new1"
         mock_connection._invalidate_cache.assert_called()
 
     @pytest.mark.asyncio
+    async def test_create_port_profile_refetches_and_reports_coerced_fields(self, switch_manager, mock_connection):
+        """The POST response is not proof of persistence; verification uses a fresh GET."""
+        mock_connection.request.side_effect = [
+            [{"_id": "p1", "name": "Access", "forward": "native"}],
+            [{"_id": "p1", "name": "Access", "forward": "all"}],
+        ]
+
+        result = await switch_manager.create_port_profile({"name": "Access", "forward": "native"})
+
+        assert result.success is False
+        assert result.mutation_applied is True
+        assert result.coerced_fields == ("forward",)
+        assert result.resource["forward"] == "all"
+
+    @pytest.mark.asyncio
     async def test_create_port_profile_missing_fields(self, switch_manager, mock_connection):
-        """Test create_port_profile returns None when required fields missing."""
+        """Test create_port_profile returns a structured failure when required fields are missing."""
         result = await switch_manager.create_port_profile({"name": "Test"})
 
-        assert result is None
+        assert result.success is False
+        assert result.mutation_applied is False
+        assert "forward" in result.error
         mock_connection.request.assert_not_called()
 
     @pytest.mark.asyncio
@@ -123,10 +140,10 @@ class TestSwitchManager:
             [stored],  # GET read-back
         ]
 
-        success, error = await switch_manager.update_port_profile("p1", {"name": "Updated"})
+        result = await switch_manager.update_port_profile("p1", {"name": "Updated"})
 
-        assert success is True
-        assert error is None
+        assert result.success is True
+        assert result.persisted_fields == ("name",)
         mock_connection._invalidate_cache.assert_called()
 
     @pytest.mark.asyncio
@@ -146,9 +163,9 @@ class TestSwitchManager:
             [stored_profile],  # GET read-back
         ]
 
-        success, error = await switch_manager.update_port_profile("pp1", {"name": "Renamed", "poe_mode": "off"})
+        result = await switch_manager.update_port_profile("pp1", {"name": "Renamed", "poe_mode": "off"})
 
-        assert success is True, error
+        assert result.success is True, result.error
         put_call = mock_connection.request.call_args_list[1]
         put_request = put_call[0][0]
         assert put_request.method == "put"
@@ -172,15 +189,17 @@ class TestSwitchManager:
             [stored],  # GET read-back
         ]
 
-        success, error = await switch_manager.update_port_profile("p1", {"forward": "native"})
+        result = await switch_manager.update_port_profile("p1", {"forward": "native"})
 
-        assert success is False, "a rewritten write must not ack as success"
-        assert "forward" in error
-        assert "native" in error and "all" in error
+        assert result.success is False, "a rewritten write must not ack as success"
+        assert result.dropped_fields == ("forward",)
+        assert result.resource["forward"] == "all"
 
     @pytest.mark.asyncio
-    async def test_update_port_profile_read_back_failure_does_not_fail_the_write(self, switch_manager, mock_connection):
-        """The PUT already landed, so a failed read-back means unverified, not failed."""
+    async def test_update_port_profile_read_back_failure_reports_unverified_mutation(
+        self, switch_manager, mock_connection
+    ):
+        """A landed PUT with failed read-back must not be reported as verified success."""
         existing = {"_id": "p1", "name": "P", "forward": "all"}
         mock_connection.request.side_effect = [
             [existing],  # GET current
@@ -188,14 +207,17 @@ class TestSwitchManager:
             RuntimeError("503 Service Unavailable"),  # GET read-back fails
         ]
 
-        success, error = await switch_manager.update_port_profile("p1", {"name": "Renamed"})
+        result = await switch_manager.update_port_profile("p1", {"name": "Renamed"})
 
-        assert success is True
-        assert error is None
+        assert result.success is False
+        assert result.mutation_applied is True
+        assert "could not be re-read" in result.error
 
     @pytest.mark.asyncio
-    async def test_update_port_profile_ignores_keys_the_controller_omits(self, switch_manager, mock_connection):
-        """An absent key means the profile does not carry that field, not that the write failed."""
+    async def test_update_port_profile_reports_requested_key_the_controller_omits(
+        self, switch_manager, mock_connection
+    ):
+        """A missing requested field is a silent drop, not verified success."""
         existing = {"_id": "p1", "name": "P", "forward": "native"}
         stored = {"_id": "p1", "name": "P", "forward": "native"}
         mock_connection.request.side_effect = [
@@ -204,13 +226,29 @@ class TestSwitchManager:
             [stored],
         ]
 
-        success, error = await switch_manager.update_port_profile("p1", {"excluded_networkconf_ids": []})
+        result = await switch_manager.update_port_profile("p1", {"excluded_networkconf_ids": ["net-9"]})
 
-        assert success is True, error
+        assert result.success is False
+        assert result.mutation_applied is True
+        assert result.dropped_fields == ("excluded_networkconf_ids",)
 
     @pytest.mark.asyncio
-    async def test_update_port_profile_list_order_is_not_a_coercion(self, switch_manager, mock_connection):
-        """The controller may return a list in a different order; that is not a rewrite."""
+    async def test_update_port_profile_treats_omitted_empty_vlan_lists_as_persisted(
+        self, switch_manager, mock_connection
+    ):
+        """The controller represents an empty VLAN set by omitting its key."""
+        existing = {"_id": "p1", "name": "P", "forward": "native"}
+        stored = {"_id": "p1", "name": "P", "forward": "native"}
+        mock_connection.request.side_effect = [[existing], {}, [stored]]
+
+        result = await switch_manager.update_port_profile("p1", {"excluded_networkconf_ids": []})
+
+        assert result.success is True
+        assert result.unchanged_fields == ("excluded_networkconf_ids",)
+
+    @pytest.mark.asyncio
+    async def test_update_port_profile_reports_list_reordering(self, switch_manager, mock_connection):
+        """Verification remains exact unless a controller normalization is explicitly documented."""
         existing = {"_id": "p1", "tagged_networkconf_ids": []}
         stored = {"_id": "p1", "tagged_networkconf_ids": ["b", "a"]}
         mock_connection.request.side_effect = [
@@ -219,9 +257,10 @@ class TestSwitchManager:
             [stored],
         ]
 
-        success, error = await switch_manager.update_port_profile("p1", {"tagged_networkconf_ids": ["a", "b"]})
+        result = await switch_manager.update_port_profile("p1", {"tagged_networkconf_ids": ["a", "b"]})
 
-        assert success is True, error
+        assert result.success is False
+        assert result.coerced_fields == ("tagged_networkconf_ids",)
 
     @pytest.mark.asyncio
     async def test_update_port_profile_not_found(self, switch_manager, mock_connection):
@@ -237,10 +276,11 @@ class TestSwitchManager:
         existing = {"_id": "p1", "name": "Original"}
         mock_connection.request.return_value = [existing]
 
-        success, error = await switch_manager.update_port_profile("p1", {})
+        result = await switch_manager.update_port_profile("p1", {})
 
-        assert success is True
-        assert error is None
+        assert result.success is True
+        assert result.mutation_applied is False
+        assert result.resource == existing
         # Only the GET (for get_port_profile_by_id) ran; no PUT.
         assert mock_connection.request.call_count == 1
 
@@ -420,7 +460,7 @@ class TestSwitchManager:
 
         await switch_manager.create_port_profile({"name": "Test", "forward": "native"})
 
-        call_args = mock_connection.request.call_args
+        call_args = mock_connection.request.call_args_list[0]
         assert call_args[0][0].path == "/rest/portconf"
         assert call_args[0][0].method == "post"
 

--- a/apps/network/tests/unit/test_switch_manager.py
+++ b/apps/network/tests/unit/test_switch_manager.py
@@ -114,17 +114,19 @@ class TestSwitchManager:
 
     @pytest.mark.asyncio
     async def test_update_port_profile_success(self, switch_manager, mock_connection):
-        """Test update_port_profile returns merged dict."""
+        """Test update_port_profile acks success when the read-back matches."""
         existing = {"_id": "p1", "name": "Original", "forward": "all"}
+        stored = {"_id": "p1", "name": "Updated", "forward": "all"}
         mock_connection.request.side_effect = [
             [existing],  # GET returns list
             {},  # PUT
+            [stored],  # GET read-back
         ]
 
-        result = await switch_manager.update_port_profile("p1", {"name": "Updated"})
+        success, error = await switch_manager.update_port_profile("p1", {"name": "Updated"})
 
-        assert result["name"] == "Updated"
-        assert result["forward"] == "all"
+        assert success is True
+        assert error is None
         mock_connection._invalidate_cache.assert_called()
 
     @pytest.mark.asyncio
@@ -137,21 +139,89 @@ class TestSwitchManager:
             "native_networkconf_id": "net1",
             "poe_mode": "auto",
         }
+        stored_profile = {**existing_profile, "name": "Renamed", "poe_mode": "off"}
         mock_connection.request.side_effect = [
             [existing_profile],  # GET returns list
             {},  # PUT
+            [stored_profile],  # GET read-back
         ]
 
-        result = await switch_manager.update_port_profile("pp1", {"name": "Renamed", "poe_mode": "off"})
+        success, error = await switch_manager.update_port_profile("pp1", {"name": "Renamed", "poe_mode": "off"})
 
-        assert result["name"] == "Renamed"
-        assert result["poe_mode"] == "off"
+        assert success is True, error
         put_call = mock_connection.request.call_args_list[1]
         put_request = put_call[0][0]
         assert put_request.method == "put"
         assert put_request.data["name"] == "Renamed"
         assert put_request.data["poe_mode"] == "off"
         assert put_request.data["forward"] == "customize"
+
+    @pytest.mark.asyncio
+    async def test_update_port_profile_returns_controller_state_not_local_merge(self, switch_manager, mock_connection):
+        """The returned profile is what the controller stored, not what we sent.
+
+        The controller rewrites some values on write (notably `forward`, to
+        agree with tagged_vlan_mgmt). Returning the local merge reported those
+        rewritten writes as if they had been applied verbatim.
+        """
+        existing = {"_id": "p1", "name": "P", "forward": "all", "tagged_vlan_mgmt": "auto"}
+        stored = {"_id": "p1", "name": "P", "forward": "all", "tagged_vlan_mgmt": "auto"}
+        mock_connection.request.side_effect = [
+            [existing],  # GET current
+            {},  # PUT
+            [stored],  # GET read-back
+        ]
+
+        success, error = await switch_manager.update_port_profile("p1", {"forward": "native"})
+
+        assert success is False, "a rewritten write must not ack as success"
+        assert "forward" in error
+        assert "native" in error and "all" in error
+
+    @pytest.mark.asyncio
+    async def test_update_port_profile_read_back_failure_does_not_fail_the_write(self, switch_manager, mock_connection):
+        """The PUT already landed, so a failed read-back means unverified, not failed."""
+        existing = {"_id": "p1", "name": "P", "forward": "all"}
+        mock_connection.request.side_effect = [
+            [existing],  # GET current
+            {},  # PUT — lands
+            RuntimeError("503 Service Unavailable"),  # GET read-back fails
+        ]
+
+        success, error = await switch_manager.update_port_profile("p1", {"name": "Renamed"})
+
+        assert success is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_update_port_profile_ignores_keys_the_controller_omits(self, switch_manager, mock_connection):
+        """An absent key means the profile does not carry that field, not that the write failed."""
+        existing = {"_id": "p1", "name": "P", "forward": "native"}
+        stored = {"_id": "p1", "name": "P", "forward": "native"}
+        mock_connection.request.side_effect = [
+            [existing],
+            {},
+            [stored],
+        ]
+
+        success, error = await switch_manager.update_port_profile("p1", {"excluded_networkconf_ids": []})
+
+        assert success is True, error
+
+    @pytest.mark.asyncio
+    async def test_update_port_profile_list_order_is_not_a_coercion(self, switch_manager, mock_connection):
+        """The controller may return a list in a different order; that is not a rewrite."""
+        existing = {"_id": "p1", "tagged_networkconf_ids": []}
+        stored = {"_id": "p1", "tagged_networkconf_ids": ["b", "a"]}
+        mock_connection.request.side_effect = [
+            [existing],
+            {},
+            [stored],
+        ]
+
+        success, error = await switch_manager.update_port_profile("p1", {"tagged_networkconf_ids": ["a", "b"]})
+
+        assert success is True, error
 
     @pytest.mark.asyncio
     async def test_update_port_profile_not_found(self, switch_manager, mock_connection):
@@ -167,9 +237,10 @@ class TestSwitchManager:
         existing = {"_id": "p1", "name": "Original"}
         mock_connection.request.return_value = [existing]
 
-        result = await switch_manager.update_port_profile("p1", {})
+        success, error = await switch_manager.update_port_profile("p1", {})
 
-        assert result == existing
+        assert success is True
+        assert error is None
         # Only the GET (for get_port_profile_by_id) ran; no PUT.
         assert mock_connection.request.call_count == 1
 

--- a/apps/network/tests/unit/test_switch_tools.py
+++ b/apps/network/tests/unit/test_switch_tools.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from unifi_core.write_verification import WriteVerificationResult
+
 os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
 os.environ.setdefault("UNIFI_USERNAME", "test")
 os.environ.setdefault("UNIFI_PASSWORD", "test")
@@ -123,12 +125,23 @@ class TestPortProfileWriteVerification:
     """
 
     @pytest.mark.asyncio
-    async def test_update_surfaces_manager_verification_failure(self) -> None:
-        """The manager verifies the write; the tool surfaces its verdict."""
-        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
-            mock_mgr.update_port_profile = AsyncMock(return_value=(False, "stored different value(s): forward ..."))
+    async def test_update_surfaces_structured_verification_failure(self) -> None:
+        """A coerced write exposes that the mutation landed and names the field."""
+        from unifi_network_mcp.tools.switch import update_port_profile
 
-            from unifi_network_mcp.tools.switch import update_port_profile
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr._connection.site = "default"
+            mock_mgr.update_port_profile = AsyncMock(
+                return_value=WriteVerificationResult(
+                    success=False,
+                    mutation_applied=True,
+                    operation="update",
+                    resource={"_id": "pp1", "forward": "all"},
+                    error="Controller accepted and applied the update request but persisted different values.",
+                    coerced_fields=("forward",),
+                    metadata={"profile_id": "pp1"},
+                )
+            )
 
             result = await update_port_profile(
                 profile_id="pp1",
@@ -137,14 +150,26 @@ class TestPortProfileWriteVerification:
             )
 
         assert result["success"] is False, result
-        assert "forward" in result["error"]
+        assert result["mutation_applied"] is True
+        assert result["coerced_fields"] == ["forward"]
+        assert result["details_after_attempt"]["forward"] == "all"
 
     @pytest.mark.asyncio
     async def test_update_success_when_manager_verifies(self) -> None:
-        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
-            mock_mgr.update_port_profile = AsyncMock(return_value=(True, None))
+        from unifi_network_mcp.tools.switch import update_port_profile
 
-            from unifi_network_mcp.tools.switch import update_port_profile
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr._connection.site = "default"
+            mock_mgr.update_port_profile = AsyncMock(
+                return_value=WriteVerificationResult(
+                    success=True,
+                    mutation_applied=True,
+                    operation="update",
+                    resource={"_id": "pp1", "forward": "native", "tagged_vlan_mgmt": "block_all"},
+                    persisted_fields=("forward", "tagged_vlan_mgmt"),
+                    metadata={"profile_id": "pp1"},
+                )
+            )
 
             result = await update_port_profile(
                 profile_id="pp1",
@@ -156,18 +181,21 @@ class TestPortProfileWriteVerification:
 
     @pytest.mark.asyncio
     async def test_create_reports_coerced_field(self) -> None:
-        created = {
-            "_id": "pp2",
-            "name": "Access",
-            "forward": "all",
-            "poe_mode": "auto",
-            "isolation": False,
-            "stp_port_mode": True,
-        }
-        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
-            mock_mgr.create_port_profile = AsyncMock(return_value=created)
+        from unifi_network_mcp.tools.switch import create_port_profile
 
-            from unifi_network_mcp.tools.switch import create_port_profile
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr._connection.site = "default"
+            mock_mgr.create_port_profile = AsyncMock(
+                return_value=WriteVerificationResult(
+                    success=False,
+                    mutation_applied=True,
+                    operation="create",
+                    resource={"_id": "pp2", "name": "Access", "forward": "all"},
+                    error="Controller accepted and applied the create request but persisted different values.",
+                    coerced_fields=("forward",),
+                    metadata={"profile_id": "pp2"},
+                )
+            )
 
             result = await create_port_profile(
                 name="Access",
@@ -177,9 +205,9 @@ class TestPortProfileWriteVerification:
             )
 
         assert result["success"] is False, result
-        assert set(result["coerced_fields"]) == {"forward"}, result["coerced_fields"]
-        assert result["coerced_fields"]["forward"]["requested"] == "native"
-        assert result["coerced_fields"]["forward"]["stored"] == "all"
+        assert result["mutation_applied"] is True
+        assert result["coerced_fields"] == ["forward"]
+        assert result["details_after_attempt"]["forward"] == "all"
 
     @pytest.mark.asyncio
     async def test_create_success_path_reports_no_coercion(self) -> None:
@@ -193,11 +221,27 @@ class TestPortProfileWriteVerification:
             "isolation": False,
             "stp_port_mode": True,
         }
+        from unifi_network_mcp.tools.switch import create_port_profile
+
         with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
-            mock_mgr.create_port_profile = AsyncMock(return_value=created)
-
-            from unifi_network_mcp.tools.switch import create_port_profile
-
+            mock_mgr._connection.site = "default"
+            mock_mgr.create_port_profile = AsyncMock(
+                return_value=WriteVerificationResult(
+                    success=True,
+                    mutation_applied=True,
+                    operation="create",
+                    resource=created,
+                    persisted_fields=(
+                        "forward",
+                        "isolation",
+                        "name",
+                        "poe_mode",
+                        "stp_port_mode",
+                        "tagged_vlan_mgmt",
+                    ),
+                    metadata={"profile_id": "pp3"},
+                )
+            )
             result = await create_port_profile(
                 name="Access",
                 forward="native",
@@ -206,7 +250,8 @@ class TestPortProfileWriteVerification:
             )
 
         assert result["success"] is True, result
-        assert "coerced_fields" not in result
+        assert result["coerced_fields"] == []
+        assert result["details"]["_id"] == "pp3"
 
     @pytest.mark.asyncio
     async def test_create_does_not_flag_keys_the_controller_omits(self) -> None:
@@ -225,11 +270,20 @@ class TestPortProfileWriteVerification:
             "isolation": False,
             "stp_port_mode": True,
         }
+        from unifi_network_mcp.tools.switch import create_port_profile
+
         with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
-            mock_mgr.create_port_profile = AsyncMock(return_value=created)
-
-            from unifi_network_mcp.tools.switch import create_port_profile
-
+            mock_mgr._connection.site = "default"
+            mock_mgr.create_port_profile = AsyncMock(
+                return_value=WriteVerificationResult(
+                    success=True,
+                    mutation_applied=True,
+                    operation="create",
+                    resource=created,
+                    persisted_fields=("forward", "name", "tagged_vlan_mgmt"),
+                    metadata={"profile_id": "pp4"},
+                )
+            )
             result = await create_port_profile(
                 name="Access",
                 forward="native",

--- a/apps/network/tests/unit/test_switch_tools.py
+++ b/apps/network/tests/unit/test_switch_tools.py
@@ -1,0 +1,272 @@
+"""Tests for port profile tool functions.
+
+Tests tool-layer behavior: which keys reach the controller payload, and the
+preview/confirm flow. Manager-level tests live in test_switch_manager.py.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+async def _create_preview(**kwargs):
+    """Run create_port_profile in preview mode and return the create payload."""
+    from unifi_network_mcp.tools.switch import create_port_profile
+
+    result = await create_port_profile(confirm=False, **kwargs)
+    assert result["success"] is True, result
+    return result["preview"]["will_create"]
+
+
+class TestCreatePortProfileDefaults:
+    """Defaults the caller accepts must actually be sent.
+
+    These fields were only added to the payload when they *differed* from the
+    tool's own documented default, so taking the default sent no key at all and
+    the controller applied its own. For poe_mode that means a profile created
+    with the documented default 'auto' came back with Auto PoE unchecked —
+    de-energising anything wired through a port using it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_poe_mode_default_is_sent(self) -> None:
+        payload = await _create_preview(name="P", forward="native")
+        assert payload["poe_mode"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_stp_port_mode_default_is_sent(self) -> None:
+        payload = await _create_preview(name="P", forward="native")
+        assert payload["stp_port_mode"] is True
+
+    @pytest.mark.asyncio
+    async def test_isolation_default_is_sent(self) -> None:
+        payload = await _create_preview(name="P", forward="native")
+        assert payload["isolation"] is False
+
+    @pytest.mark.asyncio
+    async def test_non_default_values_still_sent(self) -> None:
+        payload = await _create_preview(name="P", forward="all", poe_mode="off", stp_port_mode=False, isolation=True)
+        assert payload["poe_mode"] == "off"
+        assert payload["stp_port_mode"] is False
+        assert payload["isolation"] is True
+
+
+class TestCreatePortProfileAccessPort:
+    """An access port must be expressible in a single create call."""
+
+    @pytest.mark.asyncio
+    async def test_tagged_vlan_mgmt_is_sent(self) -> None:
+        payload = await _create_preview(name="Access", forward="native", tagged_vlan_mgmt="block_all")
+        assert payload["tagged_vlan_mgmt"] == "block_all"
+
+    @pytest.mark.asyncio
+    async def test_tagged_networkconf_ids_reachable_from_create(self) -> None:
+        payload = await _create_preview(
+            name="Trunk",
+            forward="customize",
+            tagged_vlan_mgmt="custom",
+            tagged_networkconf_ids=["net-1", "net-2"],
+        )
+        assert payload["tagged_networkconf_ids"] == ["net-1", "net-2"]
+
+    @pytest.mark.asyncio
+    async def test_excluded_networkconf_ids_reachable_from_create(self) -> None:
+        payload = await _create_preview(
+            name="Trunk",
+            forward="customize",
+            tagged_vlan_mgmt="custom",
+            excluded_networkconf_ids=["net-9"],
+        )
+        assert payload["excluded_networkconf_ids"] == ["net-9"]
+
+    @pytest.mark.asyncio
+    async def test_port_mode_edge_fields_reachable_from_create(self) -> None:
+        payload = await _create_preview(
+            name="Access",
+            forward="native",
+            tagged_vlan_mgmt="block_all",
+            stp_edge_state="enabled",
+            stp_bpdu_guard_enabled=True,
+            stp_uplink=False,
+        )
+        assert payload["stp_edge_state"] == "enabled"
+        assert payload["stp_bpdu_guard_enabled"] is True
+        assert payload["stp_uplink"] is False
+
+    @pytest.mark.asyncio
+    async def test_omitted_optional_fields_are_not_sent(self) -> None:
+        """Fields the caller never mentions stay absent so the controller keeps its own."""
+        payload = await _create_preview(name="P", forward="native")
+        for key in (
+            "tagged_vlan_mgmt",
+            "excluded_networkconf_ids",
+            "tagged_networkconf_ids",
+            "stp_edge_state",
+            "stp_bpdu_guard_enabled",
+            "stp_uplink",
+        ):
+            assert key not in payload, f"{key!r} should not be sent when not requested"
+
+
+class TestPortProfileWriteVerification:
+    """A write the controller rewrote must not be reported as a plain success.
+
+    The controller silently normalizes some values — asking for an access port
+    (`forward: 'native'`) without `tagged_vlan_mgmt` produced a trunk
+    (`forward: 'all'`) and still returned "created/updated successfully". The
+    tools now compare what was requested against what the controller stored.
+    """
+
+    @pytest.mark.asyncio
+    async def test_update_surfaces_manager_verification_failure(self) -> None:
+        """The manager verifies the write; the tool surfaces its verdict."""
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr.update_port_profile = AsyncMock(return_value=(False, "stored different value(s): forward ..."))
+
+            from unifi_network_mcp.tools.switch import update_port_profile
+
+            result = await update_port_profile(
+                profile_id="pp1",
+                profile_data={"forward": "native"},
+                confirm=True,
+            )
+
+        assert result["success"] is False, result
+        assert "forward" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_success_when_manager_verifies(self) -> None:
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr.update_port_profile = AsyncMock(return_value=(True, None))
+
+            from unifi_network_mcp.tools.switch import update_port_profile
+
+            result = await update_port_profile(
+                profile_id="pp1",
+                profile_data={"forward": "native", "tagged_vlan_mgmt": "block_all"},
+                confirm=True,
+            )
+
+        assert result["success"] is True, result
+
+    @pytest.mark.asyncio
+    async def test_create_reports_coerced_field(self) -> None:
+        created = {
+            "_id": "pp2",
+            "name": "Access",
+            "forward": "all",
+            "poe_mode": "auto",
+            "isolation": False,
+            "stp_port_mode": True,
+        }
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr.create_port_profile = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.switch import create_port_profile
+
+            result = await create_port_profile(
+                name="Access",
+                forward="native",
+                stp_port_mode=True,
+                confirm=True,
+            )
+
+        assert result["success"] is False, result
+        assert set(result["coerced_fields"]) == {"forward"}, result["coerced_fields"]
+        assert result["coerced_fields"]["forward"]["requested"] == "native"
+        assert result["coerced_fields"]["forward"]["stored"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_create_success_path_reports_no_coercion(self) -> None:
+        """The happy path: everything requested came back as requested."""
+        created = {
+            "_id": "pp3",
+            "name": "Access",
+            "forward": "native",
+            "tagged_vlan_mgmt": "block_all",
+            "poe_mode": "auto",
+            "isolation": False,
+            "stp_port_mode": True,
+        }
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr.create_port_profile = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.switch import create_port_profile
+
+            result = await create_port_profile(
+                name="Access",
+                forward="native",
+                tagged_vlan_mgmt="block_all",
+                confirm=True,
+            )
+
+        assert result["success"] is True, result
+        assert "coerced_fields" not in result
+
+    @pytest.mark.asyncio
+    async def test_create_does_not_flag_keys_the_controller_omits(self) -> None:
+        """An access profile carries no tagged_networkconf_ids key at all.
+
+        Treating an absent key as a rewritten value reported a correct create as
+        a failure — and create is not idempotent, so a caller retrying on that
+        false negative would make a duplicate profile.
+        """
+        created = {
+            "_id": "pp4",
+            "name": "Access",
+            "forward": "native",
+            "tagged_vlan_mgmt": "block_all",
+            "poe_mode": "auto",
+            "isolation": False,
+            "stp_port_mode": True,
+        }
+        with patch("unifi_network_mcp.tools.switch.switch_manager") as mock_mgr:
+            mock_mgr.create_port_profile = AsyncMock(return_value=created)
+
+            from unifi_network_mcp.tools.switch import create_port_profile
+
+            result = await create_port_profile(
+                name="Access",
+                forward="native",
+                tagged_vlan_mgmt="block_all",
+                tagged_networkconf_ids=[],
+                confirm=True,
+            )
+
+        assert result["success"] is True, result
+
+
+class TestUpdatePortProfilePreview:
+    @pytest.mark.asyncio
+    async def test_preview_warns_about_ignored_fields(self) -> None:
+        """The preview is where the caller decides whether to commit, so the
+        fields that will be dropped must be visible there too."""
+        from unifi_network_mcp.tools.switch import update_port_profile
+
+        result = await update_port_profile(
+            profile_id="pp1",
+            profile_data={"forward": "native", "stormctrl_bcast_enabled": True},
+            confirm=False,
+        )
+
+        warnings = result.get("warnings") or []
+        assert any("stormctrl_bcast_enabled" in w for w in warnings), result
+
+    @pytest.mark.asyncio
+    async def test_fully_unsupported_payload_names_the_fields(self) -> None:
+        from unifi_network_mcp.tools.switch import update_port_profile
+
+        result = await update_port_profile(
+            profile_id="pp1",
+            profile_data={"stormctrl_bcast_enabled": True},
+            confirm=True,
+        )
+
+        assert result["success"] is False
+        assert "stormctrl_bcast_enabled" in result["error"]
+        assert "not supported" in result["error"]

--- a/packages/unifi-core/src/unifi_core/network/managers/switch_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/switch_manager.py
@@ -12,48 +12,22 @@ API endpoints:
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from aiounifi.models.api import ApiRequest
 
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.merge import deep_merge
 from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.write_verification import WriteVerificationResult, failed_write, noop_write, verify_write
 
 logger = logging.getLogger("unifi-network-mcp")
 
 CACHE_PREFIX_PORT_PROFILES = "port_profiles"
-
-# Sentinel for "the controller does not return this key at all", which is not the
-# same as it storing a null — an access profile carries no tagged_networkconf_ids
-# key whatsoever, and treating that as a changed value would flag a correct write.
-_ABSENT = object()
-
-
-def coerced_fields(requested: Dict[str, Any], stored: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
-    """Return requested keys whose stored value differs from what was sent.
-
-    The controller normalizes some port-profile values on write — most
-    importantly it rewrites ``forward`` to agree with ``tagged_vlan_mgmt`` — and
-    answers rc:ok either way, so a non-raising write is not evidence that the
-    requested configuration was applied.
-
-    Keys the controller does not return are skipped rather than reported: their
-    absence means the field is not stored on this profile shape, not that the
-    write was refused. List values compare order-insensitively.
-    """
-    coerced: Dict[str, Dict[str, Any]] = {}
-    for key, want in requested.items():
-        got = stored.get(key, _ABSENT)
-        if got is _ABSENT:
-            continue
-        if isinstance(want, list) and isinstance(got, list):
-            same = sorted(map(str, want)) == sorted(map(str, got))
-        else:
-            same = got == want
-        if not same:
-            coerced[key] = {"requested": want, "stored": got}
-    return coerced
+_PORT_PROFILE_ABSENT_VALUE_DEFAULTS: Dict[str, Any] = {
+    "tagged_networkconf_ids": [],
+    "excluded_networkconf_ids": [],
+}
 
 
 class SwitchManager:
@@ -111,21 +85,21 @@ class SwitchManager:
             raise UniFiNotFoundError("port_profile", profile_id)
         return data[0]
 
-    async def create_port_profile(self, profile_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    async def create_port_profile(self, profile_data: Dict[str, Any]) -> WriteVerificationResult:
         """Create a new port profile.
 
         Args:
             profile_data: Dictionary with at minimum name and forward fields.
 
         Returns:
-            The created port profile dictionary, or None on failure.
+            Structured exact field-verification result with post-write state.
         """
         if not await self._connection.ensure_connected():
             raise ConnectionError("Not connected to controller")
 
         if not profile_data.get("name") or not profile_data.get("forward"):
             logger.error("Missing required fields 'name' and/or 'forward' for port profile")
-            return None
+            return failed_write("Missing required fields 'name' and/or 'forward'", operation="create")
 
         try:
             api_request = ApiRequest(method="post", path="/rest/portconf", data=profile_data)
@@ -140,20 +114,45 @@ class SwitchManager:
                 if isinstance(response, dict)
                 else []
             )
-            return data[0] if data else None
+            created = data[0] if data and isinstance(data[0], dict) else None
+            profile_id = created.get("_id") if created else None
+            if not profile_id:
+                return failed_write(
+                    "Controller accepted the port profile create request but did not return a resource ID; "
+                    "persistence could not be verified.",
+                    operation="create",
+                    mutation_applied=True,
+                    resource=created,
+                )
+
+            try:
+                stored = await self.get_port_profile_by_id(profile_id)
+            except Exception as e:
+                logger.warning("Created port profile %s could not be re-read: %s", profile_id, e)
+                return failed_write(
+                    f"Controller accepted the port profile create request but the resource could not be re-read: {e}",
+                    operation="create",
+                    mutation_applied=True,
+                    resource=created,
+                    metadata={"profile_id": profile_id},
+                )
+
+            return verify_write(
+                operation="create",
+                requested=profile_data,
+                after=stored,
+                absent_value_defaults=_PORT_PROFILE_ABSENT_VALUE_DEFAULTS,
+                metadata={"profile_id": profile_id},
+            )
         except Exception as e:
             logger.error("Error creating port profile: %s", e, exc_info=True)
             raise
 
-    async def update_port_profile(self, profile_id: str, update_data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+    async def update_port_profile(self, profile_id: str, update_data: Dict[str, Any]) -> WriteVerificationResult:
         """Update an existing port profile by merging updates with current state.
 
         Returns:
-            Tuple of (success, error_message). On success error_message is None.
-            The write is verified by re-reading the profile: the controller
-            normalizes some values — notably ``forward``, which it rewrites to
-            agree with ``tagged_vlan_mgmt`` — while still answering rc:ok, so a
-            non-raising request is not evidence the request was applied.
+            Structured exact field-verification result with post-write state.
 
         Raises:
             UniFiNotFoundError: If the profile does not exist.
@@ -163,7 +162,7 @@ class SwitchManager:
 
         existing = await self.get_port_profile_by_id(profile_id)  # raises on miss
         if not update_data:
-            return True, None  # No action needed
+            return noop_write(operation="update", resource=existing, metadata={"profile_id": profile_id})
 
         merged_data = deep_merge(existing, update_data)
         api_request = ApiRequest(method="put", path=f"/rest/portconf/{profile_id}", data=merged_data)
@@ -176,20 +175,20 @@ class SwitchManager:
             stored = await self.get_port_profile_by_id(profile_id)
         except Exception as e:
             logger.warning("Port profile %s was written but could not be re-read to verify it: %s", profile_id, e)
-            return True, None
-
-        coerced = coerced_fields(update_data, stored)
-        if coerced:
-            detail = ", ".join(
-                f"{key} (requested {value['requested']!r}, stored {value['stored']!r})"
-                for key, value in sorted(coerced.items())
+            return failed_write(
+                f"Controller accepted the port profile update but the resource could not be re-read: {e}",
+                operation="update",
+                mutation_applied=True,
+                metadata={"profile_id": profile_id, "details_before_attempt": existing},
             )
-            return False, (
-                f"Controller accepted the request but stored different value(s): {detail}. "
-                "forward is rewritten to agree with tagged_vlan_mgmt — an access port needs "
-                "forward='native' with tagged_vlan_mgmt='block_all'."
-            )
-        return True, None
+        return verify_write(
+            operation="update",
+            requested=update_data,
+            before=existing,
+            after=stored,
+            absent_value_defaults=_PORT_PROFILE_ABSENT_VALUE_DEFAULTS,
+            metadata={"profile_id": profile_id},
+        )
 
     async def delete_port_profile(self, profile_id: str) -> bool:
         """Delete a port profile.

--- a/packages/unifi-core/src/unifi_core/network/managers/switch_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/switch_manager.py
@@ -12,7 +12,7 @@ API endpoints:
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from aiounifi.models.api import ApiRequest
 
@@ -23,6 +23,37 @@ from unifi_core.network.managers.connection_manager import ConnectionManager
 logger = logging.getLogger("unifi-network-mcp")
 
 CACHE_PREFIX_PORT_PROFILES = "port_profiles"
+
+# Sentinel for "the controller does not return this key at all", which is not the
+# same as it storing a null — an access profile carries no tagged_networkconf_ids
+# key whatsoever, and treating that as a changed value would flag a correct write.
+_ABSENT = object()
+
+
+def coerced_fields(requested: Dict[str, Any], stored: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Return requested keys whose stored value differs from what was sent.
+
+    The controller normalizes some port-profile values on write — most
+    importantly it rewrites ``forward`` to agree with ``tagged_vlan_mgmt`` — and
+    answers rc:ok either way, so a non-raising write is not evidence that the
+    requested configuration was applied.
+
+    Keys the controller does not return are skipped rather than reported: their
+    absence means the field is not stored on this profile shape, not that the
+    write was refused. List values compare order-insensitively.
+    """
+    coerced: Dict[str, Dict[str, Any]] = {}
+    for key, want in requested.items():
+        got = stored.get(key, _ABSENT)
+        if got is _ABSENT:
+            continue
+        if isinstance(want, list) and isinstance(got, list):
+            same = sorted(map(str, want)) == sorted(map(str, got))
+        else:
+            same = got == want
+        if not same:
+            coerced[key] = {"requested": want, "stored": got}
+    return coerced
 
 
 class SwitchManager:
@@ -114,11 +145,15 @@ class SwitchManager:
             logger.error("Error creating port profile: %s", e, exc_info=True)
             raise
 
-    async def update_port_profile(self, profile_id: str, update_data: Dict[str, Any]) -> Dict[str, Any]:
+    async def update_port_profile(self, profile_id: str, update_data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         """Update an existing port profile by merging updates with current state.
 
         Returns:
-            The merged profile dict.
+            Tuple of (success, error_message). On success error_message is None.
+            The write is verified by re-reading the profile: the controller
+            normalizes some values — notably ``forward``, which it rewrites to
+            agree with ``tagged_vlan_mgmt`` — while still answering rc:ok, so a
+            non-raising request is not evidence the request was applied.
 
         Raises:
             UniFiNotFoundError: If the profile does not exist.
@@ -128,13 +163,33 @@ class SwitchManager:
 
         existing = await self.get_port_profile_by_id(profile_id)  # raises on miss
         if not update_data:
-            return existing
+            return True, None  # No action needed
 
         merged_data = deep_merge(existing, update_data)
         api_request = ApiRequest(method="put", path=f"/rest/portconf/{profile_id}", data=merged_data)
         await self._connection.request(api_request)
         self._connection._invalidate_cache(CACHE_PREFIX_PORT_PROFILES)
-        return merged_data
+
+        # The write has landed by this point. A read-back failure must not be
+        # reported as a failed write — it only means the result is unverified.
+        try:
+            stored = await self.get_port_profile_by_id(profile_id)
+        except Exception as e:
+            logger.warning("Port profile %s was written but could not be re-read to verify it: %s", profile_id, e)
+            return True, None
+
+        coerced = coerced_fields(update_data, stored)
+        if coerced:
+            detail = ", ".join(
+                f"{key} (requested {value['requested']!r}, stored {value['stored']!r})"
+                for key, value in sorted(coerced.items())
+            )
+            return False, (
+                f"Controller accepted the request but stored different value(s): {detail}. "
+                "forward is rewritten to agree with tagged_vlan_mgmt — an access port needs "
+                "forward='native' with tagged_vlan_mgmt='block_all'."
+            )
+        return True, None
 
     async def delete_port_profile(self, profile_id: str) -> bool:
         """Delete a port profile.

--- a/packages/unifi-core/src/unifi_core/network/models/switch.py
+++ b/packages/unifi-core/src/unifi_core/network/models/switch.py
@@ -52,7 +52,23 @@ class PortProfile(BaseModel):
     )
     forward: Optional[str] = Field(
         default=None,
-        description="Forwarding mode: all (trunk), native (access), customize, disabled",
+        description=(
+            "Forwarding mode: all (trunk), native (access), customize, disabled. "
+            "The controller rewrites this to agree with tagged_vlan_mgmt, so an access "
+            "port needs forward='native' together with tagged_vlan_mgmt='block_all'"
+        ),
+    )
+    tagged_vlan_mgmt: Optional[str] = Field(
+        default=None,
+        description=(
+            "Tagged VLAN Management — decides whether the port trunks: "
+            "'auto' (allow all), 'block_all' (access port), or 'custom' "
+            "(only tagged_networkconf_ids, minus excluded_networkconf_ids)"
+        ),
+    )
+    excluded_networkconf_ids: Optional[List[str]] = Field(
+        default=None,
+        description="Network IDs excluded when tagged_vlan_mgmt is 'custom'",
     )
     native_networkconf_id: Optional[str] = Field(
         default=None,
@@ -77,6 +93,21 @@ class PortProfile(BaseModel):
     stp_port_mode: Optional[bool] = Field(
         default=None,
         description="Enable STP on this port",
+    )
+    # The UI's single "Port Mode: Infrastructure | Edge" control maps to these
+    # three stored fields; Edge is stp_edge_state='enabled' + BPDU guard on +
+    # stp_uplink false.
+    stp_edge_state: Optional[str] = Field(
+        default=None,
+        description="STP edge state: 'enabled' for end-device (Edge) ports, 'disabled' for uplinks",
+    )
+    stp_bpdu_guard_enabled: Optional[bool] = Field(
+        default=None,
+        description="Shut the port if it receives a BPDU (paired with stp_edge_state for Edge ports)",
+    )
+    stp_uplink: Optional[bool] = Field(
+        default=None,
+        description="Treat the port as an STP uplink (Infrastructure ports)",
     )
     dot1x_ctrl: Optional[str] = Field(
         default=None,
@@ -123,19 +154,80 @@ def from_controller(raw: Any) -> PortProfile:
     tagged = _get(raw, "tagged_networkconf_ids") or []
     if not isinstance(tagged, list):
         tagged = []
+    excluded = _get(raw, "excluded_networkconf_ids")
     return PortProfile(
         id=_get(raw, "_id") or _get(raw, "id"),
         attr_no_delete=_get(raw, "attr_no_delete"),
         name=_get(raw, "name"),
         forward=_get(raw, "forward"),
+        tagged_vlan_mgmt=_get(raw, "tagged_vlan_mgmt"),
+        excluded_networkconf_ids=list(excluded) if isinstance(excluded, list) else None,
         native_networkconf_id=_get(raw, "native_networkconf_id"),
         tagged_networkconf_ids=list(tagged),
         voice_networkconf_id=_get(raw, "voice_networkconf_id"),
         isolation=_get(raw, "isolation"),
         poe_mode=_get(raw, "poe_mode"),
         stp_port_mode=_get(raw, "stp_port_mode"),
+        stp_edge_state=_get(raw, "stp_edge_state"),
+        stp_bpdu_guard_enabled=_get(raw, "stp_bpdu_guard_enabled"),
+        stp_uplink=_get(raw, "stp_uplink"),
         dot1x_ctrl=_get(raw, "dot1x_ctrl"),
     )
+
+
+def build_create_payload(
+    name: str,
+    forward: str,
+    native_networkconf_id: str = "",
+    tagged_vlan_mgmt: str = "",
+    tagged_networkconf_ids: Optional[List[str]] = None,
+    excluded_networkconf_ids: Optional[List[str]] = None,
+    voice_networkconf_id: str = "",
+    isolation: bool = False,
+    poe_mode: str = "auto",
+    stp_port_mode: bool = True,
+    stp_edge_state: str = "",
+    stp_bpdu_guard_enabled: Optional[bool] = None,
+    stp_uplink: Optional[bool] = None,
+    dot1x_ctrl: str = "",
+) -> Dict[str, Any]:
+    """Build a controller create payload from the tool's flat parameters.
+
+    ``poe_mode``, ``stp_port_mode`` and ``isolation`` are always included:
+    omitting a value that happens to equal the default let the controller apply
+    its own instead, so the documented default was not the one that took effect.
+    Everything else is sent only when the caller supplied it, leaving the
+    controller's own default in place.
+
+    Shared by the MCP tool and the ``/v1/actions`` dispatch translator so the two
+    entry points cannot drift.
+    """
+    payload: Dict[str, Any] = {
+        "name": name,
+        "forward": forward,
+        "isolation": isolation,
+        "poe_mode": poe_mode,
+        "stp_port_mode": stp_port_mode,
+    }
+    if native_networkconf_id:
+        payload["native_networkconf_id"] = native_networkconf_id
+    if tagged_vlan_mgmt:
+        payload["tagged_vlan_mgmt"] = tagged_vlan_mgmt
+    if tagged_networkconf_ids is not None:
+        payload["tagged_networkconf_ids"] = tagged_networkconf_ids
+    if excluded_networkconf_ids is not None:
+        payload["excluded_networkconf_ids"] = excluded_networkconf_ids
+    if voice_networkconf_id:
+        payload["voice_networkconf_id"] = voice_networkconf_id
+    if stp_edge_state:
+        payload["stp_edge_state"] = stp_edge_state
+    if stp_bpdu_guard_enabled is not None:
+        payload["stp_bpdu_guard_enabled"] = stp_bpdu_guard_enabled
+    if stp_uplink is not None:
+        payload["stp_uplink"] = stp_uplink
+    if dot1x_ctrl:
+        payload["dot1x_ctrl"] = dot1x_ctrl
+    return payload
 
 
 def to_controller_create(model: PortProfile) -> Dict[str, Any]:

--- a/packages/unifi-core/src/unifi_core/network/models/switch.py
+++ b/packages/unifi-core/src/unifi_core/network/models/switch.py
@@ -53,7 +53,7 @@ class PortProfile(BaseModel):
     forward: Optional[str] = Field(
         default=None,
         description=(
-            "Forwarding mode: all (trunk), native (access), customize, disabled. "
+            "Forwarding mode: all (trunk), native (access), or customize (selective trunk). "
             "The controller rewrites this to agree with tagged_vlan_mgmt, so an access "
             "port needs forward='native' together with tagged_vlan_mgmt='block_all'"
         ),

--- a/packages/unifi-core/tests/network/models/test_switch.py
+++ b/packages/unifi-core/tests/network/models/test_switch.py
@@ -6,6 +6,7 @@ from unifi_core.network.models.switch import (
     MUTABLE_FIELDS,
     READ_ONLY_FIELDS,
     PortProfile,
+    build_create_payload,
     from_controller,
     to_controller_create,
     to_controller_update,
@@ -134,3 +135,107 @@ class TestToControllerUpdate:
     def test_returns_empty_dict_when_no_mutable_fields(self) -> None:
         result = to_controller_update({"id": "read-only", "attr_no_delete": True})
         assert result == {}
+
+
+class TestAccessPortFields:
+    """Fields required to express an access port, plus the UI's Port Mode trio.
+
+    ``tagged_vlan_mgmt`` is the control that actually decides whether a port
+    trunks. Without it the model can only send ``forward: 'native'`` alongside
+    an inherited ``allow_all``, which the controller resolves by rewriting
+    ``forward`` to agree with the tagged setting — so no combination of the
+    previously-exposed fields produced an access port on the native LAN.
+
+    The UI's single "Port Mode: Infrastructure | Edge" control maps to three
+    stored fields, so they are exposed individually rather than behind a
+    synthetic field the controller does not have.
+    """
+
+    ACCESS_PORT_FIELDS = (
+        "tagged_vlan_mgmt",
+        "excluded_networkconf_ids",
+        "stp_edge_state",
+        "stp_bpdu_guard_enabled",
+        "stp_uplink",
+    )
+
+    def test_access_port_fields_are_mutable(self) -> None:
+        for field in self.ACCESS_PORT_FIELDS:
+            assert field in MUTABLE_FIELDS, f"Expected {field!r} in MUTABLE_FIELDS"
+
+    def test_from_controller_reads_access_port_fields(self) -> None:
+        profile = from_controller(
+            {
+                "_id": "pp-1",
+                "name": "Access - Trusted",
+                "forward": "native",
+                "tagged_vlan_mgmt": "block_all",
+                "excluded_networkconf_ids": ["net-9"],
+                "stp_edge_state": "enabled",
+                "stp_bpdu_guard_enabled": True,
+                "stp_uplink": False,
+            }
+        )
+        assert profile.tagged_vlan_mgmt == "block_all"
+        assert profile.excluded_networkconf_ids == ["net-9"]
+        assert profile.stp_edge_state == "enabled"
+        assert profile.stp_bpdu_guard_enabled is True
+        assert profile.stp_uplink is False
+
+    def test_tagged_vlan_mgmt_survives_update_filter(self) -> None:
+        result = to_controller_update({"tagged_vlan_mgmt": "block_all"})
+        assert result == {"tagged_vlan_mgmt": "block_all"}
+
+    def test_stp_uplink_false_is_preserved(self) -> None:
+        """False is meaningful for an edge port — only None is dropped."""
+        result = to_controller_update({"stp_uplink": False, "stp_bpdu_guard_enabled": False})
+        assert result["stp_uplink"] is False
+        assert result["stp_bpdu_guard_enabled"] is False
+
+    def test_excluded_networkconf_ids_empty_list_survives(self) -> None:
+        result = to_controller_update({"excluded_networkconf_ids": []})
+        assert result == {"excluded_networkconf_ids": []}
+
+    def test_access_port_round_trip_through_create(self) -> None:
+        model = PortProfile(
+            name="Access - Trusted",
+            forward="native",
+            tagged_vlan_mgmt="block_all",
+            stp_edge_state="enabled",
+            stp_bpdu_guard_enabled=True,
+            stp_uplink=False,
+        )
+        payload = to_controller_create(model)
+        assert payload["tagged_vlan_mgmt"] == "block_all"
+        assert payload["stp_edge_state"] == "enabled"
+        assert payload["stp_bpdu_guard_enabled"] is True
+        assert payload["stp_uplink"] is False
+
+
+class TestBuildCreatePayload:
+    """Shared by the MCP tool and the /v1/actions translator, so both send the
+    same defaults — notably poe_mode, which the controller otherwise defaults
+    to PoE-off."""
+
+    def test_defaults_are_always_sent(self) -> None:
+        payload = build_create_payload(name="P", forward="native")
+        assert payload["poe_mode"] == "auto"
+        assert payload["stp_port_mode"] is True
+        assert payload["isolation"] is False
+
+    def test_unsupplied_optional_fields_are_omitted(self) -> None:
+        payload = build_create_payload(name="P", forward="native")
+        for key in ("tagged_vlan_mgmt", "excluded_networkconf_ids", "stp_edge_state", "stp_uplink"):
+            assert key not in payload
+
+    def test_access_port_fields_pass_through(self) -> None:
+        payload = build_create_payload(
+            name="Access",
+            forward="native",
+            tagged_vlan_mgmt="block_all",
+            stp_uplink=False,
+            tagged_networkconf_ids=[],
+        )
+        assert payload["tagged_vlan_mgmt"] == "block_all"
+        assert payload["stp_uplink"] is False
+        assert payload["tagged_networkconf_ids"] == []


### PR DESCRIPTION
Fixes #526. Reproduced and verified on UniFi Network 10.5.67.

`tagged_vlan_mgmt` was missing from `PortProfile`, and it determines whether the controller stores an access or trunk profile. The controller rewrites `forward` to agree with it, so the previously exposed inputs could report success while storing a trunk.

Changes:

- Add `tagged_vlan_mgmt`, `excluded_networkconf_ids`, and the three fields behind the UI's Port Mode control (`stp_edge_state`, `stp_bpdu_guard_enabled`, `stp_uplink`).
- Expose `tagged_networkconf_ids` on create; it was mutable on update but unreachable from create.
- Always send `poe_mode`, `stp_port_mode`, and `isolation`, including when they equal the tool defaults.
- Build create payloads through the shared model helper so MCP and `/v1/actions` cannot drift.
- Use the shared structured write-verification contract for create and update. Both operations perform an independent read-back, fail on missing or coerced requested fields, and distinguish a rejected write from a mutation that landed but could not be verified.
- Clarify that Port State Active/Disabled is a separate controller setting and remains outside this PR's port-profile surface.

## Maintainer validation (2026-08-13)

- `make pre-commit`: passed (core 1576, relay 111, Network 993, Protect 503, Access 206, API 1217, worker 99; generation, lint, registration modes, and typecheck clean).
- Exact final commit: 25 core switch-model tests and 51 Network switch manager/tool tests passed; generated artifacts and lint clean.
- Network read-only hardware smoke: 121 passed, 7 argument-discovery skips, 0 failures or exceptions.
- Network safe smoke: passed.
- Targeted disposable profile lifecycle: create, read, update, deliberate coercion detection, restore, delete preview, and delete all behaved as expected; cleanup confirmed no orphaned profile.

Live access-port read-back:

```
forward: "native"
tagged_vlan_mgmt: "block_all"
poe_mode: "auto"
stp_edge_state: "enabled"
stp_bpdu_guard_enabled: true
stp_uplink: false
```

Deliberately requesting an inconsistent combination now returns structured failure while accurately reporting that the controller mutation landed and identifying the coerced field.
