### PR TITLE
chore(deps): require unifi-core 0.4.35 for Protect and API

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     # across the GraphQL and SSE surfaces requires Core 0.4.31; firewall-zone
     # actions require Core 0.4.32; Access system-log event normalization
     # requires Core 0.4.33; WLAN schedule-window projection requires Core
-    # 0.4.34.
-    "unifi-core[network,protect,access]>=0.4.34,<0.5",
+    # 0.4.34; Protect camera detail fields require Core 0.4.35.
+    "unifi-core[network,protect,access]>=0.4.35,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -7,8 +7,9 @@ requires-python = ">=3.13"
 dependencies = [
     "unifi-mcp-shared>=0.6.7,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
-    # [protect] extra rather than declaring uiprotect here directly.
-    "unifi-core[protect]>=0.4.22,<0.5",
+    # [protect] extra rather than declaring uiprotect here directly. Camera
+    # detail fields require Core 0.4.35.
+    "unifi-core[protect]>=0.4.35,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
## Summary

Raise the published-wheel Core minimum for Protect and API to 0.4.35, the first Core release containing the Protect camera detail model fields used by #595.

## Validation

- `unifi-core==0.4.35` independently installed from PyPI and exposes the four camera detail fields.
- Full pin-alignment validation passed.
- API exact-Core-floor contract validated 271 catalog bindings against 0.4.35.
- Protect camera suite: 93 passed.
- Focused API Protect GraphQL and REST suites: 17 passed.
- Built Protect and API wheels both declare `unifi-core>=0.4.35,<0.5`.
- Full `make pre-commit` passed, including 1,357 API tests.
