### PR TITLE
fix(network): read and write multicast enhancement under the controller's key

### DIFF
--- a/apps/api/src/unifi_api/graphql/types/network/wlan.py
+++ b/apps/api/src/unifi_api/graphql/types/network/wlan.py
@@ -110,7 +110,7 @@ class Wlan:
             schedule_enabled=raw.get("schedule_enabled"),
             l2_isolation=raw.get("l2_isolation"),
             wlan_band=raw.get("wlan_band"),
-            multicast_enhance_enabled=raw.get("multicast_enhance_enabled"),
+            multicast_enhance_enabled=raw.get("mcastenhance_enabled"),
             dtim_mode=raw.get("dtim_mode"),
             dtim_na=raw.get("dtim_na"),
             dtim_ng=raw.get("dtim_ng"),

--- a/apps/api/tests/graphql/fixtures/network/test_wlans.py
+++ b/apps/api/tests/graphql/fixtures/network/test_wlans.py
@@ -94,3 +94,34 @@ async def test_wlan_detail_policy_disabled_returns_raw_passphrase(tmp_path, monk
     )
     assert body.get("errors") is None, body
     assert body["data"]["network"]["wlan"]["xPassphrase"] == "wifi-secret"
+
+
+@pytest.mark.asyncio
+async def test_wlan_detail_reads_multicast_enhance_controller_key(tmp_path, monkeypatch):
+    """The controller reports multicast enhancement as ``mcastenhance_enabled``.
+
+    Reading the public field name instead left this null for every WLAN, so the
+    GraphQL surface reported the setting as unset even where the controller had
+    a definite value for it.
+    """
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "network_manager", "get_wlans"): [
+                {"_id": "wl-1", "name": "HomeNet", "mcastenhance_enabled": True},
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ wlan(controller: "{cid}", id: "wl-1") {{
+            id multicastEnhanceEnabled
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    assert body["data"]["network"]["wlan"]["multicastEnhanceEnabled"] is True

--- a/packages/unifi-core/src/unifi_core/network/models/wlans.py
+++ b/packages/unifi-core/src/unifi_core/network/models/wlans.py
@@ -144,7 +144,7 @@ class Wlan(BaseModel):
     )
     multicast_enhance_enabled: Optional[bool] = Field(
         default=None,
-        description="Convert multicast to unicast per client",
+        description="Convert multicast to unicast per client (controller field: mcastenhance_enabled)",
     )
     dtim_mode: Optional[str] = Field(
         default=None,
@@ -272,7 +272,7 @@ def from_controller(raw: Any) -> Wlan:
         schedule_enabled=_get(raw, "schedule_enabled"),
         l2_isolation=_get(raw, "l2_isolation"),
         wlan_band=_get(raw, "wlan_band"),
-        multicast_enhance_enabled=_get(raw, "multicast_enhance_enabled"),
+        multicast_enhance_enabled=_get(raw, "mcastenhance_enabled"),
         dtim_mode=_get(raw, "dtim_mode"),
         dtim_na=_get(raw, "dtim_na"),
         dtim_ng=_get(raw, "dtim_ng"),
@@ -306,6 +306,9 @@ def to_controller_create(model: Wlan) -> Dict[str, Any]:
     # Map vlan_id → vlan
     if "vlan_id" in payload:
         payload["vlan"] = payload.pop("vlan_id")
+    # Map multicast_enhance_enabled → mcastenhance_enabled
+    if "multicast_enhance_enabled" in payload:
+        payload["mcastenhance_enabled"] = payload.pop("multicast_enhance_enabled")
     return payload
 
 
@@ -316,12 +319,16 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     ``None`` values are dropped; boolean ``False`` is preserved.
     Callers accepting untrusted dictionaries must use ``validate_update`` first.
     Maps model field names to controller API field names.
-    Accepts ``networkconf_id`` as an alias for ``network_id`` so callers can
-    pass either the controller field name or the model field name.
+    Accepts ``networkconf_id`` as an alias for ``network_id`` and
+    ``mcastenhance_enabled`` as an alias for ``multicast_enhance_enabled`` so
+    callers can pass either the controller field name or the model field name.
     """
     if "networkconf_id" in fields and "network_id" not in fields:
         fields = {**fields, "network_id": fields["networkconf_id"]}
         fields = {k: v for k, v in fields.items() if k != "networkconf_id"}
+    if "mcastenhance_enabled" in fields and "multicast_enhance_enabled" not in fields:
+        fields = {**fields, "multicast_enhance_enabled": fields["mcastenhance_enabled"]}
+        fields = {k: v for k, v in fields.items() if k != "mcastenhance_enabled"}
     result = {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
     # Map network_id → networkconf_id
     if "network_id" in result:
@@ -329,10 +336,17 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     # Map vlan_id → vlan
     if "vlan_id" in result:
         result["vlan"] = result.pop("vlan_id")
+    # Map multicast_enhance_enabled → mcastenhance_enabled
+    if "multicast_enhance_enabled" in result:
+        result["mcastenhance_enabled"] = result.pop("multicast_enhance_enabled")
     return result
 
 
-_CONTROLLER_ALIASES = {"networkconf_id": "network_id", "vlan": "vlan_id"}
+_CONTROLLER_ALIASES = {
+    "networkconf_id": "network_id",
+    "vlan": "vlan_id",
+    "mcastenhance_enabled": "multicast_enhance_enabled",
+}
 _CONTROLLER_READ_ONLY_FIELDS = READ_ONLY_FIELDS | {"_id", "site_id"}
 _MINRATE_RATE_FIELDS = {
     "minrate_ng_data_rate_kbps": "minrate_ng_enabled",

--- a/packages/unifi-core/tests/network/models/test_wlans.py
+++ b/packages/unifi-core/tests/network/models/test_wlans.py
@@ -287,3 +287,48 @@ class TestRoamingFields:
         payload = to_controller_create(model)
         assert payload["rrm_enabled"] is True
         assert payload["roaming_assistant_6e_rssi"] == -70
+
+
+class TestMulticastEnhance:
+    """Multicast Enhancement is aliased: the controller field is ``mcastenhance_enabled``.
+
+    The public field name stays ``multicast_enhance_enabled``. Before this the
+    model both read and wrote the public name, so the read always yielded
+    ``None`` and the write went out under a key the controller ignores — which
+    also made the post-write verification report the field as unpersisted on
+    every attempt, regardless of the value sent.
+    """
+
+    def test_from_controller_reads_controller_key(self) -> None:
+        wlan = from_controller({"_id": "wlan-mc", "mcastenhance_enabled": True})
+        assert wlan.multicast_enhance_enabled is True
+
+    def test_from_controller_reads_false(self) -> None:
+        wlan = from_controller({"_id": "wlan-mc", "mcastenhance_enabled": False})
+        assert wlan.multicast_enhance_enabled is False
+
+    def test_update_maps_to_controller_key(self) -> None:
+        assert to_controller_update({"multicast_enhance_enabled": True}) == {"mcastenhance_enabled": True}
+
+    def test_update_maps_false_to_controller_key(self) -> None:
+        assert to_controller_update({"multicast_enhance_enabled": False}) == {"mcastenhance_enabled": False}
+
+    def test_create_maps_to_controller_key(self) -> None:
+        model = Wlan(name="SSID", security="open", multicast_enhance_enabled=True)
+        payload = to_controller_create(model)
+        assert payload["mcastenhance_enabled"] is True
+        assert "multicast_enhance_enabled" not in payload
+
+    def test_controller_key_alias_accepted_on_update(self) -> None:
+        """Callers may pass the controller field name directly, as with networkconf_id."""
+        assert to_controller_update({"mcastenhance_enabled": True}) == {"mcastenhance_enabled": True}
+
+    def test_validate_update_accepts_either_name(self) -> None:
+        """The public validator reaches the controller key from both spellings."""
+        assert validate_update({"multicast_enhance_enabled": True}) == {"mcastenhance_enabled": True}
+        assert validate_update({"mcastenhance_enabled": False}) == {"mcastenhance_enabled": False}
+
+    def test_validate_create_maps_to_controller_key(self) -> None:
+        payload = validate_create({"name": "SSID", "security": "open", "multicast_enhance_enabled": True})
+        assert payload["mcastenhance_enabled"] is True
+        assert "multicast_enhance_enabled" not in payload


### PR DESCRIPTION
Fixes #524. Verified on UniFi Network 10.5.67.

The controller stores Multicast Enhancement as `mcastenhance_enabled`. The model used `multicast_enhance_enabled` on both the read and the write, so the typed read always returned null and the write went out under a key the controller ignores.

That also explains the third symptom: the post-write check compares requested keys against the raw object before and after, and neither side ever contains `multicast_enhance_enabled`, so the field was reported unpersisted on every attempt whatever value was sent.

This maps the field in both directions, keeping `multicast_enhance_enabled` as the public name and accepting the controller spelling as an inbound alias, as `networkconf_id` already does. The same wrong key was read by the GraphQL projection.

Note: part 2 of the issue (Auto mode) is invalid—see the correction there. With the key fixed, the write persists on an `auto` WLAN, so no guard is warranted.

## Maintainer validation (2026-08-13)

I independently reviewed the four-file patch and found no actionable issues. I rebased it cleanly onto current `main` after #527 and ran the following gates:

- `make pre-commit`: passed, including formatting, generation, lint, all package/app tests, registration-mode smokes, generated-file checks, worker tests, and worker typecheck.
- Focused suites: 75 core WLAN model/manager tests, 40 Network tool tests, and 12 API projection/serializer tests passed.
- Network read-only hardware smoke: 121 operations passed, 7 expected argument-discovery skips, 0 failures or exceptions; both WLAN list/detail paths passed.
- Network safe hardware smoke: passed, including the repository's safe disposable lifecycles.
- Targeted disposable WLAN lifecycle: create preview, create disabled SSID, read `false`, update to `true`, read through core and API projections, restore to `false`, delete preview, delete, and cleanup verification all passed.

<details>
<summary>Independent live-smoke output</summary>

```text
network readonly ok: unifi_get_wlan_details
network readonly ok: unifi_list_wlans
connected: true
ok: 121
skipped: 7
failed: 0
exceptions: 0
```

</details>

<details>
<summary>Targeted multicast lifecycle output</summary>

```json
{
  "api_read_false": false,
  "api_read_true": true,
  "cleanup_verified": true,
  "core_read_false": false,
  "core_read_true": true,
  "create_preview_key": "mcastenhance_enabled",
  "created_value": false,
  "deleted": true,
  "restored_value": false,
  "updated_value": true
}
```

</details>
