### PR TITLE
fix(access): require Core 0.4.31

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly. Access event identity requires
-    # Core 0.4.30 so listed system-log rows remain addressable.
-    "unifi-core[access]>=0.4.30,<0.5",
+    # Core 0.4.31 for separator-insensitive Access device MAC resolution.
+    "unifi-core[access]>=0.4.31,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
## Summary

- raise the Access package dependency floor to the Core release containing separator-insensitive MAC resolution
- keep published Access wheels from resolving the pre-fix Core 0.4.30

## Validation

- `make -C apps/access pre-commit` (213 tests)
- `make pre-commit` (full repository gate)