### PR TITLE
fix(core): filter Network events by exact key

### DIFF
--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -43,12 +43,47 @@ class TestEventManagerV2:
         assert events[0]["id"] == "evt1"
 
     @pytest.mark.asyncio
-    async def test_get_events_with_search_text(self, event_manager, mock_connection):
+    async def test_get_events_with_exact_event_key(self, event_manager, mock_connection):
         mock_connection.request.return_value = [{"data": [], "total_element_count": 0}]
-        await event_manager.get_events(event_type="CLIENT_CONNECTED")
+        await event_manager.get_events(event_type="CLIENT_CONNECTED_WIRELESS_2")
         call_args = mock_connection.request.call_args
         api_request = call_args[0][0]
-        assert api_request.data["searchText"] == "CLIENT_CONNECTED"
+        assert api_request.data["keys"] == ["CLIENT_CONNECTED_WIRELESS_2"]
+        assert api_request.data["searchText"] == ""
+
+    @pytest.mark.asyncio
+    async def test_get_events_paginates_past_v2_page_size_cap(self, event_manager, mock_connection):
+        first_page = [{"id": f"evt{i}"} for i in range(100)]
+        second_page = [{"id": f"evt{i}"} for i in range(100, 150)]
+        mock_connection.request.side_effect = [
+            [{"data": first_page, "total_page_count": 2}],
+            [{"data": second_page, "total_page_count": 2}],
+        ]
+
+        events = await event_manager.get_events(limit=150)
+
+        assert len(events) == 150
+        requests = [call.args[0] for call in mock_connection.request.call_args_list]
+        assert [request.data["pageNumber"] for request in requests] == [0, 1]
+        assert all(request.data["pageSize"] == 100 for request in requests)
+
+    @pytest.mark.asyncio
+    async def test_get_events_applies_arbitrary_start_across_pages(self, event_manager, mock_connection):
+        mock_connection.request.side_effect = [
+            [{"data": [{"id": f"evt{i}"} for i in range(100, 110)], "total_page_count": 12}],
+            [{"data": [{"id": f"evt{i}"} for i in range(110, 120)], "total_page_count": 12}],
+        ]
+
+        events = await event_manager.get_events(limit=10, start=105)
+
+        assert [event["id"] for event in events] == [f"evt{i}" for i in range(105, 115)]
+        requests = [call.args[0] for call in mock_connection.request.call_args_list]
+        assert [request.data["pageNumber"] for request in requests] == [10, 11]
+
+    @pytest.mark.asyncio
+    async def test_get_events_zero_limit_makes_no_request(self, event_manager, mock_connection):
+        assert await event_manager.get_events(limit=0) == []
+        mock_connection.request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_get_events_uses_timestamp_range(self, event_manager, mock_connection):
@@ -121,10 +156,10 @@ class TestEventManagerLegacy:
     @pytest.mark.asyncio
     async def test_get_events_with_type_filter(self, event_manager, mock_connection):
         mock_connection.request.return_value = []
-        await event_manager.get_events(event_type="EVT_SW_")
+        await event_manager.get_events(event_type="EVT_SW_Connected")
         call_args = mock_connection.request.call_args
         api_request = call_args[0][0]
-        assert api_request.data["type"] == "EVT_SW_"
+        assert api_request.data["type"] == "EVT_SW_Connected"
 
     @pytest.mark.asyncio
     async def test_get_events_respects_limit(self, event_manager, mock_connection):
@@ -190,12 +225,29 @@ class TestEventManagerCommon:
 
         return EventManager(mock_connection)
 
-    def test_get_event_type_prefixes(self, event_manager):
-        prefixes = event_manager.get_event_type_prefixes()
-        assert len(prefixes) > 0
-        assert any(p["prefix"] == "EVT_SW_" for p in prefixes)
-        assert any(p["prefix"] == "EVT_AP_" for p in prefixes)
-        assert all("description" in p for p in prefixes)
+    @pytest.mark.asyncio
+    async def test_get_event_type_prefixes_returns_observed_exact_keys(self, event_manager, mock_connection):
+        event_manager._use_v2 = True
+        mock_connection.request.return_value = [
+            {
+                "data": [
+                    {"key": "CLIENT_DISCONNECTED_WIRELESS_2"},
+                    {"key": "CLIENT_CONNECTED_WIRELESS_2"},
+                    {"key": "CLIENT_DISCONNECTED_WIRELESS_2"},
+                    {"key": None},
+                ]
+            }
+        ]
+
+        event_types = await event_manager.get_event_type_prefixes()
+
+        assert [event_type["key"] for event_type in event_types] == [
+            "CLIENT_CONNECTED_WIRELESS_2",
+            "CLIENT_DISCONNECTED_WIRELESS_2",
+        ]
+        assert event_types[1]["prefix"] == "CLIENT_DISCONNECTED_WIRELESS_2"
+        assert event_types[1]["observed_count"] == 2
+        assert all("description" in event_type for event_type in event_types)
 
     def test_get_event_categories(self, event_manager):
         categories = event_manager.get_event_categories()

--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -226,7 +226,7 @@ class TestEventManagerCommon:
         return EventManager(mock_connection)
 
     @pytest.mark.asyncio
-    async def test_get_event_type_prefixes_returns_observed_exact_keys(self, event_manager, mock_connection):
+    async def test_get_event_types_returns_observed_exact_keys(self, event_manager, mock_connection):
         event_manager._use_v2 = True
         mock_connection.request.return_value = [
             {
@@ -239,7 +239,7 @@ class TestEventManagerCommon:
             }
         ]
 
-        event_types = await event_manager.get_event_type_prefixes()
+        event_types = await event_manager.get_event_types()
 
         assert [event_type["key"] for event_type in event_types] == [
             "CLIENT_CONNECTED_WIRELESS_2",
@@ -248,6 +248,12 @@ class TestEventManagerCommon:
         assert event_types[1]["prefix"] == "CLIENT_DISCONNECTED_WIRELESS_2"
         assert event_types[1]["observed_count"] == 2
         assert all("description" in event_type for event_type in event_types)
+
+    def test_get_event_type_prefixes_remains_synchronous_for_compatibility(self, event_manager):
+        prefixes = event_manager.get_event_type_prefixes()
+
+        assert any(prefix["prefix"] == "EVT_SW_" for prefix in prefixes)
+        assert any(prefix["prefix"] == "EVT_AP_" for prefix in prefixes)
 
     def test_get_event_categories(self, event_manager):
         categories = event_manager.get_event_categories()

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -327,9 +327,15 @@ class EventManager:
         severities: Optional[List[str]],
     ) -> List[Dict[str, Any]]:
         """Get events using the v2 system-log API."""
+        if limit <= 0:
+            return []
+
         try:
             now_ms = int(time.time() * 1000)
             from_ms = now_ms - (within * 3600 * 1000)
+            page_size = min(limit, 100)
+            page_number = max(start, 0) // page_size
+            page_offset = max(start, 0) % page_size
 
             payload: Dict[str, Any] = {
                 "timestampFrom": from_ms,
@@ -337,29 +343,52 @@ class EventManager:
                 "severities": severities or _DEFAULT_SEVERITIES,
                 "categories": categories or _DEFAULT_CATEGORIES,
                 "type": "GENERAL",
-                "pageNumber": start // limit if limit > 0 else 0,
-                "pageSize": min(limit, 100),
+                "pageNumber": page_number,
+                "pageSize": page_size,
                 "searchText": "",
             }
 
             if event_type:
-                payload["searchText"] = event_type
+                # ``keys`` is the controller's exact event-key filter. ``searchText``
+                # searches rendered message text and silently returns the wrong result
+                # for values such as CLIENT_DISCONNECTED_WIRELESS_2.
+                payload["keys"] = [event_type]
 
-            api_request = ApiRequestV2(
-                method="post",
-                path="/system-log/all",
-                data=payload,
-            )
-            response = await self._connection.request(api_request)
+            events: List[Dict[str, Any]] = []
+            while len(events) < limit + page_offset:
+                payload["pageNumber"] = page_number
+                api_request = ApiRequestV2(
+                    method="post",
+                    path="/system-log/all",
+                    data=payload.copy(),
+                )
+                response = await self._connection.request(api_request)
 
-            # V2 response comes as [{"data": [...], "total_element_count": N}] or {"data": [...]}
-            if isinstance(response, list) and response and isinstance(response[0], dict) and "data" in response[0]:
-                return response[0]["data"]
-            if isinstance(response, dict):
-                return response.get("data", response.get("logs", []))
-            if isinstance(response, list):
-                return response
-            return []
+                envelope: Any = response
+                if isinstance(response, list) and response and isinstance(response[0], dict) and "data" in response[0]:
+                    envelope = response[0]
+
+                if isinstance(envelope, dict):
+                    page = envelope.get("data", envelope.get("logs", []))
+                    total_pages = envelope.get("total_page_count", envelope.get("totalPageCount"))
+                elif isinstance(envelope, list):
+                    page = envelope
+                    total_pages = None
+                else:
+                    page = []
+                    total_pages = None
+
+                if not isinstance(page, list) or not page:
+                    break
+                events.extend(event for event in page if isinstance(event, dict))
+                page_number += 1
+
+                if isinstance(total_pages, int) and page_number >= total_pages:
+                    break
+                if total_pages is None and len(page) < page_size:
+                    break
+
+            return events[page_offset : page_offset + limit]
         except Exception as e:
             logger.error("Error getting events (v2): %s", e)
             raise
@@ -468,18 +497,30 @@ class EventManager:
             logger.error("Error getting alarms (legacy): %s", e)
             raise self._explain_legacy_failure("/stat/alarm", e) from e
 
-    def get_event_type_prefixes(self) -> List[Dict[str, str]]:
-        """Get a list of known event type prefixes for filtering."""
+    async def get_event_type_prefixes(self) -> List[Dict[str, Any]]:
+        """Get recently observed exact event keys for filtering.
+
+        The method name is retained for API-dispatch compatibility. Modern
+        controllers expose exact enum keys rather than the legacy ``EVT_*``
+        prefix catalog, so discover the usable values from recent events.
+        """
+        events = await self.get_events(within=168, limit=1000)
+        counts: Dict[str, int] = {}
+        for event in events:
+            key = event.get("key") or event.get("event")
+            if isinstance(key, str) and key:
+                counts[key] = counts.get(key, 0) + 1
+
         return [
-            {"prefix": "EVT_SW_", "description": "Switch events"},
-            {"prefix": "EVT_AP_", "description": "Access Point events"},
-            {"prefix": "EVT_GW_", "description": "Gateway events"},
-            {"prefix": "EVT_LAN_", "description": "LAN events"},
-            {"prefix": "EVT_WU_", "description": "WLAN User events (connect/disconnect)"},
-            {"prefix": "EVT_WG_", "description": "WLAN Guest events"},
-            {"prefix": "EVT_IPS_", "description": "IPS/IDS security events"},
-            {"prefix": "EVT_AD_", "description": "Admin events"},
-            {"prefix": "EVT_DPI_", "description": "Deep Packet Inspection events"},
+            {
+                "key": key,
+                # Retain the old field for consumers of the existing response
+                # shape; its value is now an exact key, not a prefix.
+                "prefix": key,
+                "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+                "observed_count": counts[key],
+            }
+            for key in sorted(counts)
         ]
 
     def get_event_categories(self) -> List[Dict[str, str]]:

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -497,12 +497,25 @@ class EventManager:
             logger.error("Error getting alarms (legacy): %s", e)
             raise self._explain_legacy_failure("/stat/alarm", e) from e
 
-    async def get_event_type_prefixes(self) -> List[Dict[str, Any]]:
+    def get_event_type_prefixes(self) -> List[Dict[str, str]]:
+        """Get legacy event type prefixes for backward compatibility."""
+        return [
+            {"prefix": "EVT_SW_", "description": "Switch events"},
+            {"prefix": "EVT_AP_", "description": "Access Point events"},
+            {"prefix": "EVT_GW_", "description": "Gateway events"},
+            {"prefix": "EVT_LAN_", "description": "LAN events"},
+            {"prefix": "EVT_WU_", "description": "WLAN User events (connect/disconnect)"},
+            {"prefix": "EVT_WG_", "description": "WLAN Guest events"},
+            {"prefix": "EVT_IPS_", "description": "IPS/IDS security events"},
+            {"prefix": "EVT_AD_", "description": "Admin events"},
+            {"prefix": "EVT_DPI_", "description": "Deep Packet Inspection events"},
+        ]
+
+    async def get_event_types(self) -> List[Dict[str, Any]]:
         """Get recently observed exact event keys for filtering.
 
-        The method name is retained for API-dispatch compatibility. Modern
-        controllers expose exact enum keys rather than the legacy ``EVT_*``
-        prefix catalog, so discover the usable values from recent events.
+        Modern controllers expose exact enum keys rather than the legacy
+        ``EVT_*`` prefix catalog, so discover usable values from recent events.
         """
         events = await self.get_events(within=168, limit=1000)
         counts: Dict[str, int] = {}

--- a/packages/unifi-core/src/unifi_core/network/models/system.py
+++ b/packages/unifi-core/src/unifi_core/network/models/system.py
@@ -517,9 +517,9 @@ def site_settings_from_controller(raw: Any) -> SiteSettings:
 
 
 class EventTypes(BaseModel):
-    """Wrapper for event-type prefix descriptors (read-only).
+    """Wrapper for exact event-key descriptors (read-only).
 
-    The catalog of event-type prefixes is unstructured (varies by firmware),
+    The catalog of observed event keys is unstructured (varies by firmware),
     so each descriptor passes through as a plain list exposed as JSON.
     """
 

--- a/packages/unifi-core/tests/network/managers/test_event_manager_buffer.py
+++ b/packages/unifi-core/tests/network/managers/test_event_manager_buffer.py
@@ -41,6 +41,13 @@ def test_buffer_filter_by_event_type() -> None:
     assert {e["id"] for e in out} == {"e1", "e3"}
 
 
+def test_buffer_event_type_filter_requires_exact_key() -> None:
+    buf = EventBuffer(max_size=10, ttl_seconds=300)
+    buf.add({"id": "e1", "key": "CLIENT_CONNECTED_WIRELESS_2"})
+
+    assert buf.get_recent(event_type="CLIENT_CONNECTED") == []
+
+
 def test_buffer_clear() -> None:
     buf = EventBuffer(max_size=10, ttl_seconds=300)
     buf.add({"id": "e1"})

--- a/packages/unifi-core/tests/network/managers/test_event_manager_queries.py
+++ b/packages/unifi-core/tests/network/managers/test_event_manager_queries.py
@@ -75,7 +75,7 @@ async def test_event_key_discovery_samples_recent_events_and_supports_legacy_eve
         ]
     )
 
-    event_types = await manager.get_event_type_prefixes()
+    event_types = await manager.get_event_types()
 
     manager.get_events.assert_awaited_once_with(within=168, limit=1000)
     assert event_types == [
@@ -98,4 +98,4 @@ async def test_event_key_discovery_samples_recent_events_and_supports_legacy_eve
 async def test_event_key_discovery_can_return_empty_catalog(manager: EventManager) -> None:
     manager.get_events = AsyncMock(return_value=[])
 
-    assert await manager.get_event_type_prefixes() == []
+    assert await manager.get_event_types() == []

--- a/packages/unifi-core/tests/network/managers/test_event_manager_queries.py
+++ b/packages/unifi-core/tests/network/managers/test_event_manager_queries.py
@@ -1,0 +1,101 @@
+"""Query-contract tests for the Network EventManager."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.network.managers.event_manager import EventManager
+
+
+@pytest.fixture
+def connection() -> MagicMock:
+    value = MagicMock()
+    value.site = "default"
+    value.request = AsyncMock()
+    return value
+
+
+@pytest.fixture
+def manager(connection: MagicMock) -> EventManager:
+    value = EventManager(connection)
+    value._use_v2 = True
+    return value
+
+
+@pytest.mark.asyncio
+async def test_v2_event_type_uses_exact_keys_filter(manager: EventManager, connection: MagicMock) -> None:
+    connection.request.return_value = [{"data": [], "total_element_count": 0}]
+
+    await manager.get_events(event_type="CLIENT_CONNECTED_WIRELESS_2")
+
+    request = connection.request.call_args.args[0]
+    assert request.data["keys"] == ["CLIENT_CONNECTED_WIRELESS_2"]
+    assert request.data["searchText"] == ""
+
+
+@pytest.mark.asyncio
+async def test_v2_paginates_without_total_page_count(manager: EventManager, connection: MagicMock) -> None:
+    connection.request.side_effect = [
+        {"logs": [{"id": f"evt{i}"} for i in range(100)]},
+        {"logs": [{"id": f"evt{i}"} for i in range(100, 120)]},
+    ]
+
+    events = await manager.get_events(limit=120)
+
+    assert [event["id"] for event in events] == [f"evt{i}" for i in range(120)]
+    requests = [call.args[0] for call in connection.request.call_args_list]
+    assert [request.data["pageNumber"] for request in requests] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_v2_honors_arbitrary_start_and_camel_case_page_count(
+    manager: EventManager,
+    connection: MagicMock,
+) -> None:
+    connection.request.side_effect = [
+        {"data": [{"id": f"evt{i}"} for i in range(100, 110)], "totalPageCount": 12},
+        {"data": [{"id": f"evt{i}"} for i in range(110, 120)], "totalPageCount": 12},
+    ]
+
+    events = await manager.get_events(limit=10, start=105)
+
+    assert [event["id"] for event in events] == [f"evt{i}" for i in range(105, 115)]
+    requests = [call.args[0] for call in connection.request.call_args_list]
+    assert [request.data["pageNumber"] for request in requests] == [10, 11]
+
+
+@pytest.mark.asyncio
+async def test_event_key_discovery_samples_recent_events_and_supports_legacy_event_field(
+    manager: EventManager,
+) -> None:
+    manager.get_events = AsyncMock(
+        return_value=[
+            {"key": "CLIENT_CONNECTED_WIRELESS_2"},
+            {"event": "EVT_SW_Connected"},
+            {"key": "CLIENT_CONNECTED_WIRELESS_2"},
+        ]
+    )
+
+    event_types = await manager.get_event_type_prefixes()
+
+    manager.get_events.assert_awaited_once_with(within=168, limit=1000)
+    assert event_types == [
+        {
+            "key": "CLIENT_CONNECTED_WIRELESS_2",
+            "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+            "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+            "observed_count": 2,
+        },
+        {
+            "key": "EVT_SW_Connected",
+            "prefix": "EVT_SW_Connected",
+            "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+            "observed_count": 1,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_event_key_discovery_can_return_empty_catalog(manager: EventManager) -> None:
+    manager.get_events = AsyncMock(return_value=[])
+
+    assert await manager.get_event_type_prefixes() == []


### PR DESCRIPTION
Part of #579.

The Network 10.x system-log API treats `searchText` as rendered-message search, not event-type filtering. This changes Core to send the controller-supported exact `keys` filter, keeps websocket filtering on the same exact-key contract, and fixes V2 pagination beyond the 100-record page cap.

It also replaces the stale hard-coded legacy prefix catalog with exact keys sampled from the 1,000 most recent events within the last seven days. The internal method name remains unchanged for dispatcher compatibility.

Validation:
- `make core-test` (1,786 passed)
- full `make pre-commit` passed before the review follow-ups
- live controller: discovered 7 keys; exact `CLIENT_ROAMED_2` filter returned 150/150 matching events across multiple pages
- no controller mutations performed

A downstream Network/API PR will follow after Core 0.4.37 is published, raising the minimum Core floor and updating the public MCP/API contracts.