### PR TITLE
feat(network): serve radio config for any device that has radios

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1718,7 +1718,7 @@ type RadioEntry {
   name: String
   radio: String
   channel: Int
-  ht: Int
+  ht: String
   txPower: Int
   txPowerMode: String
   currentChannel: Int

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -1149,7 +1149,7 @@ type NetworkQuery {
   """Look up a single device by MAC address."""
   device(controller: ID!, mac: ID!, site: String! = "default"): Device
 
-  """Get the radio configuration for a UniFi access point."""
+  """Get the radio configuration for a UniFi device with radios."""
   deviceRadio(controller: ID!, mac: ID!, site: String! = "default"): DeviceRadio
 
   """Get LLDP neighbors reported by a switch."""
@@ -1713,7 +1713,7 @@ type Query {
   access: AccessQuery!
 }
 
-"""Radio configuration entry on a UniFi access point."""
+"""Radio configuration entry on a UniFi device with radios."""
 type RadioEntry {
   name: String
   radio: String
@@ -2288,7 +2288,7 @@ Read-only access to UniFi Network resources.
 - `contentFilters: ContentFilterPage!`  — List content filters on the given controller/site (paginated).
 - `dashboardStats: [StatPoint!]!`  — Site dashboard timeseries (all-points).
 - `device: Device`  — Look up a single device by MAC address.
-- `deviceRadio: DeviceRadio`  — Get the radio configuration for a UniFi access point.
+- `deviceRadio: DeviceRadio`  — Get the radio configuration for a UniFi device with radios.
 - `deviceStats: [StatPoint!]!`  — Per-device stats timeseries (by MAC).
 - `devices: DevicePage!`  — List devices on the given controller/site (paginated).
 - `dnsRecord: DnsRecord`  — Look up a single DNS record by id.

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -3646,7 +3646,7 @@
       "input_schema": {
         "properties": {
           "mac_address": {
-            "description": "MAC address of the access point, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='ap')",
+            "description": "MAC address of a device with radios (AP, or UDM/gateway with built-in WiFi), in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
             "type": "string"
           }
         },
@@ -6035,7 +6035,7 @@
             "type": "string"
           },
           "mac_address": {
-            "description": "MAC address of the access point, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
+            "description": "MAC address of a device with radios (AP, or UDM/gateway with built-in WiFi), in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
             "type": "string"
           },
           "min_rssi": {

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -2043,7 +2043,7 @@ class NetworkQuery:
 
     @strawberry.field(
         permission_classes=[IsRead],
-        description="Get the radio configuration for a UniFi access point.",
+        description="Get the radio configuration for a UniFi device with radios.",
     )
     async def device_radio(
         self,

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1707,7 +1707,7 @@ type RadioEntry {
   name: String
   radio: String
   channel: Int
-  ht: Int
+  ht: String
   txPower: Int
   txPowerMode: String
   currentChannel: Int

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -1138,7 +1138,7 @@ type NetworkQuery {
   """Look up a single device by MAC address."""
   device(controller: ID!, mac: ID!, site: String! = "default"): Device
 
-  """Get the radio configuration for a UniFi access point."""
+  """Get the radio configuration for a UniFi device with radios."""
   deviceRadio(controller: ID!, mac: ID!, site: String! = "default"): DeviceRadio
 
   """Get LLDP neighbors reported by a switch."""
@@ -1702,7 +1702,7 @@ type Query {
   access: AccessQuery!
 }
 
-"""Radio configuration entry on a UniFi access point."""
+"""Radio configuration entry on a UniFi device with radios."""
 type RadioEntry {
   name: String
   radio: String

--- a/apps/api/src/unifi_api/graphql/types/network/device.py
+++ b/apps/api/src/unifi_api/graphql/types/network/device.py
@@ -123,7 +123,7 @@ class Device:
         return out
 
 
-@strawberry.type(description="Radio configuration entry on a UniFi access point.")
+@strawberry.type(description="Radio configuration entry on a UniFi device with radios.")
 class RadioEntry:
     name: str | None
     radio: str | None

--- a/apps/api/src/unifi_api/graphql/types/network/device.py
+++ b/apps/api/src/unifi_api/graphql/types/network/device.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
 from strawberry.types import Info
+from unifi_core.network.models.devices import normalize_radio_channel, normalize_radio_ht
 
 if TYPE_CHECKING:
     from unifi_api.graphql.types.network.client import Client
@@ -128,7 +129,7 @@ class RadioEntry:
     name: str | None
     radio: str | None
     channel: int | None
-    ht: int | None
+    ht: str | None
     tx_power: int | None
     tx_power_mode: str | None
     current_channel: int | None
@@ -140,11 +141,11 @@ class RadioEntry:
         return cls(
             name=_get(r, "name"),
             radio=_get(r, "radio"),
-            channel=_get(r, "channel"),
-            ht=_get(r, "ht"),
+            channel=normalize_radio_channel(_get(r, "channel")),
+            ht=normalize_radio_ht(_get(r, "ht")),
             tx_power=_get(r, "tx_power"),
             tx_power_mode=_get(r, "tx_power_mode"),
-            current_channel=_get(r, "current_channel"),
+            current_channel=normalize_radio_channel(_get(r, "current_channel")),
             current_tx_power=_get(r, "current_tx_power"),
             num_sta=_get(r, "num_sta"),
         )
@@ -156,7 +157,7 @@ class RadioEntry:
 @strawberry.type(description="Wrapper dict containing the radio table for a device.")
 class DeviceRadio:
     """Wrapper-dict shape: manager returns ``{mac, name, model, radios: [...]}``
-    (or None for non-AP devices). Pass through with light field whitelisting on
+    (or None for devices without radios). Pass through with light field whitelisting on
     the radio entries.
 
     The per-radio mutable update fields (tx_power_mode, channel, ht, …) are

--- a/apps/api/tests/graphql/fixtures/network/test_devices.py
+++ b/apps/api/tests/graphql/fixtures/network/test_devices.py
@@ -85,8 +85,14 @@ async def test_device_radio(tmp_path, monkeypatch):
         monkeypatch,
         {
             ("network", "device_manager", "get_device_radio"): {
-                "mac": "ap:01",
-                "radio_table": [],
+                "mac": "udm:01",
+                "name": "Gateway",
+                "radios": [
+                    # AP-style raw row: int channel, string ht.
+                    {"name": "wifi0", "radio": "ng", "channel": 11, "ht": "20", "current_channel": 11},
+                    # Gateway-style raw row: "auto" channel, int ht.
+                    {"name": "wifi2", "radio": "6e", "channel": "auto", "ht": 160, "current_channel": 37},
+                ],
             },
         },
     )
@@ -94,13 +100,19 @@ async def test_device_radio(tmp_path, monkeypatch):
         app,
         key,
         f'''{{
-        network {{ deviceRadio(controller: "{cid}", mac: "ap:01") {{
+        network {{ deviceRadio(controller: "{cid}", mac: "udm:01") {{
             mac
+            radios {{ radio channel ht currentChannel }}
         }} }}
     }}''',
     )
     assert body.get("errors") is None, body
-    assert body["data"]["network"]["deviceRadio"]["mac"] == "ap:01"
+    radio_data = body["data"]["network"]["deviceRadio"]
+    assert radio_data["mac"] == "udm:01"
+    assert radio_data["radios"] == [
+        {"radio": "ng", "channel": 11, "ht": "20", "currentChannel": 11},
+        {"radio": "6e", "channel": 0, "ht": "160", "currentChannel": 37},
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -167,7 +167,7 @@ Gateway-wide security / NAT / connection-tracking settings (the controller's `us
 
 - `unifi_list_devices` — List all adopted devices
 - `unifi_get_device_details` — Get full device object by MAC
-- `unifi_get_device_radio` — Get AP radio config and stats
+- `unifi_get_device_radio` — Get radio config and stats for a device with radios
 - `unifi_update_device_radio` — Update radio settings (TX power, channel, width)
 - `unifi_reboot_device` — Reboot a device by MAC
 - `unifi_rename_device` — Rename a device by MAC

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -544,7 +544,7 @@ async def update_device_radio(
                 updates=validated_data,
             )
             preview["warnings"] = [
-                "AP radio will restart briefly after changes are applied.",
+                "Device radio will restart briefly after changes are applied.",
                 "Connected clients may experience a brief disconnection.",
             ]
             return preview

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -373,7 +373,7 @@ RADIO_BAND_LABELS = {"ng": "2.4GHz", "na": "5GHz", "6e": "6GHz", "wifi6e": "6GHz
 @server.tool(
     name="unifi_get_device_radio",
     description=(
-        "Get radio configuration and live statistics for an access point. "
+        "Get radio configuration and live statistics for a device with radios (AP, or UDM/gateway with built-in WiFi). "
         "Returns per-band config (channel, tx_power, channel width, min_rssi) "
         "and live stats (actual tx_power, channel utilization, client count, retries)."
     ),
@@ -383,17 +383,17 @@ async def get_device_radio(
     mac_address: Annotated[
         str,
         Field(
-            description="MAC address of the access point, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='ap')"
+            description="MAC address of a device with radios (AP, or UDM/gateway with built-in WiFi), in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)"
         ),
     ],
 ) -> Dict[str, Any]:
-    """Implementation for getting focused radio config and stats for an AP."""
+    """Implementation for getting focused radio config and stats for a device with radios."""
     try:
         result = await device_manager.get_device_radio(mac_address)
         if result is None:
             return {
                 "success": False,
-                "error": f"Device {mac_address} is not an access point.",
+                "error": f"Device {mac_address} does not have radios.",
             }
         return {
             "success": True,
@@ -410,7 +410,7 @@ async def get_device_radio(
 @server.tool(
     name="unifi_update_device_radio",
     description=(
-        "Update radio settings for a specific band on an access point. "
+        "Update radio settings for a specific band on a device with radios (AP, or UDM/gateway with built-in WiFi). "
         "Supports tx_power_mode, tx_power (custom dBm), channel, ht (channel width), "
         "min_rssi_enabled, min_rssi, assisted_roaming_enabled (802.11k/v), "
         "antenna_gain (dBi), vwire_enabled, sens_level_enabled, sens_level. "
@@ -423,7 +423,9 @@ async def get_device_radio(
 async def update_device_radio(
     mac_address: Annotated[
         str,
-        Field(description="MAC address of the access point, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)"),
+        Field(
+            description="MAC address of a device with radios (AP, or UDM/gateway with built-in WiFi), in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)"
+        ),
     ],
     radio: Annotated[
         str,
@@ -480,7 +482,7 @@ async def update_device_radio(
         Field(description="When true, applies radio changes. When false (default), returns a preview of the changes"),
     ] = False,
 ) -> Dict[str, Any]:
-    """Implementation for updating AP radio settings."""
+    """Implementation for updating radio settings on a device with radios."""
     updates: Dict[str, Any] = {}
     if tx_power_mode is not None:
         updates["tx_power_mode"] = tx_power_mode
@@ -515,7 +517,7 @@ async def update_device_radio(
         if radio_data is None:
             return {
                 "success": False,
-                "error": f"Device {mac_address} not found or is not an access point.",
+                "error": f"Device {mac_address} not found or does not have radios.",
             }
 
         target_radio = next((r for r in radio_data["radios"] if r["radio"] == radio or r["name"] == radio), None)

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -6255,13 +6255,13 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get radio configuration and live statistics for an access point. Returns per-band config (channel, tx_power, channel width, min_rssi) and live stats (actual tx_power, channel utilization, client count, retries).",
+      "description": "Get radio configuration and live statistics for a device with radios (AP, or UDM/gateway with built-in WiFi). Returns per-band config (channel, tx_power, channel width, min_rssi) and live stats (actual tx_power, channel utilization, client count, retries).",
       "name": "unifi_get_device_radio",
       "schema": {
         "input": {
           "properties": {
             "mac_address": {
-              "description": "MAC address of the access point, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices with device_type='ap')",
+              "description": "MAC address of a device with radios (AP, or UDM/gateway with built-in WiFi), in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
               "type": "string"
             }
           },
@@ -16399,7 +16399,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Update radio settings for a specific band on an access point. Supports tx_power_mode, tx_power (custom dBm), channel, ht (channel width), min_rssi_enabled, min_rssi, assisted_roaming_enabled (802.11k/v), antenna_gain (dBi), vwire_enabled, sens_level_enabled, sens_level. Use unifi_get_device_radio first to see current settings.",
+      "description": "Update radio settings for a specific band on a device with radios (AP, or UDM/gateway with built-in WiFi). Supports tx_power_mode, tx_power (custom dBm), channel, ht (channel width), min_rssi_enabled, min_rssi, assisted_roaming_enabled (802.11k/v), antenna_gain (dBi), vwire_enabled, sens_level_enabled, sens_level. Use unifi_get_device_radio first to see current settings.",
       "name": "unifi_update_device_radio",
       "permission_action": "update",
       "permission_category": "devices",
@@ -16427,7 +16427,7 @@
               "type": "string"
             },
             "mac_address": {
-              "description": "MAC address of the access point, in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
+              "description": "MAC address of a device with radios (AP, or UDM/gateway with built-in WiFi), in format AA:BB:CC:DD:EE:FF (from unifi_list_devices)",
               "type": "string"
             },
             "min_rssi": {

--- a/apps/network/tests/unit/test_device_radio.py
+++ b/apps/network/tests/unit/test_device_radio.py
@@ -86,6 +86,102 @@ SAMPLE_RADIO_TABLE_STATS = [
 ]
 
 
+# Shapes captured from a live UDM running a 6GHz radio. The 6e entry differs from
+# every AP sample above in two ways: "channel" is the string "auto" when the radio
+# is on automatic selection, and "ht" comes back as an int rather than a string.
+UDM_RADIO_TABLE = [
+    {
+        "name": "wifi0",
+        "radio": "ng",
+        "channel": 11,
+        "ht": "20",
+        "tx_power_mode": "low",
+        "min_rssi_enabled": False,
+        "max_txpower": 23,
+        "min_txpower": 6,
+        "has_dfs": True,
+        "nss": 2,
+        "is_11ax": True,
+        "is_11be": True,
+    },
+    {
+        "name": "wifi1",
+        "radio": "na",
+        "channel": 132,
+        "ht": "80",
+        "tx_power_mode": "low",
+        "min_rssi_enabled": True,
+        "min_rssi": -75,
+        "max_txpower": 26,
+        "min_txpower": 6,
+        "has_dfs": True,
+        "nss": 2,
+        "is_11ax": True,
+        "is_11be": True,
+    },
+    {
+        "name": "wifi2",
+        "radio": "6e",
+        "channel": "auto",
+        "ht": 160,
+        "tx_power_mode": "auto",
+        "min_rssi_enabled": True,
+        "min_rssi": -75,
+        "max_txpower": 24,
+        "min_txpower": 6,
+        "has_dfs": True,
+        "nss": 2,
+        "is_11ax": True,
+        "is_11be": True,
+    },
+]
+
+UDM_RADIO_TABLE_STATS = [
+    {
+        "name": "wifi0",
+        "radio": "ng",
+        "channel": 11,
+        "tx_power": 6,
+        "cu_total": 38,
+        "cu_self_tx": 17,
+        "cu_self_rx": 20,
+        "satisfaction": -1,
+        "num_sta": 10,
+        "tx_retries": 8,
+        "tx_packets": 156,
+        "state": "RUN",
+    },
+    {
+        "name": "wifi1",
+        "radio": "na",
+        "channel": 132,
+        "tx_power": 6,
+        "cu_total": 2,
+        "cu_self_tx": 1,
+        "cu_self_rx": 0,
+        "satisfaction": -1,
+        "num_sta": 2,
+        "tx_retries": 0,
+        "tx_packets": 0,
+        "state": "RUN",
+    },
+    {
+        "name": "wifi2",
+        "radio": "6e",
+        "channel": 37,
+        "tx_power": 21,
+        "cu_total": 1,
+        "cu_self_tx": 1,
+        "cu_self_rx": 0,
+        "satisfaction": -1,
+        "num_sta": 0,
+        "tx_retries": 0,
+        "tx_packets": 0,
+        "state": "RUN",
+    },
+]
+
+
 def _make_ap_device(mac="28:70:4e:c1:b4:c8"):
     """Create a mock Device representing an AP with radio_table data."""
     device = MagicMock()
@@ -112,6 +208,36 @@ def _make_switch_device(mac="11:22:33:44:55:66"):
         "name": "Test Switch",
         "model": "USW-24-PoE",
         "type": "usw",
+    }
+    return device
+
+
+def _make_udm_device(mac="aa:bb:cc:dd:ee:01"):
+    """Create a mock Device representing a UDM/gateway WITH built-in radios (UDR-style)."""
+    device = MagicMock()
+    device.mac = mac
+    device.raw = {
+        "_id": "device_udm123",
+        "mac": mac,
+        "name": "Test UDR",
+        "model": "UDR",
+        "type": "udm",
+        "radio_table": list(UDM_RADIO_TABLE),
+        "radio_table_stats": list(UDM_RADIO_TABLE_STATS),
+    }
+    return device
+
+
+def _make_radioless_gateway_device(mac="aa:bb:cc:dd:ee:02"):
+    """Create a mock Device representing a gateway with no radio hardware (UDM Pro / UXG)."""
+    device = MagicMock()
+    device.mac = mac
+    device.raw = {
+        "_id": "device_udmpro123",
+        "mac": mac,
+        "name": "Test UDM Pro",
+        "model": "UDMPRO",
+        "type": "udm",
     }
     return device
 
@@ -172,6 +298,50 @@ class TestDeviceManagerGetRadio:
         mock_connection.controller.devices.values.return_value = [switch]
 
         result = await device_manager.get_device_radio(switch.mac)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_radio_data_for_udm(self, device_manager, mock_connection):
+        """A gateway with built-in radios is served like an AP, not rejected on its device type."""
+        udm = _make_udm_device()
+        mock_connection.controller.devices.values.return_value = [udm]
+
+        result = await device_manager.get_device_radio(udm.mac)
+
+        assert result is not None
+        assert result["mac"] == udm.mac
+        assert result["name"] == "Test UDR"
+        assert len(result["radios"]) == 3
+
+        assert [radio["radio"] for radio in result["radios"]] == ["ng", "na", "6e"]
+
+        sixe_radio = result["radios"][2]
+        assert sixe_radio["channel"] == "auto"
+        assert sixe_radio["ht"] == 160
+        assert sixe_radio["current_channel"] == 37
+        assert sixe_radio["current_tx_power"] == 21
+
+    @pytest.mark.asyncio
+    async def test_empty_radio_table_still_succeeds(self, device_manager, mock_connection):
+        """An empty radio_table stays an empty success, as it was before radios were keyed off the table."""
+        ap = _make_ap_device()
+        ap.raw["radio_table"] = []
+        ap.raw["radio_table_stats"] = []
+        mock_connection.controller.devices.values.return_value = [ap]
+
+        result = await device_manager.get_device_radio(ap.mac)
+
+        assert result is not None
+        assert result["radios"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_radioless_gateway(self, device_manager, mock_connection):
+        """UDM Pro / UXG-style gateways without radio hardware must return None, not empty success."""
+        udm = _make_radioless_gateway_device()
+        mock_connection.controller.devices.values.return_value = [udm]
+
+        result = await device_manager.get_device_radio(udm.mac)
 
         assert result is None
 
@@ -448,4 +618,4 @@ class TestGetDeviceRadioTool:
             result = await get_device_radio(mac_address="11:22:33:44:55:66")
 
         assert result["success"] is False
-        assert "not an access point" in result["error"]
+        assert "does not have radios" in result["error"]

--- a/apps/network/tests/unit/test_device_radio.py
+++ b/apps/network/tests/unit/test_device_radio.py
@@ -89,6 +89,8 @@ SAMPLE_RADIO_TABLE_STATS = [
 # Shapes captured from a live UDM running a 6GHz radio. The 6e entry differs from
 # every AP sample above in two ways: "channel" is the string "auto" when the radio
 # is on automatic selection, and "ht" comes back as an int rather than a string.
+# get_device_radio() normalises both to the canonical forms (0-for-auto int
+# channel, MHz-string ht); the raw values here stay as the controller sent them.
 UDM_RADIO_TABLE = [
     {
         "name": "wifi0",
@@ -317,10 +319,14 @@ class TestDeviceManagerGetRadio:
         assert [radio["radio"] for radio in result["radios"]] == ["ng", "na", "6e"]
 
         sixe_radio = result["radios"][2]
-        assert sixe_radio["channel"] == "auto"
-        assert sixe_radio["ht"] == 160
+        assert sixe_radio["channel"] == 0
+        assert sixe_radio["ht"] == "160"
         assert sixe_radio["current_channel"] == 37
         assert sixe_radio["current_tx_power"] == 21
+
+        ng_radio = result["radios"][0]
+        assert ng_radio["channel"] == 11
+        assert ng_radio["ht"] == "20"
 
     @pytest.mark.asyncio
     async def test_empty_radio_table_still_succeeds(self, device_manager, mock_connection):

--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -7,6 +7,7 @@ from aiounifi.models.device import Device
 
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.models.devices import normalize_radio_channel, normalize_radio_ht
 
 logger = logging.getLogger("unifi-network-mcp")
 
@@ -206,8 +207,8 @@ class DeviceManager:
             entry: Dict[str, Any] = {
                 "name": radio.get("name"),
                 "radio": radio.get("radio"),
-                "channel": radio.get("channel"),
-                "ht": radio.get("ht"),
+                "channel": normalize_radio_channel(radio.get("channel")),
+                "ht": normalize_radio_ht(radio.get("ht")),
                 "tx_power_mode": radio.get("tx_power_mode"),
                 "tx_power": radio.get("tx_power"),
                 "min_rssi_enabled": radio.get("min_rssi_enabled"),
@@ -221,7 +222,7 @@ class DeviceManager:
             }
             if stats := stats_by_name.get(radio.get("name", "")):
                 entry["current_tx_power"] = stats.get("tx_power")
-                entry["current_channel"] = stats.get("channel")
+                entry["current_channel"] = normalize_radio_channel(stats.get("channel"))
                 entry["cu_total"] = stats.get("cu_total")
                 entry["cu_self_tx"] = stats.get("cu_self_tx")
                 entry["cu_self_rx"] = stats.get("cu_self_rx")
@@ -242,7 +243,7 @@ class DeviceManager:
         """Update radio settings for a specific band on a device with radios.
 
         Args:
-            device_mac: MAC address of the AP.
+            device_mac: MAC address of the device.
             radio_id: Radio identifier -- either the band code ("na", "ng", "6e")
                       or the internal name ("wifi0", "wifi1").
             updates: Dict of radio_table fields to update (e.g. tx_power_mode, channel).

--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -189,16 +189,15 @@ class DeviceManager:
             raise
 
     async def get_device_radio(self, device_mac: str) -> Optional[Dict[str, Any]]:
-        """Get focused radio configuration and live stats for an AP.
+        """Get focused radio configuration and live stats for a device with radios.
 
-        Returns None if the device exists but is not an access point.
+        Returns None if the device exists but has no radios.
 
         Raises:
             UniFiNotFoundError: If the device does not exist.
         """
         device = await self.get_device_details(device_mac)  # raises on miss
-        device_type = device.raw.get("type", "")
-        if not device_type.startswith("uap"):
+        if "radio_table" not in device.raw:
             return None
 
         stats_by_name: Dict[str, Dict[str, Any]] = {s["name"]: s for s in device.raw.get("radio_table_stats", [])}
@@ -240,7 +239,7 @@ class DeviceManager:
         }
 
     async def update_device_radio(self, device_mac: str, radio_id: str, updates: Dict[str, Any]) -> bool:
-        """Update radio settings for a specific band on an AP.
+        """Update radio settings for a specific band on a device with radios.
 
         Args:
             device_mac: MAC address of the AP.

--- a/packages/unifi-core/src/unifi_core/network/models/devices.py
+++ b/packages/unifi-core/src/unifi_core/network/models/devices.py
@@ -9,6 +9,8 @@ Mirrors the Strawberry types in
 Factory helpers:
 - ``from_controller``              — normalise raw dict → Device
 - ``radio_from_controller``        — normalise raw radio entry dict → DeviceRadio
+- ``normalize_radio_channel``      — controller channel value → canonical int (0 = auto)
+- ``normalize_radio_ht``           — controller width value → canonical MHz string
 - ``to_controller_update``         — filter a partial Device dict to mutable keys
 - ``radio_to_controller_update``   — filter a partial radio dict to mutable keys
 
@@ -231,14 +233,40 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def normalize_radio_channel(value: Any) -> Optional[int]:
+    """Normalise a controller channel value to the canonical int form.
+
+    APs report an int; gateways report the string ``"auto"`` when the radio
+    selects its own channel. ``"auto"`` maps to 0 — the convention the update
+    schema already documents ("0 for auto").
+    """
+    if value == "auto":
+        return 0
+    if isinstance(value, str):
+        return int(value) if value.isdigit() else None
+    return value
+
+
+def normalize_radio_ht(value: Any) -> Optional[str]:
+    """Normalise a controller channel-width value to the canonical MHz string.
+
+    APs report a string (``"20"``); gateways report an int (``160``). The
+    canonical form is the string, matching VALID_HT_VALUES and the update
+    schema.
+    """
+    if value is None:
+        return None
+    return str(value)
+
+
 def radio_from_controller(raw: Any) -> DeviceRadio:
     """Build a DeviceRadio (single radio entry) from a controller radio_table row."""
     return DeviceRadio(
         radio=_get(raw, "radio"),
         tx_power_mode=_get(raw, "tx_power_mode"),
         tx_power=_get(raw, "tx_power"),
-        channel=_get(raw, "channel"),
-        ht=_get(raw, "ht"),
+        channel=normalize_radio_channel(_get(raw, "channel")),
+        ht=normalize_radio_ht(_get(raw, "ht")),
         min_rssi_enabled=_get(raw, "min_rssi_enabled"),
         min_rssi=_get(raw, "min_rssi"),
         assisted_roaming_enabled=_get(raw, "assisted_roaming_enabled"),

--- a/packages/unifi-core/src/unifi_core/network/models/devices.py
+++ b/packages/unifi-core/src/unifi_core/network/models/devices.py
@@ -84,7 +84,7 @@ class Device(BaseModel):
 
 
 class DeviceRadio(BaseModel):
-    """Canonical per-radio entry model for access point radio updates.
+    """Canonical per-radio entry model for device radio updates.
 
     Mutable fields mirror the DEVICE_RADIO_UPDATE_SCHEMA.  The model is used
     to type-check and filter radio update dicts before passing them to the

--- a/packages/unifi-core/src/unifi_core/network/models/devices.py
+++ b/packages/unifi-core/src/unifi_core/network/models/devices.py
@@ -19,9 +19,12 @@ Per-class MUTABLE_FIELDS constants drive the cross-layer symmetry test.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Device — top-level device (mutable: name only; other mutations are actions)
@@ -243,7 +246,10 @@ def normalize_radio_channel(value: Any) -> Optional[int]:
     if value == "auto":
         return 0
     if isinstance(value, str):
-        return int(value) if value.isdigit() else None
+        if value.isdigit():
+            return int(value)
+        logger.warning("Unrecognised radio channel value %r dropped from read output", value)
+        return None
     return value
 
 

--- a/packages/unifi-core/src/unifi_core/network/read_views.py
+++ b/packages/unifi-core/src/unifi_core/network/read_views.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from unifi_core.network.models.clients import _is_online, client_from_controller
+from unifi_core.network.models.devices import normalize_radio_channel
 from unifi_core.network.models.firewall import from_controller as firewall_policy_from_controller
 from unifi_core.network.models.networks import from_controller as network_from_controller
 
@@ -516,7 +517,11 @@ def shape_device_details(
         data["port_count"] = len(raw["port_table"])
     if (include_all or "radios" in sections) and "radio_table" in raw:
         data["radio_summary"] = [
-            {"radio": radio.get("radio"), "channel": radio.get("channel"), "tx_power": radio.get("tx_power")}
+            {
+                "radio": radio.get("radio"),
+                "channel": normalize_radio_channel(radio.get("channel")),
+                "tx_power": radio.get("tx_power"),
+            }
             for radio in raw["radio_table"]
         ]
         data["radio_count"] = len(raw["radio_table"])

--- a/packages/unifi-core/tests/network/models/test_devices.py
+++ b/packages/unifi-core/tests/network/models/test_devices.py
@@ -11,6 +11,8 @@ from unifi_core.network.models.devices import (
     Device,
     DeviceRadio,
     from_controller,
+    normalize_radio_channel,
+    normalize_radio_ht,
     radio_from_controller,
     radio_to_controller_update,
     to_controller_update,
@@ -155,6 +157,44 @@ class TestRadioFromController:
         radio = radio_from_controller({})
         assert radio.radio is None
         assert radio.tx_power_mode is None
+
+    def test_normalizes_live_gateway_shape(self) -> None:
+        """A UDM 6GHz radio reports channel "auto" and an int ht; both normalise
+        to the canonical forms (0-for-auto int channel, MHz-string ht)."""
+        raw = {
+            "radio": "6e",
+            "tx_power_mode": "auto",
+            "channel": "auto",
+            "ht": 160,
+            "min_rssi_enabled": True,
+            "min_rssi": -75,
+        }
+        radio = radio_from_controller(raw)
+        assert radio.channel == 0
+        assert radio.ht == "160"
+
+
+class TestRadioNormalizers:
+    def test_channel_auto_maps_to_zero(self) -> None:
+        assert normalize_radio_channel("auto") == 0
+
+    def test_channel_int_passthrough(self) -> None:
+        assert normalize_radio_channel(36) == 36
+
+    def test_channel_none_passthrough(self) -> None:
+        assert normalize_radio_channel(None) is None
+
+    def test_channel_numeric_string_coerces(self) -> None:
+        assert normalize_radio_channel("11") == 11
+
+    def test_ht_int_becomes_string(self) -> None:
+        assert normalize_radio_ht(160) == "160"
+
+    def test_ht_string_passthrough(self) -> None:
+        assert normalize_radio_ht("20") == "20"
+
+    def test_ht_none_passthrough(self) -> None:
+        assert normalize_radio_ht(None) is None
 
 
 class TestRadioToControllerUpdate:

--- a/packages/unifi-core/tests/network/models/test_devices.py
+++ b/packages/unifi-core/tests/network/models/test_devices.py
@@ -187,6 +187,11 @@ class TestRadioNormalizers:
     def test_channel_numeric_string_coerces(self) -> None:
         assert normalize_radio_channel("11") == 11
 
+    def test_channel_unknown_string_drops_with_warning(self, caplog) -> None:
+        with caplog.at_level("WARNING"):
+            assert normalize_radio_channel("disabled") is None
+        assert "disabled" in caplog.text
+
     def test_ht_int_becomes_string(self) -> None:
         assert normalize_radio_ht(160) == "160"
 

--- a/packages/unifi-core/tests/network/test_read_views.py
+++ b/packages/unifi-core/tests/network/test_read_views.py
@@ -113,6 +113,32 @@ def test_shape_device_details_supports_sections_and_missing() -> None:
     assert shape_device_details(None, site="default", mac_address="missing")["success"] is False
 
 
+def test_shape_device_details_normalizes_radio_summary_channel() -> None:
+    raw = {
+        "mac": "aa",
+        "name": "Gateway",
+        "type": "udm",
+        "state": 1,
+        "radio_table": [
+            {"radio": "ng", "channel": 11, "tx_power": 6},
+            {"radio": "6e", "channel": "auto", "tx_power": 21},
+        ],
+    }
+
+    result = shape_device_details(
+        SimpleNamespace(raw=raw),
+        site="default",
+        mac_address="aa",
+        include="radios",
+        summary=True,
+    )
+
+    assert result["device"]["radio_summary"] == [
+        {"radio": "ng", "channel": 11, "tx_power": 6},
+        {"radio": "6e", "channel": 0, "tx_power": 21},
+    ]
+
+
 def test_shape_network_list_applies_every_filter_and_projection() -> None:
     networks = [
         {"_id": "n1", "name": "Guest", "purpose": "guest", "vlan": 20, "enabled": True},

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -75,7 +75,7 @@ Always available, regardless of registration mode.
 | Tool | Type | Description |
 |------|------|-------------|
 | `unifi_get_device_details` | Read | Returns device data for one device by MAC address. |
-| `unifi_get_device_radio` | Read | Get radio configuration and live statistics for an access point. |
+| `unifi_get_device_radio` | Read | Get radio configuration and live statistics for a device with radios (AP, or UDM/gateway with built-in WiFi). |
 | `unifi_get_pdu_outlets` | Read | Return per-outlet state for a UniFi Smart Power PDU (UP6 / USP-Strip). |
 | `unifi_get_rf_scan_results` | Read | Get RF spectrum scan results for an access point. |
 | `unifi_get_speedtest_status` | Read | Check the status of a running speedtest on the gateway. |
@@ -93,7 +93,7 @@ Always available, regardless of registration mode.
 | `unifi_toggle_device` | Mutate | Enable or disable a device without unadopting it. |
 | `unifi_trigger_rf_scan` | Mutate | Trigger an RF spectrum scan on an access point. |
 | `unifi_trigger_speedtest` | Mutate | Trigger a speedtest on the gateway device. |
-| `unifi_update_device_radio` | Mutate | Update radio settings for a specific band on an access point. |
+| `unifi_update_device_radio` | Mutate | Update radio settings for a specific band on a device with radios (AP, or UDM/gateway with built-in WiFi). |
 | `unifi_upgrade_device` | Mutate | Initiate a firmware upgrade for a device by MAC address (uses cached firmware by default) |
 <!-- /AUTO:tools:devices -->
 


### PR DESCRIPTION
## Summary

`unifi_get_device_radio` reports no radios for a UniFi gateway that has built-in WiFi, because `DeviceManager.get_device_radio()` gates on `device_type.startswith("uap")` (`packages/unifi-core/src/unifi_core/network/managers/device_manager.py:201`) and a gateway falls through to `return None`. This replaces that gate with a presence check on `radio_table`:

```python
device = await self.get_device_details(device_mac)  # raises on miss
if "radio_table" not in device.raw:
    return None
```

Both radio tools are affected, not just the read. `unifi_update_device_radio` resolves its target band by calling `get_device_radio()` first (`apps/network/src/unifi_network_mcp/tools/devices.py:516`) and errors out when it gets `None`, so the same gate blocks gateway writes.

The new predicate is the one this package already uses. `read_views.shape_device_details` gates its radio section on `"radio_table" in raw` (`read_views.py:517`) with no device-type check, which is why `unifi_get_device_details` already returns `radio_summary` for a gateway that `unifi_get_device_radio` refuses. The two now agree.

Serving gateway radios also surfaces that controller radio rows differ in shape by device class: an AP row carries an int `channel` and a string width (`"ht": "20"`), while a gateway row carries `"channel": "auto"` on an automatic radio and an int width (`"ht": 160`). Rather than letting each layer see whichever shape the device emits, both fields now normalise to one canonical form at the controller boundary — `channel` as int with 0 meaning auto (the convention `DeviceRadio.channel` already documents), `ht` as the MHz string matching `VALID_HT_VALUES` and the update schema. Two helpers in `unifi_core.network.models.devices` (`normalize_radio_channel`, `normalize_radio_ht`) are applied everywhere a raw row is read: `DeviceManager.get_device_radio()`, `radio_from_controller()`, the `read_views` `radio_summary`, and the GraphQL `RadioEntry`. `RadioEntry.ht` widens from `Int` to `String` in the SDL; the `Int` declaration matched neither device class, since every AP row carries the width as a string. The update input schemas already used exactly this representation (`channel: integer`, `ht: string`), so the write contract is untouched.

Nothing that works today changes. A switch has no `radio_table` and still returns `None`, as does a gateway with no radio hardware, and a device with a present-but-empty `radio_table` keeps returning an empty-radios success — pinned by `test_empty_radio_table_still_succeeds`. AP rows pass through the normalisers unchanged (int channel in, int channel out; string width in, string width out).

Descriptions in the manager, both MCP tools, the radio update model, and the GraphQL resolver and type said access-point-only, which is what callers read. The tools manifest, action catalog, plugin skill reference, GraphQL SDL, and GraphQL reference doc are regenerated to match. Related: #71, where this tool pair was added.

## Type of change

- [ ] `fix:` bug fix
- [x] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [ ] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [x] Network MCP server
- [ ] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [x] API server
- [x] Shared packages
- [x] Plugin packaging
- [x] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

```
make -C apps/network test    998 passed
make core-test              1609 passed
make check                  exit 0 (format-check + lint + generated-drift + all suites, incl. 1221 API tests)
```

`make check` subsumes `make pre-commit`'s lint, test, generated-drift, and worker-typecheck steps; `ruff format --check` reports the tree clean. The SDL and GraphQL reference doc were re-exported after the `RadioEntry.ht` change, and the drift gates in `make check` pass, so the committed artifacts match their sources.

The canonical shape is covered at every layer the review asked for: `radio_from_controller()` over the live gateway row (`"auto"`/`160` → `0`/`"160"`) plus direct normaliser tests in the shared model suite, the manager path in `test_returns_radio_data_for_udm` (raw fixtures stay exactly as captured; assertions pin the normalised output for both the gateway-style and AP-style rows), `radio_summary` normalisation in the read-views suite, and a GraphQL fixture test that pushes both raw row shapes through an executed `radios { radio channel ht currentChannel }` query and asserts the typed results with no errors.

### Live read verification

This was verified against a live controller, not only against mocks. `get_device_radio()` ran over every device on one site, from this branch and from `main`, against the same controller in the same session:

| device | `main` | this branch |
|---|---|---|
| 3x AP (`type=uap`) | 2 radios each | 2 radios each |
| 3x switch (`type=usw`) | `None` | `None` |
| gateway, `type=udm`, built-in WiFi | **`None`** | 2.4GHz + 5GHz + 6GHz radios, each joined to its `radio_table_stats` row |

The gateway's 6GHz radio reads back as `channel: 0`, `ht: "160"` (raw: `"auto"`, `160`) with the resolved channel in `current_channel: 37` from its stats row; the 2.4GHz and 5GHz rows are byte-identical to what `main` returns for an AP-shaped row.

### Live gateway write round-trip

The newly reachable gateway write path was exercised against the same gateway with `confirm=true`: a controlled change of `tx_power_mode` on the 6GHz radio (`auto` → `low`), read back, then reverted (`low` → `auto`), read back again. The read-backs diff the full raw `radio_table` against a baseline captured before any write. The changed field landed, every unmodified field and both other radios were preserved, and after the revert the table is equal to the baseline. Because the PUT sends the entire `radio_table`, both writes also round-tripped the untouched `"channel": "auto"` value through the controller, which accepted it — closing the open question from the earlier revision of this PR.

<details>
<summary>Sanitized terminal output</summary>

```
2026-08-16 13:05:21,985 - unifi-network-mcp - INFO - Using bundled default configuration: .../apps/network/src/unifi_network_mcp/config/config.yaml
2026-08-16 13:05:22,052 - unifi-network-mcp - INFO - Attempting to connect to Unifi controller at <controller>...
2026-08-16 13:05:22,067 - unifi-network-mcp - INFO - Pre-login auto-detected controller type: UniFi OS (proxy)
2026-08-16 13:05:22,416 - unifi-network-mcp - INFO - Detected UniFi OS controller (proxy paths required)
2026-08-16 13:05:22,416 - unifi-network-mcp - INFO - Successfully connected to Unifi controller at <controller> for site 'default'
2026-08-16 13:05:22,642 - unifi-network-mcp - INFO - Radio '6e' updated on device 8c:xx:xx:xx:xx:0a: ['tx_power_mode']
2026-08-16 13:05:32,792 - unifi-network-mcp - INFO - Radio '6e' updated on device 8c:xx:xx:xx:xx:0a: ['tx_power_mode']
baseline captured: 3 radios; 6e tx_power_mode='auto', 6e channel='auto'

--- preview (confirm=False) ---
{
  "success": true,
  "requires_confirmation": true,
  "action": "update",
  "resource_type": "device_radio",
  "resource_id": "8c:xx:xx:xx:xx:0a/6e",
  "preview": {
    "current": {
      "tx_power_mode": "auto"
    },
    "proposed": {
      "tx_power_mode": "low"
    }
  },
  "message": "Will update tx_power_mode on device_radio 'Router (6GHz)'. Set confirm=true to execute.",
  "resource_name": "Router (6GHz)",
  "warnings": [
    "Device radio will restart briefly after changes are applied.",
    "Connected clients may experience a brief disconnection."
  ]
}

--- apply (confirm=True): 6e tx_power_mode auto -> low ---
{
  "success": true,
  "message": "Radio '6e' (6GHz) updated on Router (8c:xx:xx:xx:xx:0a).",
  "updated_fields": [
    "tx_power_mode"
  ]
}

read-back diff vs baseline (expect exactly one field):
  wifi2.tx_power_mode: 'auto' -> 'low'

--- revert (confirm=True): 6e tx_power_mode low -> auto ---
{
  "success": true,
  "message": "Radio '6e' (6GHz) updated on Router (8c:xx:xx:xx:xx:0a).",
  "updated_fields": [
    "tx_power_mode"
  ]
}

read-back diff vs baseline after revert (expect none):
  (no differences)

round-trip complete; radio_table restored: True
```

</details>

## Notes for reviewers

The two open items from the first review round are addressed above: the gateway radio shape now has one canonical representation enforced at the controller boundary and covered by shared-model, manager, read-views, and executed-GraphQL tests; and the gateway mutation path has live round-trip proof, including controller acceptance of the round-tripped `"channel": "auto"` value.

The normalisation is read-side only by design. The update input schemas already match the canonical form, and `DeviceManager.update_device_radio()` still merges user fields into the raw `radio_table` and PUTs it back unmodified, so the write payload for APs is byte-identical to what shipped before this PR — no unverified change rides along on the AP write path.

One device still informs the live evidence, a single gateway model with three built-in radios. I have no UDR, UXG, or UDM Pro to check against, but the radio-less-gateway and AP shapes are pinned by tests.
