### PR TITLE
feat(network): resolve DPI names in traffic-flow statistics

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -2016,7 +2016,14 @@ type TrafficFlowStatistics {
 
 """An application in a traffic-flow Top-Talkers ranking (by bytes)."""
 type TrafficFlowTopApplication {
+  """
+  Low V2 traffic-flow application ID. Scoped to the V2 traffic-flow tool family; do not pass it to Integration API DPI tools.
+  """
   applicationId: Int
+
+  """
+  V2 traffic-flow category ID used for one-way name annotation. Scoped to the V2 traffic-flow tool family; do not pass it to Integration API DPI tools.
+  """
   categoryId: Int
   bytes: Int
   applicationName: String

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -7746,6 +7746,7 @@
                 "type": "null"
               }
             ],
+            "description": "Low V2 traffic-flow application ID. Scoped to the V2 traffic-flow tool family; do not pass it to Integration API DPI tools.",
             "title": "Application Id"
           },
           "application_name": {
@@ -7779,6 +7780,7 @@
                 "type": "null"
               }
             ],
+            "description": "V2 traffic-flow category ID used for one-way name annotation. Scoped to the V2 traffic-flow tool family; do not pass it to Integration API DPI tools.",
             "title": "Category Id"
           },
           "category_name": {

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -12,8 +12,9 @@ dependencies = [
     # across the GraphQL and SSE surfaces requires Core 0.4.31; firewall-zone
     # actions require Core 0.4.32; Access system-log event normalization
     # requires Core 0.4.33; WLAN schedule-window projection requires Core
-    # 0.4.34; Protect camera detail fields require Core 0.4.35.
-    "unifi-core[network,protect,access]>=0.4.35,<0.5",
+    # 0.4.34; Protect camera detail fields require Core 0.4.35; traffic-flow
+    # DPI name enrichment requires Core 0.4.36.
+    "unifi-core[network,protect,access]>=0.4.36,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -2005,7 +2005,14 @@ type TrafficFlowStatistics {
 
 """An application in a traffic-flow Top-Talkers ranking (by bytes)."""
 type TrafficFlowTopApplication {
+  """
+  Low V2 traffic-flow application ID. Scoped to the V2 traffic-flow tool family; do not pass it to Integration API DPI tools.
+  """
   applicationId: Int
+
+  """
+  V2 traffic-flow category ID used for one-way name annotation. Scoped to the V2 traffic-flow tool family; do not pass it to Integration API DPI tools.
+  """
   categoryId: Int
   bytes: Int
   applicationName: String

--- a/apps/api/src/unifi_api/graphql/types/network/traffic_flow.py
+++ b/apps/api/src/unifi_api/graphql/types/network/traffic_flow.py
@@ -168,8 +168,18 @@ class TrafficFlowTopDestination:
 
 @strawberry.type(description="An application in a traffic-flow Top-Talkers ranking (by bytes).")
 class TrafficFlowTopApplication:
-    application_id: int | None
-    category_id: int | None
+    application_id: int | None = strawberry.field(
+        description=(
+            "Low V2 traffic-flow application ID. Scoped to the V2 traffic-flow tool family; "
+            "do not pass it to Integration API DPI tools."
+        )
+    )
+    category_id: int | None = strawberry.field(
+        description=(
+            "V2 traffic-flow category ID used for one-way name annotation. Scoped to the V2 "
+            "traffic-flow tool family; do not pass it to Integration API DPI tools."
+        )
+    )
     bytes: int | None
     application_name: str | None
     category_name: str | None

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -106,7 +106,10 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
         "stats_manager": lambda cm: StatsManager(cm, ClientManager(cm)),
         "switch_manager": lambda cm: SwitchManager(cm),
         "system_manager": lambda cm: SystemManager(cm),
-        "traffic_flow_manager": lambda cm: TrafficFlowManager(cm),
+        "traffic_flow_manager": lambda cm: TrafficFlowManager(
+            cm,
+            DpiManager(cm, getattr(cm, "unifi_auth", None)),
+        ),
         "traffic_route_manager": lambda cm: TrafficRouteManager(cm),
         "usergroup_manager": lambda cm: UsergroupManager(cm),
         "vpn_manager": lambda cm: VpnManager(cm),

--- a/apps/api/tests/graphql/fixtures/network/test_traffic_flows.py
+++ b/apps/api/tests/graphql/fixtures/network/test_traffic_flows.py
@@ -155,8 +155,8 @@ async def test_traffic_flow_statistics(tmp_path, monkeypatch):
                         "application_id": 470,
                         "category_id": 4,
                         "bytes": 999,
-                        "application_name": None,
-                        "category_name": None,
+                        "application_name": "Netflix",
+                        "category_name": "Media streaming services",
                     }
                 ],
                 "top_blocked_policies": [
@@ -174,7 +174,7 @@ async def test_traffic_flow_statistics(tmp_path, monkeypatch):
             topClients {{ count clientName clientMac }}
             topBlockedClients {{ count clientName }}
             topDestinations {{ destination mostFrequentRegion }}
-            topApplications {{ applicationId categoryId bytes applicationName }}
+            topApplications {{ applicationId categoryId bytes applicationName categoryName }}
             topBlockedPolicies {{ policyName policyType }}
         }} }}
     }}""",
@@ -186,8 +186,45 @@ async def test_traffic_flow_statistics(tmp_path, monkeypatch):
     assert stats["topBlockedClients"] == []
     assert stats["topDestinations"][0]["mostFrequentRegion"] == "US"
     assert stats["topApplications"][0]["applicationId"] == 470
-    assert stats["topApplications"][0]["applicationName"] is None
+    assert stats["topApplications"][0]["applicationName"] == "Netflix"
+    assert stats["topApplications"][0]["categoryName"] == "Media streaming services"
     assert stats["topBlockedPolicies"][0]["policyName"] == "Region Blocking"
+
+
+@pytest.mark.asyncio
+async def test_traffic_flow_statistics_preserves_unresolved_names(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="network")
+    stub_managers(
+        monkeypatch,
+        {
+            ("network", "traffic_flow_manager", "get_traffic_flow_statistics"): {
+                "top_applications": [
+                    {
+                        "application_id": 470,
+                        "category_id": 4,
+                        "bytes": 999,
+                        "application_name": None,
+                        "category_name": None,
+                    }
+                ]
+            },
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        network {{ trafficFlowStatistics(controller: "{cid}") {{
+            topApplications {{ applicationId categoryId applicationName categoryName }}
+        }} }}
+    }}''',
+    )
+
+    assert body.get("errors") is None, body
+    application = body["data"]["network"]["trafficFlowStatistics"]["topApplications"][0]
+    assert application["applicationName"] is None
+    assert application["categoryName"] is None
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/serializers/test_network_traffic_flows.py
+++ b/apps/api/tests/serializers/test_network_traffic_flows.py
@@ -104,7 +104,13 @@ _STATS_MANAGER_OUTPUT = {
     "top_blocked_clients": [{"count": 7, "client_mac": "aa:bb:cc:00:00:02", "client_name": "Blocked-Host"}],
     "top_destinations": [{"count": 200, "destination": "example.test", "most_frequent_region": "US"}],
     "top_applications": [
-        {"application_id": 470, "category_id": 4, "bytes": 999, "application_name": None, "category_name": None}
+        {
+            "application_id": 470,
+            "category_id": 4,
+            "bytes": 999,
+            "application_name": "Netflix",
+            "category_name": "Media streaming services",
+        }
     ],
     "top_blocked_policies": [
         {"count": 7, "policy_id": "p1", "policy_name": "Region Blocking", "policy_type": "PROTECTION"}
@@ -124,13 +130,35 @@ def test_statistics_from_manager_output_maps_fields() -> None:
     assert d["top_blocked_policies"][0]["policy_name"] == "Region Blocking"
 
 
-def test_statistics_top_application_name_nullable() -> None:
+def test_statistics_projects_resolved_top_application_names() -> None:
     from unifi_api.graphql.types.network.traffic_flow import TrafficFlowStatistics
 
     app = TrafficFlowStatistics.from_manager_output(_STATS_MANAGER_OUTPUT).to_dict()["top_applications"][0]
     assert app["application_id"] == 470
     assert app["category_id"] == 4
     assert app["bytes"] == 999
+    assert app["application_name"] == "Netflix"
+    assert app["category_name"] == "Media streaming services"
+
+
+def test_statistics_preserves_unresolved_top_application_names() -> None:
+    from unifi_api.graphql.types.network.traffic_flow import TrafficFlowStatistics
+
+    raw = {
+        **_STATS_MANAGER_OUTPUT,
+        "top_applications": [
+            {
+                "application_id": 470,
+                "category_id": 4,
+                "bytes": 999,
+                "application_name": None,
+                "category_name": None,
+            }
+        ],
+    }
+
+    app = TrafficFlowStatistics.from_manager_output(raw).to_dict()["top_applications"][0]
+
     assert app["application_name"] is None
     assert app["category_name"] is None
 

--- a/apps/api/tests/test_managers_factory.py
+++ b/apps/api/tests/test_managers_factory.py
@@ -104,6 +104,18 @@ def test_firewall_manager_builder_receives_connection_auth() -> None:
     assert manager._auth is auth
 
 
+def test_traffic_flow_manager_builder_receives_dpi_catalog_with_connection_auth() -> None:
+    auth = object()
+    cm = _FakeCM()
+    cm.unifi_auth = auth
+
+    manager = _build_network_managers()["traffic_flow_manager"](cm)
+
+    assert manager._connection is cm
+    assert manager._dpi_manager._connection is cm
+    assert manager._dpi_manager._auth is auth
+
+
 @pytest.mark.asyncio
 async def test_invalidate_drops_cached_instance(tmp_path: Path, monkeypatch) -> None:
     _patch_network_cm(monkeypatch)

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -11,8 +11,9 @@ dependencies = [
     # there's one source of truth.
     # WAN delegation validation requires Core 0.4.30. Firewall-zone CRUD
     # requires the dual-API bridge added in Core 0.4.32. WLAN schedule-window
-    # validation requires Core 0.4.34.
-    "unifi-core[network]>=0.4.34,<0.5",
+    # validation requires Core 0.4.34. Traffic-flow DPI name enrichment
+    # requires Core 0.4.36.
+    "unifi-core[network]>=0.4.36,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -277,7 +277,7 @@ def get_routing_manager() -> RoutingManager:
 
 @lru_cache
 def get_traffic_flow_manager() -> TrafficFlowManager:
-    return TrafficFlowManager(get_connection_manager())
+    return TrafficFlowManager(get_connection_manager(), get_dpi_manager())
 
 
 @lru_cache

--- a/apps/network/src/unifi_network_mcp/tools/traffic_flows.py
+++ b/apps/network/src/unifi_network_mcp/tools/traffic_flows.py
@@ -99,8 +99,11 @@ async def get_traffic_flows(
         "region count breakdowns plus Top-Talker rankings for a preset period: top clients, top "
         "destinations, top applications (by bytes), top blocked clients, and top blocking policies. "
         "Risk bands are low/medium/high (the UI labels these Low/Suspicious/Concerning). Application "
-        "entries carry DPI application_id/category_id and bytes; application_name/category_name are "
-        "null (DPI-catalog name resolution is not yet wired). Read-only."
+        "entries include best-effort DPI application/category names resolved from the controller catalogue; "
+        "names remain null when the catalogue is unavailable or has no matching entry. The returned "
+        "application_id is the low V2 traffic-flow application ID, not the Integration API compound ID. "
+        "These IDs are scoped to the V2 traffic-flow tool family — do not pass them to Integration API DPI "
+        "tools. Read-only."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -9481,7 +9481,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Aggregated UniFi Traffic Flows summary (Insights > Flows 'Flow Summary'). Returns risk and region count breakdowns plus Top-Talker rankings for a preset period: top clients, top destinations, top applications (by bytes), top blocked clients, and top blocking policies. Risk bands are low/medium/high (the UI labels these Low/Suspicious/Concerning). Application entries carry DPI application_id/category_id and bytes; application_name/category_name are null (DPI-catalog name resolution is not yet wired). Read-only.",
+      "description": "Aggregated UniFi Traffic Flows summary (Insights > Flows 'Flow Summary'). Returns risk and region count breakdowns plus Top-Talker rankings for a preset period: top clients, top destinations, top applications (by bytes), top blocked clients, and top blocking policies. Risk bands are low/medium/high (the UI labels these Low/Suspicious/Concerning). Application entries include best-effort DPI application/category names resolved from the controller catalogue; names remain null when the catalogue is unavailable or has no matching entry. The returned application_id is the low V2 traffic-flow application ID, not the Integration API compound ID. These IDs are scoped to the V2 traffic-flow tool family \u2014 do not pass them to Integration API DPI tools. Read-only.",
       "name": "unifi_get_traffic_flow_statistics",
       "schema": {
         "input": {

--- a/apps/network/tests/unit/test_traffic_flows_tool.py
+++ b/apps/network/tests/unit/test_traffic_flows_tool.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from unifi_network_mcp.runtime import traffic_flow_manager
+from unifi_network_mcp.runtime import dpi_manager, traffic_flow_manager
 from unifi_network_mcp.tools.traffic_flows import (
     get_traffic_flow_statistics,
     get_traffic_flows,
@@ -25,6 +25,10 @@ _ENVELOPE = {
     "has_next": True,
     "or_more": True,
 }
+
+
+def test_runtime_wires_dpi_catalog_manager_into_traffic_flow_manager():
+    assert traffic_flow_manager._dpi_manager is dpi_manager
 
 
 @pytest.mark.asyncio

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -205,6 +205,14 @@ for name in registry.all_tools():
         )
 if failures:
     raise SystemExit("\\n".join(failures))
+connection = type("Connection", (), {"unifi_auth": object()})()
+traffic_flow_manager = _PRODUCT_BUILDERS["network"]()["traffic_flow_manager"](connection)
+if traffic_flow_manager._connection is not connection:
+    raise SystemExit("traffic_flow_manager did not retain the API connection manager")
+if traffic_flow_manager._dpi_manager._connection is not connection:
+    raise SystemExit("traffic_flow_manager DPI provider did not retain the API connection manager")
+if traffic_flow_manager._dpi_manager._auth is not connection.unifi_auth:
+    raise SystemExit("traffic_flow_manager DPI provider did not retain the API connection auth")
 print(f"validated {len(registry)} catalog bindings against installed Core floor")
 """
 
@@ -246,6 +254,8 @@ for module_name in sorted(set(manifest["module_map"].values())):
             failures.append(f"{module_name}: missing {manager_name}.{call.attr}")
 if not checked:
     failures.append("no direct Core manager call sites were discovered")
+if runtime.traffic_flow_manager._dpi_manager is not runtime.dpi_manager:
+    failures.append("traffic_flow_manager is not wired to the runtime DPI catalogue manager")
 if failures:
     raise SystemExit("\\n".join(failures))
 print(f"validated {len(checked)} direct Core manager call sites against installed Core floor")


### PR DESCRIPTION
## Summary

- Resolves DPI application and category names in traffic-flow Top Applications.
- Wires the Core 0.4.36 enrichment contract into Network MCP, REST, and GraphQL.
- Keeps enrichment best-effort: unavailable or incomplete catalogues leave names null without changing V2 IDs, byte counts, or ordering.
- Scopes the returned V2 traffic-flow IDs explicitly so they are not confused with Integration API compound IDs.

Closes #546

## Type of change

- [ ] `fix:` bug fix
- [x] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [ ] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [x] Network MCP server
- [ ] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [x] API server
- [ ] Shared packages (the prerequisite landed separately in #598 and was released as Core 0.4.36)
- [x] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran `make pre-commit`.
- [x] I regenerated the Network manifest.
- [x] I regenerated GraphQL SDL, OpenAPI, and both API reference documents.
- [x] I added regression coverage for runtime wiring, exact published-Core floors, populated projections, and nullable fallback projections.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- `make pre-commit` — passed across the full workspace (including 1,780 Core, 1,074 Network, and 1,360 API tests).
- Exact published-Core floor contracts — Network 179 direct call sites and API 271 catalogue bindings passed against Core 0.4.36; both checks instantiate the new traffic-flow wiring.
- Independent post-fix correctness and test-contract reviews — no remaining findings.
- Live read-only branch probe — complete 2,112-application/35-category catalogue, supported `limit=200` pagination, 100/100 current Top Applications enriched through Network and API projection, 100/100 null-name fallback without an API key, with V2 IDs/category IDs/bytes/order preserved.

## Notes for reviewers

The V2 → Integration API mapping is a verified 1:1, read-only annotation join. It does not make either API family's IDs portable to another tool family. The original traffic-flow IDs remain unchanged, and unresolved names remain null.
