### PR TITLE
fix(access): complete stable event identity delivery

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -8,8 +8,9 @@ dependencies = [
     "unifi-mcp-shared>=0.6.7,<0.7",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
-    # declaring py-unifi-access here directly.
-    "unifi-core[access]>=0.4.22,<0.5",
+    # declaring py-unifi-access here directly. Access event identity requires
+    # Core 0.4.30 so listed system-log rows remain addressable.
+    "unifi-core[access]>=0.4.30,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/access/src/unifi_access_mcp/tools/events.py
+++ b/apps/access/src/unifi_access_mcp/tools/events.py
@@ -92,7 +92,7 @@ async def access_list_events(
     auth="local_only",
 )
 async def access_get_event(
-    event_id: Annotated[str, Field(description="Event UUID (from access_list_events or access_recent_events)")],
+    event_id: Annotated[str, Field(description="Event ID (from access_list_events or access_recent_events)")],
 ) -> Dict[str, Any]:
     """Get a single event by ID."""
     logger.info("access_get_event tool called for %s", event_id)

--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -1117,7 +1117,7 @@
         "input": {
           "properties": {
             "event_id": {
-              "description": "Event UUID (from access_list_events or access_recent_events)",
+              "description": "Event ID (from access_list_events or access_recent_events)",
               "type": "string"
             }
           },

--- a/apps/access/tests/unit/test_event_tools.py
+++ b/apps/access/tests/unit/test_event_tools.py
@@ -1,0 +1,56 @@
+"""Tool-layer tests for Access event identity."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unifi_core.access.models.events import SYNTHETIC_EVENT_ID_PREFIX, event_identity
+
+os.environ.setdefault("UNIFI_ACCESS_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_ACCESS_USERNAME", "test")
+os.environ.setdefault("UNIFI_ACCESS_PASSWORD", "test")
+
+
+@pytest.mark.asyncio
+async def test_list_events_projects_a_stable_system_log_id() -> None:
+    raw = {
+        "id": "",
+        "published": 1773766800123,
+        "event_type": "access.admin.update",
+        "metadata": {"user": {"id": "user-1"}},
+    }
+
+    with patch("unifi_access_mcp.tools.events.event_manager") as manager:
+        manager.list_events = AsyncMock(return_value=[raw])
+        from unifi_access_mcp.tools.events import access_list_events
+
+        result = await access_list_events()
+
+    event_id = result["data"]["events"][0]["id"]
+    assert result["success"] is True
+    assert event_id == event_identity(raw)
+    assert event_id.startswith(SYNTHETIC_EVENT_ID_PREFIX)
+
+
+@pytest.mark.asyncio
+async def test_get_event_round_trips_the_synthetic_id() -> None:
+    raw = {
+        "id": "",
+        "published": 1773766800123,
+        "event_type": "access.admin.update",
+        "metadata": {"user": {"id": "user-1"}},
+    }
+    event_id = event_identity(raw)
+
+    with patch("unifi_access_mcp.tools.events.event_manager") as manager:
+        manager.get_event = AsyncMock(return_value=raw)
+        from unifi_access_mcp.tools.events import access_get_event
+
+        result = await access_get_event(event_id)
+
+    assert result["success"] is True
+    assert result["data"]["id"] == event_id
+    manager.get_event.assert_awaited_once_with(event_id)

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -7,8 +7,9 @@ requires-python = ">=3.13"
 dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
-    # aiounifi / uiprotect / py-unifi-access transparently.
-    "unifi-core[network,protect,access]>=0.4.29,<0.5",
+    # aiounifi / uiprotect / py-unifi-access transparently. Access event
+    # identity and paged lookup require Core 0.4.30.
+    "unifi-core[network,protect,access]>=0.4.30,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -261,7 +261,7 @@
       "input_schema": {
         "properties": {
           "event_id": {
-            "description": "Event UUID (from access_list_events or access_recent_events)",
+            "description": "Event ID (from access_list_events or access_recent_events)",
             "type": "string"
           }
         },

--- a/apps/api/src/unifi_api/graphql/resolvers/access.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/access.py
@@ -6,10 +6,9 @@ Phase 6 PR4 Task C — wires every migrated access read tool into a typed
 - Fetch helpers route through ``ctx.cache.get_or_fetch`` so concurrent
   resolvers in the same request share a single manager round-trip.
 - Page wrappers carry pagination cursors per LIST resolver.
-- DETAIL resolvers either filter the cached LIST snapshot by primary key
-  (``door``, ``event``, ``user``, ``credential``, ``policy``, ``visitor``,
-  ``device``) or fetch per-id via cache when there is no list
-  (``doorStatus``, ``activitySummary``, ``systemInfo``, ``health``).
+- DETAIL resolvers either filter the cached LIST snapshot by primary key or
+  fetch per-id via cache when lookup needs manager-specific behavior (including
+  synthetic Access event IDs).
 
 Relationship edges (Door.policy_assignments, User.credentials, Event.door,
 Event.user) land in Task D. The ``access`` slot of ``EXEMPT_PRODUCTS`` in
@@ -27,6 +26,7 @@ from typing import Any
 
 import strawberry
 from strawberry.types import Info
+from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.graphql.context import GraphQLContext
 from unifi_api.graphql.permissions import IsRead
@@ -348,6 +348,34 @@ async def _fetch_events(
                 "access",
             )
             return list(await mgr.list_events(limit=list_limit))
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_event(
+    ctx: GraphQLContext,
+    controller: str,
+    event_id: str,
+) -> Any:
+    key = f"access/event/{controller}/{event_id}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "access",
+                "event_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "access",
+            )
+            try:
+                return await mgr.get_event(event_id)
+            except UniFiNotFoundError:
+                return None
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -931,16 +959,12 @@ class AccessQuery:
         id: strawberry.ID,
     ) -> Event | None:
         ctx: GraphQLContext = info.context
-        # Filter the cached events list — the REST detail endpoint hits a
-        # dedicated manager method, but the LIST snapshot is cheaper to
-        # reuse for resolver-graph queries.
-        raw = await _fetch_events(ctx, controller, 100)
-        for e in raw:
-            if _id_of(e) == id:
-                inst = Event.from_manager_output(e)
-                inst._controller_id = str(controller)
-                return inst
-        return None
+        raw = await _fetch_event(ctx, controller, str(id))
+        if raw is None:
+            return None
+        inst = Event.from_manager_output(raw)
+        inst._controller_id = str(controller)
+        return inst
 
     @strawberry.field(
         permission_classes=[IsRead],

--- a/apps/api/tests/graphql/fixtures/access/test_events.py
+++ b/apps/api/tests/graphql/fixtures/access/test_events.py
@@ -47,9 +47,12 @@ async def test_access_event_detail(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("access", "event_manager", "list_events"): [
-                {"id": "evt1", "type": "ACCESS_GRANTED", "timestamp": 1000, "door_id": "door1"},
-            ],
+            ("access", "event_manager", "get_event"): {
+                "id": "evt1",
+                "type": "ACCESS_GRANTED",
+                "timestamp": 1000,
+                "door_id": "door1",
+            },
         },
     )
     body = await graphql_query(

--- a/apps/api/tests/routes/resources/test_access_events_system.py
+++ b/apps/api/tests/routes/resources/test_access_events_system.py
@@ -71,6 +71,18 @@ class _FakeAccessCM:
     async def initialize(self) -> None:
         return None
 
+    has_proxy = True
+
+    def __init__(self) -> None:
+        self.response = {"data": {"events": []}, "total": 0}
+
+    async def proxy_request(self, *args, **kwargs):
+        return self.response
+
+    @staticmethod
+    def extract_data(response):
+        return response.get("data", response)
+
 
 def _stub_connection(app, cid: str) -> _FakeAccessCM:
     fake = _FakeAccessCM()
@@ -117,6 +129,52 @@ async def test_list_access_events_happy_path(tmp_path, monkeypatch) -> None:
     body = r.json()
     assert len(body["items"]) == 3
     assert body["render_hint"]["kind"] == "event_log"
+
+
+@pytest.mark.asyncio
+async def test_list_access_events_cursor_traverses_empty_native_ids(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    cm = _stub_connection(app, cid)
+    cm.response = {
+        "total": 2,
+        "data": {
+            "events": [
+                {
+                    "id": "",
+                    "published": 1773766800123,
+                    "event_type": "access.admin.update",
+                    "metadata": {"user": {"id": "user-1"}},
+                },
+                {
+                    "id": "",
+                    "published": 1773766800123,
+                    "event_type": "access.admin.update",
+                    "metadata": {"user": {"id": "user-2"}},
+                },
+            ]
+        },
+    }
+
+    seen: list[str] = []
+    cursor = None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        while True:
+            suffix = f"&cursor={cursor}" if cursor else ""
+            response = await c.get(
+                f"/v1/sites/default/access/events?controller={cid}&limit=1{suffix}",
+                headers={"Authorization": f"Bearer {key}"},
+            )
+            assert response.status_code == 200, response.text
+            body = response.json()
+            seen.extend(item["id"] for item in body["items"])
+            cursor = body["next_cursor"]
+            if cursor is None:
+                break
+
+    assert len(seen) == 2
+    assert all(seen)
+    assert len(set(seen)) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,7 +9,9 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    "unifi-core[network]>=0.4.29,<0.5",
+    # WAN delegation validation requires Core 0.4.30 so controller value
+    # "pd" remains valid through Network tool updates.
+    "unifi-core[network]>=0.4.30,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
Completes the downstream delivery for #550 after `unifi-core` 0.4.30.

## What changed

- Raise Network, Access, and API Core floors to `>=0.4.30` so the released wheels guarantee the fixes merged in #553 and #555.
- Describe Access system-log identities as event IDs rather than controller UUIDs and regenerate the Access manifest/API action catalog.
- Route GraphQL Access event detail through Core's paged multi-topic lookup rather than filtering only the newest 100-row list snapshot.
- Add MCP list-to-detail and REST cursor-pagination regressions for synthetic event IDs.

## Validation

- `make pre-commit`
- Focused Network: 43 passed
- Focused Access: 22 passed
- Focused API: 12 passed
- Full Access: 211 passed
- Full API: 1,222 passed
- Standard pin alignment: passed
- API exact-Core-floor contract: Core 0.4.30, 268 catalog bindings passed
- Clean PyPI install of `unifi-core[network,protect,access]==0.4.30`: passed
