### PR TITLE
feat(core): enrich traffic flow DPI names

### DIFF
--- a/.agents/skills/extend-unifi-api/SKILL.md
+++ b/.agents/skills/extend-unifi-api/SKILL.md
@@ -43,6 +43,7 @@ Reference `packages/unifi-core/src/unifi_core/network/managers/dns_manager.py` a
 from functools import lru_cache
 from unifi_core.network.managers.dns_manager import DnsManager
 
+
 @lru_cache
 def get_dns_manager() -> DnsManager:
     return DnsManager(get_connection_manager())
@@ -63,7 +64,8 @@ async def get_dns_record(self, record_id: str) -> dict:
 **2B: V2 single-resource responses may be wrapped in lists.** Always check `isinstance(response, list)` BEFORE `isinstance(response, dict)`:
 ```python
 response = await self._connection.request(api_request)
-if isinstance(response, list): return response[0] if response else None
+if isinstance(response, list):
+    return response[0] if response else None
 return response
 ```
 
@@ -88,6 +90,7 @@ return response
 from pydantic import BaseModel
 from typing import Optional, FrozenSet
 
+
 class DnsRecord(BaseModel):
     id: Optional[str] = None
     record_type: Optional[str] = None
@@ -97,12 +100,15 @@ class DnsRecord(BaseModel):
     enabled: Optional[bool] = None
     model_config = {"populate_by_name": True}
 
+
 MUTABLE_FIELDS = frozenset({"record_type", "key", "value", "ttl", "enabled"})
 READ_ONLY_FIELDS = frozenset({"id"})
 
+
 def to_controller_update(fields: dict) -> dict:
     invalid = set(fields) - MUTABLE_FIELDS
-    if invalid: raise ValueError(f"Read-only fields: {invalid}")
+    if invalid:
+        raise ValueError(f"Read-only fields: {invalid}")
     return fields
 ```
 
@@ -118,16 +124,27 @@ from mcp.types import Tool, ToolAnnotations
 from ..runtime import get_dns_manager
 from unifi_core.network.models.dns_record import DnsRecord, MUTABLE_FIELDS
 
+
 def get_tools() -> list[Tool]:
     _mutable = {k: v for k, v in DnsRecord.model_json_schema()["properties"].items() if k in MUTABLE_FIELDS}
     return [
-        Tool(name="network_dns_record_list", description="List DNS records.",
-             inputSchema={"type": "object", "properties": {}},
-             annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True)),
-        Tool(name="network_dns_record_update", description="Update DNS record.",
-             inputSchema={"type": "object", "properties": {"record_id": {"type": "string"}, **_mutable},
-                          "required": ["record_id"], "additionalProperties": False},
-             annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True)),
+        Tool(
+            name="network_dns_record_list",
+            description="List DNS records.",
+            inputSchema={"type": "object", "properties": {}},
+            annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        ),
+        Tool(
+            name="network_dns_record_update",
+            description="Update DNS record.",
+            inputSchema={
+                "type": "object",
+                "properties": {"record_id": {"type": "string"}, **_mutable},
+                "required": ["record_id"],
+                "additionalProperties": False,
+            },
+            annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True),
+        ),
     ]
 ```
 
@@ -140,6 +157,7 @@ All mutating tools require preview/confirm flow.
 ```python
 from pydantic import BaseModel, Field
 from typing import Optional
+
 
 class AlarmArmInput(BaseModel):
     alarm_id: str = Field(..., description="Alarm ID to arm")
@@ -158,6 +176,7 @@ class AlarmArmInput(BaseModel):
 **Action translators** (arm, disarm, toggle — no nested `rule_data`):
 ```python
 from unifi_core.protect.models._actions import AlarmArmInput
+
 DISPATCH_ARG_TRANSLATORS = {
     "protect_alarm_arm": lambda args, ctx: AlarmArmInput(**args).model_dump(),
 }
@@ -208,6 +227,7 @@ import strawberry
 from typing import Optional
 from unifi_api.types._base import UniFiType
 
+
 @strawberry.type
 class Client(UniFiType):
     kind: str = "LIST"  # required
@@ -249,8 +269,9 @@ from unifi_api.services.pagination import Cursor, paginate
 
 cursor = Cursor.decode(cursor_param) if cursor_param else None
 items = await manager.get_clients()
-page, next_cursor = paginate(items, limit=50, cursor=cursor,
-                            key_fn=lambda i: (i.raw.get("last_seen", 0), i.raw.get("_id", "")))
+page, next_cursor = paginate(
+    items, limit=50, cursor=cursor, key_fn=lambda i: (i.raw.get("last_seen", 0), i.raw.get("_id", ""))
+)
 return {"items": [...], "next_cursor": next_cursor.encode() if next_cursor else None}
 ```
 
@@ -280,6 +301,7 @@ Uses `asyncio.Lock` per controller to prevent concurrent cache-miss races. Call 
 Use `copy.deepcopy()` to preserve sibling fields during merge:
 ```python
 import copy
+
 current = await self.get_firewall_rule(rule_id)
 merged = copy.deepcopy(current.raw)
 merged.update(updates)
@@ -371,9 +393,12 @@ All `update_*` tools use the fetch-merge-put pattern. Skipping the fetch step ca
 async def update_dns_record(self, record_id: str, update_data: dict) -> dict:
     # 1. Fetch current state
     current = await self.get_dns_record(record_id)
-    if not current: raise ValueError(f"Record {record_id} not found")
+    if not current:
+        raise ValueError(f"Record {record_id} not found")
     # 2. Deep-copy before mutating (protects cached response)
-    import copy; base = copy.deepcopy(current)
+    import copy
+
+    base = copy.deepcopy(current)
     # 3. Merge caller's partial dict over the base
     merged = {**base, **update_data}
     # 4. PUT the fully-merged object
@@ -415,9 +440,9 @@ Every update tool must verify non-passed fields are preserved after the update:
 # mock_get returns {"name": "original", "vlan": 10, "notes": "keep me"}
 await manager.update_dns_record("id-1", {"name": "new-name"})
 payload = mock_put.call_args[1]["json"]
-assert payload["vlan"] == 10            # preserved
-assert payload["notes"] == "keep me"   # preserved
-assert payload["name"] == "new-name"   # updated
+assert payload["vlan"] == 10  # preserved
+assert payload["notes"] == "keep me"  # preserved
+assert payload["name"] == "new-name"  # updated
 ```
 
 ### Write-Verification Standard

--- a/packages/unifi-core/src/unifi_core/network/managers/dpi_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/dpi_manager.py
@@ -32,6 +32,15 @@ _DPI_CATALOG_CACHE_TTL = 900
 _DPI_CATALOG_PAGE_SIZE = 200
 
 
+def _parse_non_negative_integer(value: Any) -> int | None:
+    """Return a catalogue integer without accepting bools or fractional values."""
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return None
+
+
 class DpiManager:
     """Manages DPI application and category lookups via the official UniFi API."""
 
@@ -154,11 +163,8 @@ class DpiManager:
 
             page_entries = list(page.get("data") or [])
             raw_total = page.get("totalCount")
-            if isinstance(raw_total, int) and not isinstance(raw_total, bool):
-                page_total = raw_total
-            elif isinstance(raw_total, str) and raw_total.isdecimal():
-                page_total = int(raw_total)
-            else:
+            page_total = _parse_non_negative_integer(raw_total)
+            if page_total is None:
                 raise RuntimeError(f"invalid DPI {resource} catalogue totalCount")
             if total_count is None:
                 total_count = page_total
@@ -166,8 +172,10 @@ class DpiManager:
                 raise RuntimeError(f"DPI {resource} catalogue changed during pagination")
 
             reported_offset = page.get("offset")
-            if reported_offset is not None and int(reported_offset) != offset:
-                raise RuntimeError(f"incomplete DPI {resource} catalogue")
+            if reported_offset is not None:
+                parsed_offset = _parse_non_negative_integer(reported_offset)
+                if parsed_offset is None or parsed_offset != offset:
+                    raise RuntimeError(f"incomplete DPI {resource} catalogue")
             if not page_entries and len(entries) < total_count:
                 raise RuntimeError(f"incomplete DPI {resource} catalogue")
             if len(entries) + len(page_entries) > total_count:

--- a/packages/unifi-core/src/unifi_core/network/managers/dpi_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/dpi_manager.py
@@ -7,15 +7,12 @@ compound IDs: (category_id << 16) | app_id.
 Requires an API key (UNIFI_API_KEY or UNIFI_NETWORK_API_KEY).
 
 API endpoints (official integration API):
-  GET /proxy/network/integration/v1/dpi/applications  (paginated)
+  GET /proxy/network/integration/v1/dpi/applications  (paginated; maximum
+      page size 200)
   GET /proxy/network/integration/v1/dpi/categories    (paginated)
 
-TODO: As of Network App 10.1.85, the official integration API only
-returns categories 0-1 (IM, P2P — ~2,100 apps). Categories 4+ (streaming,
-social media) are not yet populated by Ubiquiti. A v2 endpoint
-(/v2/api/site/{site}/dpi) exists as a stub but returns 405.
-Revisit when Ubiquiti expands the official API coverage.
-Ref: https://github.com/sirkirby/unifi-network-mcp/issues/20
+Catalogue coverage is controller- and firmware-dependent. Callers must keep
+unresolved names null rather than infer them from a partial catalogue.
 """
 
 import logging
@@ -30,6 +27,9 @@ logger = logging.getLogger("unifi-network-mcp")
 
 CACHE_PREFIX_DPI_APPS = "dpi_apps"
 CACHE_PREFIX_DPI_CATEGORIES = "dpi_categories"
+CACHE_PREFIX_DPI_CATALOG = "dpi_catalog"
+_DPI_CATALOG_CACHE_TTL = 900
+_DPI_CATALOG_PAGE_SIZE = 200
 
 
 class DpiManager:
@@ -67,7 +67,7 @@ class DpiManager:
                 async with session.get(
                     url,
                     params=params,
-                    ssl=False,
+                    ssl=self._connection.verify_ssl,
                     timeout=aiohttp.ClientTimeout(total=10),
                 ) as resp:
                     if resp.status == 200:
@@ -133,6 +133,69 @@ class DpiManager:
         elif not search:
             self._connection._update_cache(cache_key, result)
 
+        return result
+
+    async def _get_all_integration_pages(self, path: str, resource: str) -> list[dict[str, Any]]:
+        """Fetch and validate every page from a DPI Integration-API collection."""
+        entries: list[dict[str, Any]] = []
+        seen_ids: set[int] = set()
+        offset = 0
+        total_count: int | None = None
+
+        while total_count is None or len(entries) < total_count:
+            page = await self._request_integration_api(
+                path,
+                {"limit": str(_DPI_CATALOG_PAGE_SIZE), "offset": str(offset)},
+            )
+            if page is None:
+                if offset == 0:
+                    raise RuntimeError(f"failed to fetch DPI {resource} catalogue")
+                raise RuntimeError(f"incomplete DPI {resource} catalogue")
+
+            page_entries = list(page.get("data") or [])
+            raw_total = page.get("totalCount")
+            if isinstance(raw_total, int) and not isinstance(raw_total, bool):
+                page_total = raw_total
+            elif isinstance(raw_total, str) and raw_total.isdecimal():
+                page_total = int(raw_total)
+            else:
+                raise RuntimeError(f"invalid DPI {resource} catalogue totalCount")
+            if total_count is None:
+                total_count = page_total
+            elif page_total != total_count:
+                raise RuntimeError(f"DPI {resource} catalogue changed during pagination")
+
+            reported_offset = page.get("offset")
+            if reported_offset is not None and int(reported_offset) != offset:
+                raise RuntimeError(f"incomplete DPI {resource} catalogue")
+            if not page_entries and len(entries) < total_count:
+                raise RuntimeError(f"incomplete DPI {resource} catalogue")
+            if len(entries) + len(page_entries) > total_count:
+                raise RuntimeError(f"inconsistent DPI {resource} catalogue totalCount")
+
+            for entry in page_entries:
+                entry_id = entry.get("id")
+                if isinstance(entry_id, int):
+                    if entry_id in seen_ids:
+                        raise RuntimeError(f"duplicate DPI {resource} catalogue entry")
+                    seen_ids.add(entry_id)
+            entries.extend(page_entries)
+            offset += len(page_entries)
+
+        return entries
+
+    async def get_full_dpi_catalog(self) -> Dict[str, list[dict[str, Any]]]:
+        """Fetch a complete, cached DPI catalogue for ID-to-name resolution."""
+        cache_key = f"{CACHE_PREFIX_DPI_CATALOG}_{self._connection.site}"
+        cached_data = self._connection.get_cached(cache_key, timeout=_DPI_CATALOG_CACHE_TTL)
+        if cached_data is not None:
+            return cached_data
+
+        result = {
+            "applications": await self._get_all_integration_pages("/v1/dpi/applications", "application"),
+            "categories": await self._get_all_integration_pages("/v1/dpi/categories", "category"),
+        }
+        self._connection._update_cache(cache_key, result, timeout=_DPI_CATALOG_CACHE_TTL)
         return result
 
     async def get_dpi_categories(

--- a/packages/unifi-core/src/unifi_core/network/managers/traffic_flow_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/traffic_flow_manager.py
@@ -7,21 +7,31 @@ event_manager for /system-log.
 """
 
 import json
-from typing import Any, Dict
+import logging
+from typing import Any, Dict, Protocol
 
 from aiounifi.models.api import ApiRequestV2
 
 from unifi_core.network.managers.connection_manager import ConnectionManager
 from unifi_core.network.models.traffic_flows import (
     TrafficFlowQuery,
+    enrich_traffic_flow_statistics_dpi_names,
     traffic_flow_from_controller,
     traffic_flow_statistics_from_controller,
 )
+
+logger = logging.getLogger(__name__)
 
 _FLOWS_CACHE_TTL = 45  # seconds; short-lived, matching the 60s alerts-cache precedent
 
 # Periods accepted by /traffic-flow-latest-statistics (the UI's 1h/1D/1W/1M).
 _STATISTICS_PERIODS = ("HOUR", "DAY", "WEEK", "MONTH")
+
+
+class DpiCatalogProvider(Protocol):
+    """Narrow dependency used for read-only traffic-flow DPI annotation."""
+
+    async def get_full_dpi_catalog(self) -> Dict[str, list[dict[str, Any]]]: ...
 
 
 def validate_statistics_period(period: str) -> str:
@@ -71,8 +81,9 @@ _ALL_ARRAY_FIELDS = _FILTER_FIELDS + (
 class TrafficFlowManager:
     """Reads completed traffic flows from the controller's private v2 API."""
 
-    def __init__(self, connection_manager: ConnectionManager):
+    def __init__(self, connection_manager: ConnectionManager, dpi_manager: DpiCatalogProvider | None = None):
         self._connection = connection_manager
+        self._dpi_manager = dpi_manager
 
     def _build_body(self, query: TrafficFlowQuery) -> Dict[str, Any]:
         if query.time_from is None or query.time_to is None:
@@ -153,6 +164,18 @@ class TrafficFlowManager:
         if not isinstance(response, dict):
             response = {}
 
-        result = traffic_flow_statistics_from_controller(response).model_dump()
+        statistics = traffic_flow_statistics_from_controller(response)
+        if self._dpi_manager is not None and statistics.top_applications:
+            try:
+                dpi_catalog = await self._dpi_manager.get_full_dpi_catalog()
+                statistics = enrich_traffic_flow_statistics_dpi_names(
+                    statistics,
+                    applications=dpi_catalog.get("applications", []),
+                    categories=dpi_catalog.get("categories", []),
+                )
+            except Exception as exc:
+                logger.warning("Failed to enrich traffic-flow DPI names: %s", exc)
+
+        result = statistics.model_dump()
         self._connection._update_cache(cache_key, result, timeout=_FLOWS_CACHE_TTL)
         return result

--- a/packages/unifi-core/src/unifi_core/network/models/traffic_flows.py
+++ b/packages/unifi-core/src/unifi_core/network/models/traffic_flows.py
@@ -206,13 +206,16 @@ class TrafficFlowTopDestination(BaseModel):
 class TrafficFlowTopApplication(BaseModel):
     """An application in a Top-Talkers ranking (by bytes).
 
-    ``application_id``/``category_id`` are DPI catalog ids; ``application_name``/
-    ``category_name`` are resolved via the DPI catalog and are null when the
-    catalog does not cover the application.
+    The V2 traffic-flow endpoint separates the low application ID from its
+    category. The Integration API catalogue uses the compound key
+    ``(category_id << 16) | application_id``. Resolved names are null when the
+    catalogue does not cover the entry; the original V2 IDs stay unchanged.
     """
 
     application_id: Optional[int] = Field(
-        default=None, description="DPI application id", json_schema_extra={"mutable": False}
+        default=None,
+        description="Low DPI application ID scoped to the V2 traffic-flow family",
+        json_schema_extra={"mutable": False},
     )
     category_id: Optional[int] = Field(
         default=None, description="DPI category id", json_schema_extra={"mutable": False}
@@ -351,3 +354,40 @@ def traffic_flow_statistics_from_controller(obj: Any) -> TrafficFlowStatistics:
             _top_policy_from_controller(p) for p in (_get(obj, "top_blocked_count_by_policy", []) or [])
         ],
     )
+
+
+def enrich_traffic_flow_statistics_dpi_names(
+    statistics: TrafficFlowStatistics,
+    applications: list[dict[str, Any]],
+    categories: list[dict[str, Any]],
+) -> TrafficFlowStatistics:
+    """Resolve V2 flow IDs against the Integration-API DPI catalogue.
+
+    This is a verified one-way annotation. Original V2 IDs and byte counts are
+    preserved and never made portable to the Integration-API tool family.
+    Missing application and category entries remain independently null.
+    """
+    application_names = {
+        entry["id"]: entry["name"]
+        for entry in applications
+        if isinstance(entry.get("id"), int) and isinstance(entry.get("name"), str)
+    }
+    category_names = {
+        entry["id"]: entry["name"]
+        for entry in categories
+        if isinstance(entry.get("id"), int) and isinstance(entry.get("name"), str)
+    }
+    top_applications = []
+    for application in statistics.top_applications:
+        application_name = None
+        if application.application_id is not None and application.category_id is not None:
+            application_name = application_names.get((application.category_id << 16) | application.application_id)
+        top_applications.append(
+            application.model_copy(
+                update={
+                    "application_name": application_name,
+                    "category_name": category_names.get(application.category_id),
+                }
+            )
+        )
+    return statistics.model_copy(update={"top_applications": top_applications})

--- a/packages/unifi-core/src/unifi_core/network/models/traffic_flows.py
+++ b/packages/unifi-core/src/unifi_core/network/models/traffic_flows.py
@@ -370,12 +370,16 @@ def enrich_traffic_flow_statistics_dpi_names(
     application_names = {
         entry["id"]: entry["name"]
         for entry in applications
-        if isinstance(entry.get("id"), int) and isinstance(entry.get("name"), str)
+        if isinstance(entry.get("id"), int)
+        and not isinstance(entry.get("id"), bool)
+        and isinstance(entry.get("name"), str)
     }
     category_names = {
         entry["id"]: entry["name"]
         for entry in categories
-        if isinstance(entry.get("id"), int) and isinstance(entry.get("name"), str)
+        if isinstance(entry.get("id"), int)
+        and not isinstance(entry.get("id"), bool)
+        and isinstance(entry.get("name"), str)
     }
     top_applications = []
     for application in statistics.top_applications:

--- a/packages/unifi-core/tests/network/managers/test_dpi_manager.py
+++ b/packages/unifi-core/tests/network/managers/test_dpi_manager.py
@@ -102,8 +102,10 @@ async def test_full_catalog_does_not_cache_incomplete_category_pages(manager, co
         ({"data": [{"id": 2, "name": "Second"}], "totalCount": 3, "offset": 1}, "changed"),
         ({"data": [], "totalCount": 2, "offset": 1}, "incomplete"),
         ({"data": [{"id": 2, "name": "Second"}], "totalCount": 2, "offset": 0}, "incomplete"),
+        ({"data": [{"id": 2, "name": "Second"}], "totalCount": 2, "offset": 1.5}, "incomplete"),
+        ({"data": [{"id": 2, "name": "Second"}], "totalCount": 2, "offset": True}, "incomplete"),
     ],
-    ids=["duplicate-id", "changed-total", "empty-page", "wrong-offset"],
+    ids=["duplicate-id", "changed-total", "empty-page", "wrong-offset", "fractional-offset", "boolean-offset"],
 )
 async def test_full_catalog_rejects_invalid_later_pages(manager, connection, second_page, error):
     async def fake_request(path, params=None):

--- a/packages/unifi-core/tests/network/managers/test_dpi_manager.py
+++ b/packages/unifi-core/tests/network/managers/test_dpi_manager.py
@@ -1,0 +1,174 @@
+"""Tests for complete DPI catalogue retrieval and Integration-API transport."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from unifi_core.network.managers.dpi_manager import DpiManager
+
+
+@pytest.fixture
+def connection():
+    conn = MagicMock()
+    conn.site = "default"
+    conn.host = "192.168.1.1"
+    conn.port = 443
+    conn.verify_ssl = True
+    conn.get_cached.return_value = None
+    return conn
+
+
+@pytest.fixture
+def auth():
+    value = MagicMock()
+    value.has_api_key = True
+    value.get_api_key_session = AsyncMock()
+    return value
+
+
+@pytest.fixture
+def manager(connection, auth):
+    return DpiManager(connection, auth)
+
+
+@pytest.mark.asyncio
+async def test_full_catalog_uses_supported_page_size_and_actual_offsets(manager, connection):
+    applications = [{"id": app_id, "name": f"Application {app_id}"} for app_id in range(201)]
+
+    async def fake_request(path, params=None):
+        if path == "/v1/dpi/applications" and params["offset"] == "0":
+            return {"data": applications[:200], "totalCount": 201, "offset": 0}
+        if path == "/v1/dpi/applications" and params["offset"] == "200":
+            return {"data": applications[200:], "totalCount": 201, "offset": 200}
+        if path == "/v1/dpi/categories":
+            return {"data": [{"id": 4, "name": "Media streaming"}], "totalCount": 1, "offset": 0}
+        raise AssertionError(f"Unexpected request: {path} {params}")
+
+    with patch.object(manager, "_request_integration_api", side_effect=fake_request) as mock_api:
+        result = await manager.get_full_dpi_catalog()
+
+    assert len(result["applications"]) == 201
+    assert result["categories"] == [{"id": 4, "name": "Media streaming"}]
+    assert [call.args for call in mock_api.await_args_list] == [
+        ("/v1/dpi/applications", {"limit": "200", "offset": "0"}),
+        ("/v1/dpi/applications", {"limit": "200", "offset": "200"}),
+        ("/v1/dpi/categories", {"limit": "200", "offset": "0"}),
+    ]
+    connection._update_cache.assert_called_once_with(
+        "dpi_catalog_default",
+        result,
+        timeout=900,
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_catalog_does_not_cache_incomplete_application_pages(manager, connection):
+    async def fake_request(path, params=None):
+        if params["offset"] == "0":
+            return {"data": [{"id": 1, "name": "First"}], "totalCount": 2, "offset": 0}
+        return None
+
+    with (
+        patch.object(manager, "_request_integration_api", side_effect=fake_request),
+        pytest.raises(RuntimeError, match="incomplete DPI application catalogue"),
+    ):
+        await manager.get_full_dpi_catalog()
+
+    connection._update_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_catalog_does_not_cache_incomplete_category_pages(manager, connection):
+    async def fake_request(path, params=None):
+        if path == "/v1/dpi/applications":
+            return {"data": [{"id": 1, "name": "First"}], "totalCount": 1, "offset": 0}
+        if params["offset"] == "0":
+            return {"data": [{"id": 4, "name": "Media"}], "totalCount": 2, "offset": 0}
+        return None
+
+    with (
+        patch.object(manager, "_request_integration_api", side_effect=fake_request),
+        pytest.raises(RuntimeError, match="incomplete DPI category catalogue"),
+    ):
+        await manager.get_full_dpi_catalog()
+
+    connection._update_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("second_page", "error"),
+    [
+        ({"data": [{"id": 1, "name": "First"}], "totalCount": 2, "offset": 1}, "duplicate"),
+        ({"data": [{"id": 2, "name": "Second"}], "totalCount": 3, "offset": 1}, "changed"),
+        ({"data": [], "totalCount": 2, "offset": 1}, "incomplete"),
+        ({"data": [{"id": 2, "name": "Second"}], "totalCount": 2, "offset": 0}, "incomplete"),
+    ],
+    ids=["duplicate-id", "changed-total", "empty-page", "wrong-offset"],
+)
+async def test_full_catalog_rejects_invalid_later_pages(manager, connection, second_page, error):
+    async def fake_request(path, params=None):
+        if params["offset"] == "0":
+            return {"data": [{"id": 1, "name": "First"}], "totalCount": 2, "offset": 0}
+        return second_page
+
+    with (
+        patch.object(manager, "_request_integration_api", side_effect=fake_request),
+        pytest.raises(RuntimeError, match=error),
+    ):
+        await manager.get_full_dpi_catalog()
+
+    connection._update_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first_page", "error"),
+    [
+        ({"data": [{"id": 1, "name": "First"}], "offset": 0}, "invalid"),
+        ({"data": [{"id": 1, "name": "First"}], "totalCount": "unknown", "offset": 0}, "invalid"),
+        ({"data": [{"id": 1, "name": "First"}], "totalCount": 1.5, "offset": 0}, "invalid"),
+        ({"data": [{"id": 1, "name": "First"}], "totalCount": "1.5", "offset": 0}, "invalid"),
+        (
+            {
+                "data": [{"id": 1, "name": "First"}, {"id": 2, "name": "Second"}],
+                "totalCount": 1,
+                "offset": 0,
+            },
+            "inconsistent",
+        ),
+    ],
+    ids=["missing-total", "invalid-total", "fractional-float", "fractional-string", "overfull-page"],
+)
+async def test_full_catalog_rejects_missing_or_inconsistent_totals(manager, connection, first_page, error):
+    with (
+        patch.object(manager, "_request_integration_api", new=AsyncMock(return_value=first_page)),
+        pytest.raises(RuntimeError, match=error),
+    ):
+        await manager.get_full_dpi_catalog()
+
+    connection._update_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verify_ssl", [True, False])
+async def test_integration_request_propagates_tls_verification(connection, auth, verify_ssl):
+    connection.verify_ssl = verify_ssl
+    response = AsyncMock()
+    response.status = 200
+    response.json = AsyncMock(return_value={"data": []})
+
+    response_context = AsyncMock()
+    response_context.__aenter__ = AsyncMock(return_value=response)
+    response_context.__aexit__ = AsyncMock(return_value=None)
+
+    session = AsyncMock()
+    session.get = MagicMock(return_value=response_context)
+    session.close = AsyncMock()
+    auth.get_api_key_session.return_value = session
+
+    manager = DpiManager(connection, auth)
+    await manager._request_integration_api("/v1/dpi/applications")
+
+    session.get.assert_called_once()
+    assert session.get.call_args.kwargs["ssl"] is verify_ssl
+    session.close.assert_awaited_once()

--- a/packages/unifi-core/tests/network/managers/test_traffic_flow_manager.py
+++ b/packages/unifi-core/tests/network/managers/test_traffic_flow_manager.py
@@ -229,6 +229,29 @@ async def test_statistics_preserves_order_and_resolves_partial_catalog_matches()
 
 
 @pytest.mark.asyncio
+async def test_statistics_ignores_boolean_catalog_ids():
+    class MalformedDpiCatalog:
+        async def get_full_dpi_catalog(self):
+            return {
+                "applications": [{"id": True, "name": "Not application one"}],
+                "categories": [{"id": True, "name": "Not category one"}],
+            }
+
+    response = dict(_STATS_RESPONSE)
+    response["top_all_traffic_by_application"] = [
+        {"application_id": 1, "bytes": 999, "category_id": 0},
+        {"application_id": 470, "bytes": 500, "category_id": 1},
+    ]
+    conn = _make_connection(response=response)
+    mgr = TrafficFlowManager(conn, dpi_manager=MalformedDpiCatalog())
+
+    result = await mgr.get_traffic_flow_statistics(period="DAY", top=30)
+
+    assert result["top_applications"][0]["application_name"] is None
+    assert result["top_applications"][1]["category_name"] is None
+
+
+@pytest.mark.asyncio
 async def test_statistics_is_cached_within_ttl():
     conn = _make_connection(response=_STATS_RESPONSE)
     mgr = TrafficFlowManager(conn)

--- a/packages/unifi-core/tests/network/managers/test_traffic_flow_manager.py
+++ b/packages/unifi-core/tests/network/managers/test_traffic_flow_manager.py
@@ -127,6 +127,108 @@ async def test_statistics_shapes_response():
 
 
 @pytest.mark.asyncio
+async def test_statistics_enriches_names_without_changing_v2_values():
+    class DpiCatalog:
+        async def get_full_dpi_catalog(self):
+            return {
+                "applications": [{"id": (4 << 16) | 470, "name": "Example Stream"}],
+                "categories": [{"id": 4, "name": "Media streaming services"}],
+            }
+
+    conn = _make_connection(response=_STATS_RESPONSE)
+    mgr = TrafficFlowManager(conn, dpi_manager=DpiCatalog())
+
+    result = await mgr.get_traffic_flow_statistics(period="DAY", top=30)
+
+    assert result["top_applications"] == [
+        {
+            "application_id": 470,
+            "category_id": 4,
+            "bytes": 999,
+            "application_name": "Example Stream",
+            "category_name": "Media streaming services",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_statistics_catalog_failure_is_best_effort_and_cached():
+    class FailingDpiCatalog:
+        def __init__(self):
+            self.calls = 0
+
+        async def get_full_dpi_catalog(self):
+            self.calls += 1
+            raise RuntimeError("API key unavailable")
+
+    conn = _make_connection(response=_STATS_RESPONSE)
+    dpi_catalog = FailingDpiCatalog()
+    mgr = TrafficFlowManager(conn, dpi_manager=dpi_catalog)
+
+    first = await mgr.get_traffic_flow_statistics(period="DAY", top=30)
+    second = await mgr.get_traffic_flow_statistics(period="DAY", top=30)
+
+    assert first == second
+    assert first["top_applications"] == [
+        {
+            "application_id": 470,
+            "category_id": 4,
+            "bytes": 999,
+            "application_name": None,
+            "category_name": None,
+        }
+    ]
+    assert conn.request.await_count == 1
+    assert dpi_catalog.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_statistics_preserves_order_and_resolves_partial_catalog_matches():
+    response = dict(_STATS_RESPONSE)
+    response["top_all_traffic_by_application"] = [
+        {"application_id": 470, "bytes": 999, "category_id": 4},
+        {"application_id": 471, "bytes": 500, "category_id": 5},
+        {"application_id": 472, "bytes": 250, "category_id": 6},
+    ]
+
+    class PartialDpiCatalog:
+        async def get_full_dpi_catalog(self):
+            return {
+                "applications": [{"id": (4 << 16) | 470, "name": "Application only"}],
+                "categories": [{"id": 5, "name": "Category only"}],
+            }
+
+    conn = _make_connection(response=response)
+    mgr = TrafficFlowManager(conn, dpi_manager=PartialDpiCatalog())
+
+    result = await mgr.get_traffic_flow_statistics(period="DAY", top=30)
+
+    assert result["top_applications"] == [
+        {
+            "application_id": 470,
+            "category_id": 4,
+            "bytes": 999,
+            "application_name": "Application only",
+            "category_name": None,
+        },
+        {
+            "application_id": 471,
+            "category_id": 5,
+            "bytes": 500,
+            "application_name": None,
+            "category_name": "Category only",
+        },
+        {
+            "application_id": 472,
+            "category_id": 6,
+            "bytes": 250,
+            "application_name": None,
+            "category_name": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_statistics_is_cached_within_ttl():
     conn = _make_connection(response=_STATS_RESPONSE)
     mgr = TrafficFlowManager(conn)


### PR DESCRIPTION
## Summary

- add a complete, cached DPI catalogue provider using the supported 200-row Integration API page size
- allow TrafficFlowManager to best-effort annotate V2 traffic statistics without changing IDs, byte counts, or ordering
- fail closed on incomplete or inconsistent catalogue pagination and preserve null names when enrichment is unavailable
- propagate the configured TLS verification setting to Integration API requests
- apply the formatter-only cleanup required for an unformatted skill-document code block already present on current main

This is the Core-first prerequisite for #547 and #546. The downstream Network/API wiring remains in #547 and will raise its Core floor after this change is published.

## Validation

- make pre-commit
- make core-test: 1,772 passed
- focused Core DPI and traffic-flow tests: 20 passed
- independent post-fix correctness and test reviews: no actionable findings

The implementation builds on Jonty Brook's contribution in #547; attribution is preserved in the commit.