### PR TITLE
fix(protect): expose promised camera detail fields

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -341,10 +341,13 @@ type Camera {
   model: String
   type: String
   state: String
+  firmwareVersion: String
   isRecording: Boolean
   isMotionDetected: Boolean
   isSmartDetected: Boolean
   host: String
+  smartDetectTypes: [String!]
+  isPtz: Boolean
   channels: JSON
   irLedMode: String
   hdrMode: String

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -388,6 +388,17 @@
             ],
             "title": "Channels"
           },
+          "firmware_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Firmware Version"
+          },
           "hdr_mode": {
             "anyOf": [
               {
@@ -442,6 +453,17 @@
               }
             ],
             "title": "Is Motion Detected"
+          },
+          "is_ptz": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Ptz"
           },
           "is_recording": {
             "anyOf": [
@@ -530,6 +552,20 @@
               }
             ],
             "title": "Name"
+          },
+          "smart_detect_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Smart Detect Types"
           },
           "speaker_volume": {
             "anyOf": [

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -224,7 +224,10 @@ async def _fetch_camera(ctx: GraphQLContext, controller: str, camera_id: str) ->
                 controller,
                 "protect",
             )
-            return await mgr.get_camera(camera_id)
+            try:
+                return await mgr.get_camera(camera_id)
+            except UniFiNotFoundError:
+                return None
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -984,10 +987,7 @@ class ProtectQuery:
         id: strawberry.ID,
     ) -> Camera | None:
         ctx: GraphQLContext = info.context
-        try:
-            raw = await _fetch_camera(ctx, controller, str(id))
-        except UniFiNotFoundError:
-            return None
+        raw = await _fetch_camera(ctx, controller, str(id))
         if raw is None:
             return None
         inst = Camera.from_manager_output(raw)

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -6,10 +6,11 @@ Phase 6 PR3 Task D — wires every migrated protect read tool into a typed
 - Fetch helpers route through ``ctx.cache.get_or_fetch`` so concurrent
   resolvers in the same request share a single manager round-trip.
 - Page wrappers carry pagination cursors per LIST resolver.
-- DETAIL resolvers either filter the cached LIST snapshot by primary key
-  (``camera``, ``event`` -> events list, ``recording`` -> per-camera list)
-  or fetch per-id via cache when there is no list (``snapshot``,
-  ``cameraAnalytics``, ``cameraStreams``, ``eventThumbnail``).
+- DETAIL resolvers use a per-id manager method when one exists (``camera``),
+  filter the cached LIST snapshot when the list carries the full shape
+  (``event`` -> events list, ``recording`` -> per-camera list), or fetch
+  per-id via cache when there is no list (``snapshot``, ``cameraAnalytics``,
+  ``cameraStreams``, ``eventThumbnail``).
 - Wrapper-dict tools (``alarmStatus``, ``alarmProfiles``,
   ``recordingStatus``, ``viewers``) return the typed wrapper directly via
   ``Type.from_manager_output(raw)``.
@@ -30,6 +31,7 @@ from typing import Any
 
 import strawberry
 from strawberry.types import Info
+from unifi_core.exceptions import UniFiNotFoundError
 
 from unifi_api.graphql.context import GraphQLContext
 from unifi_api.graphql.permissions import IsRead
@@ -202,6 +204,27 @@ async def _fetch_cameras(ctx: GraphQLContext, controller: str) -> list:
                 "protect",
             )
             return list(await mgr.list_cameras())
+
+    return await ctx.cache.get_or_fetch(key, _do)
+
+
+async def _fetch_camera(ctx: GraphQLContext, controller: str, camera_id: str) -> Any:
+    key = f"protect/cameras/{controller}/{camera_id}"
+
+    async def _do() -> Any:
+        async with ctx.sessionmaker() as session:
+            mgr = await ctx.manager_factory.get_domain_manager(
+                session,
+                controller,
+                "protect",
+                "camera_manager",
+            )
+            await ctx.manager_factory.get_connection_manager(
+                session,
+                controller,
+                "protect",
+            )
+            return await mgr.get_camera(camera_id)
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -961,13 +984,15 @@ class ProtectQuery:
         id: strawberry.ID,
     ) -> Camera | None:
         ctx: GraphQLContext = info.context
-        raw = await _fetch_cameras(ctx, controller)
-        for c in raw:
-            if _id_of(c) == id:
-                inst = Camera.from_manager_output(c)
-                inst._controller_id = str(controller)
-                return inst
-        return None
+        try:
+            raw = await _fetch_camera(ctx, controller, str(id))
+        except UniFiNotFoundError:
+            return None
+        if raw is None:
+            return None
+        inst = Camera.from_manager_output(raw)
+        inst._controller_id = str(controller)
+        return inst
 
     @strawberry.field(
         permission_classes=[IsRead],

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -330,10 +330,13 @@ type Camera {
   model: String
   type: String
   state: String
+  firmwareVersion: String
   isRecording: Boolean
   isMotionDetected: Boolean
   isSmartDetected: Boolean
   host: String
+  smartDetectTypes: [String!]
+  isPtz: Boolean
   channels: JSON
   irLedMode: String
   hdrMode: String

--- a/apps/api/src/unifi_api/graphql/types/protect/cameras.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/cameras.py
@@ -52,10 +52,13 @@ class Camera:
     model: str | None
     type: str | None
     state: str | None
+    firmware_version: str | None
     is_recording: bool | None
     is_motion_detected: bool | None
     is_smart_detected: bool | None
     host: str | None
+    smart_detect_types: list[str] | None
+    is_ptz: bool | None
     channels: strawberry.scalars.JSON | None  # type: ignore[name-defined]
     ir_led_mode: str | None
     hdr_mode: str | None
@@ -87,10 +90,13 @@ class Camera:
             model=_get(obj, "model"),
             type=_get(obj, "type"),
             state=_get(obj, "state"),
+            firmware_version=_get(obj, "firmware_version"),
             is_recording=_get(obj, "is_recording"),
             is_motion_detected=_get(obj, "is_motion_detected"),
             is_smart_detected=_get(obj, "is_smart_detected"),
             host=_get(obj, "ip_address") or _get(obj, "host"),
+            smart_detect_types=_get(obj, "smart_detect_types"),
+            is_ptz=_get(obj, "is_ptz"),
             channels=_get(obj, "channels") or [],
             ir_led_mode=_get(obj, "ir_led_mode"),
             hdr_mode=_get(obj, "hdr_mode"),

--- a/apps/api/src/unifi_api/routes/resources/protect/cameras.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/cameras.py
@@ -123,8 +123,8 @@ async def get_camera(
         await _maybe_set_site(cm, site_id)
         try:
             camera = await mgr.get_camera(camera_id)
-        except ValueError:
-            raise HTTPException(status_code=404, detail="camera not found")
+        except UniFiNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="camera not found") from exc
 
     type_class = request.app.state.type_registry.lookup("protect", "cameras/{id}")
     data = type_class.from_manager_output(camera).to_dict()

--- a/apps/api/tests/graphql/fixtures/edges/test_relationships.py
+++ b/apps/api/tests/graphql/fixtures/edges/test_relationships.py
@@ -165,9 +165,11 @@ async def test_edge_camera_events(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("protect", "camera_manager", "list_cameras"): [
-                {"id": "cam-1", "name": "Front Door", "model": "G4PRO"},
-            ],
+            ("protect", "camera_manager", "get_camera"): {
+                "id": "cam-1",
+                "name": "Front Door",
+                "model": "G4PRO",
+            },
             ("protect", "event_manager", "list_events"): [
                 {"id": "evt-1", "type": "motion", "camera_id": "cam-1"},
                 {"id": "evt-2", "type": "ring", "camera_id": "cam-1"},
@@ -206,9 +208,11 @@ async def test_edge_camera_recordings(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("protect", "camera_manager", "list_cameras"): [
-                {"id": "cam-1", "name": "Garage", "model": "G5FLEX"},
-            ],
+            ("protect", "camera_manager", "get_camera"): {
+                "id": "cam-1",
+                "name": "Garage",
+                "model": "G5FLEX",
+            },
             ("protect", "recording_manager", "list_recordings"): [
                 {
                     "id": "rec-1",

--- a/apps/api/tests/graphql/fixtures/protect/test_cameras.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_cameras.py
@@ -50,9 +50,11 @@ async def test_protect_camera_detail(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("protect", "camera_manager", "list_cameras"): [
-                {"id": "cam1", "name": "Front Door", "model": "G4_PRO"},
-            ],
+            ("protect", "camera_manager", "get_camera"): {
+                "id": "cam1",
+                "name": "Front Door",
+                "model": "G4_PRO",
+            },
         },
     )
     body = await graphql_query(

--- a/apps/api/tests/graphql/test_query_e2e_protect.py
+++ b/apps/api/tests/graphql/test_query_e2e_protect.py
@@ -21,6 +21,7 @@ from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
 from unifi_api.db.models import ApiKey, Base, Controller
 from unifi_api.server import create_app
+from unifi_core.exceptions import UniFiNotFoundError
 
 
 def _cfg(tmp_path: Path) -> ApiConfig:
@@ -73,6 +74,7 @@ def _stub_protect_managers(
     monkeypatch,
     *,
     cameras: list[Any] | None = None,
+    camera_details: dict[str, Any] | None = None,
     chimes: list[Any] | None = None,
     lights: list[Any] | None = None,
     sensors: list[Any] | None = None,
@@ -87,6 +89,7 @@ def _stub_protect_managers(
     """
     call_counts: dict[str, int] = {
         "list_cameras": 0,
+        "get_camera": 0,
         "list_chimes": 0,
         "list_lights": 0,
         "list_sensors": 0,
@@ -98,6 +101,16 @@ def _stub_protect_managers(
     async def _stub_list_cameras():
         call_counts["list_cameras"] += 1
         return cameras or []
+
+    async def _stub_get_camera(camera_id: str):
+        call_counts["get_camera"] += 1
+        if camera_details is not None:
+            camera = camera_details.get(camera_id)
+        else:
+            camera = next((camera for camera in (cameras or []) if camera.get("id") == camera_id), None)
+        if camera is None:
+            raise UniFiNotFoundError("camera", camera_id)
+        return camera
 
     async def _stub_list_chimes():
         call_counts["list_chimes"] += 1
@@ -125,6 +138,7 @@ def _stub_protect_managers(
 
     fake_camera_mgr = MagicMock()
     fake_camera_mgr.list_cameras = _stub_list_cameras
+    fake_camera_mgr.get_camera = _stub_get_camera
     fake_chime_mgr = MagicMock()
     fake_chime_mgr.list_chimes = _stub_list_chimes
     fake_light_mgr = MagicMock()
@@ -185,18 +199,12 @@ async def test_e2e_cameras_flat_list(tmp_path: Path, monkeypatch) -> None:
             "id": "cam1",
             "name": "Front Door",
             "model": "G4_PRO",
-            "firmware_version": "5.4.132",
-            "ip_address": "192.0.2.10",
-            "smart_detect_types": ["person", "vehicle"],
             "is_ptz": False,
         },
         {
             "id": "cam2",
             "name": "Garage",
             "model": "G5_FLEX",
-            "firmware_version": "5.4.131",
-            "ip_address": "192.0.2.11",
-            "smart_detect_types": [],
             "is_ptz": True,
         },
     ]
@@ -206,7 +214,7 @@ async def test_e2e_cameras_flat_list(tmp_path: Path, monkeypatch) -> None:
     query = f'''{{
       protect {{
         cameras(controller: "{cid}") {{
-          items {{ id name model firmwareVersion host smartDetectTypes isPtz }}
+          items {{ id name model isPtz }}
           nextCursor
         }}
       }}
@@ -220,10 +228,73 @@ async def test_e2e_cameras_flat_list(tmp_path: Path, monkeypatch) -> None:
         assert len(items) == 2
         assert {it["name"] for it in items} == {"Front Door", "Garage"}
         front_door = next(it for it in items if it["id"] == "cam1")
-        assert front_door["firmwareVersion"] == "5.4.132"
-        assert front_door["host"] == "192.0.2.10"
-        assert front_door["smartDetectTypes"] == ["person", "vehicle"]
         assert front_door["isPtz"] is False
+
+
+@pytest.mark.asyncio
+async def test_e2e_camera_detail_uses_get_camera(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+
+    camera_summary = {"id": "cam1", "name": "Front Door", "model": "G4_PRO", "is_ptz": False}
+    camera_detail = {
+        **camera_summary,
+        "firmware_version": "5.4.132",
+        "ip_address": "192.0.2.10",
+        "smart_detect_types": ["person", "vehicle"],
+    }
+    call_counts = _stub_protect_managers(
+        monkeypatch,
+        cameras=[camera_summary],
+        camera_details={"cam1": camera_detail},
+    )
+
+    headers = {"Authorization": f"Bearer {key}"}
+    query = f'''{{
+      protect {{
+        camera(controller: "{cid}", id: "cam1") {{
+          id
+          name
+          firmwareVersion
+          host
+          smartDetectTypes
+          isPtz
+        }}
+      }}
+    }}'''
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("errors") is None, body
+        camera = body["data"]["protect"]["camera"]
+        assert camera == {
+            "id": "cam1",
+            "name": "Front Door",
+            "firmwareVersion": "5.4.132",
+            "host": "192.0.2.10",
+            "smartDetectTypes": ["person", "vehicle"],
+            "isPtz": False,
+        }
+        assert call_counts["get_camera"] == 1
+        assert call_counts["list_cameras"] == 0
+
+
+@pytest.mark.asyncio
+async def test_e2e_camera_detail_not_found_is_nullable(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    call_counts = _stub_protect_managers(monkeypatch, camera_details={})
+
+    headers = {"Authorization": f"Bearer {key}"}
+    query = f'{{ protect {{ camera(controller: "{cid}", id: "missing") {{ id }} }} }}'
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        assert r.status_code == 200
+        body = r.json()
+        assert body.get("errors") is None, body
+        assert body["data"]["protect"]["camera"] is None
+        assert call_counts["get_camera"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/graphql/test_query_e2e_protect.py
+++ b/apps/api/tests/graphql/test_query_e2e_protect.py
@@ -7,6 +7,7 @@ sibling in ``test_query_e2e_network.py``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
@@ -288,13 +289,23 @@ async def test_e2e_camera_detail_not_found_is_nullable(tmp_path: Path, monkeypat
 
     headers = {"Authorization": f"Bearer {key}"}
     query = f'{{ protect {{ camera(controller: "{cid}", id: "missing") {{ id }} }} }}'
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-        r = await c.post("/v1/graphql", headers=headers, json={"query": query})
-        assert r.status_code == 200
-        body = r.json()
-        assert body.get("errors") is None, body
-        assert body["data"]["protect"]["camera"] is None
-        assert call_counts["get_camera"] == 1
+    loop = asyncio.get_running_loop()
+    loop_errors: list[dict[str, Any]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            r = await c.post("/v1/graphql", headers=headers, json={"query": query})
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("errors") is None, body
+    assert body["data"]["protect"]["camera"] is None
+    assert call_counts["get_camera"] == 1
+    assert loop_errors == []
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/graphql/test_query_e2e_protect.py
+++ b/apps/api/tests/graphql/test_query_e2e_protect.py
@@ -181,13 +181,36 @@ async def test_e2e_cameras_flat_list(tmp_path: Path, monkeypatch) -> None:
     app, key, cid = await _bootstrap(tmp_path)
 
     fixture_cameras = [
-        {"id": "cam1", "name": "Front Door", "model": "G4_PRO"},
-        {"id": "cam2", "name": "Garage", "model": "G5_FLEX"},
+        {
+            "id": "cam1",
+            "name": "Front Door",
+            "model": "G4_PRO",
+            "firmware_version": "5.4.132",
+            "ip_address": "192.0.2.10",
+            "smart_detect_types": ["person", "vehicle"],
+            "is_ptz": False,
+        },
+        {
+            "id": "cam2",
+            "name": "Garage",
+            "model": "G5_FLEX",
+            "firmware_version": "5.4.131",
+            "ip_address": "192.0.2.11",
+            "smart_detect_types": [],
+            "is_ptz": True,
+        },
     ]
     _stub_protect_managers(monkeypatch, cameras=fixture_cameras)
 
     headers = {"Authorization": f"Bearer {key}"}
-    query = f'{{ protect {{ cameras(controller: "{cid}") {{ items {{ id name model }} nextCursor }} }} }}'
+    query = f'''{{
+      protect {{
+        cameras(controller: "{cid}") {{
+          items {{ id name model firmwareVersion host smartDetectTypes isPtz }}
+          nextCursor
+        }}
+      }}
+    }}'''
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.post("/v1/graphql", headers=headers, json={"query": query})
         assert r.status_code == 200
@@ -196,6 +219,11 @@ async def test_e2e_cameras_flat_list(tmp_path: Path, monkeypatch) -> None:
         items = body["data"]["protect"]["cameras"]["items"]
         assert len(items) == 2
         assert {it["name"] for it in items} == {"Front Door", "Garage"}
+        front_door = next(it for it in items if it["id"] == "cam1")
+        assert front_door["firmwareVersion"] == "5.4.132"
+        assert front_door["host"] == "192.0.2.10"
+        assert front_door["smartDetectTypes"] == ["person", "vehicle"]
+        assert front_door["isPtz"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/routes/resources/test_protect_resources.py
+++ b/apps/api/tests/routes/resources/test_protect_resources.py
@@ -10,6 +10,7 @@ from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
 from unifi_api.db.crypto import ColumnCipher, derive_key
 from unifi_api.db.models import ApiKey, Base, Controller
 from unifi_api.server import create_app
+from unifi_core.exceptions import UniFiNotFoundError
 
 
 def _cfg(tmp_path):
@@ -148,7 +149,7 @@ async def test_get_camera_happy_and_404(tmp_path, monkeypatch) -> None:
     async def fake_get(self, camera_id):
         if camera_id == "cam-1":
             return target
-        raise ValueError(f"Camera not found: {camera_id}")
+        raise UniFiNotFoundError("camera", camera_id)
 
     from unifi_core.protect.managers.camera_manager import CameraManager
 

--- a/apps/api/tests/routes/resources/test_protect_resources.py
+++ b/apps/api/tests/routes/resources/test_protect_resources.py
@@ -138,7 +138,10 @@ async def test_get_camera_happy_and_404(tmp_path, monkeypatch) -> None:
         "type": "camera",
         "state": "CONNECTED",
         "is_recording": True,
+        "firmware_version": "5.4.132",
         "ip_address": "10.0.0.5",
+        "smart_detect_types": ["person", "package"],
+        "is_ptz": False,
         "channels": [],
     }
 
@@ -164,6 +167,10 @@ async def test_get_camera_happy_and_404(tmp_path, monkeypatch) -> None:
     assert ok.status_code == 200, ok.text
     body = ok.json()
     assert body["data"]["id"] == "cam-1"
+    assert body["data"]["firmware_version"] == "5.4.132"
+    assert body["data"]["host"] == "10.0.0.5"
+    assert body["data"]["smart_detect_types"] == ["person", "package"]
+    assert body["data"]["is_ptz"] is False
     assert body["render_hint"]["kind"] == "detail"
     assert miss.status_code == 404
 

--- a/apps/api/tests/serializers/test_protect_serializers.py
+++ b/apps/api/tests/serializers/test_protect_serializers.py
@@ -32,7 +32,10 @@ def test_camera_serializer_shape() -> None:
         "is_recording": True,
         "is_motion_detected": False,
         "is_smart_detected": False,
+        "firmware_version": "5.4.132",
         "ip_address": "10.0.0.50",
+        "smart_detect_types": ["person", "vehicle"],
+        "is_ptz": False,
         "channels": [{"id": 0, "name": "high"}],
     }
     out = Camera.from_manager_output(sample).to_dict()
@@ -41,6 +44,10 @@ def test_camera_serializer_shape() -> None:
     assert out["name"] == "Front Door"
     assert out["model"] == "G4 Pro"
     assert out["state"] == "CONNECTED"
+    assert out["firmware_version"] == "5.4.132"
+    assert out["host"] == "10.0.0.50"
+    assert out["smart_detect_types"] == ["person", "vehicle"]
+    assert out["is_ptz"] is False
 
 
 def test_event_serializer_shape() -> None:

--- a/apps/protect/tests/unit/test_cameras.py
+++ b/apps/protect/tests/unit/test_cameras.py
@@ -808,11 +808,22 @@ class TestProtectGetCameraTool:
         from unifi_protect_mcp.tools.cameras import protect_get_camera
 
         mock_camera_manager.get_camera = AsyncMock(
-            return_value={"id": "cam-001", "name": "Front Door", "firmware_version": "4.69.55"}
+            return_value={
+                "id": "cam-001",
+                "name": "Front Door",
+                "firmware_version": "4.69.55",
+                "ip_address": "192.0.2.10",
+                "smart_detect_types": [],
+                "is_ptz": False,
+            }
         )
         result = await protect_get_camera("cam-001")
         assert result["success"] is True
         assert result["data"]["id"] == "cam-001"
+        assert result["data"]["firmware_version"] == "4.69.55"
+        assert result["data"]["host"] == "192.0.2.10"
+        assert result["data"]["smart_detect_types"] == []
+        assert result["data"]["is_ptz"] is False
 
     @pytest.mark.asyncio
     async def test_not_found(self, mock_camera_manager):

--- a/packages/unifi-core/src/unifi_core/protect/models/cameras.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/cameras.py
@@ -20,6 +20,9 @@ class Camera(BaseModel):
     model: Optional[str] = Field(default=None, description="Camera model", json_schema_extra={"mutable": False})
     type: Optional[str] = Field(default=None, description="Camera type", json_schema_extra={"mutable": False})
     state: Optional[str] = Field(default=None, description="Connection state", json_schema_extra={"mutable": False})
+    firmware_version: Optional[str] = Field(
+        default=None, description="Camera firmware version", json_schema_extra={"mutable": False}
+    )
     is_recording: Optional[bool] = Field(
         default=None, description="Whether camera is currently recording", json_schema_extra={"mutable": False}
     )
@@ -30,6 +33,14 @@ class Camera(BaseModel):
         default=None, description="Whether a smart detection is active", json_schema_extra={"mutable": False}
     )
     host: Optional[str] = Field(default=None, description="Camera IP/host", json_schema_extra={"mutable": False})
+    smart_detect_types: Optional[list[str]] = Field(
+        default=None,
+        description="Smart detection object types supported by the camera",
+        json_schema_extra={"mutable": False},
+    )
+    is_ptz: Optional[bool] = Field(
+        default=None, description="Whether the camera supports PTZ", json_schema_extra={"mutable": False}
+    )
     channels: Optional[Any] = Field(
         default=None,
         description="Channel configuration — controller returns dict or list of channel descriptors",
@@ -73,10 +84,13 @@ def from_controller(raw: Any) -> Camera:
         model=_get(raw, "model"),
         type=_get(raw, "type"),
         state=_get(raw, "state"),
+        firmware_version=_get(raw, "firmware_version"),
         is_recording=_get(raw, "is_recording"),
         is_motion_detected=_get(raw, "is_motion_detected"),
         is_smart_detected=_get(raw, "is_smart_detected"),
-        host=_get(raw, "host"),
+        host=_get(raw, "ip_address") or _get(raw, "host"),
+        smart_detect_types=_get(raw, "smart_detect_types"),
+        is_ptz=_get(raw, "is_ptz"),
         channels=channels,
         ir_led_mode=_get(raw, "ir_led_mode"),
         hdr_mode=_get(raw, "hdr_mode"),

--- a/packages/unifi-core/tests/protect/models/test_cameras.py
+++ b/packages/unifi-core/tests/protect/models/test_cameras.py
@@ -21,7 +21,10 @@ SAMPLE = {
     "is_recording": True,
     "is_motion_detected": False,
     "is_smart_detected": False,
-    "host": "10.0.1.42",
+    "firmware_version": "5.4.132",
+    "ip_address": "10.0.1.42",
+    "smart_detect_types": ["person", "vehicle"],
+    "is_ptz": False,
     "channels": {"0": {"resolution": "3840x2160"}},
     "ir_led_mode": "auto",
     "hdr_mode": "auto",
@@ -46,6 +49,9 @@ class TestCameraModel:
         assert "id" in READ_ONLY_FIELDS
         assert "mac" in READ_ONLY_FIELDS
         assert "is_recording" in READ_ONLY_FIELDS
+        assert "firmware_version" in READ_ONLY_FIELDS
+        assert "smart_detect_types" in READ_ONLY_FIELDS
+        assert "is_ptz" in READ_ONLY_FIELDS
         assert "channels" in READ_ONLY_FIELDS
         assert "name" not in READ_ONLY_FIELDS
 
@@ -59,7 +65,15 @@ class TestCameraModel:
         assert cam.is_recording is True
         assert cam.ir_led_mode == "auto"
         assert cam.mic_volume == 80
+        assert cam.firmware_version == "5.4.132"
+        assert cam.host == "10.0.1.42"
+        assert cam.smart_detect_types == ["person", "vehicle"]
+        assert cam.is_ptz is False
         assert cam.channels == {"0": {"resolution": "3840x2160"}}
+
+    def test_from_controller_accepts_host_fallback(self) -> None:
+        cam = from_controller({"id": "cam-host", "host": "10.0.1.43"})
+        assert cam.host == "10.0.1.43"
 
     def test_from_controller_handles_missing_fields(self) -> None:
         cam = from_controller({"id": "cam002"})


### PR DESCRIPTION
## Summary

- expose per-camera firmware version, IP/host, smart detection types, and PTZ capability through the shared Protect camera model
- preserve the existing public `host` field while accepting the manager's `ip_address` key
- surface the same fields through REST and GraphQL and regenerate API artifacts
- fetch GraphQL camera detail through the per-camera manager path instead of the summary list
- add regression coverage across Core, Protect MCP, serializers, REST, and GraphQL, including false, empty-list, nullable not-found, and cached-miss behavior

Closes #589.

## Type of change

- [x] `fix:` bug fix
- [ ] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [ ] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [ ] Network MCP server
- [x] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [x] API server
- [x] Shared packages
- [x] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- Core Protect camera model: 14 passed
- Protect camera tool suite: 93 passed
- Focused API serializer, REST, GraphQL, symmetry, and drift suites: 103 passed
- `make pre-commit`: passed, including the full 1,357-test API suite and generated-artifact checks
- `uv run --all-packages python scripts/live_smoke.py --server protect --phase readonly`: 46 checks passed; 3 intentional heavy/argument-dependent skips; `protect_get_camera` passed
- one-shot live field probe: `firmware_version`, `host`, `smart_detect_types`, and `is_ptz` were all present in the public tool response
- end-to-end live GraphQL detail probe: 14/14 cameras returned host values, smart-detection lists, and PTZ booleans; 13/14 returned firmware values and one returned the valid nullable value
- live REST unknown-camera probe returned HTTP 404 with `camera not found`
- the GraphQL nullable-miss regression verifies the cached fetch produces no event-loop exception warning
- `uv run --all-packages python scripts/live_smoke.py --server protect --phase safe`: 58 checks passed; 0 failures or exceptions; 11 risky physical operations deferred; 16 expected skips
- safe lifecycle cleanup: the disposable alarm rule completed create, update, read, preview-delete, and delete; the cleanup ledger matched and a fresh controller query confirmed the rule was absent
- all 18 GitHub CI checks passed on the final head

## Notes for reviewers

- The manager already emitted all four values. The loss occurred at the shared Pydantic model boundary, where undeclared fields were dropped and `host` did not recognize the manager's `ip_address` key.
- GraphQL camera detail now calls `get_camera`; the list endpoint intentionally remains summary-shaped.
- Missing camera detail is normalized inside the request-cache fetch, avoiding both HTTP 500 responses and unhandled cached-future warnings.
- `firmware_version`, `smart_detect_types`, and `is_ptz` are read-only model fields. The public IP field remains `host` for compatibility.
- This changes the shared Core model consumed by Protect and API, so release sequencing is Core first, followed by Protect and API.
- The change intentionally remains scoped to the four fields documented in #589; broader manager-to-model field drift can be audited separately.
