### PR TITLE
fix(core): re-authenticate on the handler-refresh path, not just request()

### DIFF
--- a/apps/network/tests/unit/test_client_details.py
+++ b/apps/network/tests/unit/test_client_details.py
@@ -19,6 +19,14 @@ def mock_connection():
     conn._update_cache = MagicMock()
     conn._invalidate_cache = MagicMock()
     conn.ensure_connected = AsyncMock(return_value=True)
+
+    # ConnectionManager.refresh_handler() is how the managers refresh a
+    # handler collection now; delegate to the same ``update()`` these
+    # tests already stub so their setup keeps its meaning.
+    async def _refresh_handler(name, _c=conn):
+        return await getattr(_c.controller, name).update()
+
+    conn.refresh_handler = _refresh_handler
     conn.controller = MagicMock()
     conn.controller.clients = MagicMock()
     conn.controller.clients.update = AsyncMock()

--- a/apps/network/tests/unit/test_client_ip_settings.py
+++ b/apps/network/tests/unit/test_client_ip_settings.py
@@ -28,6 +28,14 @@ class TestClientIPSettings:
         conn.controller.clients_all.update = AsyncMock()
         conn.controller.clients_all.values = MagicMock(return_value=[])
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture

--- a/apps/network/tests/unit/test_client_lookup.py
+++ b/apps/network/tests/unit/test_client_lookup.py
@@ -28,6 +28,14 @@ class TestGetClientByIP:
         conn.controller.clients_all.update = AsyncMock()
         conn.controller.clients_all.values = MagicMock(return_value=[])
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture

--- a/apps/network/tests/unit/test_device_radio.py
+++ b/apps/network/tests/unit/test_device_radio.py
@@ -260,6 +260,14 @@ class TestDeviceManagerGetRadio:
         conn.controller.devices.update = AsyncMock()
         conn.controller.devices.values = MagicMock(return_value=[])
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture
@@ -377,6 +385,14 @@ class TestDeviceManagerUpdateRadio:
         conn.controller.devices.update = AsyncMock()
         conn.controller.devices.values = MagicMock(return_value=[])
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture

--- a/apps/network/tests/unit/test_handler_refresh_reauth.py
+++ b/apps/network/tests/unit/test_handler_refresh_reauth.py
@@ -1,0 +1,177 @@
+"""An expired session must be recovered on the handler-refresh path too.
+
+#500 reported `unifi_list_devices`, `get_client_details` and `get_top_clients`
+failing with 401 after the controller had been up for a while, while
+`get_network_health`, `get_traffic_flows` and `get_system_info` kept working.
+That split is not arbitrary: the working tools go through
+``ConnectionManager.request()``, which catches ``LoginRequired`` and
+re-authenticates. The failing ones call an aiounifi handler's ``update()``
+directly, so the exception is raised straight past that wrapper and no login is
+ever attempted.
+
+#514 added the re-authentication and closed #500, but its test drove
+``ConnectionManager.request()`` — the path that already recovered. These tests
+drive ``handler.update()`` instead, which is the path that did not, so they fail
+against the code #514 shipped.
+"""
+
+import pytest
+from aiounifi.errors import LoginRequired
+
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.device_manager import DeviceManager
+
+
+class _Handler:
+    """Stand-in for an aiounifi handler such as ``controller.devices``.
+
+    ``update()`` raises ``LoginRequired`` until a login happens, which is what an
+    expired controller session does. Crucially the failure surfaces from
+    ``update()`` and not from ``controller.request()`` — reproducing the real
+    call path rather than the one #514's test exercised.
+    """
+
+    def __init__(self, controller, values):
+        self._controller = controller
+        self._values = values
+        self.update_calls = 0
+
+    async def update(self):
+        self.update_calls += 1
+        if not self._controller.logged_in:
+            raise LoginRequired("expired")
+
+    def values(self):
+        return list(self._values)
+
+
+class _Controller:
+    def __init__(self, values=()):
+        self.logged_in = False
+        self.login_calls = 0
+        self.connectivity = _Connectivity()
+        self.devices = _Handler(self, values)
+
+    async def login(self):
+        self.login_calls += 1
+        self.logged_in = True
+
+
+class _Connectivity:
+    def __init__(self):
+        self.can_retry_login = True
+        self.config = _Config()
+
+
+class _Config:
+    def __init__(self):
+        self.session = _Session()
+
+
+class _Session:
+    closed = False
+
+    async def close(self):
+        return None
+
+
+def _manager(controller):
+    manager = ConnectionManager("192.168.1.1", "admin", "secret")
+    manager.controller = controller
+    manager._aiohttp_session = controller.connectivity.config.session
+    manager._initialized = True
+    manager._auth_generation = 1
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_handler_refresh_reauthenticates_and_retries():
+    """The bare defect: an expired session must produce a login, not a 401."""
+    controller = _Controller()
+    manager = _manager(controller)
+
+    await manager.refresh_handler("devices")
+
+    assert controller.login_calls == 1, "no re-authentication was attempted on the handler path"
+    assert controller.devices.update_calls == 2, "the refresh was not retried after logging back in"
+    assert manager._auth_generation == 2
+    assert controller.connectivity.can_retry_login is False
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_handler_refresh_does_not_log_in_when_the_session_is_valid():
+    """The happy path must stay a single call with no spurious login."""
+    controller = _Controller()
+    controller.logged_in = True
+    manager = _manager(controller)
+
+    await manager.refresh_handler("devices")
+
+    assert controller.login_calls == 0
+    assert controller.devices.update_calls == 1
+    assert manager._auth_generation == 1
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_handler_refresh_reraises_when_reauthentication_fails():
+    """A login that cannot succeed must surface the original error, not mask it."""
+    controller = _Controller()
+
+    async def _failing_login():
+        controller.login_calls += 1
+        raise LoginRequired("still expired")
+
+    controller.login = _failing_login
+    manager = _manager(controller)
+
+    with pytest.raises(LoginRequired):
+        await manager.refresh_handler("devices")
+
+    assert controller.login_calls == 1
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_persistent_login_required_after_refresh_opens_the_auth_circuit():
+    """A login that succeeds but is not accepted must not become a login storm.
+
+    ``request()`` already treats a second ``LoginRequired`` as terminal; the
+    refresh path has to agree, or every later tool call starts another login
+    against a controller that is already refusing them.
+    """
+    controller = _Controller()
+
+    async def _login_that_is_not_accepted():
+        controller.login_calls += 1
+        # Login "succeeds" but the session it produces is still rejected.
+
+    controller.login = _login_that_is_not_accepted
+    manager = _manager(controller)
+
+    with pytest.raises(LoginRequired):
+        await manager.refresh_handler("devices")
+
+    assert controller.login_calls == 1
+    assert controller.devices.update_calls == 2, "the refresh should have been retried exactly once"
+    assert manager._reconnect_block_active(), "a rejected refreshed session must open the auth circuit"
+    await manager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_get_devices_recovers_from_an_expired_session():
+    """The user-visible regression from #500, end to end.
+
+    `unifi_list_devices` is `DeviceManager.get_devices`. Against the code #514
+    shipped this raises `LoginRequired` and the tool reports
+    "received 401 Unauthorized".
+    """
+    controller = _Controller(values=[{"mac": "aa:bb:cc:dd:ee:ff", "name": "sw"}])
+    manager = _manager(controller)
+
+    devices = await DeviceManager(manager).get_devices()
+
+    assert controller.login_calls == 1, "get_devices did not re-authenticate an expired session"
+    assert [d["mac"] for d in devices] == ["aa:bb:cc:dd:ee:ff"]
+    await manager.cleanup()

--- a/apps/network/tests/unit/test_mac_case_insensitivity.py
+++ b/apps/network/tests/unit/test_mac_case_insensitivity.py
@@ -39,6 +39,11 @@ def mock_connection():
     conn.controller.devices = MagicMock()
     conn.controller.devices.update = AsyncMock()
     conn.controller.devices.values = MagicMock(return_value=[])
+
+    async def _refresh_handler(name, _c=conn):
+        return await getattr(_c.controller, name).update()
+
+    conn.refresh_handler = _refresh_handler
     conn.request = AsyncMock(return_value=None)
     return conn
 

--- a/apps/network/tests/unit/test_outlet_control.py
+++ b/apps/network/tests/unit/test_outlet_control.py
@@ -131,6 +131,14 @@ def mock_connection():
     conn.controller.devices.update = AsyncMock()
     conn.controller.devices.values = MagicMock(return_value=[])
     conn.ensure_connected = AsyncMock(return_value=True)
+
+    # ConnectionManager.refresh_handler() is how the managers refresh a
+    # handler collection now; delegate to the same ``update()`` these
+    # tests already stub so their setup keeps its meaning.
+    async def _refresh_handler(name, _c=conn):
+        return await getattr(_c.controller, name).update()
+
+    conn.refresh_handler = _refresh_handler
     return conn
 
 

--- a/apps/network/tests/unit/test_wifi_tools.py
+++ b/apps/network/tests/unit/test_wifi_tools.py
@@ -24,6 +24,14 @@ class TestDeviceManagerWifi:
         conn._update_cache = MagicMock()
         conn._invalidate_cache = MagicMock()
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture
@@ -245,6 +253,14 @@ class TestNetworkManagerWlan:
         conn._update_cache = MagicMock()
         conn._invalidate_cache = MagicMock()
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture
@@ -280,6 +296,14 @@ class TestNetworkManagerApGroups:
         conn._update_cache = MagicMock()
         conn._invalidate_cache = MagicMock()
         conn.ensure_connected = AsyncMock(return_value=True)
+
+        # ConnectionManager.refresh_handler() is how the managers refresh a
+        # handler collection now; delegate to the same ``update()`` these
+        # tests already stub so their setup keeps its meaning.
+        async def _refresh_handler(name, _c=conn):
+            return await getattr(_c.controller, name).update()
+
+        conn.refresh_handler = _refresh_handler
         return conn
 
     @pytest.fixture

--- a/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
@@ -43,7 +43,7 @@ class ClientManager:
             return cached_data
 
         try:
-            await self._connection.controller.clients.update()
+            await self._connection.refresh_handler("clients")
             clients: List[Client] = list(self._connection.controller.clients.values())
             # Fallback rationale:
             # - Some controller models/versions may not populate the collection
@@ -76,7 +76,7 @@ class ClientManager:
             return cached_data
 
         try:
-            await self._connection.controller.clients_all.update()
+            await self._connection.refresh_handler("clients_all")
             all_clients: List[Client] = list(self._connection.controller.clients_all.values())
             # Fallback rationale:
             # - When the clients_all collection is empty, query the canonical

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -617,6 +617,45 @@ class ConnectionManager:
         """Close the connection using the common manager lifecycle contract."""
         await self.cleanup()
 
+    async def refresh_handler(self, name: str) -> Any:
+        """Refresh an aiounifi handler collection, recovering an expired session.
+
+        ``request()`` is not the only way this project reaches the controller:
+        the device, client and DPI collections are refreshed through their
+        aiounifi handler's own ``update()``, which builds and issues its request
+        internally. ``LoginRequired`` therefore propagates past ``request()``'s
+        recovery entirely, and an expired session surfaced to the caller as a
+        bare 401 with no login ever attempted (#500).
+
+        The handler is resolved by *name* rather than passed in, so the retry
+        reads it off ``self.controller`` again — the same reason ``request()``
+        re-derives its request method after re-authenticating.
+        """
+        if not await self.ensure_connected() or not self.controller:
+            raise self._not_connected_error()
+
+        auth_generation = self._auth_generation
+        try:
+            return await getattr(self.controller, name).update()
+        except LoginRequired:
+            logger.warning("Login required detected during %s refresh, attempting explicit re-authentication...", name)
+            if not await self._reauthenticate(auth_generation):
+                raise
+            if not self.controller:
+                raise ConnectionError("Re-authentication failed, controller not available.")
+            logger.info("Re-authentication successful, retrying %s refresh...", name)
+            try:
+                return await getattr(self.controller, name).update()
+            except LoginRequired as retry_error:
+                # Same terminal treatment ``request()`` applies: a second
+                # LoginRequired means the refreshed session was rejected, so
+                # stop here rather than let every later tool call start another
+                # controller login.
+                logger.error("%s refresh failed even after re-authentication: %s", name, retry_error)
+                self._block_automatic_reconnect(retry_error)
+                await self._discard_connection()
+                raise
+
     async def request(self, api_request: ApiRequest | ApiRequestV2, return_raw: bool = False) -> Any:
         """Make a request to the controller API, handling raw responses."""
         if not await self.ensure_connected() or not self.controller:

--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -39,7 +39,7 @@ class DeviceManager:
             return cached_data
 
         try:
-            await self._connection.controller.devices.update()
+            await self._connection.refresh_handler("devices")
             devices: List[Device] = list(self._connection.controller.devices.values())
             self._connection._update_cache(cache_key, devices)
             return devices

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -328,8 +328,8 @@ class StatsManager:
             raise ConnectionError("Not connected to controller")
 
         try:
-            await self._connection.controller.dpi_apps.update()
-            await self._connection.controller.dpi_groups.update()
+            await self._connection.refresh_handler("dpi_apps")
+            await self._connection.refresh_handler("dpi_groups")
 
             dpi_apps: List[DPIRestrictionApp] = list(self._connection.controller.dpi_apps.values())
             dpi_groups: List[DPIRestrictionGroup] = list(self._connection.controller.dpi_groups.values())


### PR DESCRIPTION
Relates to #500 — **deliberately non-closing.** That issue is not mine and its reporter should be the one to confirm; I have commented there with the evidence.

#500's symptom is back on a current controller: `unifi_list_devices` returning `401 Unauthorized` after the session ages out. #514 fixed a real bug, but not the one #500 reported.

## The split #500 described is the whole diagnosis

The reporter listed exactly which tools failed and which kept working:

- **failing** — `list_devices`, `get_client_details`, `get_top_clients`
- **working** — `get_network_health`, `get_traffic_flows`, `get_system_info`

That maps cleanly onto two different call paths. The working ones go through `ConnectionManager.request()`, which catches `LoginRequired` and re-authenticates. The failing ones call an aiounifi handler's own `update()`:

```
device_manager.py:41   controller.devices.update()
client_manager.py:45   controller.clients.update()
client_manager.py:78   controller.clients_all.update()
stats_manager.py:328   controller.dpi_apps.update()
stats_manager.py:329   controller.dpi_groups.update()
```

`handler.update()` builds and issues its own request internally — `controller.request()` → `connectivity.request()` → `raise LoginRequired`. It never passes through `ConnectionManager.request()`, so the recovery added in #514 is not on that path at all.

## Why the fix verified clean

#514's regression is `test_expired_session_explicitly_reauthenticates_and_retries_request`. It sets `controller.request` to raise `LoginRequired` once, then drives `manager.request(...)`. That exercises the path that already recovered. Nothing in the suite drove `handler.update()`, so the five call sites above were never covered, and the reported symptom survived a green test suite.

This is the part worth guarding against: the new tests here deliberately drive `handler.update()` rather than `request()`, because that distinction is what the previous round missed.

## Observed live

On a controller running Network 10.5.67, after the gateway took a firmware upgrade and rebooted — which invalidates the session server-side:

```
unifi_list_devices -> "Call https://<controller>/proxy/network/api/s/default/stat/device
                      received 401 Unauthorized"
```

Three consecutive failures at 20ms / 6ms / 13ms, and **no `/api/auth/login` line in the log after the startup login**. A real re-authentication is a network round-trip and logs `Login required detected during request`. Neither appears — no login was attempted. Managers that do use the wrapped `request()` (`oon`, `qos`, `traffic_route`, `content_filter`, `vpn`) recovered normally against the same controller in the same window.

## The change

`ConnectionManager.refresh_handler(name)` wraps `handler.update()` in the same logic `request()` already applies:

- the same generation-locked `_reauthenticate(auth_generation)`, so concurrent refreshes share one login rather than starting a stampede;
- the same terminal treatment of a **second** `LoginRequired` — `_block_automatic_reconnect()` + `_discard_connection()` — so a refreshed-but-rejected session cannot turn every later tool call into another login attempt;
- the handler resolved **by name**, so the retry reads it off `self.controller` again. This mirrors `request()` re-deriving its request method after re-authenticating, and matters if the controller object is ever replaced rather than re-logged-in.

All five call sites converted. I also grepped `apps/protect` and `apps/access` for the same shape — `controller.<handler>.update()` — and there are no other occurrences anywhere in `packages/unifi-core/src`.

## Tests

Five, all driving `handler.update()`:

- re-authenticates and retries once on an expired session
- no spurious login when the session is valid
- re-raises the original error when the login itself fails
- a persistent `LoginRequired` after re-authentication opens the auth circuit rather than looping
- `DeviceManager.get_devices()` recovers end to end — this is `unifi_list_devices`, the tool from #500

Each was confirmed to fail without the fix: removing the re-authentication fails 3 of 5, and removing the circuit guard fails the fourth. Against the code currently on `main` all of them fail.

Six existing test files needed their `mock_connection` double taught the new seam. Those doubles are `MagicMock`, so an awaited call on the connection returns a non-awaitable; each now delegates to the very same `controller.<name>.update()` mock the test already set up, so no existing assertion loses its meaning.

## Verification

`unifi-core` 1,624 passed, `apps/network` 1,007 passed, `apps/api` 1,331 passed. `ruff format --check` and `ruff check` clean at the `uv.lock` pin (0.16.2). `generate_skill_references.py --check` and `generate_api_action_catalog.py --check` both report no drift; `check_pin_alignment.py` exits 0 against the published Core 0.4.30 floor.

Exercised on a live controller from a build of this branch: `unifi_list_devices`, the client lookups and the DPI stats paths all return normally through `refresh_handler`, and an absent device still reports not-found rather than an empty success.

One limit I would rather state than gloss: the re-authentication branch itself is not triggerable on demand against a live controller without invalidating its session, so live QA covers the converted call sites' behavior, and the recovery branch rests on the tests above.
