### PR TITLE
fix(api): order Access events by a key that cannot collide

### DIFF
--- a/apps/api/src/unifi_api/graphql/errors.py
+++ b/apps/api/src/unifi_api/graphql/errors.py
@@ -11,13 +11,17 @@ from typing import Any
 
 from graphql import GraphQLError
 
+from unifi_api.services.access_event_key import InvalidAccessEventCursor
 from unifi_api.services.controllers import ControllerNotFound
+from unifi_api.services.pagination import InvalidCursor
 
 
 def _classify(error: GraphQLError) -> str:
     orig = error.original_error
     if isinstance(orig, ControllerNotFound):
         return "NOT_FOUND"
+    if isinstance(orig, (InvalidAccessEventCursor, InvalidCursor)):
+        return "BAD_REQUEST"
     if isinstance(orig, PermissionError):
         msg = str(orig)
         if msg.startswith("UNAUTHENTICATED:"):

--- a/apps/api/src/unifi_api/graphql/resolvers/access.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/access.py
@@ -40,7 +40,7 @@ from unifi_api.graphql.types.access.schedules import Schedule
 from unifi_api.graphql.types.access.system import AccessHealth, AccessSystemInfo
 from unifi_api.graphql.types.access.users import User
 from unifi_api.graphql.types.access.visitors import Visitor
-from unifi_api.services.access_event_key import event_sort_key
+from unifi_api.services.access_event_key import event_sort_key, paginate_access_events
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -64,15 +64,15 @@ def _id_of(obj: Any) -> Any:
 
 
 def _decode_cursor(cursor: str | None):
-    """Translate an opaque cursor string to a Cursor (or raise ValueError)."""
+    """Translate an opaque cursor string to a Cursor (or raise InvalidCursor)."""
     from unifi_api.services.pagination import Cursor, InvalidCursor
 
     if not cursor:
         return None
     try:
         return Cursor.decode(cursor)
-    except InvalidCursor:
-        raise ValueError("invalid cursor")
+    except InvalidCursor as exc:
+        raise InvalidCursor("invalid cursor") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -927,13 +927,10 @@ class AccessQuery:
         # paginate() has enough rows to cursor through.
         raw = await _fetch_events(ctx, controller, max(limit, 100))
 
-        from unifi_api.services.pagination import paginate
-
-        cursor_obj = _decode_cursor(cursor)
-        page, next_cursor = paginate(
+        page, next_cursor = paginate_access_events(
             list(raw),
             limit=limit,
-            cursor=cursor_obj,
+            cursor=cursor,
             key_fn=_event_key,
         )
         items: list[Event] = []
@@ -943,7 +940,7 @@ class AccessQuery:
             items.append(inst)
         return AccessEventPage(
             items=items,
-            next_cursor=next_cursor.encode() if next_cursor else None,
+            next_cursor=next_cursor,
         )
 
     @strawberry.field(

--- a/apps/api/src/unifi_api/graphql/resolvers/access.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/access.py
@@ -40,6 +40,7 @@ from unifi_api.graphql.types.access.schedules import Schedule
 from unifi_api.graphql.types.access.system import AccessHealth, AccessSystemInfo
 from unifi_api.graphql.types.access.users import User
 from unifi_api.graphql.types.access.visitors import Visitor
+from unifi_api.services.access_event_key import event_sort_key
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -84,17 +85,14 @@ def _id_key(obj: Any) -> tuple:
 
 
 def _event_key(obj: Any) -> tuple:
-    """Sort by (timestamp, id) — newest-first ordering is captured by the
-    REST routes; paginate() sorts ascending which is fine for cursor stability.
+    """Sort by the canonical Access event key.
+
+    Shared with the REST route and defined in ``unifi_api.services``, because cursor
+    windowing only works if every surface agrees: system-log rows carry
+    ``published`` rather than ``timestamp`` and an empty ``id``, so the old
+    ``(raw["timestamp"], raw["id"])`` collapsed every row onto ``(0, "")``.
     """
-    raw = _raw(obj)
-    if isinstance(raw, dict):
-        ts = raw.get("timestamp") or raw.get("time") or 0
-        rid = raw.get("id") or ""
-    else:
-        ts = getattr(raw, "timestamp", None) or getattr(raw, "time", None) or 0
-        rid = getattr(raw, "id", None) or ""
-    return (int(ts or 0), str(rid))
+    return event_sort_key(_raw(obj))
 
 
 def _visitor_key(obj: Any) -> tuple:

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -1841,15 +1841,15 @@ def _speedtest_key(row: Any) -> tuple:
 
 
 def _decode_cursor(cursor: str | None):
-    """Translate an opaque cursor string to a Cursor (or raise ValueError)."""
+    """Translate an opaque cursor string to a Cursor (or raise InvalidCursor)."""
     from unifi_api.services.pagination import Cursor, InvalidCursor
 
     if not cursor:
         return None
     try:
         return Cursor.decode(cursor)
-    except InvalidCursor:
-        raise ValueError("invalid cursor")
+    except InvalidCursor as exc:
+        raise InvalidCursor("invalid cursor") from exc
 
 
 # ---- Traffic-flows cursor helpers ----------------------------------------

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -92,15 +92,15 @@ def _id_of(obj: Any) -> Any:
 
 
 def _decode_cursor(cursor: str | None):
-    """Translate an opaque cursor string to a Cursor (or raise ValueError)."""
+    """Translate an opaque cursor string to a Cursor (or raise InvalidCursor)."""
     from unifi_api.services.pagination import Cursor, InvalidCursor
 
     if not cursor:
         return None
     try:
         return Cursor.decode(cursor)
-    except InvalidCursor:
-        raise ValueError("invalid cursor")
+    except InvalidCursor as exc:
+        raise InvalidCursor("invalid cursor") from exc
 
 
 async def _maybe_set_site(cm: Any, site: str | None) -> None:

--- a/apps/api/src/unifi_api/routes/resources/access/events.py
+++ b/apps/api/src/unifi_api/routes/resources/access/events.py
@@ -27,8 +27,11 @@ from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
-from unifi_api.services.access_event_key import event_sort_key
-from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
+from unifi_api.services.access_event_key import (
+    InvalidAccessEventCursor,
+    event_sort_key,
+    paginate_access_events,
+)
 
 router = APIRouter()
 
@@ -89,19 +92,15 @@ async def list_access_events(
         await _maybe_set_site(cm, site_id)
         all_events = await mgr.list_events(limit=max(limit, 100))
 
-    cursor_obj = None
-    if cursor:
-        try:
-            cursor_obj = Cursor.decode(cursor)
-        except InvalidCursor:
-            raise HTTPException(status_code=400, detail="invalid cursor")
-
-    page, next_cursor = paginate(
-        list(all_events),
-        limit=limit,
-        cursor=cursor_obj,
-        key_fn=_event_key,
-    )
+    try:
+        page, next_cursor = paginate_access_events(
+            list(all_events),
+            limit=limit,
+            cursor=cursor,
+            key_fn=_event_key,
+        )
+    except InvalidAccessEventCursor as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     type_registry = request.app.state.type_registry
     tool_type = type_registry.lookup_tool("access_list_events")
@@ -116,7 +115,7 @@ async def list_access_events(
         hint = registry.render_hint_for_tool("access_list_events")
     return {
         "items": items,
-        "next_cursor": next_cursor.encode() if next_cursor else None,
+        "next_cursor": next_cursor,
         "render_hint": hint,
     }
 

--- a/apps/api/src/unifi_api/routes/resources/access/events.py
+++ b/apps/api/src/unifi_api/routes/resources/access/events.py
@@ -27,18 +27,31 @@ from unifi_api.routes.resources._common import (
     require_capability,
     resolve_controller,
 )
+from unifi_api.services.access_event_key import event_sort_key
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
 router = APIRouter()
 
 
 def _event_key(obj) -> tuple:
-    """Sort by (timestamp, id) — newest first via the manifest's
-    ``sort_default = "timestamp:desc"``. paginate() sorts ascending; the
-    user-facing direction is captured in the serializer metadata.
+    """Sort by the canonical Access event key — newest first via the manifest's
+    ``sort_default = "timestamp:desc"``.
+
+    Uses the same key as the GraphQL resolver. Reading ``timestamp`` straight
+    off the raw row put a bare ``0`` next to a string for system-log rows,
+    which raises ``TypeError`` inside ``sorted()`` as soon as the two shapes
+    meet and takes ``GET /access/events`` down.
     """
-    raw = obj if isinstance(obj, dict) else getattr(obj, "raw", {}) or {}
-    return (raw.get("timestamp") or raw.get("time") or 0, raw.get("id") or "")
+    # Do NOT fall back to {}: that keyed every non-dict, non-.raw row to the
+    # same constant, so paginate()'s strict `<` window dropped all of them from
+    # page 2 - the exact collapse this key exists to prevent. Passing the object
+    # through lets event_sort_key read it via getattr, matching the GraphQL side.
+    raw = obj
+    if not isinstance(obj, dict):
+        wrapped = getattr(obj, "raw", None)
+        if isinstance(wrapped, dict):
+            raw = wrapped
+    return event_sort_key(raw)
 
 
 async def _maybe_set_site(cm, site_id: str) -> None:

--- a/apps/api/src/unifi_api/services/access_event_key.py
+++ b/apps/api/src/unifi_api/services/access_event_key.py
@@ -1,0 +1,127 @@
+"""Canonical ordering key for UniFi Access event rows.
+
+Both API surfaces — the GraphQL resolver and the REST resource route — must
+agree on this, because cursor pagination windows with a strict
+``(ts, id) < (last_ts, last_id)``: two rows sharing a key make the next page
+drop both, and a key that differs between requests silently skips or repeats
+rows.
+
+The identity half is not computed here. ``unifi_core`` already assigns every
+Access row a stable public identity — the controller's own ID when it has
+one, otherwise a digest over the row's complete canonical payload — and this
+module defers to it. An earlier version digested a hand-picked subset of
+fields instead, which collided for two admin rows differing only at
+``metadata.user.id`` and lost one row from a 68-row cursor traversal. A subset
+cannot be shown to be exhaustive; the whole row can.
+
+The time half does belong here: ordering is an API-surface concern, and the
+raw rows carry time in three different shapes that have to sort against each
+other.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from unifi_core.access.models.events import event_identity
+
+__all__ = ["event_sort_key"]
+
+# Not controller data: a process-local arrival stamp that changes every time a
+# websocket row is buffered, so including it would give one event a different
+# identity on each read. ``unifi_core`` excludes it for the same reason.
+_LOCAL_ONLY_FIELDS = frozenset({"_buffered_at"})
+
+
+def _get(raw: Any, key: str) -> Any:
+    if isinstance(raw, dict):
+        return raw.get(key)
+    return getattr(raw, key, None)
+
+
+# Epoch seconds and epoch milliseconds both appear: system-log rows use millis
+# (``published``) while legacy/websocket rows carry seconds. Left unconverted, a
+# seconds row keys ~1000x lower than a millis row for the same instant, so in a
+# mixed list every legacy row sinks to the bottom and can be stranded past the
+# cursor window. Anything below this bound cannot plausibly be millis (it would
+# be 1973), so it is seconds.
+_MILLIS_LOWER_BOUND = 100_000_000_000
+
+
+def _to_millis(value: int) -> int:
+    if 0 < value < _MILLIS_LOWER_BOUND:
+        return value * 1000
+    return value
+
+
+def _sortable_millis(value: Any) -> int:
+    """Coerce an event time to sortable epoch milliseconds.
+
+    Access event times arrive in three shapes: ``published`` as epoch millis on
+    system-log rows, an ISO 8601 string once normalised, and a bare number on
+    legacy/websocket rows. A plain ``int()`` raises ``ValueError`` on the ISO
+    form, which is enough to take a whole events query down.
+    """
+    if value is None or isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return _to_millis(int(value))
+    text = str(value).strip()
+    if not text:
+        return 0
+    try:
+        return _to_millis(int(text))
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if parsed.tzinfo is None:
+        # A naive string would otherwise be read in the host's local zone,
+        # which misorders it against the "+00:00" rows by the UTC offset and
+        # makes the key differ between workers in different timezones - so a
+        # cursor minted by one would window wrongly on another.
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
+def _whole_row_digest(raw: dict[str, Any]) -> str:
+    """Digest a complete row, for the shapes ``event_identity`` declines.
+
+    It returns ``None`` for a row that is neither identified nor recognisably a
+    system-log record. Such a row still has to sort deterministically against
+    its neighbours, and only its full content can distinguish it.
+    """
+    canonical = {key: value for key, value in raw.items() if key not in _LOCAL_ONLY_FIELDS and key != "id"}
+    try:
+        payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    except (TypeError, ValueError):
+        # Controller rows are JSON, so this is defensive. ``default=str`` keeps
+        # a value that is merely unserialisable (a datetime, a Decimal) from
+        # collapsing the whole row onto a shared key.
+        payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def event_sort_key(raw: Any) -> tuple[int, str]:
+    """Return a stable ``(time, identity)`` ordering key for an event row.
+
+    System-log rows are why the identity is not simply ``id``: the controller
+    leaves it empty on those, so without a content identity every row of a page
+    collapses onto the same key and the next page comes back short.
+    """
+    published = _get(raw, "published")
+    ts = _sortable_millis(published) if published is not None else 0
+    if not ts:
+        ts = _sortable_millis(_get(raw, "timestamp") or _get(raw, "time"))
+
+    identity = event_identity(raw)
+    if not identity:
+        # Both call sites unwrap ``.raw`` to a dict before calling, so the
+        # non-dict branch is defensive; there is nothing to digest there.
+        identity = _whole_row_digest(raw) if isinstance(raw, dict) else str(_get(raw, "id") or "")
+    return (ts, str(identity))

--- a/apps/api/src/unifi_api/services/access_event_key.py
+++ b/apps/api/src/unifi_api/services/access_event_key.py
@@ -24,13 +24,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-import math
 from datetime import datetime, timezone
 from typing import Any, Callable
 
 from unifi_core.access.models.events import event_identity
 
-from unifi_api.services.pagination import Cursor, paginate
+from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
 __all__ = [
     "InvalidAccessEventCursor",
@@ -183,13 +182,14 @@ def _decode_access_event_cursor(encoded: str) -> tuple[Cursor, bool]:
             raise InvalidAccessEventCursor("invalid Access event cursor: version 1 requires epoch milliseconds")
         return Cursor(last_id=identity, last_ts=last_ts), False
 
-    if set(payload) - {"last_id", "last_ts"}:
+    if set(payload) != {"last_id", "last_ts"}:
         raise InvalidAccessEventCursor("invalid Access event cursor: unknown legacy format")
+    try:
+        cursor = Cursor.decode(encoded)
+    except InvalidCursor as exc:
+        raise InvalidAccessEventCursor(f"invalid Access event cursor: {exc}") from exc
     identity = _validated_identity(payload)
-    last_ts = payload.get("last_ts")
-    if isinstance(last_ts, float) and not math.isfinite(last_ts):
-        raise InvalidAccessEventCursor("invalid Access event cursor: last_ts must be finite")
-    return Cursor(last_id=identity, last_ts=last_ts), True
+    return Cursor(last_id=identity, last_ts=cursor.last_ts), True
 
 
 def _migrate_legacy_cursor(

--- a/apps/api/src/unifi_api/services/access_event_key.py
+++ b/apps/api/src/unifi_api/services/access_event_key.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import math
 from datetime import datetime, timezone
 from typing import Any, Callable
 
@@ -185,7 +186,10 @@ def _decode_access_event_cursor(encoded: str) -> tuple[Cursor, bool]:
     if set(payload) - {"last_id", "last_ts"}:
         raise InvalidAccessEventCursor("invalid Access event cursor: unknown legacy format")
     identity = _validated_identity(payload)
-    return Cursor(last_id=identity, last_ts=payload.get("last_ts")), True
+    last_ts = payload.get("last_ts")
+    if isinstance(last_ts, float) and not math.isfinite(last_ts):
+        raise InvalidAccessEventCursor("invalid Access event cursor: last_ts must be finite")
+    return Cursor(last_id=identity, last_ts=last_ts), True
 
 
 def _migrate_legacy_cursor(

--- a/apps/api/src/unifi_api/services/access_event_key.py
+++ b/apps/api/src/unifi_api/services/access_event_key.py
@@ -21,14 +21,24 @@ other.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Callable
 
 from unifi_core.access.models.events import event_identity
 
-__all__ = ["event_sort_key"]
+from unifi_api.services.pagination import Cursor, paginate
+
+__all__ = [
+    "InvalidAccessEventCursor",
+    "event_sort_key",
+    "paginate_access_events",
+]
+
+_CURSOR_RESOURCE = "access_events"
+_CURSOR_VERSION = 1
 
 # Not controller data: a process-local arrival stamp that changes every time a
 # websocket row is buffered, so including it would give one event a different
@@ -51,10 +61,10 @@ def _get(raw: Any, key: str) -> Any:
 _MILLIS_LOWER_BOUND = 100_000_000_000
 
 
-def _to_millis(value: int) -> int:
+def _to_millis(value: int | float) -> int:
     if 0 < value < _MILLIS_LOWER_BOUND:
-        return value * 1000
-    return value
+        return int(value * 1000)
+    return int(value)
 
 
 def _sortable_millis(value: Any) -> int:
@@ -68,7 +78,7 @@ def _sortable_millis(value: Any) -> int:
     if value is None or isinstance(value, bool):
         return 0
     if isinstance(value, (int, float)):
-        return _to_millis(int(value))
+        return _to_millis(value)
     text = str(value).strip()
     if not text:
         return 0
@@ -121,7 +131,115 @@ def event_sort_key(raw: Any) -> tuple[int, str]:
 
     identity = event_identity(raw)
     if not identity:
-        # Both call sites unwrap ``.raw`` to a dict before calling, so the
-        # non-dict branch is defensive; there is nothing to digest there.
-        identity = _whole_row_digest(raw) if isinstance(raw, dict) else str(_get(raw, "id") or "")
+        if not isinstance(raw, dict):
+            raise ValueError("Access event row lacks a stable identity")
+        identity = _whole_row_digest(raw)
     return (ts, str(identity))
+
+
+class InvalidAccessEventCursor(ValueError):
+    """An Access-event cursor cannot be decoded or safely migrated."""
+
+
+def _decode_cursor_payload(encoded: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded.encode()).decode())
+    except Exception as exc:
+        raise InvalidAccessEventCursor(f"invalid Access event cursor: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise InvalidAccessEventCursor("invalid Access event cursor: expected an object payload")
+    return payload
+
+
+def _validated_identity(payload: dict[str, Any]) -> str:
+    if (
+        "last_id" not in payload
+        or isinstance(payload["last_id"], bool)
+        or not isinstance(payload["last_id"], (str, int))
+    ):
+        raise InvalidAccessEventCursor("invalid Access event cursor: last_id is required")
+    identity = str(payload["last_id"])
+    if not identity:
+        raise InvalidAccessEventCursor("invalid Access event cursor: last_id must be a stable identity")
+    return identity
+
+
+def _decode_access_event_cursor(encoded: str) -> tuple[Cursor, bool]:
+    """Return ``(cursor, is_legacy)`` after validating its resource format."""
+    payload = _decode_cursor_payload(encoded)
+    marker_keys = {"resource", "version"} & payload.keys()
+    if marker_keys:
+        if payload.get("resource") != _CURSOR_RESOURCE:
+            raise InvalidAccessEventCursor("invalid Access event cursor: unknown resource format")
+        version = payload.get("version")
+        if isinstance(version, bool) or not isinstance(version, int) or version != _CURSOR_VERSION:
+            raise InvalidAccessEventCursor(f"unsupported Access event cursor version: {version!r}")
+        if set(payload) != {"resource", "version", "last_id", "last_ts"}:
+            raise InvalidAccessEventCursor("invalid Access event cursor: unknown versioned format")
+        identity = _validated_identity(payload)
+        last_ts = payload.get("last_ts")
+        if isinstance(last_ts, bool) or not isinstance(last_ts, int):
+            raise InvalidAccessEventCursor("invalid Access event cursor: version 1 requires epoch milliseconds")
+        return Cursor(last_id=identity, last_ts=last_ts), False
+
+    if set(payload) - {"last_id", "last_ts"}:
+        raise InvalidAccessEventCursor("invalid Access event cursor: unknown legacy format")
+    identity = _validated_identity(payload)
+    return Cursor(last_id=identity, last_ts=payload.get("last_ts")), True
+
+
+def _migrate_legacy_cursor(
+    cursor: Cursor,
+    items: list[Any],
+    key_fn: Callable[[Any], tuple[int, str]],
+) -> Cursor:
+    """Recover the new key from stable identity, then fall back to timestamp."""
+    matching_keys = set()
+    for item in items:
+        key = key_fn(item)
+        if key[1] == cursor.last_id:
+            matching_keys.add(key)
+    if len(matching_keys) == 1:
+        timestamp, identity = matching_keys.pop()
+        return Cursor(last_id=identity, last_ts=timestamp)
+    if len(matching_keys) > 1:
+        raise InvalidAccessEventCursor(
+            "cannot resume legacy Access event cursor: stable identity matches multiple event positions"
+        )
+
+    timestamp = _sortable_millis(cursor.last_ts)
+    if not timestamp:
+        raise InvalidAccessEventCursor(
+            "cannot resume legacy Access event cursor: event identity is absent and timestamp is unrecoverable"
+        )
+    return Cursor(last_id=cursor.last_id, last_ts=timestamp)
+
+
+def _encode_access_event_cursor(cursor: Cursor) -> str:
+    payload = json.dumps(
+        {
+            "resource": _CURSOR_RESOURCE,
+            "version": _CURSOR_VERSION,
+            "last_id": cursor.last_id,
+            "last_ts": cursor.last_ts,
+        }
+    ).encode()
+    return base64.urlsafe_b64encode(payload).decode()
+
+
+def paginate_access_events(
+    items: list[Any],
+    *,
+    limit: int,
+    cursor: str | None,
+    key_fn: Callable[[Any], tuple[int, str]],
+) -> tuple[list[Any], str | None]:
+    """Paginate Access events with resource-specific cursor compatibility."""
+    cursor_obj = None
+    if cursor:
+        cursor_obj, is_legacy = _decode_access_event_cursor(cursor)
+        if is_legacy:
+            cursor_obj = _migrate_legacy_cursor(cursor_obj, items, key_fn)
+
+    page, next_cursor = paginate(items, limit=limit, cursor=cursor_obj, key_fn=key_fn)
+    return page, _encode_access_event_cursor(next_cursor) if next_cursor else None

--- a/apps/api/src/unifi_api/services/pagination.py
+++ b/apps/api/src/unifi_api/services/pagination.py
@@ -21,7 +21,7 @@ class InvalidCursor(Exception):
 @dataclass(frozen=True)
 class Cursor:
     last_id: str | int
-    last_ts: int | None = None
+    last_ts: str | int | float | None = None
 
     def encode(self) -> str:
         payload = json.dumps({"last_id": self.last_id, "last_ts": self.last_ts}).encode()
@@ -31,7 +31,15 @@ class Cursor:
     def decode(cls, s: str) -> "Cursor":
         try:
             payload = json.loads(base64.urlsafe_b64decode(s.encode()).decode())
-            return cls(last_id=payload["last_id"], last_ts=payload.get("last_ts"))
+            if not isinstance(payload, dict) or set(payload) != {"last_id", "last_ts"}:
+                raise ValueError("expected exact legacy cursor payload")
+            last_id = payload["last_id"]
+            last_ts = payload["last_ts"]
+            if isinstance(last_id, bool) or not isinstance(last_id, (str, int)):
+                raise ValueError("last_id must be a string or integer")
+            if isinstance(last_ts, bool) or (last_ts is not None and not isinstance(last_ts, (str, int, float))):
+                raise ValueError("last_ts must be a string, integer, float, or null")
+            return cls(last_id=last_id, last_ts=last_ts)
         except Exception as e:
             raise InvalidCursor(f"failed to decode cursor: {e}")
 

--- a/apps/api/src/unifi_api/services/pagination.py
+++ b/apps/api/src/unifi_api/services/pagination.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import json
+import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -39,6 +40,8 @@ class Cursor:
                 raise ValueError("last_id must be a string or integer")
             if isinstance(last_ts, bool) or (last_ts is not None and not isinstance(last_ts, (str, int, float))):
                 raise ValueError("last_ts must be a string, integer, float, or null")
+            if isinstance(last_ts, float) and not math.isfinite(last_ts):
+                raise ValueError("last_ts must be finite")
             return cls(last_id=last_id, last_ts=last_ts)
         except Exception as e:
             raise InvalidCursor(f"failed to decode cursor: {e}")

--- a/apps/api/tests/graphql/fixtures/access/test_events.py
+++ b/apps/api/tests/graphql/fixtures/access/test_events.py
@@ -28,6 +28,10 @@ def _legacy_cursor(row: dict) -> str:
     return Cursor(last_id=identity, last_ts=timestamp).encode()
 
 
+def _encode_cursor_payload(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
 def _migration_rows(timestamp_format: str) -> tuple[list[dict], dict]:
     if timestamp_format == "published":
         raw_rows = [
@@ -205,6 +209,46 @@ async def test_access_events_reject_unrecoverable_cursor(
         monkeypatch,
         {("access", "event_manager", "list_events"): []},
     )
+
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ events(controller: "{cid}", cursor: "{cursor}") {{ items {{ id }} }} }}
+    }}''',
+    )
+
+    assert body["data"] is None
+    assert expected_message in body["errors"][0]["message"]
+    assert body["errors"][0]["extensions"]["code"] == "BAD_REQUEST"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        ({"last_id": "present", "last_ts": True}, "last_ts must be a string, integer, float, or null"),
+        ({"last_id": "present", "last_ts": [1787054400000]}, "last_ts must be a string, integer, float, or null"),
+        (
+            {"last_id": "present", "last_ts": {"millis": 1787054400000}},
+            "last_ts must be a string, integer, float, or null",
+        ),
+        ({"last_id": "present"}, "unknown legacy format"),
+    ],
+)
+async def test_access_events_reject_malformed_cursor_when_identity_is_present(
+    tmp_path,
+    monkeypatch,
+    payload,
+    expected_message,
+):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    stub_managers(
+        monkeypatch,
+        {("access", "event_manager", "list_events"): [{"id": "present", "timestamp": 1787054400}]},
+    )
+    cursor = _encode_cursor_payload(payload)
 
     body = await graphql_query(
         app,

--- a/apps/api/tests/graphql/fixtures/access/test_events.py
+++ b/apps/api/tests/graphql/fixtures/access/test_events.py
@@ -175,6 +175,9 @@ async def test_access_events_encoded_cursor_traversal(tmp_path, monkeypatch):
     ("cursor", "expected_message"),
     [
         (Cursor(last_id="missing", last_ts="not-a-time").encode(), "timestamp is unrecoverable"),
+        (Cursor(last_id="missing", last_ts=float("nan")).encode(), "last_ts must be finite"),
+        (Cursor(last_id="missing", last_ts=float("inf")).encode(), "last_ts must be finite"),
+        (Cursor(last_id="missing", last_ts=float("-inf")).encode(), "last_ts must be finite"),
         (
             base64.urlsafe_b64encode(
                 json.dumps({"resource": "access_events", "version": 99, "last_id": "evt", "last_ts": 1}).encode()

--- a/apps/api/tests/graphql/fixtures/access/test_events.py
+++ b/apps/api/tests/graphql/fixtures/access/test_events.py
@@ -7,9 +7,53 @@
 
 from __future__ import annotations
 
+import base64
+import json
+
 import pytest
+from unifi_api.services.access_event_key import event_sort_key
+from unifi_api.services.pagination import Cursor
+from unifi_core.access.models.events import with_event_identity
 
 from tests.graphql.fixtures._helpers import bootstrap, graphql_query, stub_managers
+
+
+def _legacy_event_key(row: dict) -> tuple:
+    """The exact Access REST ordering key used before timestamp normalization."""
+    return (row.get("timestamp") or row.get("time") or 0, row.get("id") or "")
+
+
+def _legacy_cursor(row: dict) -> str:
+    timestamp, identity = _legacy_event_key(row)
+    return Cursor(last_id=identity, last_ts=timestamp).encode()
+
+
+def _migration_rows(timestamp_format: str) -> tuple[list[dict], dict]:
+    if timestamp_format == "published":
+        raw_rows = [
+            {
+                "id": "",
+                "log_key": "access.door.unlock",
+                "event_type": "access.door.unlock",
+                "message": f"row {index}",
+                "published": 1787054400000 + offset,
+            }
+            for index, offset in enumerate((1000, 0, -1000))
+        ]
+        rows = [with_event_identity(row) for row in raw_rows]
+    elif timestamp_format == "seconds":
+        rows = [{"id": f"evt-{index}", "timestamp": 1787054400 + offset} for index, offset in enumerate((1, 0, -1))]
+    elif timestamp_format == "millis":
+        rows = [
+            {"id": f"evt-{index}", "timestamp": 1787054400000 + offset} for index, offset in enumerate((1000, 0, -1000))
+        ]
+    else:
+        rows = [
+            {"id": "evt-0", "timestamp": "2026-08-18T12:00:01Z"},
+            {"id": "evt-1", "timestamp": "2026-08-18T12:00:00Z"},
+            {"id": "evt-2", "timestamp": "2026-08-18T11:59:59Z"},
+        ]
+    return rows, rows[1]
 
 
 @pytest.mark.asyncio
@@ -38,6 +82,138 @@ async def test_access_events_list(tmp_path, monkeypatch):
     items = body["data"]["access"]["events"]["items"]
     assert len(items) == 2
     assert {it["id"] for it in items} == {"evt1", "evt2"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timestamp_format", ["published", "seconds", "millis", "iso"])
+async def test_access_events_resume_legacy_cursor(tmp_path, monkeypatch, timestamp_format):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    rows, legacy_target = _migration_rows(timestamp_format)
+    stub_managers(
+        monkeypatch,
+        {("access", "event_manager", "list_events"): rows},
+    )
+    cursor = _legacy_cursor(legacy_target)
+
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ events(controller: "{cid}", limit: 10, cursor: "{cursor}") {{
+            items {{ id }}
+            nextCursor
+        }} }}
+    }}''',
+    )
+
+    assert body.get("errors") is None, body
+    returned_ids = [item["id"] for item in body["data"]["access"]["events"]["items"]]
+    assert returned_ids == [rows[2]["id"]]
+    assert len(returned_ids) == len(set(returned_ids))
+    assert rows[0]["id"] not in returned_ids
+    assert rows[1]["id"] not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_access_events_encoded_cursor_traversal(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    raw_rows = []
+    for index in range(34):
+        base = {
+            "id": "",
+            "log_key": "admin.activity",
+            "event_type": "admin.activity",
+            "message": f"Admin action {index}",
+            "published": 1787054400000 + index,
+        }
+        raw_rows.append({**base, "metadata": {"user": {"id": f"user-{index}-a"}}})
+        raw_rows.append({**base, "metadata": {"user": {"id": f"user-{index}-b"}}})
+    rows = [with_event_identity(row) for row in raw_rows]
+    stub_managers(
+        monkeypatch,
+        {("access", "event_manager", "list_events"): rows},
+    )
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(len(rows) + 1):
+        cursor_arg = f', cursor: "{cursor}"' if cursor else ""
+        body = await graphql_query(
+            app,
+            key,
+            f'''{{
+            access {{ events(controller: "{cid}", limit: 2{cursor_arg}) {{
+                items {{ id }}
+                nextCursor
+            }} }}
+        }}''',
+        )
+        assert body.get("errors") is None, body
+        page = body["data"]["access"]["events"]
+        page_ids = [item["id"] for item in page["items"]]
+        assert set(page_ids).isdisjoint(seen)
+        seen.extend(page_ids)
+        cursor = page["nextCursor"]
+        if cursor is None:
+            break
+
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        assert payload["resource"] == "access_events"
+        assert payload["version"] == 1
+
+    expected = [row["id"] for row in sorted(rows, key=event_sort_key, reverse=True)]
+    assert cursor is None, "traversal did not terminate"
+    assert seen == expected
+    assert len(seen) == len(rows)
+    assert len(set(seen)) == len(rows)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("cursor", "expected_message"),
+    [
+        (Cursor(last_id="missing", last_ts="not-a-time").encode(), "timestamp is unrecoverable"),
+        (
+            base64.urlsafe_b64encode(
+                json.dumps({"resource": "access_events", "version": 99, "last_id": "evt", "last_ts": 1}).encode()
+            ).decode(),
+            "unsupported Access event cursor version",
+        ),
+        (
+            base64.urlsafe_b64encode(
+                json.dumps({"resource": "network_events", "version": 1, "last_id": "evt", "last_ts": 1}).encode()
+            ).decode(),
+            "unknown resource format",
+        ),
+        ("not-base64", "invalid Access event cursor"),
+    ],
+)
+async def test_access_events_reject_unrecoverable_cursor(
+    tmp_path,
+    monkeypatch,
+    cursor,
+    expected_message,
+):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="access")
+    stub_managers(
+        monkeypatch,
+        {("access", "event_manager", "list_events"): []},
+    )
+
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        access {{ events(controller: "{cid}", cursor: "{cursor}") {{ items {{ id }} }} }}
+    }}''',
+    )
+
+    assert body["data"] is None
+    assert expected_message in body["errors"][0]["message"]
+    assert body["errors"][0]["extensions"]["code"] == "BAD_REQUEST"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/graphql/test_access_event_sort_key.py
+++ b/apps/api/tests/graphql/test_access_event_sort_key.py
@@ -58,10 +58,10 @@ def test_cursor_windowing_advances_past_a_page_of_system_log_rows() -> None:
 
 
 def test_a_full_cursor_traversal_returns_every_row_exactly_once() -> None:
-    """Reviewer's live check on #549: traversing a 68-row snapshot at
-    `limit=2` returned 67 rows, because one colliding pair was windowed out
-    together. Page-at-a-time is the only way to catch that - a single
-    `paginate()` call cannot.
+    """A live 68-row traversal once lost one member of a colliding pair.
+
+    Page-at-a-time is the only way to catch that; a single `paginate()` call
+    cannot.
     """
     from unifi_api.services.pagination import paginate
 

--- a/apps/api/tests/graphql/test_access_event_sort_key.py
+++ b/apps/api/tests/graphql/test_access_event_sort_key.py
@@ -1,0 +1,94 @@
+"""Both API surfaces must order Access events by the same canonical key.
+
+`paginate()` windows with a strict `(ts, id) < (last_ts, last_id)`. The two
+`_event_key` helpers read `raw["timestamp"]` and `raw["id"]`, neither of which
+a system-log row has — it carries `published` (epoch ms) and `id: ""`. Every
+row therefore keyed to `(0, "")`: page 2 came back empty on GraphQL, and on
+REST a bare `0` sitting next to a string raised TypeError inside `sorted()`.
+"""
+
+from __future__ import annotations
+
+from unifi_api.graphql.resolvers.access import _event_key as gql_event_key
+from unifi_api.routes.resources.access.events import _event_key as rest_event_key
+
+SYSTEM_LOG_ROW = {
+    "id": "",
+    "log_key": "access.door.unlock",
+    "event_type": "access.door.unlock",
+    "message": "Access Granted (Face)",
+    "published": 1787054400000,
+    "result": "ACCESS",
+}
+
+
+def test_both_surfaces_agree_on_the_key() -> None:
+    assert gql_event_key(SYSTEM_LOG_ROW) == rest_event_key(SYSTEM_LOG_ROW)
+
+
+def test_a_system_log_row_does_not_key_to_zero() -> None:
+    """(0, "") for every row is what emptied page 2."""
+    assert gql_event_key(SYSTEM_LOG_ROW) != (0, "")
+
+
+def test_distinct_rows_get_distinct_keys_on_both_surfaces() -> None:
+    other = {**SYSTEM_LOG_ROW, "message": "Door status - Opened", "log_key": "access.dps.status.update"}
+    assert gql_event_key(SYSTEM_LOG_ROW) != gql_event_key(other)
+    assert rest_event_key(SYSTEM_LOG_ROW) != rest_event_key(other)
+
+
+def test_mixed_shapes_sort_without_raising() -> None:
+    """A string timestamp meeting the `0` default is the TypeError case."""
+    rows = [SYSTEM_LOG_ROW, {"id": "evt-2"}, {"id": "evt-3", "timestamp": "2026-08-18T12:00:00Z"}]
+    assert len(sorted(rows, key=gql_event_key)) == 3
+    assert len(sorted(rows, key=rest_event_key)) == 3
+
+
+def test_cursor_windowing_advances_past_a_page_of_system_log_rows() -> None:
+    """The end-to-end symptom: with identical keys nothing is strictly less
+    than the cursor, so the second page is empty."""
+    from unifi_api.services.pagination import paginate
+
+    rows = [{**SYSTEM_LOG_ROW, "published": 1787054400000 + i, "message": f"row {i}"} for i in range(5)]
+    page1, cursor = paginate(rows, limit=2, cursor=None, key_fn=gql_event_key)
+    assert len(page1) == 2 and cursor is not None
+    page2, _ = paginate(rows, limit=2, cursor=cursor, key_fn=gql_event_key)
+    assert len(page2) == 2, "page 2 is empty — every row shares a cursor key"
+    assert {r["message"] for r in page1}.isdisjoint({r["message"] for r in page2})
+
+
+def test_a_full_cursor_traversal_returns_every_row_exactly_once() -> None:
+    """Reviewer's live check on #549: traversing a 68-row snapshot at
+    `limit=2` returned 67 rows, because one colliding pair was windowed out
+    together. Page-at-a-time is the only way to catch that - a single
+    `paginate()` call cannot.
+    """
+    from unifi_api.services.pagination import paginate
+
+    rows = []
+    for i in range(34):
+        base = {
+            "id": "",
+            "log_key": "admin.activity",
+            "event_type": "admin.activity",
+            "message": f"Admin action {i}",
+            "published": 1787054400000 + i,
+            "result": "SUCCESS",
+        }
+        # Each pair shares every top-level field and differs only in nested
+        # actor metadata - the shape that collided live.
+        rows.append({**base, "metadata": {"user": {"id": f"user-{i}-a", "type": "user"}}})
+        rows.append({**base, "metadata": {"user": {"id": f"user-{i}-b", "type": "user"}}})
+
+    for key_fn in (gql_event_key, rest_event_key):
+        seen: list[dict] = []
+        cursor = None
+        for _ in range(len(rows) + 1):
+            page, cursor = paginate(rows, limit=2, cursor=cursor, key_fn=key_fn)
+            seen.extend(page)
+            if cursor is None:
+                break
+        assert cursor is None, "traversal did not terminate"
+        assert len(seen) == len(rows), f"traversal lost {len(rows) - len(seen)} of {len(rows)} rows"
+        keys = {key_fn(r) for r in rows}
+        assert len(keys) == len(rows), "distinct rows share an ordering key"

--- a/apps/api/tests/graphql/test_access_event_sort_key_unit.py
+++ b/apps/api/tests/graphql/test_access_event_sort_key_unit.py
@@ -7,7 +7,13 @@ with `(ts, id) < (last_ts, last_id)`, page 2 of an events query came back
 empty - nothing can be strictly less than the key every row shares.
 """
 
-from unifi_api.services.access_event_key import event_sort_key
+from datetime import datetime, timezone
+
+import pytest
+from unifi_api.graphql.resolvers.access import _event_key as gql_event_key
+from unifi_api.routes.resources.access.events import _event_key as rest_event_key
+from unifi_api.services.access_event_key import event_sort_key, paginate_access_events
+from unifi_api.services.pagination import Cursor
 
 SYSTEM_LOG_ROW = {
     "id": "",
@@ -113,8 +119,8 @@ def test_same_millisecond_rows_for_different_doors_do_not_collide() -> None:
 
 
 def test_rows_differing_only_in_nested_user_metadata_do_not_collide() -> None:
-    """Reviewer's live finding on #549: two admin rows identical except for
-    `metadata.user.id` produced one key, so a cursor traversal dropped both.
+    """Two admin rows identical except for `metadata.user.id` once collided,
+    so a cursor traversal dropped both.
 
     A hand-picked field subset cannot be proven exhaustive - any nested field
     left out of it is a collision waiting for the row that differs only there.
@@ -143,3 +149,91 @@ def test_rows_differing_only_in_an_unmodelled_field_do_not_collide() -> None:
         "published": 1787054400000,
     }
     assert event_sort_key({**base, "some_future_field": "a"}) != event_sort_key({**base, "some_future_field": "b"})
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_millis"),
+    [
+        ({"id": "evt", "timestamp": 1787054400.75}, 1787054400750),
+        ({"id": "evt", "timestamp": "1787054400"}, 1787054400000),
+        ({"id": "evt", "timestamp": "1787054400000"}, 1787054400000),
+        ({"id": "evt", "timestamp": "2026-08-18T08:00:00-04:00"}, 1787054400000),
+        ({"id": "evt", "timestamp": ""}, 0),
+        ({"id": "evt", "timestamp": True}, 0),
+        ({"id": "evt", "timestamp": "not-a-time"}, 0),
+        ({"id": "evt", "timestamp": "1787054400.5"}, 0),
+        ({"id": "evt", "published": "bad", "timestamp": 1787054400}, 1787054400000),
+        ({"id": "evt", "published": "", "time": "2026-08-18T12:00:00Z"}, 1787054400000),
+    ],
+)
+def test_timestamp_normalization_and_fallbacks_match_on_both_surfaces(row, expected_millis) -> None:
+    assert event_sort_key(row)[0] == expected_millis
+    assert gql_event_key(row) == (expected_millis, "evt")
+    assert rest_event_key(row) == (expected_millis, "evt")
+
+
+def test_fractional_epoch_seconds_preserve_sub_second_ordering() -> None:
+    earlier = {"id": "earlier", "timestamp": 1787054400.1}
+    later = {"id": "later", "timestamp": 1787054400.9}
+    assert event_sort_key(earlier)[0] == 1787054400100
+    assert event_sort_key(later)[0] == 1787054400900
+    assert event_sort_key(earlier) < event_sort_key(later)
+
+
+def test_mapping_without_native_identity_uses_complete_row_digest() -> None:
+    first = {"timestamp": 1787054400, "unknown": {"value": "first"}}
+    second = {"timestamp": 1787054400, "unknown": {"value": "second"}}
+    assert event_sort_key(first)[1]
+    assert event_sort_key(first) != event_sort_key(second)
+
+
+def test_unserializable_mapping_values_still_receive_stable_identity() -> None:
+    row = {
+        "timestamp": 1787054400,
+        "unknown": datetime(2026, 8, 18, 12, tzinfo=timezone.utc),
+    }
+    assert event_sort_key(row) == event_sort_key(dict(row))
+    assert event_sort_key(row)[1]
+
+
+def test_raw_wrappers_match_dict_keys_on_both_surfaces() -> None:
+    class Wrapped:
+        def __init__(self, raw) -> None:
+            self.raw = raw
+
+    wrapped = Wrapped(SYSTEM_LOG_ROW)
+    assert gql_event_key(wrapped) == gql_event_key(SYSTEM_LOG_ROW)
+    assert rest_event_key(wrapped) == rest_event_key(SYSTEM_LOG_ROW)
+
+
+def test_plain_objects_without_stable_identity_fail_closed() -> None:
+    class UnsupportedEvent:
+        timestamp = 1787054400
+
+    with pytest.raises(ValueError, match="lacks a stable identity"):
+        gql_event_key(UnsupportedEvent())
+    with pytest.raises(ValueError, match="lacks a stable identity"):
+        rest_event_key(UnsupportedEvent())
+
+
+@pytest.mark.parametrize(
+    "legacy_timestamp",
+    [1787054400, 1787054400000, "2026-08-18T12:00:00Z"],
+    ids=["epoch-seconds", "epoch-millis", "iso"],
+)
+def test_legacy_cursor_normalizes_timestamp_when_identity_is_not_in_snapshot(legacy_timestamp) -> None:
+    rows = [
+        {"id": "newer", "timestamp": 1787054401},
+        {"id": "older", "timestamp": 1787054399},
+    ]
+    legacy_cursor = Cursor(last_id="event-no-longer-in-snapshot", last_ts=legacy_timestamp).encode()
+
+    page, next_cursor = paginate_access_events(
+        rows,
+        limit=10,
+        cursor=legacy_cursor,
+        key_fn=event_sort_key,
+    )
+
+    assert [row["id"] for row in page] == ["older"]
+    assert next_cursor is None

--- a/apps/api/tests/graphql/test_access_event_sort_key_unit.py
+++ b/apps/api/tests/graphql/test_access_event_sort_key_unit.py
@@ -7,12 +7,19 @@ with `(ts, id) < (last_ts, last_id)`, page 2 of an events query came back
 empty - nothing can be strictly less than the key every row shares.
 """
 
+import base64
+import json
 from datetime import datetime, timezone
 
 import pytest
 from unifi_api.graphql.resolvers.access import _event_key as gql_event_key
 from unifi_api.routes.resources.access.events import _event_key as rest_event_key
-from unifi_api.services.access_event_key import event_sort_key, paginate_access_events
+from unifi_api.services.access_event_key import (
+    InvalidAccessEventCursor,
+    _decode_access_event_cursor,
+    event_sort_key,
+    paginate_access_events,
+)
 from unifi_api.services.pagination import Cursor
 
 SYSTEM_LOG_ROW = {
@@ -23,6 +30,10 @@ SYSTEM_LOG_ROW = {
     "published": 1787054400000,
     "result": "ACCESS",
 }
+
+
+def _encode_cursor_payload(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
 
 
 def test_a_system_log_row_has_a_real_timestamp_not_zero() -> None:
@@ -237,3 +248,75 @@ def test_legacy_cursor_normalizes_timestamp_when_identity_is_not_in_snapshot(leg
 
     assert [row["id"] for row in page] == ["older"]
     assert next_cursor is None
+
+
+@pytest.mark.parametrize(
+    ("last_id", "last_ts"),
+    [
+        ("event-id", "2026-08-18T12:00:00Z"),
+        (42, 1787054400000),
+        ("event-id", 1787054400.75),
+        ("event-id", None),
+    ],
+    ids=["iso", "integer", "finite-float", "null"],
+)
+def test_legacy_cursor_accepts_exact_supported_contract(last_id, last_ts) -> None:
+    encoded = _encode_cursor_payload({"last_id": last_id, "last_ts": last_ts})
+
+    cursor, is_legacy = _decode_access_event_cursor(encoded)
+
+    assert is_legacy is True
+    assert cursor == Cursor(last_id=str(last_id), last_ts=last_ts)
+
+
+def test_versioned_access_cursor_is_not_treated_as_legacy() -> None:
+    encoded = _encode_cursor_payload(
+        {
+            "resource": "access_events",
+            "version": 1,
+            "last_id": "event-id",
+            "last_ts": 1787054400000,
+        }
+    )
+
+    cursor, is_legacy = _decode_access_event_cursor(encoded)
+
+    assert is_legacy is False
+    assert cursor == Cursor(last_id="event-id", last_ts=1787054400000)
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"last_id": "event-id"}, "unknown legacy format"),
+        ({"last_ts": 1787054400000}, "unknown legacy format"),
+        ({"last_id": "event-id", "last_ts": 1787054400000, "extra": True}, "unknown legacy format"),
+        ({"last_id": "", "last_ts": 1787054400000}, "last_id must be a stable identity"),
+        ({"last_id": True, "last_ts": 1787054400000}, "last_id must be a string or integer"),
+        ({"last_id": 1.5, "last_ts": 1787054400000}, "last_id must be a string or integer"),
+        ({"last_id": None, "last_ts": 1787054400000}, "last_id must be a string or integer"),
+        ({"last_id": ["event-id"], "last_ts": 1787054400000}, "last_id must be a string or integer"),
+        ({"last_id": {"id": "event-id"}, "last_ts": 1787054400000}, "last_id must be a string or integer"),
+        ({"last_id": "event-id", "last_ts": True}, "last_ts must be a string, integer, float, or null"),
+        ({"last_id": "event-id", "last_ts": [1787054400000]}, "last_ts must be a string, integer, float, or null"),
+        (
+            {"last_id": "event-id", "last_ts": {"millis": 1787054400000}},
+            "last_ts must be a string, integer, float, or null",
+        ),
+        ({"last_id": "event-id", "last_ts": float("nan")}, "last_ts must be finite"),
+        ({"last_id": "event-id", "last_ts": float("inf")}, "last_ts must be finite"),
+        ({"last_id": "event-id", "last_ts": float("-inf")}, "last_ts must be finite"),
+        (
+            {"resource": "network_events", "version": 1, "last_id": "event-id", "last_ts": 1787054400000},
+            "unknown resource format",
+        ),
+        ({"version": 1, "last_id": "event-id", "last_ts": 1787054400000}, "unknown resource format"),
+        (
+            {"resource": "access_events", "version": 99, "last_id": "event-id", "last_ts": 1787054400000},
+            "unsupported Access event cursor version",
+        ),
+    ],
+)
+def test_legacy_cursor_rejects_values_outside_supported_contract(payload, error) -> None:
+    with pytest.raises(InvalidAccessEventCursor, match=error):
+        _decode_access_event_cursor(_encode_cursor_payload(payload))

--- a/apps/api/tests/graphql/test_access_event_sort_key_unit.py
+++ b/apps/api/tests/graphql/test_access_event_sort_key_unit.py
@@ -1,0 +1,145 @@
+"""Access events need one canonical ordering identity, shared by every surface.
+
+Both API surfaces sorted on `(raw["timestamp"], raw["id"])`. System-log rows
+carry neither: the time is `published` (epoch ms) and the id is the empty
+string. Every row therefore keyed to `(0, "")`, and since `paginate()` windows
+with `(ts, id) < (last_ts, last_id)`, page 2 of an events query came back
+empty - nothing can be strictly less than the key every row shares.
+"""
+
+from unifi_api.services.access_event_key import event_sort_key
+
+SYSTEM_LOG_ROW = {
+    "id": "",
+    "log_key": "access.door.unlock",
+    "event_type": "access.door.unlock",
+    "message": "Access Granted (Face)",
+    "published": 1787054400000,
+    "result": "ACCESS",
+}
+
+
+def test_a_system_log_row_has_a_real_timestamp_not_zero() -> None:
+    assert event_sort_key(SYSTEM_LOG_ROW)[0] > 0
+
+
+def test_rows_order_by_published_time() -> None:
+    older = {**SYSTEM_LOG_ROW, "published": 1787054391000}
+    newer = {**SYSTEM_LOG_ROW, "published": 1787054490000}
+    assert event_sort_key(older) < event_sort_key(newer)
+
+
+def test_distinct_rows_never_share_a_key() -> None:
+    """The cursor filter is strict `<`, so any two rows sharing a key make the
+    next page drop both."""
+    a = {**SYSTEM_LOG_ROW, "published": 1787054400000, "message": "Access Granted (Face)"}
+    b = {**SYSTEM_LOG_ROW, "published": 1787054400000, "message": "Door status - Opened"}
+    assert event_sort_key(a) != event_sort_key(b)
+
+
+def test_sub_second_ordering_is_preserved() -> None:
+    """`published` is milliseconds; truncating to whole seconds collapses
+    events that happen within the same second into one key."""
+    a = {**SYSTEM_LOG_ROW, "published": 1787054400100}
+    b = {**SYSTEM_LOG_ROW, "published": 1787054400900}
+    assert event_sort_key(a) < event_sort_key(b)
+
+
+def test_a_real_id_is_used_as_the_identity_when_present() -> None:
+    row = {**SYSTEM_LOG_ROW, "id": "evt-1"}
+    assert event_sort_key(row)[1] == "evt-1"
+
+
+def test_the_key_is_reproducible_across_calls() -> None:
+    """Cursors are handed back to a later request; an unstable identity would
+    silently skip or repeat rows."""
+    assert event_sort_key(SYSTEM_LOG_ROW) == event_sort_key(dict(SYSTEM_LOG_ROW))
+
+
+def test_legacy_websocket_rows_still_key() -> None:
+    legacy = {"id": "evt-1", "type": "access.door.unlock", "timestamp": "2026-08-18T12:00:00Z"}
+    ts, ident = event_sort_key(legacy)
+    assert ts > 0
+    assert ident == "evt-1"
+
+
+def test_a_row_with_no_time_at_all_sorts_last_rather_than_raising() -> None:
+    ts, ident = event_sort_key({"id": "evt-2"})
+    assert ts == 0
+    assert ident == "evt-2"
+
+
+def test_the_key_is_comparable_across_a_mixed_list() -> None:
+    """sorted() raises TypeError the moment a str meets an int in the tuple."""
+    rows = [SYSTEM_LOG_ROW, {"id": "evt-2"}, {"id": "evt-3", "timestamp": "2026-08-18T12:00:00Z"}]
+    assert len(sorted(rows, key=event_sort_key)) == 3
+
+
+# --- scale, timezone and identity ---------------------------------------------
+
+
+def test_epoch_seconds_and_millis_sort_together() -> None:
+    """Legacy rows carry seconds, system-log rows carry millis. Left
+    unconverted a seconds row keys ~1000x lower and sinks below every millis
+    row, where the cursor window can strand it."""
+    secs = {"id": "a", "timestamp": 1787054400}
+    millis = {"id": "b", "published": 1787054400000}
+    assert abs(event_sort_key(secs)[0] - event_sort_key(millis)[0]) < 1000
+
+
+def test_a_naive_iso_string_is_read_as_utc() -> None:
+    """Otherwise it is read in the host's local zone, so the key differs
+    between workers and a cursor minted by one windows wrongly on another."""
+    naive = {"id": "a", "timestamp": "2026-08-18T12:00:00"}
+    aware = {"id": "b", "timestamp": "2026-08-18T12:00:00+00:00"}
+    assert event_sort_key(naive)[0] == event_sort_key(aware)[0]
+
+
+def test_same_millisecond_rows_for_different_doors_do_not_collide() -> None:
+    """Two door-status rows published in the same millisecond with the same
+    rendered message must not share an identity - a shared key drops both from
+    the next page."""
+    base = {
+        "id": "",
+        "log_key": "access.dps.status.update",
+        "event_type": "access.dps.status.update",
+        "message": "Door status - Opened",
+        "published": 1787054400000,
+        "result": "SUCCESS",
+    }
+    a = {**base, "metadata": {"door": {"id": "door-1", "type": "door"}}}
+    b = {**base, "metadata": {"door": {"id": "door-2", "type": "door"}}}
+    assert event_sort_key(a) != event_sort_key(b)
+
+
+def test_rows_differing_only_in_nested_user_metadata_do_not_collide() -> None:
+    """Reviewer's live finding on #549: two admin rows identical except for
+    `metadata.user.id` produced one key, so a cursor traversal dropped both.
+
+    A hand-picked field subset cannot be proven exhaustive - any nested field
+    left out of it is a collision waiting for the row that differs only there.
+    """
+    base = {
+        "id": "",
+        "log_key": "admin.activity",
+        "event_type": "admin.activity",
+        "message": "Admin updated a setting",
+        "published": 1787054400000,
+        "result": "SUCCESS",
+    }
+    a = {**base, "metadata": {"user": {"id": "user-1", "type": "user"}}}
+    b = {**base, "metadata": {"user": {"id": "user-2", "type": "user"}}}
+    assert event_sort_key(a) != event_sort_key(b)
+
+
+def test_rows_differing_only_in_an_unmodelled_field_do_not_collide() -> None:
+    """The same class of defect one level out: a field this module has never
+    heard of still distinguishes two controller rows."""
+    base = {
+        "id": "",
+        "log_key": "access.door.unlock",
+        "event_type": "access.door.unlock",
+        "message": "Access Granted (Face)",
+        "published": 1787054400000,
+    }
+    assert event_sort_key({**base, "some_future_field": "a"}) != event_sort_key({**base, "some_future_field": "b"})

--- a/apps/api/tests/graphql/test_errors.py
+++ b/apps/api/tests/graphql/test_errors.py
@@ -2,7 +2,9 @@
 
 from graphql import GraphQLError
 from unifi_api.graphql.errors import format_graphql_error
+from unifi_api.services.access_event_key import InvalidAccessEventCursor
 from unifi_api.services.controllers import ControllerNotFound
+from unifi_api.services.pagination import InvalidCursor
 
 
 def test_format_unauthenticated() -> None:
@@ -35,6 +37,20 @@ def test_format_not_found_from_controller_not_found() -> None:
     err.original_error = ControllerNotFound("xyz")
     formatted = format_graphql_error(err)
     assert formatted["extensions"]["code"] == "NOT_FOUND"
+
+
+def test_format_invalid_access_event_cursor_as_bad_request() -> None:
+    err = GraphQLError("unsupported Access event cursor version: 99")
+    err.original_error = InvalidAccessEventCursor("unsupported Access event cursor version: 99")
+    formatted = format_graphql_error(err)
+    assert formatted["extensions"]["code"] == "BAD_REQUEST"
+
+
+def test_format_invalid_generic_cursor_as_bad_request() -> None:
+    err = GraphQLError("invalid cursor")
+    err.original_error = InvalidCursor("invalid cursor")
+    formatted = format_graphql_error(err)
+    assert formatted["extensions"]["code"] == "BAD_REQUEST"
 
 
 def test_format_unknown_internal() -> None:

--- a/apps/api/tests/routes/resources/test_access_doors_policies.py
+++ b/apps/api/tests/routes/resources/test_access_doors_policies.py
@@ -528,6 +528,51 @@ async def test_list_visitors_happy_path(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_visitors_server_cursor_round_trips_iso_timestamp(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    visitors = [
+        {
+            "id": f"vis-{i}",
+            "first_name": "Visitor",
+            "last_name": str(i),
+            "status": 6,
+            "created_at": f"2026-08-18T12:00:0{i}Z",
+        }
+        for i in range(4)
+    ]
+
+    async def fake_list(self):
+        return visitors
+
+    from unifi_core.access.managers.visitor_manager import VisitorManager
+
+    monkeypatch.setattr(VisitorManager, "list_visitors", fake_list)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        first = await c.get(
+            f"/v1/sites/default/visitors?controller={cid}",
+            params={"limit": 2},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        assert first.status_code == 200, first.text
+        first_body = first.json()
+        second = await c.get(
+            f"/v1/sites/default/visitors?controller={cid}",
+            params={"limit": 2, "cursor": first_body["next_cursor"]},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert second.status_code == 200, second.text
+    second_body = second.json()
+    assert [item["id"] for item in first_body["items"]] == ["vis-3", "vis-2"]
+    assert [item["id"] for item in second_body["items"]] == ["vis-1", "vis-0"]
+    assert second_body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
 async def test_get_visitor_happy_and_404(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)

--- a/apps/api/tests/routes/resources/test_access_events_system.py
+++ b/apps/api/tests/routes/resources/test_access_events_system.py
@@ -274,6 +274,9 @@ async def test_list_access_events_issues_versioned_resource_cursor(tmp_path, mon
     ("cursor", "expected_detail"),
     [
         (Cursor(last_id="missing", last_ts="not-a-time").encode(), "timestamp is unrecoverable"),
+        (Cursor(last_id="missing", last_ts=float("nan")).encode(), "last_ts must be finite"),
+        (Cursor(last_id="missing", last_ts=float("inf")).encode(), "last_ts must be finite"),
+        (Cursor(last_id="missing", last_ts=float("-inf")).encode(), "last_ts must be finite"),
         (
             base64.urlsafe_b64encode(
                 json.dumps({"resource": "access_events", "version": 99, "last_id": "evt", "last_ts": 1}).encode()

--- a/apps/api/tests/routes/resources/test_access_events_system.py
+++ b/apps/api/tests/routes/resources/test_access_events_system.py
@@ -8,6 +8,8 @@ Covers 6 endpoint families across 2 route modules:
   (product-prefixed paths to disambiguate from network/protect)
 """
 
+import base64
+import json
 import uuid
 from datetime import datetime, timezone
 
@@ -18,6 +20,8 @@ from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
 from unifi_api.db.models import ApiKey, Base, Controller
 from unifi_api.server import create_app
+from unifi_api.services.pagination import Cursor
+from unifi_core.access.models.events import event_identity, with_event_identity
 from unifi_core.exceptions import UniFiNotFoundError
 
 
@@ -88,6 +92,48 @@ def _stub_connection(app, cid: str) -> _FakeAccessCM:
     fake = _FakeAccessCM()
     app.state.manager_factory._connection_cache[(cid, "access", None)] = fake
     return fake
+
+
+def _legacy_event_key(row: dict) -> tuple:
+    """The exact Access REST ordering key used before timestamp normalization."""
+    return (row.get("timestamp") or row.get("time") or 0, row.get("id") or "")
+
+
+def _legacy_cursor(row: dict) -> str:
+    timestamp, identity = _legacy_event_key(row)
+    return Cursor(last_id=identity, last_ts=timestamp).encode()
+
+
+def _cursor_payload(cursor: str) -> dict:
+    return json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+
+
+def _migration_rows(timestamp_format: str) -> tuple[list[dict], dict]:
+    if timestamp_format == "published":
+        rows = [
+            {
+                "id": "",
+                "log_key": "access.door.unlock",
+                "event_type": "access.door.unlock",
+                "message": f"row {index}",
+                "published": 1787054400000 + offset,
+            }
+            for index, offset in enumerate((1000, 0, -1000))
+        ]
+        return rows, with_event_identity(rows[1])
+    if timestamp_format == "seconds":
+        rows = [{"id": f"evt-{index}", "timestamp": 1787054400 + offset} for index, offset in enumerate((1, 0, -1))]
+    elif timestamp_format == "millis":
+        rows = [
+            {"id": f"evt-{index}", "timestamp": 1787054400000 + offset} for index, offset in enumerate((1000, 0, -1000))
+        ]
+    else:
+        rows = [
+            {"id": "evt-0", "timestamp": "2026-08-18T12:00:01Z"},
+            {"id": "evt-1", "timestamp": "2026-08-18T12:00:00Z"},
+            {"id": "evt-2", "timestamp": "2026-08-18T11:59:59Z"},
+        ]
+    return rows, rows[1]
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +221,93 @@ async def test_list_access_events_cursor_traverses_empty_native_ids(tmp_path, mo
     assert len(seen) == 2
     assert all(seen)
     assert len(set(seen)) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timestamp_format", ["published", "seconds", "millis", "iso"])
+async def test_list_access_events_resumes_legacy_cursor(tmp_path, monkeypatch, timestamp_format) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    cm = _stub_connection(app, cid)
+    rows, legacy_target = _migration_rows(timestamp_format)
+    cm.response = {"total": len(rows), "data": {"events": rows}}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/sites/default/access/events?controller={cid}",
+            params={"limit": 10, "cursor": _legacy_cursor(legacy_target)},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 200, response.text
+    returned_ids = [item["id"] for item in response.json()["items"]]
+    expected_older_id = event_identity(rows[2])
+    assert returned_ids == [expected_older_id]
+    assert len(returned_ids) == len(set(returned_ids))
+    assert event_identity(rows[0]) not in returned_ids
+    assert event_identity(rows[1]) not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_list_access_events_issues_versioned_resource_cursor(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    cm = _stub_connection(app, cid)
+    rows, _ = _migration_rows("seconds")
+    cm.response = {"total": len(rows), "data": {"events": rows}}
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/sites/default/access/events?controller={cid}",
+            params={"limit": 1},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 200, response.text
+    payload = _cursor_payload(response.json()["next_cursor"])
+    assert payload["resource"] == "access_events"
+    assert payload["version"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("cursor", "expected_detail"),
+    [
+        (Cursor(last_id="missing", last_ts="not-a-time").encode(), "timestamp is unrecoverable"),
+        (
+            base64.urlsafe_b64encode(
+                json.dumps({"resource": "access_events", "version": 99, "last_id": "evt", "last_ts": 1}).encode()
+            ).decode(),
+            "unsupported Access event cursor version",
+        ),
+        (
+            base64.urlsafe_b64encode(
+                json.dumps({"resource": "network_events", "version": 1, "last_id": "evt", "last_ts": 1}).encode()
+            ).decode(),
+            "unknown resource format",
+        ),
+        ("not-base64", "invalid Access event cursor"),
+    ],
+)
+async def test_list_access_events_rejects_unrecoverable_cursor(
+    tmp_path,
+    monkeypatch,
+    cursor,
+    expected_detail,
+) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/sites/default/access/events?controller={cid}",
+            params={"cursor": cursor},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 400
+    assert expected_detail in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/routes/resources/test_access_events_system.py
+++ b/apps/api/tests/routes/resources/test_access_events_system.py
@@ -108,6 +108,10 @@ def _cursor_payload(cursor: str) -> dict:
     return json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
 
 
+def _encode_cursor_payload(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
 def _migration_rows(timestamp_format: str) -> tuple[list[dict], dict]:
     if timestamp_format == "published":
         rows = [
@@ -306,6 +310,44 @@ async def test_list_access_events_rejects_unrecoverable_cursor(
         response = await client.get(
             f"/v1/sites/default/access/events?controller={cid}",
             params={"cursor": cursor},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 400
+    assert expected_detail in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected_detail"),
+    [
+        ({"last_id": "present", "last_ts": True}, "last_ts must be a string, integer, float, or null"),
+        ({"last_id": "present", "last_ts": [1787054400000]}, "last_ts must be a string, integer, float, or null"),
+        (
+            {"last_id": "present", "last_ts": {"millis": 1787054400000}},
+            "last_ts must be a string, integer, float, or null",
+        ),
+        ({"last_id": "present"}, "unknown legacy format"),
+    ],
+)
+async def test_list_access_events_rejects_malformed_cursor_when_identity_is_present(
+    tmp_path,
+    monkeypatch,
+    payload,
+    expected_detail,
+) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    cm = _stub_connection(app, cid)
+    cm.response = {
+        "total": 1,
+        "data": {"events": [{"id": "present", "timestamp": 1787054400}]},
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/sites/default/access/events?controller={cid}",
+            params={"cursor": _encode_cursor_payload(payload)},
             headers={"Authorization": f"Bearer {key}"},
         )
 

--- a/apps/api/tests/routes/resources/test_network_stats_events_system.py
+++ b/apps/api/tests/routes/resources/test_network_stats_events_system.py
@@ -1,5 +1,7 @@
 """Phase 5A PR2 Cluster 6 — network stats / events / system routes."""
 
+import base64
+import json
 import uuid
 from datetime import datetime, timezone
 
@@ -307,6 +309,60 @@ async def test_list_events_event_log(tmp_path, monkeypatch) -> None:
     body = r.json()
     assert body["render_hint"]["kind"] == "event_log"
     assert len(body["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_network_events_reject_access_event_cursor(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, within=24, limit=100, start=0, event_type=None, categories=None, severities=None):
+        return []
+
+    from unifi_core.network.managers.event_manager import EventManager
+
+    monkeypatch.setattr(EventManager, "get_events", fake_get)
+    access_cursor = base64.urlsafe_b64encode(
+        json.dumps({"resource": "access_events", "version": 1, "last_id": "evt", "last_ts": 1700000000000}).encode()
+    ).decode()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/sites/default/events?controller={cid}",
+            params={"cursor": access_cursor},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid cursor"
+
+
+@pytest.mark.asyncio
+async def test_network_events_reject_cursor_with_invalid_value_types(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_get(self, within=24, limit=100, start=0, event_type=None, categories=None, severities=None):
+        return []
+
+    from unifi_core.network.managers.event_manager import EventManager
+
+    monkeypatch.setattr(EventManager, "get_events", fake_get)
+    invalid_cursor = base64.urlsafe_b64encode(
+        json.dumps({"last_id": "evt", "last_ts": {"millis": 1700000000000}}).encode()
+    ).decode()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/sites/default/events?controller={cid}",
+            params={"cursor": invalid_cursor},
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid cursor"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_pagination.py
+++ b/apps/api/tests/test_pagination.py
@@ -58,6 +58,13 @@ def test_cursor_decode_rejects_invalid_value_types(payload, error) -> None:
         Cursor.decode(encoded)
 
 
+@pytest.mark.parametrize("last_ts", [float("nan"), float("inf"), float("-inf")])
+def test_cursor_decode_rejects_non_finite_float_timestamps(last_ts) -> None:
+    encoded = Cursor(last_id="event-id", last_ts=last_ts).encode()
+    with pytest.raises(InvalidCursor, match="last_ts must be finite"):
+        Cursor.decode(encoded)
+
+
 def test_paginate_first_page_no_cursor() -> None:
     items = [{"id": str(i), "ts": i} for i in range(10)]
     page, next_cursor = paginate(items, limit=3, cursor=None, key_fn=lambda x: (x["ts"], x["id"]))

--- a/apps/api/tests/test_pagination.py
+++ b/apps/api/tests/test_pagination.py
@@ -1,5 +1,8 @@
 """Cursor + paginate() tests."""
 
+import base64
+import json
+
 import pytest
 from unifi_api.services.pagination import Cursor, InvalidCursor, paginate
 
@@ -13,9 +16,46 @@ def test_cursor_encode_decode_roundtrip() -> None:
     assert decoded.last_ts == 1000
 
 
+@pytest.mark.parametrize("last_ts", ["2026-08-18T12:00:00Z", 1787054400.75])
+def test_cursor_roundtrip_preserves_emitted_timestamp_scalars(last_ts) -> None:
+    cursor = Cursor(last_id="event-id", last_ts=last_ts)
+    assert Cursor.decode(cursor.encode()) == cursor
+
+
 def test_cursor_decode_invalid_raises() -> None:
     with pytest.raises(InvalidCursor):
         Cursor.decode("not-base64-or-json")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"last_id": "evt", "last_ts": 1000, "resource": "access_events", "version": 1},
+        {"last_id": "evt"},
+    ],
+)
+def test_cursor_decode_rejects_non_legacy_payload_shapes(payload) -> None:
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    with pytest.raises(InvalidCursor, match="exact legacy cursor payload"):
+        Cursor.decode(encoded)
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"last_id": True, "last_ts": 1000}, "last_id must be a string or integer"),
+        ({"last_id": ["evt"], "last_ts": 1000}, "last_id must be a string or integer"),
+        ({"last_id": "evt", "last_ts": False}, "last_ts must be a string, integer, float, or null"),
+        (
+            {"last_id": "evt", "last_ts": {"millis": 1000}},
+            "last_ts must be a string, integer, float, or null",
+        ),
+    ],
+)
+def test_cursor_decode_rejects_invalid_value_types(payload, error) -> None:
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    with pytest.raises(InvalidCursor, match=error):
+        Cursor.decode(encoded)
 
 
 def test_paginate_first_page_no_cursor() -> None:


### PR DESCRIPTION
`_event_key` on both API surfaces sorted Access events on `(raw["timestamp"], raw["id"])`. A system-log row has neither: its time is `published` in epoch milliseconds and, before the identity work in #555, its id was empty. Every row therefore keyed to `(0, "")`, and because `paginate()` windows with a strict `(ts, id) < (last_ts, last_id)`, page 2 of an events query came back empty on GraphQL, while on REST a bare `0` meeting a string raised `TypeError` inside `sorted()`.

## What changed

- **Identity comes from `unifi_core`'s `event_identity`**, which digests the complete canonical row. An earlier revision of this work digested a hand-picked subset of fields instead; on a live controller, two admin rows differing only at `metadata.user.id` produced the same key, and a full cursor traversal at `limit=2` lost one row out of 68. A subset cannot be shown to be exhaustive — the whole row can.
- **Time is coerced in the API layer**, where ordering belongs. Rows arrive as epoch millis (`published`), epoch seconds, or ISO 8601; left unconverted, a seconds row keys ~1000x below a millis row for the same instant and is stranded past the cursor window. A naive ISO string is read as UTC, so a cursor minted by one worker windows identically on another.

## Scope

Ordering only — no schema, manifest, or projection change. Nothing here needs more than the published `unifi-core` 0.4.30 floor this package already declares.

## Validation

- `apps/api`: 1,246 passed. `ruff format --check` and `ruff check` clean at the `uv.lock` pin (0.16.2); `make check-generated` exit 0; `check_pin_alignment.py` exit 0 ("Core floor 0.4.30: validated 268 catalog bindings").
- Confirmed against the published wheel that `unifi-core[access]==0.4.30` exposes `event_identity`, so a fresh install is safe at the declared floor.
- Regressions added: two rows differing only in nested user metadata; two differing only in a field this module has never heard of; and a page-at-a-time traversal of 68 rows asserting every row is returned exactly once (a single `paginate()` call cannot catch the loss).
- Exercised against a live UniFi Access controller as part of a deployed build at `06f412b`, which layers this branch together with the two related changes below.

Relates to #548. Does not close it.
