### PR TITLE
feat(network): expose WLAN setting_preference read-only

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -2155,6 +2155,7 @@ type VpnServerPage {
 type Wlan {
   id: ID
   name: String
+  settingPreference: String
   enabled: Boolean!
   security: String
   networkId: String

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8614,6 +8614,17 @@
             ],
             "title": "Security"
           },
+          "setting_preference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Setting Preference"
+          },
           "uapsd_enabled": {
             "anyOf": [
               {

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -2144,6 +2144,7 @@ type VpnServerPage {
 type Wlan {
   id: ID
   name: String
+  settingPreference: String
   enabled: Boolean!
   security: String
   networkId: String

--- a/apps/api/src/unifi_api/graphql/types/network/wlan.py
+++ b/apps/api/src/unifi_api/graphql/types/network/wlan.py
@@ -32,6 +32,7 @@ def _get(obj: Any, *keys: str, default: Any = None) -> Any:
 class Wlan:
     id: strawberry.ID | None
     name: str | None
+    setting_preference: str | None
     enabled: bool
     security: str | None
     network_id: str | None
@@ -87,6 +88,7 @@ class Wlan:
         return cls(
             id=raw.get("_id") or raw.get("id"),
             name=raw.get("name"),
+            setting_preference=raw.get("setting_preference"),
             enabled=bool(raw.get("enabled", False)),
             security=raw.get("security"),
             network_id=raw.get("networkconf_id") or raw.get("network_id"),

--- a/apps/api/tests/serializers/test_network_serializers.py
+++ b/apps/api/tests/serializers/test_network_serializers.py
@@ -1,5 +1,6 @@
 """Network serializer unit tests — one fixture per resource."""
 
+import pytest
 from unifi_api.serializers._registry import (
     discover_serializers,
     serializer_registry_singleton,
@@ -168,6 +169,22 @@ def test_wlan_projection_redacts_passphrase() -> None:
     ).to_dict()
 
     assert out["x_passphrase"] == REDACTED
+
+
+@pytest.mark.parametrize("setting_preference", ["auto", "manual"])
+def test_wlan_projection_maps_setting_preference(setting_preference: str) -> None:
+    from unifi_api.graphql.types.network.wlan import Wlan
+
+    out = Wlan.from_manager_output(
+        {
+            "_id": "wlan1",
+            "name": "MyWiFi",
+            "enabled": True,
+            "setting_preference": setting_preference,
+        }
+    ).to_dict()
+
+    assert out["setting_preference"] == setting_preference
 
 
 def test_wlan_projection_maps_roaming_fields() -> None:

--- a/packages/unifi-core/src/unifi_core/network/models/wlans.py
+++ b/packages/unifi-core/src/unifi_core/network/models/wlans.py
@@ -40,6 +40,16 @@ class Wlan(BaseModel):
         description="Site ID this WLAN belongs to",
         json_schema_extra={"mutable": False},
     )
+    setting_preference: Optional[str] = Field(
+        default=None,
+        description=(
+            "Advanced settings mode: 'auto' (the controller manages the advanced "
+            "radio settings and omits them from the object) or 'manual'. Read-only "
+            "here: changing it makes the controller rebuild the WLAN, and which "
+            "settings it covers varies by controller version"
+        ),
+        json_schema_extra={"mutable": False},
+    )
 
     # --- mutable (accepted by create and update) ---
     name: Optional[str] = Field(
@@ -276,6 +286,7 @@ def from_controller(raw: Any) -> Wlan:
         dtim_mode=_get(raw, "dtim_mode"),
         dtim_na=_get(raw, "dtim_na"),
         dtim_ng=_get(raw, "dtim_ng"),
+        setting_preference=_get(raw, "setting_preference"),
         minrate_setting_preference=_get(raw, "minrate_setting_preference"),
         minrate_ng_enabled=_get(raw, "minrate_ng_enabled"),
         minrate_ng_data_rate_kbps=_get(raw, "minrate_ng_data_rate_kbps"),

--- a/packages/unifi-core/tests/network/models/test_wlans.py
+++ b/packages/unifi-core/tests/network/models/test_wlans.py
@@ -332,13 +332,15 @@ class TestMulticastEnhance:
         payload = validate_create({"name": "SSID", "security": "open", "multicast_enhance_enabled": True})
         assert payload["mcastenhance_enabled"] is True
         assert "multicast_enhance_enabled" not in payload
+
+
 class TestSettingPreference:
     """The SSID's Advanced mode (UI: Auto | Manual), exposed read-only.
 
     While it is "auto" the controller manages a set of advanced settings itself
     and omits them from the WLAN object; switching to "manual" makes them
-    appear. The field was absent from the model entirely, so the mode governing
-    them was not even visible through the tool.
+    appear. The field was absent from the canonical model, so the mode governing
+    them was not available through typed REST and GraphQL responses.
 
     It is deliberately NOT mutable. Changing it makes the controller rebuild the
     WLAN object — observed regenerating ``external_id`` and normalising away
@@ -357,10 +359,16 @@ class TestSettingPreference:
     def test_absent_setting_preference_is_none(self) -> None:
         assert from_controller({"_id": "w"}).setting_preference is None
 
-    def test_update_drops_setting_preference(self) -> None:
-        """Read-only fields are filtered out rather than forwarded."""
-        assert to_controller_update({"setting_preference": "manual", "enabled": True}) == {"enabled": True}
+    def test_validate_update_rejects_setting_preference(self) -> None:
+        with pytest.raises(ValueError, match="read-only"):
+            validate_update({"setting_preference": "manual", "enabled": True})
 
-    def test_create_omits_setting_preference(self) -> None:
-        model = Wlan(name="SSID", security="open", setting_preference="manual")
-        assert "setting_preference" not in to_controller_create(model)
+    def test_validate_create_rejects_setting_preference(self) -> None:
+        with pytest.raises(ValueError, match="read-only"):
+            validate_create(
+                {
+                    "name": "SSID",
+                    "security": "open",
+                    "setting_preference": "manual",
+                }
+            )

--- a/packages/unifi-core/tests/network/models/test_wlans.py
+++ b/packages/unifi-core/tests/network/models/test_wlans.py
@@ -332,3 +332,35 @@ class TestMulticastEnhance:
         payload = validate_create({"name": "SSID", "security": "open", "multicast_enhance_enabled": True})
         assert payload["mcastenhance_enabled"] is True
         assert "multicast_enhance_enabled" not in payload
+class TestSettingPreference:
+    """The SSID's Advanced mode (UI: Auto | Manual), exposed read-only.
+
+    While it is "auto" the controller manages a set of advanced settings itself
+    and omits them from the WLAN object; switching to "manual" makes them
+    appear. The field was absent from the model entirely, so the mode governing
+    them was not even visible through the tool.
+
+    It is deliberately NOT mutable. Changing it makes the controller rebuild the
+    WLAN object — observed regenerating ``external_id`` and normalising away
+    stale keys — and which settings the mode covers is controller-version
+    specific, so a write path here would be a footgun rather than a feature.
+    """
+
+    def test_setting_preference_is_read_only(self) -> None:
+        assert "setting_preference" in READ_ONLY_FIELDS
+        assert "setting_preference" not in MUTABLE_FIELDS
+
+    def test_from_controller_reads_setting_preference(self) -> None:
+        assert from_controller({"_id": "w", "setting_preference": "auto"}).setting_preference == "auto"
+        assert from_controller({"_id": "w", "setting_preference": "manual"}).setting_preference == "manual"
+
+    def test_absent_setting_preference_is_none(self) -> None:
+        assert from_controller({"_id": "w"}).setting_preference is None
+
+    def test_update_drops_setting_preference(self) -> None:
+        """Read-only fields are filtered out rather than forwarded."""
+        assert to_controller_update({"setting_preference": "manual", "enabled": True}) == {"enabled": True}
+
+    def test_create_omits_setting_preference(self) -> None:
+        model = Wlan(name="SSID", security="open", setting_preference="manual")
+        assert "setting_preference" not in to_controller_create(model)


### PR DESCRIPTION
Closes #530.

The UI's per-SSID "Advanced: Auto | Manual" toggle (`setting_preference`) was absent from the WLAN model, so it was not a typed field and did not appear on the REST or GraphQL surface. `unifi_get_wlan_details` showed it only incidentally, by passing the raw controller object through.

The mode decides who owns a group of advanced settings. Measured on Network 10.5.67 by flipping one SSID and diffing the object, 11 keys exist only under Manual and are omitted while the SSID is on Auto (`bc_filter_enabled`, `mlo_enabled`, `sae_sync`, `hotspot2conf_enabled`, `iot_channel_lock`, `iot_dtim_lock`, `dns_assistance_mode`, plus mDNS/schedule and beacon-name keys). Without the mode a caller cannot distinguish "unset" from "controller-managed".

Read-only, deliberately. Changing the mode makes the controller rebuild the WLAN — `external_id` was regenerated on every transition observed, and the first Manual→Auto also normalised away keys left by earlier edits — and which settings Auto covers is controller-version specific. None of the 11 is currently writable through this server, so nothing needs guarding.

Verified against a live controller (Network 10.5.67): REST `GET /v1/sites/default/wlans` and GraphQL `network.wlans { settingPreference }` both return `auto` / `manual` matching the UI.

## Maintainer verification — 2026-08-13

Rebased onto current `main` after #527, #528, and #529. The maintainer follow-up preserves the multicast test coverage added by #528, verifies read-only enforcement through the public create/update validators, and directly covers both API projection values.

<details>
<summary>Independent branch-local and controller-backed evidence</summary>

```text
Targeted live controller and API projection probe:
{"api_projection_verified": 5, "controller_wlan_count": 5, "modes": {"manual": 5}, "read_only_guard_verified": true, "success": true}

Network live smoke — readonly:
exit 0; connected=true; ok=121; skipped=7

Network live smoke — safe:
exit 0; connected=true; ok=159; pending_approval=34; skipped=52
created_resources=3; cleaned_resources=3

API resource smoke — WLAN endpoint:
api-resources pass: /v1/sites/default/wlans http=200 items=5

Full repository gate — make pre-commit:
exit 0
unifi-core: 1599 passed
network: 995 passed
protect: 503 passed
access: 206 passed
api: 1220 passed
worker: 81 tests passed
generated references: 39 sections checked, no drift
```

The full API-resource harness also reports the same client/device pagination-order parity mismatch on unchanged `main`; the WLAN endpoint passes on both trees.

</details>
