### PR TITLE
chore(deps): require unifi-core 0.4.34 for Network and API

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -11,8 +11,9 @@ dependencies = [
     # identity and paged lookup require Core 0.4.30; shared MAC comparison
     # across the GraphQL and SSE surfaces requires Core 0.4.31; firewall-zone
     # actions require Core 0.4.32; Access system-log event normalization
-    # requires Core 0.4.33.
-    "unifi-core[network,protect,access]>=0.4.33,<0.5",
+    # requires Core 0.4.33; WLAN schedule-window projection requires Core
+    # 0.4.34.
+    "unifi-core[network,protect,access]>=0.4.34,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -10,8 +10,9 @@ dependencies = [
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.
     # WAN delegation validation requires Core 0.4.30. Firewall-zone CRUD
-    # requires the dual-API bridge added in Core 0.4.32.
-    "unifi-core[network]>=0.4.32,<0.5",
+    # requires the dual-API bridge added in Core 0.4.32. WLAN schedule-window
+    # validation requires Core 0.4.34.
+    "unifi-core[network]>=0.4.34,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
## Summary

Raise the published-wheel Core minimum for Network and API to 0.4.34, which is the first Core release containing the WLAN schedule-window model used by #557.

## Validation

- `unifi-core==0.4.34` independently installed from PyPI and passed a schedule-model import smoke.
- Network exact-Core-floor contract: 179 call sites validated against 0.4.34.
- API exact-Core-floor contract: 271 catalog bindings validated against 0.4.34.
- Built Network and API wheels both declare `unifi-core>=0.4.34,<0.5`.
- Full `make pre-commit` passed.