### PR TITLE
fix(access,api): deliver the system-log event fixes to every surface

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -8,9 +8,9 @@ dependencies = [
     "unifi-mcp-shared>=0.6.7,<0.7",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
-    # declaring py-unifi-access here directly. Access event identity requires
-    # Core 0.4.31 for separator-insensitive Access device MAC resolution.
-    "unifi-core[access]>=0.4.31,<0.5",
+    # declaring py-unifi-access here directly. Access system-log event
+    # normalization and websocket topics require Core 0.4.33.
+    "unifi-core[access]>=0.4.33,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/access/src/unifi_access_mcp/main.py
+++ b/apps/access/src/unifi_access_mcp/main.py
@@ -69,8 +69,12 @@ async def main_async():
         if ws_enabled:
             try:
                 event_manager.set_server(server)
-                # TODO: Implement websocket event listening for Access
-                logger.info("Access event websocket listener not yet implemented.")
+                # start_listening needs an API client: the Access websocket is
+                # key-authenticated, and a proxy-only session cannot open it.
+                # It logs that condition itself and returns without raising, so
+                # a proxy-only deployment keeps working with REST queries and
+                # an empty recent-events buffer.
+                await event_manager.start_listening()
             except Exception as ws_exc:
                 logger.error(
                     "Failed to start event websocket listener: %s. "

--- a/apps/access/src/unifi_access_mcp/tools/events.py
+++ b/apps/access/src/unifi_access_mcp/tools/events.py
@@ -38,7 +38,12 @@ async def access_list_events(
     topic: Annotated[
         str,
         Field(
-            description="Event topic to query: 'admin' (user/account changes) or 'admin_activity' (admin actions). Default: admin."
+            description=(
+                "Event topic, mirroring the Access UI's syslog Category filter: 'unlocks' "
+                "(door grants and open/close), 'access_denial' (refused attempts), 'ring' "
+                "(doorbell), 'updates', 'critical', 'admin' (user/account changes), "
+                "'admin_activity' (admin actions). No other value is accepted. Default: admin."
+            )
         ),
     ] = "admin",
     start: Annotated[
@@ -122,7 +127,14 @@ async def access_get_event(
 async def access_recent_events(
     event_type: Annotated[
         Optional[str],
-        Field(description=("Filter by event type: door_open, door_close, access_granted, access_denied, door_alarm.")),
+        Field(
+            description=(
+                "Filter by event type, matched exactly against the controller's own dotted "
+                "event names as delivered over the websocket - e.g. 'access.door.unlock', "
+                "'access.dps.status.update', 'access.logs.add', 'access.hw.door_bell', "
+                "'access.data.device.remote_unlock'. Omit to return every buffered event."
+            )
+        ),
     ] = None,
     door_id: Annotated[
         Optional[str],

--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -1941,7 +1941,7 @@
               "type": "string"
             },
             "topic": {
-              "description": "Event topic to query: 'admin' (user/account changes) or 'admin_activity' (admin actions). Default: admin.",
+              "description": "Event topic, mirroring the Access UI's syslog Category filter: 'unlocks' (door grants and open/close), 'access_denial' (refused attempts), 'ring' (doorbell), 'updates', 'critical', 'admin' (user/account changes), 'admin_activity' (admin actions). No other value is accepted. Default: admin.",
               "type": "string"
             },
             "user_id": {
@@ -2639,7 +2639,7 @@
               "type": "string"
             },
             "event_type": {
-              "description": "Filter by event type: door_open, door_close, access_granted, access_denied, door_alarm.",
+              "description": "Filter by event type, matched exactly against the controller's own dotted event names as delivered over the websocket - e.g. 'access.door.unlock', 'access.dps.status.update', 'access.logs.add', 'access.hw.door_bell', 'access.data.device.remote_unlock'. Omit to return every buffered event.",
               "type": "string"
             },
             "limit": {

--- a/apps/access/tests/unit/test_websocket_wiring.py
+++ b/apps/access/tests/unit/test_websocket_wiring.py
@@ -1,0 +1,71 @@
+"""Guard the call site: `main_async` must start the event listener.
+
+`EventManager.start_listening` existed, was unit-tested, and was never called
+by the application — `main_async` carried a TODO and a log line claiming the
+feature was unimplemented, where the Protect server calls it. The manager tests
+passed because they invoked the manager directly, so nothing caught that the
+buffer could not fill in production.
+
+These tests drive `main_async` and assert on what it actually awaits. An
+earlier version asserted that the call appeared in `inspect.getsource`, which
+would have passed with the call commented out — the very state it was written
+to catch.
+"""
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+from unifi_access_mcp import main as access_main
+from unifi_access_mcp.runtime import config
+
+
+@contextmanager
+def _startup(*, connected: bool, websocket_enabled: bool, listener: AsyncMock | None = None):
+    """Run `main_async` with its side effects stubbed.
+
+    Only the connection, the listener and the two long-running tails are
+    replaced. The websocket decision itself runs for real, since that branch is
+    what these tests are about.
+    """
+    events = dict(getattr(config.access, "events", {}) or {})
+    events["websocket_enabled"] = websocket_enabled
+    with (
+        patch.object(config.access, "events", events),
+        patch("unifi_mcp_shared.bootstrap.assert_credentials_configured"),
+        patch.object(access_main.connection_manager, "initialize", AsyncMock(return_value=connected)),
+        patch.object(access_main.event_manager, "set_server"),
+        patch.object(access_main.event_manager, "start_listening", listener or AsyncMock()) as started,
+        patch("unifi_mcp_shared.tool_registration.register_tools_for_mode", AsyncMock()),
+        patch("unifi_mcp_shared.transport.resolve_http_config", return_value=(False, "http", "0.0.0.0", 3002)),
+        patch("unifi_mcp_shared.transport.run_transports", AsyncMock()) as transports,
+    ):
+        asyncio.run(access_main.main_async())
+        yield started, transports
+
+
+def test_the_listener_is_started_on_a_successful_websocket_enabled_startup() -> None:
+    with _startup(connected=True, websocket_enabled=True) as (started, transports):
+        started.assert_awaited_once()
+        assert transports.await_count == 1, "startup never reached its transports"
+
+
+def test_the_listener_is_not_started_when_the_connection_fails() -> None:
+    """A failed connection has no session to listen on."""
+    with _startup(connected=False, websocket_enabled=True) as (started, _):
+        started.assert_not_awaited()
+
+
+def test_the_listener_is_not_started_when_the_websocket_is_disabled() -> None:
+    """`websocket_enabled: false` is a supported deployment — REST queries only."""
+    with _startup(connected=True, websocket_enabled=False) as (started, _):
+        started.assert_not_awaited()
+
+
+def test_a_listener_failure_does_not_take_the_server_down() -> None:
+    """The websocket is optional: a proxy-only deployment must still serve
+    tools, so the failure is logged and startup continues."""
+    failing = AsyncMock(side_effect=RuntimeError("no api client"))
+    with _startup(connected=True, websocket_enabled=True, listener=failing) as (started, transports):
+        started.assert_awaited_once()
+        assert transports.await_count == 1, "a websocket failure stopped the server starting"

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -53,6 +53,7 @@ type AccessEvent {
   doorId: String
   userId: String
   credentialId: String
+  message: String
   result: String
 
   """The door this event references."""

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -9,9 +9,10 @@ dependencies = [
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently. Access event
     # identity and paged lookup require Core 0.4.30; shared MAC comparison
-    # across the GraphQL and SSE surfaces requires Core 0.4.31. Firewall-zone
-    # actions require the dual-API bridge added in Core 0.4.32.
-    "unifi-core[network,protect,access]>=0.4.32,<0.5",
+    # across the GraphQL and SSE surfaces requires Core 0.4.31; firewall-zone
+    # actions require Core 0.4.32; Access system-log event normalization
+    # requires Core 0.4.33.
+    "unifi-core[network,protect,access]>=0.4.33,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -437,7 +437,7 @@
             "type": "string"
           },
           "topic": {
-            "description": "Event topic to query: 'admin' (user/account changes) or 'admin_activity' (admin actions). Default: admin.",
+            "description": "Event topic, mirroring the Access UI's syslog Category filter: 'unlocks' (door grants and open/close), 'access_denial' (refused attempts), 'ring' (doorbell), 'updates', 'critical', 'admin' (user/account changes), 'admin_activity' (admin actions). No other value is accepted. Default: admin.",
             "type": "string"
           },
           "user_id": {
@@ -573,7 +573,7 @@
             "type": "string"
           },
           "event_type": {
-            "description": "Filter by event type: door_open, door_close, access_granted, access_denied, door_alarm.",
+            "description": "Filter by event type, matched exactly against the controller's own dotted event names as delivered over the websocket - e.g. 'access.door.unlock', 'access.dps.status.update', 'access.logs.add', 'access.hw.door_bell', 'access.data.device.remote_unlock'. Omit to return every buffered event.",
             "type": "string"
           },
           "limit": {

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -42,6 +42,7 @@ type AccessEvent {
   doorId: String
   userId: String
   credentialId: String
+  message: String
   result: String
 
   """The door this event references."""

--- a/apps/api/src/unifi_api/graphql/types/access/events.py
+++ b/apps/api/src/unifi_api/graphql/types/access/events.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
 from strawberry.types import Info
+from unifi_core.access.models.events import event_from_controller
 
 if TYPE_CHECKING:
     from unifi_api.graphql.types.access.doors import Door
@@ -66,6 +67,7 @@ class Event:
     door_id: str | None
     user_id: str | None
     credential_id: str | None
+    message: str | None
     result: str | None
 
     # Context for relationship edges — NOT in SDL, NOT in to_dict().
@@ -83,19 +85,41 @@ class Event:
 
     @classmethod
     def from_manager_output(cls, obj: Any) -> "Event":
-        door_id = _get(obj, "door_id")
-        user_id = _get(obj, "user_id")
+        """Project a controller row.
+
+        ``access_list_events`` hands back RAW controller rows, not ``Event``
+        models. The ``insights/system_log/search`` shape uses ``event_type``,
+        ``published`` in epoch millis, and nests the actor/door/credential under
+        ``metadata`` — so reading ``type``/``timestamp``/``door_id``/``user_id``
+        straight off it produced a row carrying nothing but an id and a result.
+        Normalising through the same function the MCP tool uses is what keeps
+        all three surfaces agreeing on one shape.
+        """
+        # Unwrap ``.raw`` first: this module's ``_get`` does, but the core
+        # helper's does not, so a wrapper object would otherwise normalise to
+        # an all-None row - silently, with no error.
+        source = obj
+        if not isinstance(obj, dict):
+            raw = getattr(obj, "raw", None)
+            if isinstance(raw, dict):
+                source = raw
+        norm = event_from_controller(source)
         inst = cls(
-            id=_get(obj, "id"),
-            type=_get(obj, "type"),
-            timestamp=_get(obj, "timestamp") or _get(obj, "time"),
-            door_id=door_id,
-            user_id=user_id,
-            credential_id=_get(obj, "credential_id"),
-            result=_get(obj, "result"),
+            id=norm.id,
+            type=norm.type,
+            timestamp=norm.timestamp,
+            door_id=norm.door_id,
+            user_id=norm.user_id,
+            credential_id=norm.credential_id,
+            # Read ``message`` from the row rather than the model: the declared
+            # unifi-core floor has no ``message`` field, so ``norm.message``
+            # raises AttributeError and 500s every events request until a core
+            # release lands. The row carries it at every floor.
+            message=_get(source, "message"),
+            result=norm.result,
         )
-        inst._door_id = door_id
-        inst._user_id = user_id
+        inst._door_id = norm.door_id
+        inst._user_id = norm.user_id
         return inst
 
     def to_dict(self) -> dict:

--- a/apps/api/src/unifi_api/graphql/types/access/events.py
+++ b/apps/api/src/unifi_api/graphql/types/access/events.py
@@ -111,11 +111,7 @@ class Event:
             door_id=norm.door_id,
             user_id=norm.user_id,
             credential_id=norm.credential_id,
-            # Read ``message`` from the row rather than the model: the declared
-            # unifi-core floor has no ``message`` field, so ``norm.message``
-            # raises AttributeError and 500s every events request until a core
-            # release lands. The row carries it at every floor.
-            message=_get(source, "message"),
+            message=norm.message,
             result=norm.result,
         )
         inst._door_id = norm.door_id

--- a/apps/api/src/unifi_api/serializers/access/events.py
+++ b/apps/api/src/unifi_api/serializers/access/events.py
@@ -40,6 +40,7 @@ def _event_payload(obj) -> dict:
         "door_id": _get(obj, "door_id"),
         "user_id": _get(obj, "user_id"),
         "credential_id": _get(obj, "credential_id"),
+        "message": _get(obj, "message"),
         "result": _get(obj, "result"),
     }
 

--- a/apps/api/tests/graphql/fixtures/access/test_events.py
+++ b/apps/api/tests/graphql/fixtures/access/test_events.py
@@ -425,10 +425,9 @@ def test_projection_unwraps_a_raw_wrapped_row() -> None:
     assert projected.timestamp is not None
 
 
-def test_projection_reads_message_without_touching_the_model_attribute() -> None:
-    """The declared unifi-core floor has no `message` field on Event, so
-    reading `norm.message` raises AttributeError and 500s every events
-    request. The value must come from the row."""
+def test_projection_reads_message_from_the_normalized_model() -> None:
+    """The declared Core floor owns the canonical event projection, including
+    the human-readable message exposed by GraphQL and REST."""
     from unifi_api.graphql.types.access.events import Event
 
     assert Event.from_manager_output({"id": "e1", "message": "Access Granted (Face)"}).message == (

--- a/apps/api/tests/graphql/fixtures/access/test_events.py
+++ b/apps/api/tests/graphql/fixtures/access/test_events.py
@@ -322,3 +322,115 @@ async def test_access_activity_summary(tmp_path, monkeypatch):
     assert summary["totalEvents"] == 42
     assert summary["grantedCount"] == 38
     assert summary["deniedCount"] == 4
+
+
+@pytest.mark.asyncio
+async def test_access_events_expose_the_controller_message(tmp_path, monkeypatch):
+    """The system-log rows carry a human-readable summary; the API surfaces
+    must not drop it. `access.door.unlock` renders as "Access Granted (Face)",
+    which is the only field that says what actually happened."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    stub_managers(
+        monkeypatch,
+        {
+            ("access", "event_manager", "list_events"): [
+                {
+                    "id": "evt1",
+                    "type": "access.door.unlock",
+                    "message": "Access Granted (Face)",
+                    "timestamp": "2026-08-18T12:00:00+00:00",
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ events(controller: "{cid}", limit: 10) {{
+            items {{ id message }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    items = body["data"]["access"]["events"]["items"]
+    assert items[0]["message"] == "Access Granted (Face)"
+
+
+@pytest.mark.asyncio
+async def test_access_events_project_the_real_system_log_shape(tmp_path, monkeypatch):
+    """`access_list_events` returns raw controller rows, not Event models, and
+    the system-log shape uses `event_type` / `published` / nested `metadata`.
+    Reading `type`/`timestamp`/`door_id`/`user_id` off it yielded a row that was
+    nothing but an id and a result — on GraphQL and REST, the exact bug the core
+    model fix addresses."""
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    stub_managers(
+        monkeypatch,
+        {
+            ("access", "event_manager", "list_events"): [
+                {
+                    "id": "",
+                    "log_key": "access.door.unlock",
+                    "event_type": "access.door.unlock",
+                    "message": "Access Granted (Face)",
+                    "published": 1787054400000,
+                    "result": "ACCESS",
+                    "metadata": {
+                        "actor": {"id": "person-uuid", "type": "user", "display_name": "Test Person"},
+                        "door": {"id": "door-uuid", "type": "door", "display_name": "Test Door"},
+                    },
+                },
+            ],
+        },
+    )
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ events(controller: "{cid}", limit: 10) {{
+            items {{ type timestamp doorId userId message result }}
+        }} }}
+    }}''',
+    )
+    assert body.get("errors") is None, body
+    row = body["data"]["access"]["events"]["items"][0]
+    assert row["type"] == "access.door.unlock", row
+    assert row["timestamp"] is not None, "every system-log row was timeless"
+    assert row["doorId"] == "door-uuid", row
+    assert row["userId"] == "person-uuid", row
+    assert row["message"] == "Access Granted (Face)"
+    assert row["result"] == "ACCESS"
+
+
+# --- projection unwrapping ----------------------------------------------------
+
+
+def test_projection_unwraps_a_raw_wrapped_row() -> None:
+    """Manager output may be a wrapper exposing `.raw`. This module's `_get`
+    unwraps it; the core normaliser's does not, so handing the wrapper straight
+    over yielded an all-None row - silently, with no error."""
+    from unifi_api.graphql.types.access.events import Event
+
+    class Wrapped:
+        def __init__(self, raw):
+            self.raw = raw
+
+    row = Wrapped({"event_type": "access.door.unlock", "message": "Access Granted (Face)", "published": 1787054400000})
+    projected = Event.from_manager_output(row)
+    assert projected.type == "access.door.unlock"
+    assert projected.message == "Access Granted (Face)"
+    assert projected.timestamp is not None
+
+
+def test_projection_reads_message_without_touching_the_model_attribute() -> None:
+    """The declared unifi-core floor has no `message` field on Event, so
+    reading `norm.message` raises AttributeError and 500s every events
+    request. The value must come from the row."""
+    from unifi_api.graphql.types.access.events import Event
+
+    assert Event.from_manager_output({"id": "e1", "message": "Access Granted (Face)"}).message == (
+        "Access Granted (Face)"
+    )

--- a/apps/api/tests/serializers/test_access_credentials_visitors_events.py
+++ b/apps/api/tests/serializers/test_access_credentials_visitors_events.py
@@ -185,12 +185,14 @@ def test_access_recent_events_shape() -> None:
             "door_id": "door-1",
             "user_id": "user-2",
             "credential_id": None,
+            "message": "Access denied",
             "result": "denied",
         }
     ]
     out = s.serialize_action(sample, tool_name="access_recent_events")
     assert out["success"] is True
     assert out["data"][0]["id"] == "evt-2"
+    assert out["data"][0]["message"] == "Access denied"
     assert out["data"][0]["result"] == "denied"
     assert out["render_hint"]["kind"] == "event_log"
 


### PR DESCRIPTION
## What changed

This delivers the Access system-log fixes from #559 through every downstream surface:

- starts the Access websocket listener during MCP server startup
- documents all seven supported system-log topics and the controller's dotted websocket event names
- normalizes Access system-log rows consistently across MCP, REST, GraphQL, and SSE
- exposes the controller-rendered `message` field through REST, GraphQL, and recent-event serialization
- raises the Access and API `unifi-core` floors to `0.4.33`, the published release containing the required normalization and websocket behavior

## Why

The Core fix is now merged and published as `core/v0.4.33`. Without this downstream delivery, the listener remains dead during Access MCP startup and API clients still receive incomplete system-log rows.

Credential projection remains intentionally narrow because the live controller has not established a safe canonical mapping between `authentication`, `nfc_id`, and credential UUIDs. API topic selection remains separate follow-up #560 because it changes the public API contract.

Closes #548.

## Validation

- rebased cleanly onto current `main`
- `make pre-commit` passed
- focused Access startup tests: 4 passed
- focused Access GraphQL fixtures: 23 passed
- Access/API event projection and resource tests: 99 passed
- full pin-alignment checks passed, including 271 API action bindings against published Core 0.4.33
- maintainer live smoke passed for Access safe lifecycle, API actions, API resource parity, and Network/Protect/Access SSE streams
- targeted live startup established a connected Access websocket using the wildcard handler
- targeted live REST/GraphQL projection returned the same 10 IDs with `id`, `type`, `timestamp`, and `message` populated on all 10 rows

<details>
<summary>Maintainer live validation excerpts</summary>

```text
access readonly ok: access_list_events (77ms)
access readonly ok: access_get_event (6415ms)
access lifecycle:create ok: access_create_visitor (101ms)
access lifecycle:delete ok: access_delete_visitor (105ms)
access lifecycle:verify-cleanup-status ok: access_delete_visitor - Developer API DELETE revokes access and retains the visitor as cancelled history

api-actions pass: access_list_doors http=200 success=True live_count=1
api-actions pass: access_list_users http=200 success=True live_count=5
api-actions pass: access_list_visitors http=200 success=True live_count=16

api-resources pass: /v1/sites/default/doors http=200 items=1 parity=ok
api-resources pass: /v1/sites/default/users http=200 items=5 parity=ok
api-resources pass: /v1/sites/default/visitors http=200 items=10 parity=ok

api-streams pass: /v1/streams/network/events events=0 keepalives=1
api-streams pass: /v1/streams/protect/events events=0 keepalives=1
api-streams pass: /v1/streams/access/events events=0 keepalives=1

{'rest_count': 10, 'graphql_count': 10, 'matching_ids': 10, 'populated_rest_fields': {'id': 10, 'type': 10, 'timestamp': 10, 'message': 10}}

{'listener_called': True, 'handlers': ['*'], 'socket_type': 'UnifiAccessWebsocket', 'is_running': True, 'is_connected': True}
```

</details>
