### PR TITLE
docs(network): correct mdns_enabled description

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1061,6 +1061,10 @@ type Network {
   igmpSnooping: Boolean
   igmpQuerierSwitches: JSON
   igmpFloodUnknownMulticast: Boolean
+
+  """
+  Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is configured site-wide on current UniFi Network versions, and this key only mirrors that site-wide scope — the mirror can go stale for hours, so treat the site-level setting as the source of truth (this server does not expose it). The controller accepts this field on the per-network write path but silently ignores it; unifi_update_network rejects it as read-only.
+  """
   mdnsEnabled: Boolean
   networkIsolationEnabled: Boolean
   internetAccessEnabled: Boolean

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4657,6 +4657,7 @@
                 "type": "null"
               }
             ],
+            "description": "Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is configured site-wide on current UniFi Network versions, and this key only mirrors that site-wide scope \u2014 the mirror can go stale for hours, so treat the site-level setting as the source of truth (this server does not expose it). The controller accepts this field on the per-network write path but silently ignores it; unifi_update_network rejects it as read-only.",
             "title": "Mdns Enabled"
           },
           "name": {

--- a/apps/api/src/unifi_api/graphql/pydantic_export.py
+++ b/apps/api/src/unifi_api/graphql/pydantic_export.py
@@ -12,7 +12,7 @@ import datetime
 from typing import Any, get_args, get_origin
 
 import strawberry
-from pydantic import BaseModel, ConfigDict, create_model
+from pydantic import BaseModel, ConfigDict, Field, create_model
 from strawberry.types.base import StrawberryList, StrawberryOptional
 from strawberry.types.private import StrawberryPrivate
 
@@ -104,7 +104,8 @@ def to_pydantic_model(strawberry_type: type) -> type[BaseModel]:
             # strawberry.Private — internal context, not in to_dict()
             continue
         annotation = _strawberry_type_to_pydantic(field.type)
-        fields[field.python_name] = (annotation, None)
+        default = Field(default=None, description=field.description) if field.description else None
+        fields[field.python_name] = (annotation, default)
 
     model = create_model(
         f"{strawberry_type.__name__}Model",

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1050,6 +1050,10 @@ type Network {
   igmpSnooping: Boolean
   igmpQuerierSwitches: JSON
   igmpFloodUnknownMulticast: Boolean
+
+  """
+  Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is configured site-wide on current UniFi Network versions, and this key only mirrors that site-wide scope — the mirror can go stale for hours, so treat the site-level setting as the source of truth (this server does not expose it). The controller accepts this field on the per-network write path but silently ignores it; unifi_update_network rejects it as read-only.
+  """
   mdnsEnabled: Boolean
   networkIsolationEnabled: Boolean
   internetAccessEnabled: Boolean

--- a/apps/api/src/unifi_api/graphql/types/network/network.py
+++ b/apps/api/src/unifi_api/graphql/types/network/network.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
 from strawberry.types import Info
+from unifi_core.network.models.networks import MDNS_ENABLED_DESCRIPTION
 
 if TYPE_CHECKING:
     from unifi_api.graphql.types.network.client import Client
@@ -72,7 +73,7 @@ class Network:
     igmp_snooping: bool | None
     igmp_querier_switches: strawberry.scalars.JSON | None  # type: ignore[name-defined]
     igmp_flood_unknown_multicast: bool | None
-    mdns_enabled: bool | None
+    mdns_enabled: bool | None = strawberry.field(description=MDNS_ENABLED_DESCRIPTION)
     # Access control
     network_isolation_enabled: bool | None
     internet_access_enabled: bool | None

--- a/apps/api/tests/graphql/test_pydantic_export.py
+++ b/apps/api/tests/graphql/test_pydantic_export.py
@@ -74,6 +74,19 @@ def test_pydantic_model_rejects_unknown_fields_loosely() -> None:
     Model(**sample)  # must not raise
 
 
+def test_network_mdns_description_reaches_rest_schema() -> None:
+    """The network mDNS warning survives projection into the REST schema."""
+    from unifi_api.graphql.types.network.network import Network
+
+    model = to_pydantic_model(Network)
+    description = model.model_json_schema()["properties"]["mdns_enabled"].get("description")
+
+    assert description is not None
+    assert "configured site-wide" in description
+    assert "stale for hours" in description
+    assert "read-only" in description
+
+
 def test_to_pydantic_model_caches_by_type() -> None:
     """Repeated calls return the same Pydantic class (identity-stable for response_model=)."""
     from unifi_api.graphql.types.network.client import Client

--- a/apps/network/src/unifi_network_mcp/tools/network.py
+++ b/apps/network/src/unifi_network_mcp/tools/network.py
@@ -23,6 +23,7 @@ from unifi_core.network.models.ap_group import (
     to_controller_update as ap_group_to_update,
 )
 from unifi_core.network.models.networks import DELETABLE_PURPOSES as NETWORK_DELETABLE_PURPOSES
+from unifi_core.network.models.networks import MDNS_ENABLED_DESCRIPTION
 from unifi_core.network.models.networks import validate_create as validate_network_create
 from unifi_core.network.models.networks import validate_update as validate_network_update
 from unifi_core.network.models.wlans import validate_create as validate_wlan_create
@@ -148,6 +149,7 @@ async def list_networks(
         "Get details for a specific network by ID. By default (summary=false) returns the full raw "
         "network configuration. Set summary=true to trim to selected sections via include "
         "(basic, dhcp, ipv6, vpn, wan, all).\n\n"
+        f"mDNS field note: {MDNS_ENABLED_DESCRIPTION}\n\n"
         "Examples: <no args> (full raw); summary=true,include='basic' (minimal); "
         "summary=true,include='basic,dhcp' (adds DHCP server config); summary=true,include='all'."
     ),

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -7442,7 +7442,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get details for a specific network by ID. By default (summary=false) returns the full raw network configuration. Set summary=true to trim to selected sections via include (basic, dhcp, ipv6, vpn, wan, all).\n\nExamples: <no args> (full raw); summary=true,include='basic' (minimal); summary=true,include='basic,dhcp' (adds DHCP server config); summary=true,include='all'.",
+      "description": "Get details for a specific network by ID. By default (summary=false) returns the full raw network configuration. Set summary=true to trim to selected sections via include (basic, dhcp, ipv6, vpn, wan, all).\n\nmDNS field note: Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is configured site-wide on current UniFi Network versions, and this key only mirrors that site-wide scope \u2014 the mirror can go stale for hours, so treat the site-level setting as the source of truth (this server does not expose it). The controller accepts this field on the per-network write path but silently ignores it; unifi_update_network rejects it as read-only.\n\nExamples: <no args> (full raw); summary=true,include='basic' (minimal); summary=true,include='basic,dhcp' (adds DHCP server config); summary=true,include='all'.",
       "name": "unifi_get_network_details",
       "schema": {
         "input": {

--- a/packages/unifi-core/src/unifi_core/network/models/networks.py
+++ b/packages/unifi-core/src/unifi_core/network/models/networks.py
@@ -29,6 +29,15 @@ UNSAFE_GUEST_PURPOSE_ERROR = (
     "Create or move the network to the Hotspot zone in the UniFi UI instead."
 )
 
+MDNS_ENABLED_DESCRIPTION = (
+    "Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is "
+    "configured site-wide on current UniFi Network versions, and this key only mirrors that "
+    "site-wide scope — the mirror can go stale for hours, so treat the site-level setting as "
+    "the source of truth (this server does not expose it). The controller accepts this field "
+    "on the per-network write path but silently ignores it; unifi_update_network rejects it "
+    "as read-only."
+)
+
 # ---------------------------------------------------------------------------
 # Pydantic domain model
 # ---------------------------------------------------------------------------
@@ -194,14 +203,7 @@ class Network(BaseModel):
     )
     mdns_enabled: Optional[bool] = Field(
         default=None,
-        description=(
-            "Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is "
-            "configured site-wide on current UniFi Network versions, and this key only mirrors that "
-            "site-wide scope — the mirror can go stale for hours, so treat the site-level setting as "
-            "the source of truth (this server does not expose it). The controller accepts this field "
-            "on the per-network write path but silently ignores it; unifi_update_network rejects it "
-            "as read-only."
-        ),
+        description=MDNS_ENABLED_DESCRIPTION,
         json_schema_extra={"mutable": False},
     )
     # Access control

--- a/packages/unifi-core/src/unifi_core/network/models/networks.py
+++ b/packages/unifi-core/src/unifi_core/network/models/networks.py
@@ -195,9 +195,12 @@ class Network(BaseModel):
     mdns_enabled: Optional[bool] = Field(
         default=None,
         description=(
-            "Whether mDNS reflection is enabled on this network (read-only via this tool). "
-            "On UniFi OS 5+, the controller accepts this field on the per-network write path "
-            "but silently ignores it. Per-network mDNS is not currently settable via the API."
+            "Whether mDNS is enabled for this network. Read-only and not authoritative: mDNS is "
+            "configured site-wide on current UniFi Network versions, and this key only mirrors that "
+            "site-wide scope — the mirror can go stale for hours, so treat the site-level setting as "
+            "the source of truth (this server does not expose it). The controller accepts this field "
+            "on the per-network write path but silently ignores it; unifi_update_network rejects it "
+            "as read-only."
         ),
         json_schema_extra={"mutable": False},
     )


### PR DESCRIPTION
Fixes #534.

## What changed

- Corrects the `Network.mdns_enabled` description: the field is a read-only, non-authoritative mirror of the current site-wide mDNS setting and can remain stale for hours.
- Makes that warning discoverable through `unifi_get_network_details`, the generated MCP manifest, GraphQL SDL/reference documentation, and the REST/OpenAPI schema.
- Preserves Strawberry field descriptions when the API server derives Pydantic response models, with a regression test at the REST-schema boundary.
- Regenerates the affected MCP, GraphQL, and OpenAPI artifacts.

## Why

The old text documented that the field is unwritable but not that the read itself is derived. Read as per-network state, an unrelated network write that happens to re-sync the mirror can look like it clobbered mDNS.

The warning now names both write layers accurately: the controller silently ignores the field on the per-network write path, while `unifi_update_network` rejects it as read-only before any mutation. It also avoids the inaccurate UniFi OS version claim and directs readers to the site-wide setting as the source of truth.

This PR intentionally does not add general site-settings support. #533 remains the separate broader request for that capability.

## Testing

Richard verified the original diagnosis on a live Network 10.5.67 controller: list/details reads were unaffected, and `unifi_update_network` rejected `mdns_enabled` without mutating the network.

I rebased the branch onto current `main`, added the public-surface propagation and regression coverage, and independently verified the repaired branch.

<details>
<summary>Maintainer verification output</summary>

```text
$ uv run pytest apps/api/tests/graphql/test_pydantic_export.py apps/api/tests/graphql/test_sdl_drift.py apps/api/tests/graphql/test_openapi_drift.py apps/api/tests/graphql/test_docs_drift.py apps/api/tests/graphql/test_openapi_docs_drift.py -q
...........                                                              [100%]
11 passed in 1.09s

$ make lint
All checks passed!

$ make check-generated
Done. Checked 39 sections; no drift.

$ make pre-commit
1599 passed
359 passed, 1 warning
33 passed
111 passed, 1 warning
81 passed
995 passed, 1 warning
503 passed, 1 warning
206 passed, 1 warning
1221 passed
Done. Checked 39 sections; no drift.

$ MCP discovery smoke
# Real stdio sessions covering index search, explicit load + tools/list,
# and unifi_execute auto-promotion + tools/list.
discovery_paths=pass index=pass preload=pass lazy_execute_promotion=pass

$ uv run --package unifi-network-mcp python scripts/live_smoke.py --server network --phase safe
records=245 ok=159 pending_approval=34 skipped=52 unexpected_failures=0
created_resources=3 cleaned_resources=3
gateway_setting_changed=true siblings_preserved=true reverted=true

$ uv run --package unifi-api-server python scripts/live_api_smoke.py --output /tmp/unifi-pr535-live-api.json
Live smoke: products=[network, protect, access] retry=3
Result: 36/36 passed, 0 failed
```

</details>