### PR TITLE
fix(api): normalize MAC lookups and event filtering

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,8 +8,9 @@ dependencies = [
     # API server registers controllers across all three products, so it
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently. Access event
-    # identity and paged lookup require Core 0.4.30.
-    "unifi-core[network,protect,access]>=0.4.30,<0.5",
+    # identity and paged lookup require Core 0.4.30; shared MAC comparison
+    # across the GraphQL and SSE surfaces requires Core 0.4.31.
+    "unifi-core[network,protect,access]>=0.4.31,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import strawberry
 from strawberry.types import Info
+from unifi_core.mac import mac_equal
 
 from unifi_api.graphql.context import GraphQLContext
 from unifi_api.graphql.permissions import IsRead
@@ -1928,7 +1929,7 @@ class NetworkQuery:
         for c in raw:
             r = _raw(c)
             c_mac = r.get("mac") if isinstance(r, dict) else getattr(r, "mac", None)
-            if c_mac == mac:
+            if mac_equal(c_mac, mac):
                 inst = Client.from_manager_output(c)
                 inst._controller_id = controller
                 inst._site = site
@@ -2034,7 +2035,7 @@ class NetworkQuery:
         for d in raw:
             r = _raw(d)
             d_mac = r.get("mac") if isinstance(r, dict) else getattr(r, "mac", None)
-            if d_mac == mac:
+            if mac_equal(d_mac, mac):
                 inst = Device.from_manager_output(d)
                 inst._controller_id = controller
                 inst._site = site

--- a/apps/api/src/unifi_api/routes/streams/network_per_device.py
+++ b/apps/api/src/unifi_api/routes/streams/network_per_device.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import StreamingResponse
+from unifi_core.mac import mac_equal
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
@@ -51,7 +52,7 @@ async def stream_network_device_events(
             serializer=serializer,
             redact_sensitive=request.app.state.config.policy.response.redact_sensitive_fields,
             last_event_id=last_event_id,
-            filter_fn=lambda evt: evt.get("mac") == mac,
+            filter_fn=lambda evt: mac_equal(evt.get("mac"), mac),
         ),
         media_type="text/event-stream",
         headers={

--- a/apps/api/tests/graphql/fixtures/network/test_clients.py
+++ b/apps/api/tests/graphql/fixtures/network/test_clients.py
@@ -51,14 +51,14 @@ async def test_clients_list(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_client_detail(tmp_path, monkeypatch):
+async def test_client_detail_matches_equivalent_mac_format(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="network")
     stub_managers(
         monkeypatch,
         {
             ("network", "client_manager", "get_clients"): [
-                {"mac": "aa:01", "hostname": "alpha"},
+                {"mac": "aa:bb:cc:dd:ee:01", "hostname": "alpha"},
             ],
         },
     )
@@ -66,13 +66,13 @@ async def test_client_detail(tmp_path, monkeypatch):
         app,
         key,
         f'''{{
-        network {{ client(controller: "{cid}", mac: "aa:01") {{
+        network {{ client(controller: "{cid}", mac: "AA-BB-CC-DD-EE-01") {{
             mac hostname
         }} }}
     }}''',
     )
     assert body.get("errors") is None, body
-    assert body["data"]["network"]["client"]["mac"] == "aa:01"
+    assert body["data"]["network"]["client"]["mac"] == "aa:bb:cc:dd:ee:01"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/graphql/fixtures/network/test_devices.py
+++ b/apps/api/tests/graphql/fixtures/network/test_devices.py
@@ -53,14 +53,14 @@ async def test_devices_list(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_device_detail(tmp_path, monkeypatch):
+async def test_device_detail_matches_equivalent_mac_format(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await bootstrap(tmp_path, product="network")
     stub_managers(
         monkeypatch,
         {
             ("network", "device_manager", "get_devices"): [
-                {"mac": "ap:01", "name": "AP-Living", "model": "U7PRO"},
+                {"mac": "aa:bb:cc:dd:ee:01", "name": "AP-Living", "model": "U7PRO"},
             ],
         },
     )
@@ -68,13 +68,13 @@ async def test_device_detail(tmp_path, monkeypatch):
         app,
         key,
         f'''{{
-        network {{ device(controller: "{cid}", mac: "ap:01") {{
+        network {{ device(controller: "{cid}", mac: "AABBCCDDEE01") {{
             mac name
         }} }}
     }}''',
     )
     assert body.get("errors") is None, body
-    assert body["data"]["network"]["device"]["mac"] == "ap:01"
+    assert body["data"]["network"]["device"]["mac"] == "aa:bb:cc:dd:ee:01"
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/routes/streams/test_per_resource_streams.py
+++ b/apps/api/tests/routes/streams/test_per_resource_streams.py
@@ -181,6 +181,8 @@ async def test_stream_network_device_events_filters_by_mac(tmp_path, monkeypatch
             {"id": "n1", "key": "STA_CONNECT", "mac": mac_a, "time": 1700000000},
             {"id": "n2", "key": "STA_CONNECT", "mac": mac_b, "time": 1700000001},
             {"id": "n3", "key": "STA_DISCONNECT", "mac": mac_a, "time": 1700000002},
+            {"id": "n4", "key": "STA_CONNECT", "time": 1700000003},
+            {"id": "n5", "key": "STA_CONNECT", "mac": "device-1", "time": 1700000004},
         ],
     )
     app.state.manager_factory.get_domain_manager = AsyncMock(return_value=fake_mgr)
@@ -191,7 +193,7 @@ async def test_stream_network_device_events_filters_by_mac(tmp_path, monkeypatch
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(
-            f"/v1/streams/network/devices/{mac_a}/events?controller={cid}",
+            f"/v1/streams/network/devices/{mac_a.upper().replace(':', '-')}/events?controller={cid}",
             headers={"Authorization": f"Bearer {key}"},
         )
     assert r.status_code == 200, r.text
@@ -200,4 +202,6 @@ async def test_stream_network_device_events_filters_by_mac(tmp_path, monkeypatch
     assert "id: n1" in body
     assert "id: n3" in body
     assert "id: n2" not in body
+    assert "id: n4" not in body
+    assert "id: n5" not in body
     assert "event: network.event" in body


### PR DESCRIPTION
## What

- use the shared Core MAC comparator for GraphQL client and device detail lookups
- use the same comparator for per-device Network SSE filtering
- raise the API Core floor to 0.4.31, where the shared helper is published
- add behavioral coverage for uppercase, hyphenated, bare-hex, missing, and opaque identifiers

## Why

The Core half of the MAC normalization fix landed in #541. The API half was intentionally deferred until the helper was available from a published Core release. Core 0.4.31 is now published and independently verified, so the API can adopt the shared behavior without importing unpublished code.

Fixes #540

## Testing

- make pre-commit
- 1,331 API tests passed
- Core floor and full pin-alignment checks passed
- SDL, OpenAPI, GraphQL reference, and OpenAPI reference regenerated with no drift
- live api-actions: 7/7 reads, 3/3 confirmation controls, 2/2 read-contract probes
- live api-resources: 9/9 endpoints passed; the two diagnostic count mismatches are expected REST pagination versus full action inventory
- live api-streams: 3/3 product streams passed
- targeted live Network API: GraphQL client uppercase/hyphen lookup passed; GraphQL device uppercase bare-hex lookup passed; per-device SSE uppercase/bare-hex filtering passed