### PR TITLE
fix(smoke): compare Network resource parity by MAC

### DIFF
--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -2893,7 +2893,14 @@ def run_api_actions_phase(args: argparse.Namespace) -> int:
 # - parity_collection_keys: the keys under the action's data payload that hold
 #   the item collection — we look at each in order and use the first present.
 API_RESOURCES_SAMPLE: list[tuple[str, str, dict[str, Any], str | None, dict[str, Any] | None, tuple[str, ...]]] = [
-    ("network", "/v1/sites/{site}/clients", {"limit": 10}, "unifi_list_clients", {}, ("clients", "items")),
+    (
+        "network",
+        "/v1/sites/{site}/clients",
+        {"limit": 10},
+        "unifi_list_clients",
+        {"limit": 1000},
+        ("clients", "items"),
+    ),
     ("network", "/v1/sites/{site}/devices", {"limit": 10}, "unifi_list_devices", {}, ("devices", "items")),
     ("network", "/v1/sites/{site}/networks", {"limit": 10}, None, None, ()),
     ("network", "/v1/sites/{site}/wlans", {"limit": 10}, None, None, ()),
@@ -2910,6 +2917,15 @@ API_RESOURCES_SAMPLE: list[tuple[str, str, dict[str, Any], str | None, dict[str,
         ("visitors", "items"),
     ),
 ]
+
+# Network resource types intentionally expose MAC addresses as their public
+# identities, while the matching action rows can also carry private controller
+# ``id``/``_id`` values. Comparing the generic identifiers mixes namespaces and
+# reports false parity failures even when both surfaces contain the same device.
+API_RESOURCE_PARITY_ID_KEYS: dict[str, tuple[str, ...]] = {
+    "/v1/sites/{site}/clients": ("mac",),
+    "/v1/sites/{site}/devices": ("mac",),
+}
 
 
 def _items_id_set(items: Any, id_keys: tuple[str, ...] = ("id", "_id", "mac", "uuid")) -> set[str]:
@@ -3142,8 +3158,12 @@ def run_api_resources_phase(args: argparse.Namespace) -> int:
 
                 if a_status == 200 and isinstance(a_response, dict) and a_response.get("success"):
                     action_collection = _action_collection(a_response, parity_keys)
-                    resource_ids = _items_id_set(items)
-                    action_ids = _items_id_set(action_collection)
+                    parity_id_keys = API_RESOURCE_PARITY_ID_KEYS.get(
+                        path_tpl,
+                        ("id", "_id", "mac", "uuid"),
+                    )
+                    resource_ids = _items_id_set(items, parity_id_keys)
+                    action_ids = _items_id_set(action_collection, parity_id_keys)
                     is_subset = resource_ids.issubset(action_ids) if resource_ids else True
                     parity = {
                         "tool": parity_tool,

--- a/tests/test_live_smoke_harness.py
+++ b/tests/test_live_smoke_harness.py
@@ -159,6 +159,27 @@ def test_api_actions_have_no_baseline_failure_exemption():
     assert live_smoke._classify_api_action_result(True, False) == "regression"
 
 
+def test_api_resource_parity_uses_public_network_mac_identity_and_complete_client_collection():
+    import live_smoke
+
+    client_sample = next(
+        sample for sample in live_smoke.API_RESOURCES_SAMPLE if sample[1] == "/v1/sites/{site}/clients"
+    )
+    assert client_sample[4] == {"limit": 1000}
+    assert live_smoke.API_RESOURCE_PARITY_ID_KEYS == {
+        "/v1/sites/{site}/clients": ("mac",),
+        "/v1/sites/{site}/devices": ("mac",),
+    }
+
+    resource_rows = [{"mac": "aa:bb:cc:dd:ee:ff"}]
+    action_rows = [{"_id": "controller-object-id", "mac": "aa:bb:cc:dd:ee:ff"}]
+
+    assert live_smoke._items_id_set(resource_rows, ("mac",)) == live_smoke._items_id_set(
+        action_rows,
+        ("mac",),
+    )
+
+
 def test_live_api_non_default_read_contract_requires_projection_limit_and_metadata():
     import live_smoke
 


### PR DESCRIPTION
## Summary

- Compare Network client and device REST/action parity using their public MAC identity.
- Request the complete client action collection instead of the default first 100 rows.
- Add a regression test for controller-object IDs that differ across the two projections.

## Why

The pre-release live API resource phase returned HTTP 200 with valid shapes for every endpoint, but falsely failed clients and devices because REST rows expose MAC as their identity while action rows also carry private controller IDs. The generic comparison selected different ID namespaces. On the fixed harness, live parity passes for 10/173 clients and 10/47 devices.

## Validation

- Focused live-smoke harness tests: 17 passed.
- Ruff format and lint: passed.
- Live API resources: all 9 endpoints passed; 6/6 parity checks matched.
- Full pre-commit gate: passed.
