### PR TITLE
fix(plugins): resolve names in versioned Codex cache

### DIFF
--- a/plugins/unifi-access/scripts/set-env.sh
+++ b/plugins/unifi-access/scripts/set-env.sh
@@ -70,6 +70,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_NAME="$(basename "$PLUGIN_ROOT")"
 
+# Codex installs marketplace plugins as <plugin>/<version>/scripts, while the
+# source-tree, Claude, and OpenClaw layouts use <plugin>/scripts. Resolve the
+# semantic plugin name from the parent directory only for a known UniFi plugin.
+case "$PLUGIN_NAME" in
+  unifi-network|unifi-protect|unifi-access) ;;
+  *)
+    plugin_parent_name="$(basename "$(dirname "$PLUGIN_ROOT")")"
+    case "$plugin_parent_name" in
+      unifi-network|unifi-protect|unifi-access) PLUGIN_NAME="$plugin_parent_name" ;;
+    esac
+    ;;
+esac
+
 detect_package_pin() {
   for manifest in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.mcp.json"; do
     if [ -f "$manifest" ]; then

--- a/plugins/unifi-network/scripts/set-env.sh
+++ b/plugins/unifi-network/scripts/set-env.sh
@@ -70,6 +70,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_NAME="$(basename "$PLUGIN_ROOT")"
 
+# Codex installs marketplace plugins as <plugin>/<version>/scripts, while the
+# source-tree, Claude, and OpenClaw layouts use <plugin>/scripts. Resolve the
+# semantic plugin name from the parent directory only for a known UniFi plugin.
+case "$PLUGIN_NAME" in
+  unifi-network|unifi-protect|unifi-access) ;;
+  *)
+    plugin_parent_name="$(basename "$(dirname "$PLUGIN_ROOT")")"
+    case "$plugin_parent_name" in
+      unifi-network|unifi-protect|unifi-access) PLUGIN_NAME="$plugin_parent_name" ;;
+    esac
+    ;;
+esac
+
 detect_package_pin() {
   for manifest in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.mcp.json"; do
     if [ -f "$manifest" ]; then

--- a/plugins/unifi-protect/scripts/set-env.sh
+++ b/plugins/unifi-protect/scripts/set-env.sh
@@ -70,6 +70,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PLUGIN_NAME="$(basename "$PLUGIN_ROOT")"
 
+# Codex installs marketplace plugins as <plugin>/<version>/scripts, while the
+# source-tree, Claude, and OpenClaw layouts use <plugin>/scripts. Resolve the
+# semantic plugin name from the parent directory only for a known UniFi plugin.
+case "$PLUGIN_NAME" in
+  unifi-network|unifi-protect|unifi-access) ;;
+  *)
+    plugin_parent_name="$(basename "$(dirname "$PLUGIN_ROOT")")"
+    case "$plugin_parent_name" in
+      unifi-network|unifi-protect|unifi-access) PLUGIN_NAME="$plugin_parent_name" ;;
+    esac
+    ;;
+esac
+
 detect_package_pin() {
   for manifest in "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT/.mcp.json"; do
     if [ -f "$manifest" ]; then

--- a/scripts/smoke-plugin-setup.sh
+++ b/scripts/smoke-plugin-setup.sh
@@ -256,6 +256,34 @@ got_host=$(python3 -c "import json; print(json.load(open('mcp.json'))['env']['UN
 assert "openclaw JSON includes host env" "$got_host" "10.0.0.1"
 assert_not_contains "openclaw write stdout hides raw password" "$out" "hunter2secret"
 
+# 3h. Codex's versioned plugin cache still uses the semantic plugin name
+rm -rf "$work" && mkdir -p "$work/bin" && cd "$work"
+cat > "$work/bin/uvx" <<'SH'
+#!/bin/sh
+echo "uvx 0.0.0"
+SH
+cat > "$work/bin/codex" <<'SH'
+#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf '%s\n' "$3" > "$CODEX_CAPTURE_NAME"
+fi
+exit 0
+SH
+chmod +x "$work/bin/uvx" "$work/bin/codex"
+for plugin in "${PLUGINS[@]}"; do
+  versioned_root="$work/cache/example-marketplace/$plugin/9.8.7"
+  mkdir -p "$versioned_root/scripts"
+  cp "$REPO_ROOT/plugins/$plugin/scripts/set-env.sh" "$versioned_root/scripts/set-env.sh"
+  set +e
+  out=$(PATH="$work/bin:$PATH" CODEX_CAPTURE_NAME="$work/$plugin-name.txt" /bin/bash "$versioned_root/scripts/set-env.sh" --target codex \
+    UNIFI_TEST_HOST=10.0.0.1 2>&1)
+  ec=$?
+  set -e
+  assert "versioned-cache $plugin setup exits 0" "$ec" "0"
+  got_name=$(cat "$work/$plugin-name.txt" 2>/dev/null || true)
+  assert "versioned-cache $plugin uses semantic server name" "$got_name" "$plugin"
+done
+
 # --- 4. Bash version this test ran under (informational) ---
 echo ""
 echo "== 4. Test run info =="


### PR DESCRIPTION
## Summary

- resolve canonical UniFi plugin names from Codex versioned cache paths
- preserve the existing source-tree, Claude, and OpenClaw layouts
- add executable regression coverage for Network, Protect, and Access

## Validation

- `/bin/bash scripts/smoke-plugin-setup.sh` (52 passed)
- `make pre-commit`
- dry-run from the installed Codex cache layout preserved `unifi-network-mcp==0.29.0` and registered `unifi-network`

Closes #551