### PR TITLE
feat(firewall): expose firewall-zone CRUD downstream

### DIFF
--- a/.agents/skills/monorepo-release-pipeline/SKILL.md
+++ b/.agents/skills/monorepo-release-pipeline/SKILL.md
@@ -216,15 +216,16 @@ Workspace `[tool.uv.sources]` overrides take precedence over the version range d
 
 `scripts/check_pin_alignment.py` validates the direct dependency bounds declared in each package's own `pyproject.toml` — it does not walk the full transitive/nested dependency chain (e.g., relay → shared → core, multiple hops deep). A downstream package can pass the gate while a deeper transitive package in the chain is still misaligned. When releasing a change that touches a multi-hop dependency chain, manually trace and verify bounds at each hop rather than trusting a single green run of this script.
 
-### `--api-core-floor-only` Flag — Cross-Package Bridge-Method Validation
+### Exact-Core-floor flags — Cross-Package Bridge-Method Validation
 
-When a downstream package (e.g., `unifi-api-server`) is changed to call new bridge methods added to an upstream shared package (`unifi-core`), run:
+When Network or API code calls new bridge methods added to `unifi-core`, run the matching exact-floor checks:
 
 ```bash
+python3 scripts/check_pin_alignment.py --network-core-floor-only
 python3 scripts/check_pin_alignment.py --api-core-floor-only
 ```
 
-This mode enforces that the downstream package's declared `unifi-core` floor bound in `pyproject.toml` is actually high enough to guarantee the new bridge methods exist — catching the case where code was written against an unreleased Core API before the floor bound was raised to match. Run this whenever a PR adds calls to newly-added `unifi-core` methods, in addition to the standard (no-flag) pin-alignment check.
+These modes enforce that each downstream package's declared `unifi-core` floor bound in `pyproject.toml` is actually high enough to guarantee the Core manager methods it calls exist. The standard no-flag check runs both contracts automatically. Use the focused flag while developing a change to either surface.
 
 ### Pre-tag wheel-metadata check
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 
 | Server | Status | Tools | Package |
 |--------|--------|-------|---------|
-| [Network](apps/network/) | Stable | 189 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
+| [Network](apps/network/) | Stable | 192 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
 | [Protect](apps/protect/) | Stable | 61 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
 | [Access](apps/access/) | Stable | 36 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
 
@@ -251,7 +251,7 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 189 tools)
+  network/          # UniFi Network MCP server (stable, 192 tools)
   protect/          # UniFi Protect MCP server (stable, 61 tools)
   access/           # UniFi Access MCP server (stable, 36 tools)
   api/              # Independent REST + GraphQL API server (beta)

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -804,7 +804,9 @@ type FirewallRulePage {
   nextCursor: String
 }
 
-"""A firewall zone (V2 /firewall/zone-matrix entry)."""
+"""
+A firewall zone from the V2 controller API. Its ID is a V2 ObjectID, not an Integration API UUID.
+"""
 type FirewallZone {
   id: ID
   name: String

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -9,8 +9,9 @@ dependencies = [
     # needs every product extra. unifi-core's optional extras pull in
     # aiounifi / uiprotect / py-unifi-access transparently. Access event
     # identity and paged lookup require Core 0.4.30; shared MAC comparison
-    # across the GraphQL and SSE surfaces requires Core 0.4.31.
-    "unifi-core[network,protect,access]>=0.4.31,<0.5",
+    # across the GraphQL and SSE surfaces requires Core 0.4.31. Firewall-zone
+    # actions require the dual-API bridge added in Core 0.4.32.
+    "unifi-core[network,protect,access]>=0.4.32,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -2538,6 +2538,28 @@
       }
     },
     {
+      "name": "unifi_create_firewall_zone",
+      "product": "network",
+      "category": "firewall",
+      "permission_action": "create",
+      "read_only_hint": false,
+      "manager_attr": "firewall_manager",
+      "manager_method": "create_firewall_zone",
+      "input_schema": {
+        "properties": {
+          "name": {
+            "description": "Name of the firewall zone (must be unique)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "unifi_create_network",
       "product": "network",
       "category": "networks",
@@ -3122,6 +3144,28 @@
         },
         "required": [
           "policy_id"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "unifi_delete_firewall_zone",
+      "product": "network",
+      "category": "firewall",
+      "permission_action": "delete",
+      "read_only_hint": false,
+      "manager_attr": "firewall_manager",
+      "manager_method": "delete_firewall_zone",
+      "input_schema": {
+        "properties": {
+          "zone_id": {
+            "description": "V2 controller ObjectID from unifi_list_firewall_zones; not an Integration API UUID",
+            "type": "string"
+          }
+        },
+        "required": [
+          "zone_id"
         ],
         "type": "object",
         "additionalProperties": false
@@ -6206,6 +6250,33 @@
         "required": [
           "policy_id",
           "update_data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "unifi_update_firewall_zone",
+      "product": "network",
+      "category": "firewall",
+      "permission_action": "update",
+      "read_only_hint": false,
+      "manager_attr": "firewall_manager",
+      "manager_method": "update_firewall_zone",
+      "input_schema": {
+        "properties": {
+          "name": {
+            "description": "New name for the zone",
+            "type": "string"
+          },
+          "zone_id": {
+            "description": "V2 controller ObjectID from unifi_list_firewall_zones; not an Integration API UUID",
+            "type": "string"
+          }
+        },
+        "required": [
+          "zone_id",
+          "name"
         ],
         "type": "object",
         "additionalProperties": false

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -793,7 +793,9 @@ type FirewallRulePage {
   nextCursor: String
 }
 
-"""A firewall zone (V2 /firewall/zone-matrix entry)."""
+"""
+A firewall zone from the V2 controller API. Its ID is a V2 ObjectID, not an Integration API UUID.
+"""
 type FirewallZone {
   id: ID
   name: String

--- a/apps/api/src/unifi_api/graphql/types/network/firewall.py
+++ b/apps/api/src/unifi_api/graphql/types/network/firewall.py
@@ -134,7 +134,9 @@ class FirewallGroup:
         return asdict(self)
 
 
-@strawberry.type(description="A firewall zone (V2 /firewall/zone-matrix entry).")
+@strawberry.type(
+    description=("A firewall zone from the V2 controller API. Its ID is a V2 ObjectID, not an Integration API UUID.")
+)
 class FirewallZone:
     id: strawberry.ID | None
     name: str | None

--- a/apps/api/src/unifi_api/serializers/network/firewall_rules.py
+++ b/apps/api/src/unifi_api/serializers/network/firewall_rules.py
@@ -3,11 +3,13 @@
 Phase 6 PR2 Task 22 migrated the read shapes (firewall rules, firewall groups,
 firewall zones) to Strawberry types at
 ``unifi_api.graphql.types.network.firewall``. Only the cross-cutting mutation
-ack remains here — it covers create/update/delete/toggle for both firewall
-policies and firewall groups.
+ack remains here — it covers create/update/delete/toggle for firewall
+policies, firewall groups, and firewall zones.
 """
 
 from typing import Any
+
+from unifi_core.network.models.firewall import firewall_zone_from_controller
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
 
@@ -31,13 +33,21 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
         "unifi_create_firewall_group": {"kind": RenderKind.DETAIL},
         "unifi_update_firewall_group": {"kind": RenderKind.DETAIL},
         "unifi_delete_firewall_group": {"kind": RenderKind.DETAIL},
+        "unifi_create_firewall_zone": {"kind": RenderKind.DETAIL},
+        "unifi_update_firewall_zone": {"kind": RenderKind.DETAIL},
+        "unifi_delete_firewall_zone": {"kind": RenderKind.DETAIL},
     },
 )
 class FirewallMutationAckSerializer(Serializer):
-    """DETAIL ack for firewall policy + group mutations.
+    """DETAIL ack for firewall policy + group + zone mutations.
 
     ``create_*`` returns a dict or ``FirewallPolicy``; ``update_*`` /
     ``delete_*`` / ``toggle_*`` return ``bool``."""
+
+    def serialize_action(self, result, *, tool_name: str, redact_sensitive: bool = True) -> dict:
+        if tool_name == "unifi_create_firewall_zone" and isinstance(result, dict):
+            result = firewall_zone_from_controller(result).model_dump(exclude_none=True)
+        return super().serialize_action(result, tool_name=tool_name, redact_sensitive=redact_sensitive)
 
     @staticmethod
     def serialize(obj) -> dict:

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -96,6 +96,8 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     "unifi_get_firewall_policy_details": ("firewall_manager", "get_firewall_policy_by_id"),
     "unifi_update_firewall_policy": ("firewall_manager", "update_firewall_policy"),
     "unifi_reorder_firewall_policies": ("firewall_manager", "reorder_firewall_policies"),
+    "unifi_update_firewall_zone": ("firewall_manager", "update_firewall_zone"),
+    "unifi_delete_firewall_zone": ("firewall_manager", "delete_firewall_zone"),
     # Toggle tools: tool body needs current enabled flag to compute new state.
     "unifi_toggle_port_forward": ("firewall_manager", "toggle_port_forward"),
     "unifi_toggle_qos_rule_enabled": ("qos_manager", "toggle_qos_rule_enabled"),
@@ -264,6 +266,19 @@ def _rename_and_drop(
         return (), out
 
     return translate
+
+
+def _translate_firewall_zone_crud(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Normalize zone identifiers and names before preview or confirmed dispatch."""
+    out = {key: value for key, value in args.items() if key != "confirm"}
+    for key in ("zone_id", "name"):
+        value = out.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                raise ValueError(f"{key} is required")
+            out[key] = value
+    return (), out
 
 
 def _pack_fields(
@@ -1584,6 +1599,9 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslatorSpec] = {
     "unifi_create_firewall_group": _spec(
         _pack_fields("group_data", frozenset({"name", "group_type", "group_members"})), "group_data"
     ),
+    "unifi_create_firewall_zone": _spec(_translate_firewall_zone_crud, "name"),
+    "unifi_update_firewall_zone": _spec(_translate_firewall_zone_crud, "zone_id", "name"),
+    "unifi_delete_firewall_zone": _spec(_translate_firewall_zone_crud, "zone_id"),
     "unifi_create_oon_policy": _spec(_translate_create_oon_policy, "policy_data"),
     "unifi_create_port_forward": _spec(_translate_create_port_forward, "rule_data"),
     "unifi_create_simple_port_forward": _spec(_translate_create_simple_port_forward, "rule_data"),

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -91,7 +91,10 @@ def _build_network_managers() -> dict[str, Callable[[Any], Any]]:
         "dpi_manager": lambda cm: DpiManager(cm, getattr(cm, "unifi_auth", None)),
         "dynamic_dns_manager": lambda cm: DynamicDnsManager(cm),
         "event_manager": lambda cm: EventManager(cm),
-        "firewall_manager": lambda cm: FirewallManager(cm),
+        # FirewallManager uses both V2 session auth and the public Integration
+        # API. Pass the connection's UniFiAuth so zone CRUD and policy ordering
+        # can supply X-API-Key when an API token is configured.
+        "firewall_manager": lambda cm: FirewallManager(cm, getattr(cm, "unifi_auth", None)),
         "gateway_settings_manager": lambda cm: GatewaySettingsManager(cm),
         "hotspot_manager": lambda cm: HotspotManager(cm),
         "network_manager": lambda cm: NetworkManager(cm),

--- a/apps/api/tests/serializers/test_network_filtering.py
+++ b/apps/api/tests/serializers/test_network_filtering.py
@@ -102,10 +102,35 @@ def test_firewall_mutation_ack_dispatches_for_all_mutations() -> None:
         "unifi_create_firewall_group",
         "unifi_update_firewall_group",
         "unifi_delete_firewall_group",
+        "unifi_create_firewall_zone",
+        "unifi_update_firewall_zone",
+        "unifi_delete_firewall_zone",
     ):
         s = reg.serializer_for_tool(tool)
         out = s.serialize_action(True, tool_name=tool)
         assert out["render_hint"]["kind"] == "detail"
+
+
+def test_create_firewall_zone_ack_uses_canonical_v2_shape() -> None:
+    serializer = _registry().serializer_for_tool("unifi_create_firewall_zone")
+
+    out = serializer.serialize_action(
+        {
+            "_id": "v2-zone",
+            "external_id": "integration-zone-uuid",
+            "name": "IoT",
+            "network_ids": ["v2-network"],
+            "default_policy": "BLOCK",
+        },
+        tool_name="unifi_create_firewall_zone",
+    )
+
+    assert out["data"] == {
+        "id": "v2-zone",
+        "name": "IoT",
+        "networks": ["v2-network"],
+        "default_policy": "BLOCK",
+    }
 
 
 # ---- QoS rules ----

--- a/apps/api/tests/test_action_catalog_packaging.py
+++ b/apps/api/tests/test_action_catalog_packaging.py
@@ -53,7 +53,7 @@ sys.path.insert(0, sys.argv[1])
 sys.meta_path.insert(0, BlockSiblingApps())
 from unifi_api.services.manifest import ManifestRegistry
 registry = ManifestRegistry.load()
-assert len(registry) == 268
+assert len(registry) == 271
 assert registry.has('unifi_list_clients')
 assert registry.has('protect_list_cameras')
 assert registry.has('access_list_doors')

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -1429,6 +1429,121 @@ def test_update_network_translator_forwards_firewall_zone_and_wan_monitor_fields
     assert kwargs == {"network_id": "wan-1", "update_data": fields}
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "args", "expected_kwargs"),
+    [
+        ("unifi_create_firewall_zone", {"name": "IoT", "confirm": True}, {"name": "IoT"}),
+        (
+            "unifi_update_firewall_zone",
+            {"zone_id": "v2-zone", "name": "Devices", "confirm": True},
+            {"zone_id": "v2-zone", "name": "Devices"},
+        ),
+        ("unifi_delete_firewall_zone", {"zone_id": "v2-zone", "confirm": True}, {"zone_id": "v2-zone"}),
+    ],
+)
+def test_firewall_zone_crud_translators_drop_confirmation(
+    tool_name: str,
+    args: dict[str, object],
+    expected_kwargs: dict[str, object],
+) -> None:
+    positional, kwargs = DISPATCH_ARG_TRANSLATORS[tool_name](args)
+
+    assert positional == ()
+    assert kwargs == expected_kwargs
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args", "expected_kwargs"),
+    [
+        ("unifi_create_firewall_zone", {"name": "  IoT  "}, {"name": "IoT"}),
+        (
+            "unifi_update_firewall_zone",
+            {"zone_id": "  v2-zone  ", "name": "  Devices  "},
+            {"zone_id": "v2-zone", "name": "Devices"},
+        ),
+        ("unifi_delete_firewall_zone", {"zone_id": "  v2-zone  "}, {"zone_id": "v2-zone"}),
+    ],
+)
+def test_firewall_zone_crud_translators_trim_strings(
+    tool_name: str,
+    args: dict[str, object],
+    expected_kwargs: dict[str, object],
+) -> None:
+    _, kwargs = DISPATCH_ARG_TRANSLATORS[tool_name](args)
+
+    assert kwargs == expected_kwargs
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "args", "field"),
+    [
+        ("unifi_create_firewall_zone", {"name": "   "}, "name"),
+        ("unifi_update_firewall_zone", {"zone_id": "z1", "name": "   "}, "name"),
+        ("unifi_delete_firewall_zone", {"zone_id": "   "}, "zone_id"),
+    ],
+)
+def test_firewall_zone_crud_translators_reject_blank_strings(
+    tool_name: str,
+    args: dict[str, object],
+    field: str,
+) -> None:
+    with pytest.raises(ValueError, match=rf"^{field} is required$"):
+        DISPATCH_ARG_TRANSLATORS[tool_name](args)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "args", "method_name", "expected_args"),
+    [
+        (
+            "unifi_update_firewall_zone",
+            {"zone_id": "v2-zone", "name": "Devices"},
+            "update_firewall_zone",
+            ("v2-zone", "Devices"),
+        ),
+        (
+            "unifi_delete_firewall_zone",
+            {"zone_id": "v2-zone"},
+            "delete_firewall_zone",
+            ("v2-zone",),
+        ),
+    ],
+)
+async def test_dispatch_real_table_binds_firewall_zone_preview_tools_to_mutations(
+    tool_name: str,
+    args: dict[str, object],
+    method_name: str,
+    expected_args: tuple[object, ...],
+) -> None:
+    entry = ToolEntry(name=tool_name, product="network", category="firewall", manager="", method="")
+    registry = _registry_with(entry)
+    domain_manager = MagicMock()
+    setattr(domain_manager, method_name, AsyncMock(return_value=True))
+    domain_manager.get_firewall_zone_by_id = AsyncMock(return_value={"_id": "v2-zone", "name": "IoT"})
+    conn_manager = MagicMock(site="default")
+    conn_manager.set_site = AsyncMock()
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=domain_manager)
+    factory.get_connection_manager = AsyncMock(return_value=conn_manager)
+
+    await dispatch_action(
+        registry=registry,
+        factory=factory,
+        session=MagicMock(),
+        tool_name=tool_name,
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args=args,
+        confirm=True,
+        dispatch_table=build_dispatch_table(),
+    )
+
+    expected_kwargs = dict(zip(args, expected_args, strict=True))
+    getattr(domain_manager, method_name).assert_awaited_once_with(**expected_kwargs)
+    domain_manager.get_firewall_zone_by_id.assert_not_awaited()
+
+
 def _ddns_factory():
     domain_manager = MagicMock()
     domain_manager.update_dynamic_dns = AsyncMock(return_value={"_id": "ddns001"})

--- a/apps/api/tests/test_managers_factory.py
+++ b/apps/api/tests/test_managers_factory.py
@@ -15,6 +15,7 @@ from unifi_api.db.session import get_sessionmaker
 from unifi_api.services.managers import (
     ManagerFactory,
     UnknownProduct,
+    _build_network_managers,
 )
 
 
@@ -90,6 +91,17 @@ async def test_factory_caches_connection_manager(tmp_path: Path, monkeypatch) ->
         cm2 = await factory.get_connection_manager(session, cid, "network")
     assert cm1 is cm2
     await engine.dispose()
+
+
+def test_firewall_manager_builder_receives_connection_auth() -> None:
+    auth = object()
+    cm = _FakeCM()
+    cm.unifi_auth = auth
+
+    manager = _build_network_managers()["firewall_manager"](cm)
+
+    assert manager._connection is cm
+    assert manager._auth is auth
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_manifest.py
+++ b/apps/api/tests/test_manifest.py
@@ -52,7 +52,7 @@ def test_loads_packaged_catalog_with_manager_binding(monkeypatch) -> None:
 def test_real_packaged_catalog_has_all_product_sentinels() -> None:
     registry = ManifestRegistry.load()
 
-    assert len(registry) == 268
+    assert len(registry) == 271
     assert registry.has("unifi_list_clients")
     assert registry.has("protect_list_cameras")
     assert registry.has("access_list_doors")

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -5,7 +5,7 @@
   <img src="../../assets/hero-network.svg" alt="UniFi Network MCP Server" width="720">
 </p>
 
-MCP server exposing 189 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
+MCP server exposing 192 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
 
 ## Install
 
@@ -229,7 +229,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 189 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 192 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 189 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 192 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy/meta-only workflows, call the `unifi_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`.
 
@@ -13,7 +13,7 @@ These are always registered regardless of mode:
 - `unifi_batch` — Execute multiple tools in parallel
 - `unifi_batch_status` — Check batch job status
 
-## Firewall (12 tools)
+## Firewall (15 tools)
 
 - `unifi_list_firewall_policies` — List all firewall policies
 - `unifi_get_firewall_policy_details` — Get policy details by ID
@@ -21,6 +21,9 @@ These are always registered regardless of mode:
 - `unifi_create_firewall_policy` — Create a V2 zone-based policy with schema validation
 - `unifi_update_firewall_policy` — Update policy fields
 - `unifi_list_firewall_zones` — List firewall zones (V2 API)
+- `unifi_create_firewall_zone` — Create a custom firewall zone
+- `unifi_update_firewall_zone` — Rename a custom firewall zone
+- `unifi_delete_firewall_zone` — Delete a custom firewall zone
 - `unifi_list_legacy_firewall_rules` — List legacy pre-zone-based firewall rules (V1 API)
 - `unifi_list_firewall_groups` — List firewall groups (address and port groups)
 - `unifi_get_firewall_group_details` — Get firewall group details by ID

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -9,9 +9,9 @@ dependencies = [
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
-    # WAN delegation validation requires Core 0.4.30 so controller value
-    # "pd" remains valid through Network tool updates.
-    "unifi-core[network]>=0.4.30,<0.5",
+    # WAN delegation validation requires Core 0.4.30. Firewall-zone CRUD
+    # requires the dual-API bridge added in Core 0.4.32.
+    "unifi-core[network]>=0.4.32,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -776,7 +776,9 @@ async def reorder_firewall_policies(
 
 @server.tool(
     name="unifi_list_firewall_zones",
-    description="List controller firewall zones (V2 API).",
+    description="List controller firewall zones (V2 API). Returned IDs are V2 controller "
+    "ObjectIDs, not Integration API UUIDs; use them with the firewall-zone CRUD tools and "
+    "network firewall_zone_id.",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
 async def list_firewall_zones() -> Dict[str, Any]:
@@ -795,6 +797,163 @@ async def list_firewall_zones() -> Dict[str, Any]:
     except Exception as exc:
         logger.error("Error listing firewall zones: %s", exc, exc_info=True)
         return {"success": False, "error": f"Failed to list firewall zones: {exc}"}
+
+
+@server.tool(
+    name="unifi_create_firewall_zone",
+    description="Create a new firewall zone. Zones group networks for zone-based "
+    "firewall policy targeting. Network assignment happens separately via "
+    "firewall_zone_id on unifi_update_network. Requires a UniFi API key "
+    "(UNIFI_API_KEY). Returns a V2 controller ObjectID, not an Integration API UUID. "
+    "Requires confirmation.",
+    permission_category="firewall",
+    permission_action="create",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False),
+)
+async def create_firewall_zone(
+    name: Annotated[str, Field(description="Name of the firewall zone (must be unique)")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, creates the zone. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Creates a new firewall zone."""
+    name = name.strip()
+    if not name:
+        return {"success": False, "error": "name is required"}
+
+    if not confirm:
+        return create_preview(
+            resource_type="firewall_zone",
+            resource_data={"name": name, "networkIds": []},
+            resource_name=name,
+        )
+
+    try:
+        zone = await firewall_manager.create_firewall_zone(name)
+        return {
+            "success": True,
+            "message": f"Firewall zone '{name}' created successfully.",
+            "zone": firewall_zone_from_controller(zone).model_dump(exclude_none=True),
+        }
+    except Exception as e:
+        logger.error("Error creating firewall zone: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to create firewall zone: {e}"}
+
+
+@server.tool(
+    name="unifi_update_firewall_zone",
+    description="Rename an existing firewall zone by ID. Only the name is mutable; "
+    "network membership is managed via firewall_zone_id on the network. Requires a "
+    "UniFi API key (UNIFI_API_KEY). The ID must come from unifi_list_firewall_zones; "
+    "it is a V2 controller ObjectID, not an Integration API UUID. Requires confirmation.",
+    permission_category="firewall",
+    permission_action="update",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
+)
+async def update_firewall_zone(
+    zone_id: Annotated[
+        str,
+        Field(description="V2 controller ObjectID from unifi_list_firewall_zones; not an Integration API UUID"),
+    ],
+    name: Annotated[str, Field(description="New name for the zone")],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, updates the zone. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Renames an existing firewall zone."""
+    if not zone_id:
+        return {"success": False, "error": "zone_id is required"}
+    name = name.strip()
+    if not name:
+        return {"success": False, "error": "name is required"}
+
+    if not confirm:
+        try:
+            current = await firewall_manager.get_firewall_zone_by_id(zone_id)
+            if current.get("default_zone"):
+                return {
+                    "success": False,
+                    "error": f"Cannot rename system-defined firewall zone '{current.get('name')}'.",
+                }
+            current_state = firewall_zone_from_controller(current).model_dump(exclude_none=True)
+            return update_preview(
+                resource_type="firewall_zone",
+                resource_id=zone_id,
+                resource_name=current_state.get("name") or zone_id,
+                current_state=current_state,
+                updates={"name": name},
+            )
+        except Exception as e:
+            logger.error("Error previewing firewall zone update %s: %s", zone_id, e, exc_info=True)
+            return {"success": False, "error": f"Failed to preview firewall zone update '{zone_id}': {e}"}
+
+    try:
+        success = await firewall_manager.update_firewall_zone(zone_id, name)
+        if success:
+            return {"success": True, "message": f"Firewall zone '{zone_id}' renamed to '{name}'."}
+        return {"success": False, "error": f"Failed to update firewall zone '{zone_id}'."}
+    except Exception as e:
+        logger.error("Error updating firewall zone %s: %s", zone_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to update firewall zone '{zone_id}': {e}"}
+
+
+@server.tool(
+    name="unifi_delete_firewall_zone",
+    description="Delete a firewall zone by ID. System-defined zones cannot be deleted. "
+    "Requires a UniFi API key (UNIFI_API_KEY). The ID must come from "
+    "unifi_list_firewall_zones; it is a V2 controller ObjectID, not an Integration API UUID. "
+    "Requires confirmation.",
+    permission_category="firewall",
+    permission_action="delete",
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False),
+)
+async def delete_firewall_zone(
+    zone_id: Annotated[
+        str,
+        Field(description="V2 controller ObjectID from unifi_list_firewall_zones; not an Integration API UUID"),
+    ],
+    confirm: Annotated[
+        bool,
+        Field(description="When true, deletes the zone. When false (default), returns a preview"),
+    ] = False,
+) -> Dict[str, Any]:
+    """Deletes a firewall zone."""
+    if not zone_id:
+        return {"success": False, "error": "zone_id is required"}
+
+    if not confirm:
+        try:
+            current = await firewall_manager.get_firewall_zone_by_id(zone_id)
+            if current.get("default_zone"):
+                return {
+                    "success": False,
+                    "error": f"Cannot delete system-defined firewall zone '{current.get('name')}'.",
+                }
+            current_state = firewall_zone_from_controller(current).model_dump(exclude_none=True)
+            return delete_preview(
+                resource_type="firewall_zone",
+                resource_id=zone_id,
+                resource_data=current_state,
+                resource_name=current_state.get("name") or zone_id,
+                warnings=[
+                    "System-defined zones cannot be deleted.",
+                    "Reassign member networks and review policies before deleting this zone.",
+                ],
+            )
+        except Exception as e:
+            logger.error("Error previewing firewall zone deletion %s: %s", zone_id, e, exc_info=True)
+            return {"success": False, "error": f"Failed to preview firewall zone deletion '{zone_id}': {e}"}
+
+    try:
+        success = await firewall_manager.delete_firewall_zone(zone_id)
+        if success:
+            return {"success": True, "message": f"Firewall zone '{zone_id}' deleted successfully."}
+        return {"success": False, "error": f"Failed to delete firewall zone '{zone_id}'."}
+    except Exception as e:
+        logger.error("Error deleting firewall zone %s: %s", zone_id, e, exc_info=True)
+        return {"success": False, "error": f"Failed to delete firewall zone '{zone_id}': {e}"}
 
 
 # ---- Legacy Firewall Rules (v1 REST) ----

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 189,
+  "count": 192,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -17,6 +17,7 @@
     "unifi_create_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_create_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_create_firewall_policy": "unifi_network_mcp.tools.firewall",
+    "unifi_create_firewall_zone": "unifi_network_mcp.tools.firewall",
     "unifi_create_network": "unifi_network_mcp.tools.network",
     "unifi_create_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_create_port_forward": "unifi_network_mcp.tools.port_forwards",
@@ -37,6 +38,7 @@
     "unifi_delete_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_delete_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_delete_firewall_policy": "unifi_network_mcp.tools.firewall",
+    "unifi_delete_firewall_zone": "unifi_network_mcp.tools.firewall",
     "unifi_delete_network": "unifi_network_mcp.tools.network",
     "unifi_delete_oon_policy": "unifi_network_mcp.tools.oon",
     "unifi_delete_port_forward": "unifi_network_mcp.tools.port_forwards",
@@ -171,6 +173,7 @@
     "unifi_update_dynamic_dns": "unifi_network_mcp.tools.dynamic_dns",
     "unifi_update_firewall_group": "unifi_network_mcp.tools.firewall",
     "unifi_update_firewall_policy": "unifi_network_mcp.tools.firewall",
+    "unifi_update_firewall_zone": "unifi_network_mcp.tools.firewall",
     "unifi_update_gateway_settings": "unifi_network_mcp.tools.gateway_settings",
     "unifi_update_network": "unifi_network_mcp.tools.network",
     "unifi_update_oon_policy": "unifi_network_mcp.tools.oon",
@@ -1876,6 +1879,106 @@
         }
       },
       "title": "Create Firewall Policy"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Create a new firewall zone. Zones group networks for zone-based firewall policy targeting. Network assignment happens separately via firewall_zone_id on unifi_update_network. Requires a UniFi API key (UNIFI_API_KEY). Returns a V2 controller ObjectID, not an Integration API UUID. Requires confirmation.",
+      "name": "unifi_create_firewall_zone",
+      "permission_action": "create",
+      "permission_category": "firewall",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, creates the zone. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "Name of the firewall zone (must be unique)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Create Firewall Zone"
     },
     {
       "annotations": {
@@ -4026,6 +4129,106 @@
         }
       },
       "title": "Delete Firewall Policy"
+    },
+    {
+      "annotations": {
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Delete a firewall zone by ID. System-defined zones cannot be deleted. Requires a UniFi API key (UNIFI_API_KEY). The ID must come from unifi_list_firewall_zones; it is a V2 controller ObjectID, not an Integration API UUID. Requires confirmation.",
+      "name": "unifi_delete_firewall_zone",
+      "permission_action": "delete",
+      "permission_category": "firewall",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, deletes the zone. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "zone_id": {
+              "description": "V2 controller ObjectID from unifi_list_firewall_zones; not an Integration API UUID",
+              "type": "string"
+            }
+          },
+          "required": [
+            "zone_id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Delete Firewall Zone"
     },
     {
       "annotations": {
@@ -11719,7 +11922,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List controller firewall zones (V2 API).",
+      "description": "List controller firewall zones (V2 API). Returned IDs are V2 controller ObjectIDs, not Integration API UUIDs; use them with the firewall-zone CRUD tools and network firewall_zone_id.",
       "name": "unifi_list_firewall_zones",
       "schema": {
         "input": {
@@ -16984,6 +17187,111 @@
         }
       },
       "title": "Update Firewall Policy"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": false
+      },
+      "description": "Rename an existing firewall zone by ID. Only the name is mutable; network membership is managed via firewall_zone_id on the network. Requires a UniFi API key (UNIFI_API_KEY). The ID must come from unifi_list_firewall_zones; it is a V2 controller ObjectID, not an Integration API UUID. Requires confirmation.",
+      "name": "unifi_update_firewall_zone",
+      "permission_action": "update",
+      "permission_category": "firewall",
+      "schema": {
+        "input": {
+          "properties": {
+            "confirm": {
+              "description": "When true, updates the zone. When false (default), returns a preview",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "New name for the zone",
+              "type": "string"
+            },
+            "zone_id": {
+              "description": "V2 controller ObjectID from unifi_list_firewall_zones; not an Integration API UUID",
+              "type": "string"
+            }
+          },
+          "required": [
+            "zone_id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "additionalProperties": true,
+          "description": "Structured view of the existing UniFi MCP tool response contract.",
+          "properties": {
+            "data": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Successful result payload.",
+              "title": "Data"
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Actionable error message for handled failures.",
+              "title": "Error"
+            },
+            "preview": {
+              "anyOf": [
+                {},
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Mutation preview payload returned before confirmation.",
+              "title": "Preview"
+            },
+            "requires_confirmation": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when a mutation preview requires caller confirmation.",
+              "title": "Requires Confirmation"
+            },
+            "success": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "True when the tool call succeeded; false for handled errors.",
+              "title": "Success"
+            }
+          },
+          "title": "UniFiToolResponse",
+          "type": "object"
+        }
+      },
+      "title": "Update Firewall Zone"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -1448,3 +1448,107 @@ async def test_list_firewall_policies_routes_through_typed_model():
     policy = result["policies"][0]
     assert policy["rule_index"] == 3000
     assert isinstance(policy["rule_index"], int)  # int (model coercion), not "3000" from raw
+
+
+class TestFirewallZoneWriteTools:
+    """Zone write tools: preview/confirm flow and manager delegation."""
+
+    @pytest.mark.asyncio
+    async def test_create_zone_preview(self) -> None:
+        from unifi_network_mcp.tools.firewall import create_firewall_zone
+
+        result = await create_firewall_zone(name="  IoT  ", confirm=False)
+
+        assert result["success"] is True
+        assert result["preview"]["will_create"]["name"] == "IoT"
+        assert result["preview"]["will_create"]["networkIds"] == []
+
+    @pytest.mark.asyncio
+    async def test_create_zone_confirm(self) -> None:
+        from unifi_network_mcp.tools.firewall import create_firewall_zone
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_zone = AsyncMock(
+                return_value={"_id": "z1", "name": "IoT", "network_ids": [], "default_zone": False}
+            )
+            result = await create_firewall_zone(name="IoT", confirm=True)
+
+        assert result["success"] is True
+        assert result["zone"]["id"] == "z1"
+
+    @pytest.mark.asyncio
+    async def test_delete_zone_preview(self) -> None:
+        from unifi_network_mcp.tools.firewall import delete_firewall_zone
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_zone_by_id = AsyncMock(
+                return_value={"_id": "z1", "name": "IoT", "network_ids": ["network-1"]}
+            )
+            result = await delete_firewall_zone(zone_id="z1", confirm=False)
+
+        assert result["success"] is True
+        assert result["resource_id"] == "z1"
+        assert result["preview"]["will_delete"]["name"] == "IoT"
+        assert "Reassign member networks" in result["warnings"][1]
+
+    @pytest.mark.asyncio
+    async def test_delete_zone_confirm(self) -> None:
+        from unifi_network_mcp.tools.firewall import delete_firewall_zone
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.delete_firewall_zone = AsyncMock(return_value=True)
+            result = await delete_firewall_zone(zone_id="z1", confirm=True)
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_zone_preview(self) -> None:
+        from unifi_network_mcp.tools.firewall import update_firewall_zone
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_zone_by_id = AsyncMock(return_value={"_id": "z1", "name": "IoT"})
+            result = await update_firewall_zone(zone_id="z1", name="IoT2", confirm=False)
+
+        assert result["success"] is True
+        assert result["preview"]["current"]["name"] == "IoT"
+        assert result["preview"]["proposed"]["name"] == "IoT2"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("operation", ["update", "delete"])
+    async def test_system_zone_preview_is_refused(self, operation: str) -> None:
+        from unifi_network_mcp.tools.firewall import delete_firewall_zone, update_firewall_zone
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_zone_by_id = AsyncMock(
+                return_value={"_id": "z1", "name": "Internal", "default_zone": True}
+            )
+            if operation == "update":
+                result = await update_firewall_zone(zone_id="z1", name="Renamed", confirm=False)
+            else:
+                result = await delete_firewall_zone(zone_id="z1", confirm=False)
+
+        assert result == {
+            "success": False,
+            "error": f"Cannot {operation if operation == 'delete' else 'rename'} system-defined firewall zone 'Internal'.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_update_zone_confirm_delegates_trimmed_name(self) -> None:
+        from unifi_network_mcp.tools.firewall import update_firewall_zone
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.update_firewall_zone = AsyncMock(return_value=True)
+            result = await update_firewall_zone(zone_id="z1", name="  Devices  ", confirm=True)
+
+        assert result["success"] is True
+        mock_fm.update_firewall_zone.assert_awaited_once_with("z1", "Devices")
+
+    @pytest.mark.asyncio
+    async def test_zone_names_reject_whitespace_only(self) -> None:
+        from unifi_network_mcp.tools.firewall import create_firewall_zone, update_firewall_zone
+
+        create_result = await create_firewall_zone(name="   ", confirm=False)
+        update_result = await update_firewall_zone(zone_id="z1", name="   ", confirm=False)
+
+        assert create_result == {"success": False, "error": "name is required"}
+        assert update_result == {"success": False, "error": "name is required"}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Used by: `apps/network`, `apps/protect`, `apps/access`.
 
 ### apps/network
 
-The UniFi Network MCP server. 189 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
+The UniFi Network MCP server. 192 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
 
 - `src/unifi_network_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,9 +119,9 @@
             </div>
           </div>
           <div class="server-list">
-            <div class="server-row network" data-product="network" data-tool-count="189">
+            <div class="server-row network" data-product="network" data-tool-count="192">
               <div><h4>Network <span>Stable</span></h4><p>Inventory, clients, routing, Wi-Fi, firewall policy, traffic, and controlled configuration.</p></div>
-              <div class="server-meta"><strong>189 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
+              <div class="server-meta"><strong>192 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
             </div>
             <div class="server-row protect" data-product="protect" data-tool-count="61">
               <div><h4>Protect <span>Stable</span></h4><p>Cameras, events, detections, recordings, devices, and incident investigation workflows.</p></div>

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (189 tools)
+# Network Server Tool Reference (192 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 
@@ -107,7 +107,7 @@ Always available, regardless of registration mode.
 ## Firewall
 
 <!-- AUTO:tools:firewall -->
-15 tools.
+18 tools.
 
 | Tool | Type | Description |
 |------|------|-------------|
@@ -120,12 +120,15 @@ Always available, regardless of registration mode.
 | `unifi_list_legacy_firewall_rules` | Read | List legacy pre-zone-based firewall rules from the UniFi controller. |
 | `unifi_create_firewall_group` | Mutate | Create a new firewall group (address or port group). |
 | `unifi_create_firewall_policy` | Mutate | Create a V2 zone-based firewall policy with schema validation. |
+| `unifi_create_firewall_zone` | Mutate | Create a new firewall zone. |
 | `unifi_delete_firewall_group` | Mutate | Delete a firewall group. |
 | `unifi_delete_firewall_policy` | Mutate | Delete a firewall policy by ID. |
+| `unifi_delete_firewall_zone` | Mutate | Delete a firewall zone by ID. |
 | `unifi_reorder_firewall_policies` | Mutate | Reorder user-defined firewall policies for a source/destination firewall zone pair. |
 | `unifi_toggle_firewall_policy` | Mutate | Enable or disable a specific firewall policy by ID. |
 | `unifi_update_firewall_group` | Mutate | Update an existing firewall group. |
 | `unifi_update_firewall_policy` | Mutate | Update specific fields of an existing V2 zone-based firewall policy by ID. |
+| `unifi_update_firewall_zone` | Mutate | Rename an existing firewall zone by ID. |
 <!-- /AUTO:tools:firewall -->
 
 **Tips:**

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -38,6 +38,9 @@ How this script catches it
    succeeds, the declared pin permits a working upstream version. If it fails
    with ``ModuleNotFoundError`` (or pip itself fails with no matching version),
    the pin is stale and a fresh PyPI install would crash.
+7. Install the Network and API wheels against exactly their declared published
+   ``unifi-core`` floors and validate their manager-call contracts. This catches
+   newly used Core methods that ordinary imports do not execute.
 
 Exit code 0 on success, 1 on any failure. Diagnostic output is printed to
 stdout and is intended to be read directly from the CI log.
@@ -203,6 +206,49 @@ for name in registry.all_tools():
 if failures:
     raise SystemExit("\\n".join(failures))
 print(f"validated {len(registry)} catalog bindings against installed Core floor")
+"""
+
+_NETWORK_CORE_FLOOR_CONTRACT = """
+import ast, json
+from importlib.resources import files
+from unifi_network_mcp import runtime
+
+root = files("unifi_network_mcp")
+manifest = json.loads(root.joinpath("tools_manifest.json").read_text())
+manager_instances = {
+    name: value
+    for name, value in vars(runtime).items()
+    if name.endswith("_manager") and not name.startswith("get_")
+}
+checked = set()
+failures = []
+for module_name in sorted(set(manifest["module_map"].values())):
+    prefix = "unifi_network_mcp."
+    if not module_name.startswith(prefix):
+        failures.append(f"{module_name}: outside the Network package")
+        continue
+    relative = module_name.removeprefix(prefix).replace(".", "/") + ".py"
+    tree = ast.parse(root.joinpath(relative).read_text(), filename=module_name)
+    for node in ast.walk(tree):
+        call = node.func if isinstance(node, ast.Call) else None
+        if not isinstance(call, ast.Attribute) or not isinstance(call.value, ast.Name):
+            continue
+        manager_name = call.value.id
+        manager = manager_instances.get(manager_name)
+        if manager is None:
+            continue
+        key = (module_name, manager_name, call.attr)
+        if key in checked:
+            continue
+        checked.add(key)
+        method = getattr(type(manager), call.attr, None)
+        if method is None or not callable(method):
+            failures.append(f"{module_name}: missing {manager_name}.{call.attr}")
+if not checked:
+    failures.append("no direct Core manager call sites were discovered")
+if failures:
+    raise SystemExit("\\n".join(failures))
+print(f"validated {len(checked)} direct Core manager call sites against installed Core floor")
 """
 
 
@@ -383,8 +429,8 @@ def check_downstream(pkg: Downstream, downstream_wheel: Path, find_links: Path, 
     return True, upgrade_message
 
 
-def api_core_floor_from_wheel(wheel: Path) -> str:
-    """Extract the API wheel's declared minimum unifi-core version."""
+def core_floor_from_wheel(wheel: Path, package_label: str) -> str:
+    """Extract a wheel's declared minimum unifi-core version."""
     with zipfile.ZipFile(wheel) as archive:
         metadata_name = next(name for name in archive.namelist() if name.endswith(".dist-info/METADATA"))
         metadata = archive.read(metadata_name).decode()
@@ -393,16 +439,33 @@ def api_core_floor_from_wheel(wheel: Path) -> str:
         None,
     )
     if requirement is None:
-        raise RuntimeError("API wheel does not declare a unifi-core dependency")
+        raise RuntimeError(f"{package_label} wheel does not declare a unifi-core dependency")
     match = re.search(r">=\s*([0-9]+(?:\.[0-9]+)*)", requirement)
     if match is None:
-        raise RuntimeError(f"API unifi-core dependency has no minimum version: {requirement}")
+        raise RuntimeError(f"{package_label} unifi-core dependency has no minimum version: {requirement}")
     return match.group(1)
 
 
-def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
-    """Install and contract-check the API against exactly its published Core floor."""
-    floor = api_core_floor_from_wheel(api_wheel)
+def api_core_floor_from_wheel(wheel: Path) -> str:
+    """Extract the API wheel's declared minimum unifi-core version."""
+    return core_floor_from_wheel(wheel, "API")
+
+
+def network_core_floor_from_wheel(wheel: Path) -> str:
+    """Extract the Network wheel's declared minimum unifi-core version."""
+    return core_floor_from_wheel(wheel, "Network")
+
+
+def check_core_floor_contract(
+    wheel: Path,
+    venv_dir: Path,
+    *,
+    package_label: str,
+    core_extras: str,
+    contract: str,
+) -> tuple[bool, str]:
+    """Install and contract-check a wheel against exactly its published Core floor."""
+    floor = core_floor_from_wheel(wheel, package_label)
     venv.create(venv_dir, with_pip=True, clear=True, symlinks=True)
     py = venv_dir / "bin" / "python"
     try:
@@ -416,12 +479,12 @@ def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
                 "--disable-pip-version-check",
                 "--index-url",
                 "https://pypi.org/simple",
-                f"unifi-core[network,protect,access]=={floor}",
-                str(api_wheel),
+                f"unifi-core[{core_extras}]=={floor}",
+                str(wheel),
             ]
         )
         run_capture([str(py), "-m", "pip", "check"])
-        result = run_capture([str(py), "-c", _API_CATALOG_FLOOR_CONTRACT])
+        result = run_capture([str(py), "-c", contract])
     except subprocess.CalledProcessError as exc:
         detail = (exc.stderr or exc.stdout or "").strip()[-3000:]
         return (
@@ -431,12 +494,40 @@ def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
     return True, f"Core floor {floor}: {(result.stdout or '').strip()}"
 
 
+def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
+    """Install and contract-check the API against exactly its published Core floor."""
+    return check_core_floor_contract(
+        api_wheel,
+        venv_dir,
+        package_label="API",
+        core_extras="network,protect,access",
+        contract=_API_CATALOG_FLOOR_CONTRACT,
+    )
+
+
+def check_network_core_floor(network_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
+    """Install and contract-check Network against exactly its published Core floor."""
+    return check_core_floor_contract(
+        network_wheel,
+        venv_dir,
+        package_label="Network",
+        core_extras="network",
+        contract=_NETWORK_CORE_FLOOR_CONTRACT,
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    floor_group = parser.add_mutually_exclusive_group()
+    floor_group.add_argument(
         "--api-core-floor-only",
         action="store_true",
         help="Verify the API wheel against exactly its published minimum unifi-core version.",
+    )
+    floor_group.add_argument(
+        "--network-core-floor-only",
+        action="store_true",
+        help="Verify the Network wheel against exactly its published minimum unifi-core version.",
     )
     args = parser.parse_args()
     if shutil.which("uv") is None:
@@ -453,9 +544,15 @@ def main() -> int:
             ok, message = check_api_core_floor(api_wheel, tmp_path / "api-floor-venv")
             print(("PASS: " if ok else "FAIL: ") + message)
             return 0 if ok else 1
+        if args.network_core_floor_only:
+            network_wheel = build_wheel(REPO / "apps/network", tmp_path / "network")
+            ok, message = check_network_core_floor(network_wheel, tmp_path / "network-floor-venv")
+            print(("PASS: " if ok else "FAIL: ") + message)
+            return 0 if ok else 1
 
         failures: list[tuple[str, str]] = []
         upstream_wheels: dict[str, Path] = {}
+        downstream_wheels: dict[str, Path] = {}
         print("Building upstream wheels (workspace) -> --find-links source")
         for name, path in UPSTREAM_PACKAGES.items():
             wheel = build_wheel(path, find_links)
@@ -486,6 +583,7 @@ def main() -> int:
         print("Checking each downstream wheel over a vulnerable baseline against PyPI")
         for pkg in DOWNSTREAM_PACKAGES:
             wheel = build_wheel(pkg.src, tmp_path / "downstream" / pkg.dist_name)
+            downstream_wheels[pkg.dist_name] = wheel
             metadata_ok, metadata_msg = check_security_floors(pkg.dist_name, wheel)
             if not metadata_ok:
                 print(f"  [FAIL] {pkg.dist_name} ({wheel.name}) — {metadata_msg}")
@@ -536,7 +634,17 @@ def main() -> int:
             )
             return 1
 
-        api_wheel = build_wheel(REPO / "apps/api", tmp_path / "api-floor")
+        network_wheel = downstream_wheels["unifi-network-mcp"]
+        network_floor_ok, network_floor_message = check_network_core_floor(
+            network_wheel, tmp_path / "network-floor-venv"
+        )
+        print()
+        print(f"  [{'PASS' if network_floor_ok else 'FAIL'}] Network tools against published Core floor")
+        print(f"  {network_floor_message}")
+        if not network_floor_ok:
+            return 1
+
+        api_wheel = downstream_wheels["unifi-api-server"]
         floor_ok, floor_message = check_api_core_floor(api_wheel, tmp_path / "api-floor-venv")
         print()
         print(f"  [{'PASS' if floor_ok else 'FAIL'}] API catalog against published Core floor")

--- a/tests/test_check_pin_alignment.py
+++ b/tests/test_check_pin_alignment.py
@@ -39,6 +39,13 @@ def test_extracts_api_core_lower_bound_from_wheel_metadata(tmp_path: Path) -> No
     assert module.api_core_floor_from_wheel(wheel) == "0.4.23"
 
 
+def test_extracts_network_core_lower_bound_from_wheel_metadata(tmp_path: Path) -> None:
+    module = _module()
+    wheel = _wheel(tmp_path, "unifi-core[network]>=0.4.32,<0.5")
+
+    assert module.network_core_floor_from_wheel(wheel) == "0.4.32"
+
+
 @pytest.mark.parametrize("requirement", [None, "unifi-core<0.5"])
 def test_missing_core_floor_fails_closed(tmp_path: Path, requirement: str | None) -> None:
     module = _module()
@@ -52,6 +59,12 @@ def test_api_floor_contract_is_valid_python() -> None:
     module = _module()
 
     compile(module._API_CATALOG_FLOOR_CONTRACT, "<api-catalog-floor-contract>", "exec")
+
+
+def test_network_floor_contract_is_valid_python() -> None:
+    module = _module()
+
+    compile(module._NETWORK_CORE_FLOOR_CONTRACT, "<network-core-floor-contract>", "exec")
 
 
 def test_security_floor_check_accepts_explicit_safe_wheel_metadata(tmp_path: Path) -> None:

--- a/tests/test_generate_api_action_catalog.py
+++ b/tests/test_generate_api_action_catalog.py
@@ -320,7 +320,7 @@ def test_repository_catalog_is_complete_with_only_streaming_exclusions() -> None
 
     payload = json.loads(generator.render_catalog(REPO_ROOT))
 
-    assert len(payload["actions"]) == 268
+    assert len(payload["actions"]) == 271
     assert [item["name"] for item in payload["excluded"]] == [
         "access_subscribe_events",
         "protect_subscribe_events",
@@ -339,6 +339,14 @@ def test_repository_catalog_is_complete_with_only_streaming_exclusions() -> None
     assert by_name["unifi_get_event_types"]["manager_method"] == "get_event_type_prefixes"
     assert by_name["unifi_archive_alarm"]["manager_method"] == "archive_alarm"
     assert by_name["unifi_archive_all_alarms"]["manager_method"] == "archive_all_alarms"
+    assert (
+        by_name["unifi_create_firewall_zone"]["manager_attr"],
+        by_name["unifi_create_firewall_zone"]["manager_method"],
+    ) == (
+        "firewall_manager",
+        "create_firewall_zone",
+    )
+    assert by_name["unifi_delete_firewall_zone"]["manager_method"] == "delete_firewall_zone"
 
 
 def test_repository_catalog_bindings_resolve_to_core_manager_methods() -> None:


### PR DESCRIPTION
## Summary

Completes the downstream half of #569 after `unifi-core 0.4.32` was published and independently verified.

- Adds `unifi_create_firewall_zone`, `unifi_update_firewall_zone`, and `unifi_delete_firewall_zone` to Network MCP.
- Exposes the same mutations through the API action catalog with validated argument translation and canonical response serialization.
- Raises both Network and API Core floors to `>=0.4.32`.
- Adds an exact-published-Core Network contract gate that scans all direct manager call sites; the standard pin-alignment job now checks both Network and API against their declared Core floors.
- Regenerates Network manifest, API catalog/SDL/docs, skill references, and user-facing tool counts.

Daniel Neto authored the original implementation in #569 and is credited as co-author. The maintainer hardening from that review is preserved here.

## Correctness and safety

- Explicit V2 ObjectID vs Integration UUID boundaries.
- Integration API pagination and API-key remediation.
- Membership preservation on rename.
- Cache invalidation and bounded create/update/delete readback.
- System-defined zones refused before mutation.
- Preview/current-state parity and blank-input rejection.

## Verification

- `make pre-commit` — green across the full workspace.
- `scripts/check_pin_alignment.py` — all wheel/security checks green.
- Network exact Core floor — 179 direct manager call sites validated against published Core 0.4.32.
- API exact Core floor — 271 action bindings validated against published Core 0.4.32.
- Focused suites — 11 pin tests, 65 Network firewall tests, 335 API tests.
- Prior live lifecycle on the identical implementation — create, V2 readback, rename preview/readback, delete preview, cross-API absence verification, cleanup complete.

Follow-up to #569.