### PR TITLE
fix(access): read the system-log shape and the websocket the controller sends

### DIFF
--- a/packages/unifi-core/src/unifi_core/access/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/event_manager.py
@@ -19,6 +19,7 @@ import logging
 import time
 from collections import deque
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 from unifi_core.access.models.events import event_identity, with_event_identity
@@ -27,15 +28,6 @@ from unifi_core.exceptions import UniFiConnectionError, UniFiNotFoundError
 logger = logging.getLogger(__name__)
 
 _GET_EVENT_PAGE_SIZE = 100
-_EVENT_SEARCH_TOPICS = (
-    "unlocks",
-    "access_denial",
-    "ring",
-    "updates",
-    "critical",
-    "admin",
-    "admin_activity",
-)
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +95,79 @@ class EventBuffer:
 # ---------------------------------------------------------------------------
 
 
+# The topics are the Access UI's own syslog Category filters, lowercased and
+# snake_cased. All seven verified against a live controller; anything else is
+# rejected with CODE_PARAMS_INVALID "no such topic".
+#
+# "unlocks" is the door history - access.door.unlock and access.dps.status.update
+# records, i.e. "Access Granted (Face)" and door open/close. Guessing at names
+# like door_openings or access finds nothing, which is what made this look
+# unreachable.
+SYSTEM_LOG_TOPICS: tuple[str, ...] = (
+    "unlocks",
+    "access_denial",
+    "ring",
+    "updates",
+    "critical",
+    "admin",
+    "admin_activity",
+)
+
+
+# The controller's histogram endpoint fails with CODE_SYSTEM_ERROR once the
+# request spans too many buckets. Measured live: 100 buckets succeed, 104 and
+# above return a 500. Kept well under the observed edge.
+_MAX_HISTOGRAM_BUCKETS = 96
+
+# Finest-to-coarsest: the loop below returns the FIRST interval that fits, so
+# this order is what makes the chosen bucket the finest one available. Reordering
+# it would silently pick the coarsest interval every time.
+_HISTOGRAM_INTERVALS = (3600, 7200, 21600, 43200, 86400, 604800)
+
+
+def _histogram_interval(days: int) -> int:
+    """Pick the finest bucket interval whose bucket count the controller accepts.
+
+    A fixed ``interval=3600`` meant the default 7-day window asked for 168
+    buckets and always failed, so the tool never worked at its own default.
+
+    Raises ``ValueError`` when no interval fits. Falling back to the coarsest
+    one instead would re-create the very failure this guards: 1000 days at one
+    bucket per week is 142 buckets, back over the limit. ``days`` is unbounded
+    on the MCP tool and the GraphQL resolver, so the bound has to be here.
+    """
+    span = max(int(days), 1) * 86400
+    for interval in _HISTOGRAM_INTERVALS:
+        # Ceil, not floor: the controller sees ceil(span/interval) buckets, so
+        # flooring let days=673 pass the guard and then ask for 97 against a
+        # cap of 96, while the error text still claimed 672 was the limit.
+        if -(-span // interval) <= _MAX_HISTOGRAM_BUCKETS:
+            return interval
+    max_days = _MAX_HISTOGRAM_BUCKETS * _HISTOGRAM_INTERVALS[-1] // 86400
+    raise ValueError(
+        f"A {int(days)}-day activity window cannot be served: even at one bucket "
+        f"per week it exceeds the controller's histogram limit. "
+        f"Request at most {max_days} days."
+    )
+
+
+# Delivered by the "*" subscription but deliberately NOT buffered: these are
+# high-rate telemetry, and the ring holds only 100 entries. A burst of them
+# would evict a door unlock seconds after it happened, so
+# get_recent(event_type="access.door.unlock") would come back empty.
+_BUFFER_EXCLUDED_EVENTS: frozenset[str] = frozenset(
+    {
+        "access.data.v2.location.update",
+        "access.data.device.location_update_v2",
+        "access.data.location.update",
+        "access.data.v2.device.update",
+        "access.remote_view",
+        "access.remote_view.change",
+        "access.base.info",
+    }
+)
+
+
 class EventManager:
     """Domain logic for UniFi Access events.
 
@@ -148,32 +213,75 @@ class EventManager:
             return
 
         try:
-            handlers = {
-                "door_open": self._on_event,
-                "door_close": self._on_event,
-                "access_granted": self._on_event,
-                "access_denied": self._on_event,
-                "door_alarm": self._on_event,
-            }
+            # The client dispatches on ``WebsocketMessage.event``, whose values
+            # are the controller's dotted names - ``access.logs.add``,
+            # ``access.hw.door_bell``, ``access.data.device.remote_unlock`` and
+            # friends. Enumerating friendly names like ``door_open`` matched
+            # none of them, so every message hit the client's "unhandled" branch
+            # and the buffer stayed empty. ``"*"`` is the client's wildcard.
+            handlers = {"*": self._on_event}
+            # NB: the wildcard also delivers high-rate telemetry frames. See
+            # _BUFFER_EXCLUDED_EVENTS - they are logged but not buffered, so a
+            # burst cannot evict a just-occurred door event from the ring.
             self._cm.start_websocket(handlers)
             logger.info("[event-mgr] Websocket subscription started.")
         except Exception as e:
             logger.error("[event-mgr] Failed to start websocket: %s", e, exc_info=True)
 
+    @staticmethod
+    def _normalize_ws_event(event_data: Any) -> dict[str, Any]:
+        """Flatten a websocket message into the buffer's dict shape.
+
+        The client hands the handler a frozen ``WebsocketMessage`` carrying
+        ``event`` / ``event_object_id`` / ``door_id``. It has no ``type``,
+        ``id``, ``user_id`` or ``timestamp``, so reading those names off it
+        buffered ``{"type": "unknown", "door_id": ""}`` - a row that no
+        ``get_recent`` filter could match and that carried no time at all.
+        """
+        raw: dict[str, Any] = {}
+        if isinstance(event_data, dict):
+            raw = dict(event_data)
+        else:
+            # Prefer the model's own dump, but only when it really yields a
+            # mapping - `hasattr` alone is true for any mock or proxy object.
+            dump = getattr(event_data, "model_dump", None)
+            if callable(dump):
+                try:
+                    dumped = dump()
+                except Exception:  # pragma: no cover - defensive
+                    dumped = None
+                if isinstance(dumped, dict):
+                    raw = dict(dumped)
+            if not raw:
+                # Plain object: read both naming schemes, since callers may
+                # hand us either the websocket model or a legacy event object.
+                raw = {
+                    key: getattr(event_data, key, None)
+                    for key in ("id", "type", "door_id", "user_id", "timestamp", "event", "event_object_id")
+                }
+
+        # Project to a known flat shape rather than carrying the whole dump.
+        # `model_dump()` includes the `data` sub-payload (actor display names,
+        # credential and device identifiers), and both `access_recent_events`
+        # and GET /access/recent-events return buffered rows unprojected - so
+        # keeping it would widen what a READ-scoped caller sees.
+        normalized: dict[str, Any] = {}
+        normalized["type"] = raw.get("type") or raw.get("event") or "unknown"
+        normalized["id"] = raw.get("id") or raw.get("event_object_id") or None
+        normalized["door_id"] = raw.get("door_id") or None
+        normalized["user_id"] = raw.get("user_id") or None
+        # Websocket messages are not timestamped by the controller; stamp on
+        # arrival so buffered rows can be ordered and aged like any other.
+        normalized["timestamp"] = raw.get("timestamp") or datetime.now(timezone.utc).isoformat()
+        return normalized
+
     def _on_event(self, event_data: Any) -> None:
         """Callback invoked for websocket events. Buffers the event."""
         try:
-            if isinstance(event_data, dict):
-                event_dict = event_data
-            else:
-                # Convert to dict if it's an object
-                event_dict = {
-                    "id": getattr(event_data, "id", None),
-                    "type": getattr(event_data, "type", "unknown"),
-                    "door_id": getattr(event_data, "door_id", None),
-                    "user_id": getattr(event_data, "user_id", None),
-                    "timestamp": getattr(event_data, "timestamp", None),
-                }
+            event_dict = self._normalize_ws_event(event_data)
+            if event_dict.get("type") in _BUFFER_EXCLUDED_EVENTS:
+                logger.debug("[event-mgr] Skipping high-rate frame %s", event_dict.get("type"))
+                return
             self._buffer.add(event_dict)
             logger.debug("[event-mgr] Buffered event from websocket")
             # Phase 4B: fan out to subscribers
@@ -240,8 +348,10 @@ class EventManager:
         Parameters
         ----------
         topic:
-            Event topic to query.  Valid values include ``admin`` and
-            ``admin_activity``.  The Access API requires this field.
+            Event topic to query. One of :data:`SYSTEM_LOG_TOPICS`, which
+            mirrors the Access UI's syslog Category filter. ``unlocks`` is the
+            door history (grants plus open/close), ``access_denial`` the
+            refused attempts. Anything else is rejected with ``no such topic``.
         start:
             ISO 8601 start time filter.
         end:
@@ -253,6 +363,13 @@ class EventManager:
         limit:
             Maximum number of events to return (page size).
         """
+        if topic not in SYSTEM_LOG_TOPICS:
+            raise ValueError(
+                f"Unsupported topic {topic!r}. The controller accepts only "
+                f"{', '.join(SYSTEM_LOG_TOPICS)}. Door unlock and open/close history "
+                "is under 'unlocks'; denied attempts are under 'access_denial'."
+            )
+
         if not self._cm.has_proxy:
             raise UniFiConnectionError("No proxy session available for list_events")
 
@@ -304,7 +421,7 @@ class EventManager:
             # The controller has no direct event-by-id endpoint. Search every
             # page of each supported topic so any ID returned by list_events
             # remains addressable, including synthetic system-log IDs.
-            for topic in _EVENT_SEARCH_TOPICS:
+            for topic in SYSTEM_LOG_TOPICS:
                 page_num = 1
                 while True:
                     path = f"insights/system_log/search?page_size={_GET_EVENT_PAGE_SIZE}&page_num={page_num}&isAccess"
@@ -370,9 +487,14 @@ class EventManager:
             raise UniFiConnectionError("No proxy session available for get_activity_summary")
 
         try:
+            # Clamp once and use the clamped value for the window too: the MCP
+            # tool declares `days: int` with no bounds, so days=0 sent an empty
+            # window and days=-5 sent since > until, both slipping past the
+            # interval guard that had already judged the request servable.
+            window_days = max(int(days), 1)
             now = int(time.time())
-            since = now - (days * 86400)
-            path = f"activities/histogram?since={since}&until={now}&interval=3600"
+            since = now - (window_days * 86400)
+            path = f"activities/histogram?since={since}&until={now}&interval={_histogram_interval(window_days)}"
             if door_id:
                 path += f"&door_id={door_id}"
 

--- a/packages/unifi-core/src/unifi_core/access/models/events.py
+++ b/packages/unifi-core/src/unifi_core/access/models/events.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
@@ -45,6 +46,11 @@ class Event(BaseModel):
     )
     credential_id: Optional[str] = Field(
         default=None, description="Credential UUID used in the event", json_schema_extra={"mutable": False}
+    )
+    message: Optional[str] = Field(
+        default=None,
+        description="Human-readable summary of the event, as the controller renders it",
+        json_schema_extra={"mutable": False},
     )
     result: Optional[str] = Field(
         default=None, description="Event result (granted, denied, etc.)", json_schema_extra={"mutable": False}
@@ -143,15 +149,67 @@ def with_event_identity(raw: dict[str, Any]) -> dict[str, Any]:
     return {**raw, "id": identity}
 
 
+def _epoch_millis_to_iso(value: Any) -> Optional[str]:
+    """Render an epoch-millisecond integer as a UTC ISO 8601 string."""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _metadata_entry_id(raw: Any, *keys: str, expected_type: Optional[str] = None) -> Optional[str]:
+    """Pull an id out of the system log's ``metadata`` sub-objects.
+
+    Each entry looks like ``{"id": ..., "type": ..., "display_name": ...}``.
+    The first key resolving to an entry with an id wins.
+
+    ``expected_type`` guards against mis-attribution, which the entries invite:
+    ``actor`` is whatever caused the event, and for an ``access.dps.status.update``
+    record that is the door hub rather than a person. Reading its id ungated
+    reports a device as the user who opened the door. The same applies to
+    readers, which carry a device id that is not the id of any door.
+    """
+    metadata = _get(raw, "metadata")
+    if not isinstance(metadata, dict):
+        return None
+    for key in keys:
+        entry = metadata.get(key)
+        if not isinstance(entry, dict) or not entry.get("id"):
+            continue
+        if expected_type is not None and entry.get("type") != expected_type:
+            continue
+        return str(entry["id"])
+    return None
+
+
 def event_from_controller(raw: Any) -> Event:
-    """Build an Event from a manager dict or object."""
+    """Build an Event from a manager dict or object.
+
+    Handles both event shapes this project sees. The websocket/legacy records
+    carry ``type``/``timestamp``/``door_id``/``user_id`` directly. The
+    ``insights/system_log/search`` records - what ``list_events`` actually
+    returns - use ``event_type``, ``published`` in epoch milliseconds, and
+    nest the actor and door inside ``metadata``. Reading only the first set
+    left every system-log row serializing to nothing but an id and a result.
+
+    ``credential_id`` is deliberately read only from a top-level field. The
+    live system-log rows carry credential context under ``authentication``
+    and ``nfc_id`` rather than ``credential``, and which of those is the
+    canonical credential identity is not yet established, so this serializer
+    makes no claim rather than a plausible-looking wrong one.
+    """
     return Event(
         id=event_identity(raw),
-        type=_get(raw, "type"),
-        timestamp=_stringify_dt(_get(raw, "timestamp") or _get(raw, "time")),
-        door_id=_get(raw, "door_id"),
-        user_id=_get(raw, "user_id"),
+        type=_get(raw, "type") or _get(raw, "event_type") or _get(raw, "log_key"),
+        timestamp=(
+            _stringify_dt(_get(raw, "timestamp") or _get(raw, "time")) or _epoch_millis_to_iso(_get(raw, "published"))
+        ),
+        door_id=_get(raw, "door_id") or _metadata_entry_id(raw, "door", expected_type="door"),
+        user_id=_get(raw, "user_id") or _metadata_entry_id(raw, "actor", "user", expected_type="user"),
         credential_id=_get(raw, "credential_id"),
+        message=_get(raw, "message"),
         result=_get(raw, "result"),
     )
 

--- a/packages/unifi-core/tests/access/managers/test_event_manager_histogram.py
+++ b/packages/unifi-core/tests/access/managers/test_event_manager_histogram.py
@@ -1,0 +1,144 @@
+"""The activity histogram must not ask the controller for too many buckets.
+
+Measured against a live controller: `activities/histogram` succeeds at 100
+buckets and fails with CODE_SYSTEM_ERROR at 104 and above. The default of 7
+days at a hard-coded interval of 3600 asks for 168, so the tool never worked
+at its own default.
+
+The interval is therefore derived from the window rather than fixed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from unifi_core.access.managers.event_manager import EventManager
+
+MAX_BUCKETS = 100
+
+
+def _manager() -> EventManager:
+    cm = MagicMock()
+    cm.has_proxy = True
+    cm.has_api_client = False
+    cm.proxy_request = AsyncMock(return_value={"data": {"buckets": []}})
+    cm.extract_data = MagicMock(side_effect=lambda d: d.get("data", {}))
+    return EventManager(cm)
+
+
+def _bucket_count(path: str) -> int:
+    q = parse_qs(urlparse(path).query)
+    since, until, interval = int(q["since"][0]), int(q["until"][0]), int(q["interval"][0])
+    return (until - since) // interval
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("days", [1, 7, 30, 90, 365])
+async def test_histogram_never_exceeds_the_controllers_bucket_cap(days) -> None:
+    mgr = _manager()
+    await mgr.get_activity_summary(days=days)
+    path = mgr._cm.proxy_request.call_args.args[1]
+    assert _bucket_count(path) <= MAX_BUCKETS, f"{days}d asked for {_bucket_count(path)} buckets"
+
+
+@pytest.mark.asyncio
+async def test_short_windows_keep_hourly_resolution() -> None:
+    """Coarsening must not cost resolution where it was not needed: a 1-day
+    window still fits in hourly buckets."""
+    mgr = _manager()
+    await mgr.get_activity_summary(days=1)
+    path = mgr._cm.proxy_request.call_args.args[1]
+    assert "interval=3600" in path, path
+
+
+# --- topic vocabulary --------------------------------------------------------
+
+
+def test_topics_match_the_ui_category_filter() -> None:
+    """Verified live. The vocabulary is the Access UI's syslog Category list
+    lowercased and snake_cased - guessing at door_openings, doors, access or
+    activity finds nothing, which is what made the door history look
+    unreachable."""
+    from unifi_core.access.managers.event_manager import SYSTEM_LOG_TOPICS
+
+    assert set(SYSTEM_LOG_TOPICS) == {
+        "unlocks",
+        "access_denial",
+        "ring",
+        "updates",
+        "critical",
+        "admin",
+        "admin_activity",
+    }
+
+
+def test_door_history_topic_is_accepted() -> None:
+    """The whole point of the tool: `unlocks` carries access.door.unlock and
+    access.dps.status.update records."""
+    from unifi_core.access.managers.event_manager import SYSTEM_LOG_TOPICS
+
+    assert "unlocks" in SYSTEM_LOG_TOPICS
+
+
+@pytest.mark.asyncio
+async def test_an_unsupported_topic_fails_before_the_request_is_sent() -> None:
+    """The controller's own error is `CODE_PARAMS_INVALID ... no such topic`,
+    which tells a caller nothing about what IS valid."""
+    mgr = _manager()
+    with pytest.raises(ValueError) as excinfo:
+        await mgr.list_events(topic="door_openings")
+    msg = str(excinfo.value)
+    assert "door_openings" in msg
+    assert "unlocks" in msg, "the error must name the valid topics"
+    mgr._cm.proxy_request.assert_not_awaited()
+
+
+# --- window bounds -----------------------------------------------------------
+
+
+def test_a_window_too_large_for_any_interval_is_rejected_not_silently_coarsened() -> None:
+    """Falling back to the coarsest interval just re-creates the failure this
+    helper exists to prevent: 1000 days at one bucket per week is 142 buckets,
+    straight back to CODE_SYSTEM_ERROR. `days` is unbounded on the MCP tool and
+    the GraphQL resolver, so the guard has to live here."""
+    from unifi_core.access.managers.event_manager import _histogram_interval
+
+    with pytest.raises(ValueError) as excinfo:
+        _histogram_interval(1000)
+    assert "672" in str(excinfo.value), "the error must say what the limit actually is"
+
+
+def test_the_largest_supported_window_still_works() -> None:
+    from unifi_core.access.managers.event_manager import _histogram_interval
+
+    assert _histogram_interval(672) == 604800
+
+
+# --- get_event ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_event_still_finds_an_event_that_carries_a_real_id() -> None:
+    mgr = _manager()
+    found = {"id": "evt-9", "event_type": "access.admin.update"}
+
+    async def _search(method, path, json=None, **kw):
+        return {"data": {"events": [found] if json and json.get("topic") == "admin" else []}}
+
+    mgr._cm.proxy_request = AsyncMock(side_effect=_search)
+    mgr._cm.extract_data = MagicMock(side_effect=lambda d: d.get("data", {}))
+    assert await mgr.get_event("evt-9") == found
+
+
+def test_the_bucket_guard_agrees_with_its_own_advertised_limit() -> None:
+    """The controller counts ceil(span/interval); flooring let days=673 pass
+    and then request 97 buckets against a cap of 96."""
+    from unifi_core.access.managers.event_manager import (
+        _MAX_HISTOGRAM_BUCKETS,
+        _histogram_interval,
+    )
+
+    interval = _histogram_interval(672)
+    assert -(-672 * 86400 // interval) <= _MAX_HISTOGRAM_BUCKETS
+    with pytest.raises(ValueError):
+        _histogram_interval(673)

--- a/packages/unifi-core/tests/access/managers/test_event_manager_websocket.py
+++ b/packages/unifi-core/tests/access/managers/test_event_manager_websocket.py
@@ -1,0 +1,119 @@
+"""The websocket listener has to receive the events the controller actually sends.
+
+`start_listening` registered handlers keyed `door_open` / `door_close` /
+`access_granted` / `access_denied` / `door_alarm`. The client dispatches on
+`WebsocketMessage.event`, whose real values are `access.logs.add`,
+`access.hw.door_bell`, `access.data.device.remote_unlock`, ... - so every
+message fell through to the "Unhandled websocket message type" branch and the
+ring buffer stayed empty. Starting the listener was therefore inert: it
+connected and buffered nothing.
+
+The message is also a frozen model carrying `event` / `event_object_id` /
+`door_id` - it has no `type`, `id`, `user_id` or `timestamp` - so reading those
+names off it buffered `{"type": "unknown", "door_id": ""}`, which no
+`get_recent` filter can match.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.access.managers.event_manager import EventManager
+
+# The real contract this code has to satisfy.
+WebsocketMessage = pytest.importorskip("unifi_access_api.models.websocket").WebsocketMessage
+
+
+def _manager() -> EventManager:
+    cm = MagicMock()
+    cm.has_proxy = True
+    cm.has_api_client = True
+    cm.proxy_request = AsyncMock()
+    return EventManager(cm)
+
+
+@pytest.mark.asyncio
+async def test_listener_subscribes_to_every_event_type() -> None:
+    """The client supports a `"*"` wildcard. Enumerating invented names means
+    every real event is dropped."""
+    mgr = _manager()
+    await mgr.start_listening()
+    handlers = mgr._cm.start_websocket.call_args.args[0]
+    assert "*" in handlers, f"no wildcard; only {sorted(handlers)} would ever be delivered"
+
+
+def test_a_real_message_buffers_with_its_event_name_as_the_type() -> None:
+    mgr = _manager()
+    mgr._on_event(WebsocketMessage(event="access.logs.add", event_object_id="evt-1", door_id="door-1"))
+    recent = mgr.get_recent_from_buffer()
+    assert len(recent) == 1
+    assert recent[0]["type"] == "access.logs.add", recent[0]
+    assert recent[0]["id"] == "evt-1", recent[0]
+    assert recent[0]["door_id"] == "door-1", recent[0]
+
+
+def test_a_buffered_message_is_findable_by_its_real_event_type() -> None:
+    """`get_recent(event_type=...)` filters on `type`; with `type` stuck at
+    "unknown" no caller could ever retrieve a specific event."""
+    mgr = _manager()
+    mgr._on_event(WebsocketMessage(event="access.hw.door_bell", event_object_id="evt-2", door_id="door-2"))
+    assert len(mgr.get_recent_from_buffer(event_type="access.hw.door_bell")) == 1
+
+
+def test_a_buffered_message_is_findable_by_door() -> None:
+    mgr = _manager()
+    mgr._on_event(WebsocketMessage(event="access.logs.add", event_object_id="evt-3", door_id="door-3"))
+    assert len(mgr.get_recent_from_buffer(door_id="door-3")) == 1
+
+
+def test_a_buffered_message_is_not_timeless() -> None:
+    """Every buffered row had `timestamp: None`, so nothing downstream could
+    order or age them."""
+    mgr = _manager()
+    mgr._on_event(WebsocketMessage(event="access.logs.add", event_object_id="evt-4", door_id="door-4"))
+    assert mgr.get_recent_from_buffer()[0].get("timestamp")
+
+
+def test_plain_dict_events_still_buffer_unchanged() -> None:
+    mgr = _manager()
+    mgr._on_event({"id": "evt-5", "type": "door_open", "door_id": "door-5", "timestamp": "2026-08-18T12:00:00Z"})
+    recent = mgr.get_recent_from_buffer()
+    assert recent[0]["type"] == "door_open"
+    assert recent[0]["id"] == "evt-5"
+
+
+def test_subscribers_receive_the_normalized_shape() -> None:
+    mgr = _manager()
+    seen: list[dict] = []
+    mgr.add_subscriber(seen.append)
+    mgr._on_event(WebsocketMessage(event="access.logs.add", event_object_id="evt-6", door_id="door-6"))
+    assert seen and seen[0]["type"] == "access.logs.add"
+
+
+# --- what reaches the buffer --------------------------------------------------
+
+
+def test_the_data_subpayload_is_not_buffered() -> None:
+    """`access_recent_events` and GET /access/recent-events return buffered
+    rows unprojected, so carrying the whole model dump would put actor display
+    names and credential ids in front of any READ-scoped caller."""
+    mgr = _manager()
+    mgr._on_event(
+        WebsocketMessage(
+            event="access.logs.add",
+            event_object_id="e1",
+            data={"actor": {"display_name": "Test Person", "id": "user-1"}, "credential": {"id": "cred-1"}},
+        )
+    )
+    row = mgr.get_recent_from_buffer()[0]
+    assert "data" not in row, row
+    assert not any("cred-1" in str(v) for v in row.values()), row
+
+
+def test_high_rate_telemetry_does_not_evict_real_events() -> None:
+    """The wildcard also delivers location/remote-view frames. The ring holds
+    100 entries, so a burst would push out a just-occurred door unlock."""
+    mgr = _manager()
+    mgr._on_event(WebsocketMessage(event="access.door.unlock", event_object_id="unlock-1", door_id="door-1"))
+    for i in range(200):
+        mgr._on_event(WebsocketMessage(event="access.data.v2.location.update", event_object_id=f"loc-{i}"))
+    assert len(mgr.get_recent_from_buffer(event_type="access.door.unlock")) == 1

--- a/packages/unifi-core/tests/access/models/test_events_system_log.py
+++ b/packages/unifi-core/tests/access/models/test_events_system_log.py
@@ -1,0 +1,185 @@
+"""The Access event serializer must understand what the controller sends.
+
+`insights/system_log/search` returns a shape the serializer was never written
+for: `event_type` not `type`, `published` (epoch ms) not `timestamp`, and the
+actor/door nested under `metadata` rather than as `*_id` keys. Every
+one of those mapped to None and `exclude_none=True` dropped it, so a caller got
+`{"id": "", "result": "SUCCESS"}` and nothing else - no time, no door, no actor,
+no event type.
+
+The payload below mirrors a real controller response; identifiers and
+timestamps are synthetic.
+"""
+
+from unifi_core.access.models.events import event_from_controller
+
+RAW_SYSTEM_LOG_EVENT = {
+    "id": "",
+    "log_key": "access.device.update",
+    "event_type": "access.device.update",
+    "message": "Updated Device Configuration",
+    "published": 1787054408829,
+    "result": "SUCCESS",
+    "metadata": {
+        "actor": {"id": "actor-uuid", "type": "user", "display_name": "Test Actor"},
+        "device": {
+            "id": "device-uuid",
+            "type": "UVC G6 Pro Entry",
+            "display_name": "Test Reader",
+            "alternate_id": "AABBCCDDEEFF",
+            "alternate_name": "mac",
+        },
+    },
+}
+
+
+def test_event_type_comes_from_event_type_key() -> None:
+    assert event_from_controller(RAW_SYSTEM_LOG_EVENT).type == "access.device.update"
+
+
+def test_timestamp_comes_from_published_epoch_millis() -> None:
+    ts = event_from_controller(RAW_SYSTEM_LOG_EVENT).timestamp
+    assert ts is not None, "published was dropped, so every row is timeless"
+    assert ts.startswith("2026-08-"), ts
+
+
+def test_actor_is_surfaced_as_the_user() -> None:
+    assert event_from_controller(RAW_SYSTEM_LOG_EVENT).user_id == "actor-uuid"
+
+
+def test_message_is_preserved() -> None:
+    """The human-readable summary is the single most useful field and was
+    being discarded outright."""
+    assert event_from_controller(RAW_SYSTEM_LOG_EVENT).message == "Updated Device Configuration"
+
+
+def test_a_serialized_row_is_not_empty() -> None:
+    """The whole-row regression: model_dump(exclude_none=True) used to leave
+    exactly {"id": "", "result": "SUCCESS"}."""
+    dumped = event_from_controller(RAW_SYSTEM_LOG_EVENT).model_dump(exclude_none=True)
+    assert set(dumped) - {"id", "result"}, f"row still carries nothing useful: {dumped}"
+
+
+def test_legacy_websocket_shape_still_maps() -> None:
+    """The websocket/legacy shape uses the original key names; supporting the
+    system-log shape must not break it."""
+    legacy = {
+        "id": "evt-1",
+        "type": "access.door.unlock",
+        "timestamp": "2026-08-18T12:00:00Z",
+        "door_id": "door-1",
+        "user_id": "user-1",
+        "result": "GRANTED",
+    }
+    event = event_from_controller(legacy)
+    assert event.id == "evt-1"
+    assert event.type == "access.door.unlock"
+    assert event.door_id == "door-1"
+    assert event.user_id == "user-1"
+
+
+# A real `topic: unlocks` record - the door history the tool exists to serve.
+# Identifiers, names and timestamps are synthetic; shape and keys mirror the controller.
+RAW_DOOR_UNLOCK = {
+    "id": "",
+    "log_key": "access.door.unlock",
+    "event_type": "access.door.unlock",
+    "message": "Access Granted (Face)",
+    "published": 1787054400000,
+    "result": "ACCESS",
+    "metadata": {
+        "actor": {"id": "person-uuid", "type": "user", "display_name": "Test Person"},
+        "authentication": {
+            "id": "auth-id",
+            "type": "authentication",
+            "display_name": "FACE",
+            "credential_provider": "face",
+        },
+        "door": {"id": "door-uuid", "type": "door", "display_name": "Test Door"},
+    },
+}
+
+RAW_DOOR_STATUS = {
+    "id": "",
+    "log_key": "access.dps.status.update",
+    "event_type": "access.dps.status.update",
+    "message": "Door status - Opened",
+    "published": 1787054402000,
+    "result": "SUCCESS",
+    "metadata": {"actor": {"id": "hub-id", "type": "UA-Hub-Door-Mini", "display_name": "Test Door"}},
+}
+
+
+def test_a_door_unlock_serializes_with_everything_a_caller_needs() -> None:
+    event = event_from_controller(RAW_DOOR_UNLOCK)
+    assert event.type == "access.door.unlock"
+    assert event.message == "Access Granted (Face)"
+    assert event.result == "ACCESS"
+    assert event.user_id == "person-uuid"
+    assert event.door_id == "door-uuid"
+    assert event.timestamp is not None and event.timestamp.startswith("2026-08-")
+
+
+def test_a_door_open_close_record_serializes() -> None:
+    event = event_from_controller(RAW_DOOR_STATUS)
+    assert event.type == "access.dps.status.update"
+    assert event.message == "Door status - Opened"
+    assert event.timestamp is not None
+
+
+# --- metadata attribution ----------------------------------------------------
+#
+# The metadata sub-objects are typed, and the type matters: `actor` is whoever
+# or whatever caused the event, which for a door-status record is the door hub,
+# not a person. Reading the id without checking the type presents a device as
+# the user and a reader as the door.
+
+
+def test_a_device_actor_is_not_reported_as_a_user() -> None:
+    """`access.dps.status.update` is raised by the hub. Attributing it to a
+    person invents a user who did nothing, and the GraphQL `user` edge then
+    resolves to null against a non-existent id."""
+    assert event_from_controller(RAW_DOOR_STATUS).user_id is None
+
+
+def test_a_reader_is_not_reported_as_a_door() -> None:
+    """A `UVC G6 Pro Entry` reader has its own device UUID. Feeding it back as
+    `door_id` to access_list_events or a door lookup matches nothing."""
+    assert event_from_controller(RAW_SYSTEM_LOG_EVENT).door_id is None
+
+
+def test_a_real_door_is_still_read() -> None:
+    assert event_from_controller(RAW_DOOR_UNLOCK).door_id == "door-uuid"
+
+
+def test_a_real_user_actor_is_still_read() -> None:
+    assert event_from_controller(RAW_DOOR_UNLOCK).user_id == "person-uuid"
+
+
+def test_credential_id_is_not_guessed_from_metadata() -> None:
+    """The live rows carry credential context under `authentication` and
+    `nfc_id`, not `credential`, and which of those is the canonical credential
+    identity is unestablished. An earlier version read `metadata.credential`,
+    which no sampled row had, so `credential_id` was empty anyway - a claim the
+    serializer could not keep.
+
+    Mapping either field on a guess would put a reader id or an auth-method id
+    into a field callers read as a credential UUID. Until the semantics are
+    confirmed the serializer reports nothing.
+    """
+    row = {
+        "id": "",
+        "event_type": "access.door.unlock",
+        "published": 1787054400000,
+        "metadata": {
+            "authentication": {"id": "auth-1", "type": "authentication"},
+            "nfc_id": {"id": "nfc-1", "type": "nfc"},
+            "credential": {"id": "cred-1", "type": "credential"},
+        },
+    }
+    assert event_from_controller(row).credential_id is None
+
+
+def test_a_top_level_credential_id_is_still_read() -> None:
+    """Websocket/legacy rows carry it directly; that path is unchanged."""
+    assert event_from_controller({"id": "e1", "credential_id": "cred-1"}).credential_id == "cred-1"


### PR DESCRIPTION
`list_events` queries `insights/system_log/search`, whose rows use `event_type`, `published` in epoch milliseconds, and nest the actor and door inside `metadata`. The serializer read `type`, `timestamp`, `door_id` and `user_id`, so every one of them resolved to `None` and `exclude_none=True` dropped it — a caller got an id and a result and nothing else.

This is the Core half only, so it can be released independently before anything downstream depends on it.

## What changed

- **Read the system-log shape** in `event_from_controller`, and expose the controller's rendered `message`. The websocket/legacy shape still reads exactly as before.
- **Name the seven topics the controller accepts.** The docstring advertised `admin` and `admin_activity`; the vocabulary is the Access UI's syslog Category list, and door history lives under `unlocks` — guessing at `door_openings` or `doors` finds nothing, which is what made that history look unreachable. An unsupported topic is now refused up front with the valid list instead of by the controller's own `no such topic`.
- **Subscribe to the websocket keys the controller actually sends.** Handlers were registered under five friendly names (`door_open`, `access_granted`, …) that never appear in a frame; the client dispatches on `WebsocketMessage.event`, whose values are dotted names like `access.logs.add`. Every message hit the client's "unhandled" branch, so the ring buffer behind `access_recent_events` could not fill.
- **Buffer a flat projection rather than the whole frame.** `model_dump()` carries the `data` sub-payload — actor display names, credential and device identifiers — into a tool that returns buffered rows unprojected. High-rate location and remote-view frames are also no longer buffered: against a 100-entry ring, a burst could evict a door unlock seconds after it happened.
- **Derive the histogram interval from the window.** A hard-coded `interval=3600` asked for 168 buckets at the tool's own 7-day default and the controller fails above ~100, so the tool never worked at its default. Bucket counting uses ceil, since flooring let `days=673` pass a guard advertising 672 and then request 97 against a cap of 96; a non-positive `days` is clamped before the window is built.

`credential_id` is deliberately left reading only a top-level field. The live `unlocks`/`access_denial` rows carry credential context under `authentication` and `nfc_id`, never `credential`, and which of those is the canonical credential identity is not established — so the serializer makes no claim rather than a plausible-looking wrong one.

## Validation

- `unifi-core`: 1,660 passed. `apps/access`: 215 passed. `apps/api`: 1,246 passed. `ruff format --check` and `ruff check` clean at the `uv.lock` pin (0.16.2); `make check-generated` exit 0; `check_pin_alignment.py` exit 0.
- Exercised against a live UniFi Access controller from a deployed build at `06f412b` (this branch layered with #558 and the downstream delivery):
  - system-log rows project a full shape — id, type, ISO timestamp with sub-second precision, door, actor, message, result — where they previously returned only an empty id and a result;
  - all seven topics accepted; `door_openings` refused before any controller request;
  - `get_event` round-trips a listed id, including a four-month-old event surfaced from the `access_denial` topic;
  - `get_activity_summary` returns 84 buckets at its own 7-day default (interval 7200); `days=673` and `days=1000` are refused with the accurate 672-day limit;
  - the listener starts and the websocket connects on boot (log: `[event-mgr] Websocket subscription started.` / `Websocket connection established`). **Not covered live:** the ring buffer filling from a real door event — no door activity occurred in the test window, and I don't actuate hardware for QA. That path is covered by unit tests written against the real `WebsocketMessage` contract.

Relates to #548. Does not close it — the downstream delivery that raises the Core floors follows once this is released.
