### PR TITLE
fix(network): use exact event keys

### DIFF
--- a/.github/workflows/release-network.yml
+++ b/.github/workflows/release-network.yml
@@ -22,6 +22,24 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/unifi-network-mcp
 
 jobs:
+  published-core-contract:
+    name: Verify published Core dependency floor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install and verify the exact published Core floor
+        run: uv run scripts/check_pin_alignment.py --network-core-floor-only
+
   # ----------------------------------------------------------------------- 1
   test:
     name: Run unifi-network-mcp tests
@@ -49,7 +67,7 @@ jobs:
   # ----------------------------------------------------------------------- 2a
   publish-pypi:
     name: Build wheel + publish to PyPI
-    needs: test
+    needs: [test, published-core-contract]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -86,7 +104,7 @@ jobs:
   # ----------------------------------------------------------------------- 2b
   publish-docker:
     name: Build + push Docker image
-    needs: test
+    needs: [test, published-core-contract]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -753,7 +753,7 @@ type EventThumbnail {
   sizeBytes: Int
 }
 
-"""Wrapper for event-type prefix descriptors."""
+"""Wrapper for exact event-key descriptors."""
 type EventTypes {
   eventTypes: JSON!
 }
@@ -1362,7 +1362,9 @@ type NetworkQuery {
   """Get gateway (USG) security / NAT / connection-tracking settings."""
   gatewaySettings(controller: ID!, site: String! = "default"): GatewaySettings
 
-  """Get the controller's event-type prefix catalog."""
+  """
+  Get exact event keys sampled from the controller's 1,000 most recent events within the last 7 days.
+  """
   eventTypes(controller: ID!, site: String! = "default"): EventTypes
 
   """Get auto-backup schedule + retention settings."""
@@ -2342,7 +2344,7 @@ Read-only access to UniFi Network resources.
 - `dynamicDns: DynamicDnsPage!`  — List Dynamic DNS provider entries on the given controller/site (paginated).
 - `dynamicDnsEntry: DynamicDns`  — Look up a single Dynamic DNS entry by id.
 - `eventLog: EventLogPage!`  — List recent controller events (paginated).
-- `eventTypes: EventTypes`  — Get the controller's event-type prefix catalog.
+- `eventTypes: EventTypes`  — Get exact event keys sampled from the controller's 1,000 most recent events within the last 7 days.
 - `firewallGroup: FirewallGroup`  — Look up a single firewall group by id.
 - `firewallGroups: FirewallGroupPage!`  — List firewall address/port groups (paginated).
 - `firewallPolicies: FirewallRulePage!`  — List firewall policies/rules on the given controller/site (paginated).

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1277,7 +1277,7 @@ DETAIL kind currently; manager method is stats_manager.get_dpi_stats.
 ### `GET /v1/sites/{site_id}/event-types` — Get Event Types
 
 
-DETAIL — event_manager.get_event_type_prefixes (sync method, returns list).
+DETAIL — event_manager.get_event_types (async method, returns list).
 
 
 **Parameters:**

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -14305,7 +14305,7 @@
     },
     "/v1/sites/{site_id}/event-types": {
       "get": {
-        "description": "DETAIL \u2014 event_manager.get_event_type_prefixes (sync method, returns list).",
+        "description": "DETAIL \u2014 event_manager.get_event_types (async method, returns list).",
         "operationId": "get_event_types_v1_sites__site_id__event_types_get",
         "parameters": [
           {

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -13,8 +13,9 @@ dependencies = [
     # actions require Core 0.4.32; Access system-log event normalization
     # requires Core 0.4.33; WLAN schedule-window projection requires Core
     # 0.4.34; Protect camera detail fields require Core 0.4.35; traffic-flow
-    # DPI name enrichment requires Core 0.4.36.
-    "unifi-core[network,protect,access]>=0.4.36,<0.5",
+    # DPI name enrichment requires Core 0.4.36; exact Network event-key
+    # filtering and discovery require Core 0.4.37.
+    "unifi-core[network,protect,access]>=0.4.37,<0.5",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -3820,7 +3820,7 @@
       "permission_action": "read",
       "read_only_hint": true,
       "manager_attr": "event_manager",
-      "manager_method": "get_event_type_prefixes",
+      "manager_method": "get_event_types",
       "input_schema": {
         "properties": {},
         "type": "object",
@@ -4940,7 +4940,7 @@
       "input_schema": {
         "properties": {
           "event_type": {
-            "description": "Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events, 'EVT_SW_' for switch events). Use unifi_get_event_types to see valid prefixes",
+            "description": "Filter by an exact event key (for example 'CLIENT_DISCONNECTED_WIRELESS_2'). Use unifi_get_event_types to see recently observed keys",
             "type": "string"
           },
           "limit": {
@@ -5390,7 +5390,7 @@
       "input_schema": {
         "properties": {
           "event_type": {
-            "description": "Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events). Use unifi_get_event_types for valid prefixes.",
+            "description": "Filter by an exact event key (for example 'CLIENT_CONNECTED_WIRELESS_2'). Use unifi_get_event_types for recently observed keys.",
             "type": "string"
           },
           "limit": {

--- a/apps/api/src/unifi_api/graphql/resolvers/network.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/network.py
@@ -1171,7 +1171,7 @@ async def _fetch_event_types(
             )
             import inspect as _inspect
 
-            result = mgr.get_event_type_prefixes()
+            result = mgr.get_event_types()
             if _inspect.isawaitable(result):
                 result = await result
             return result
@@ -3485,7 +3485,9 @@ class NetworkQuery:
 
     @strawberry.field(
         permission_classes=[IsRead],
-        description="Get the controller's event-type prefix catalog.",
+        description=(
+            "Get exact event keys sampled from the controller's 1,000 most recent events within the last 7 days."
+        ),
     )
     async def event_types(
         self,

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -742,7 +742,7 @@ type EventThumbnail {
   sizeBytes: Int
 }
 
-"""Wrapper for event-type prefix descriptors."""
+"""Wrapper for exact event-key descriptors."""
 type EventTypes {
   eventTypes: JSON!
 }
@@ -1351,7 +1351,9 @@ type NetworkQuery {
   """Get gateway (USG) security / NAT / connection-tracking settings."""
   gatewaySettings(controller: ID!, site: String! = "default"): GatewaySettings
 
-  """Get the controller's event-type prefix catalog."""
+  """
+  Get exact event keys sampled from the controller's 1,000 most recent events within the last 7 days.
+  """
   eventTypes(controller: ID!, site: String! = "default"): EventTypes
 
   """Get auto-backup schedule + retention settings."""

--- a/apps/api/src/unifi_api/graphql/types/network/system.py
+++ b/apps/api/src/unifi_api/graphql/types/network/system.py
@@ -328,9 +328,9 @@ class SnmpSettings:
         return d
 
 
-@strawberry.type(description="Wrapper for event-type prefix descriptors.")
+@strawberry.type(description="Wrapper for exact event-key descriptors.")
 class EventTypes:
-    # The catalog of event-type prefixes is unstructured (varies by
+    # The catalog of observed event keys is unstructured (varies by
     # firmware), so each descriptor passes through as a plain dict.
     # Exposed as a ``JSON`` scalar on the GraphQL surface so the
     # heterogeneous payload survives without an enumerated sub-type.

--- a/apps/api/src/unifi_api/routes/resources/network/system.py
+++ b/apps/api/src/unifi_api/routes/resources/network/system.py
@@ -297,7 +297,7 @@ async def get_event_types(
     site_id: str,
     controller=Depends(resolve_controller),
 ) -> dict:
-    """DETAIL — event_manager.get_event_type_prefixes (sync method, returns list)."""
+    """DETAIL — event_manager.get_event_types (async method, returns list)."""
     require_capability(controller, "network")
     factory = request.app.state.manager_factory
     sm = request.app.state.sessionmaker
@@ -309,7 +309,7 @@ async def get_event_types(
             "event_manager",
             site=site_id,
         )
-        result = mgr.get_event_type_prefixes()
+        result = mgr.get_event_types()
         if inspect.isawaitable(result):
             result = await result
     return _detail_response(request, result, "unifi_get_event_types")

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -129,7 +129,7 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     "unifi_list_events": ("event_manager", "get_events"),
     "unifi_list_alarms": ("event_manager", "get_alarms"),
     "unifi_recent_events": ("event_manager", "get_recent_from_buffer"),
-    "unifi_get_event_types": ("event_manager", "get_event_type_prefixes"),
+    "unifi_get_event_types": ("event_manager", "get_event_types"),
     "unifi_archive_alarm": ("event_manager", "archive_alarm"),
     "unifi_archive_all_alarms": ("event_manager", "archive_all_alarms"),
     # =========================================================================

--- a/apps/api/tests/graphql/fixtures/network/test_system.py
+++ b/apps/api/tests/graphql/fixtures/network/test_system.py
@@ -237,9 +237,19 @@ async def test_event_types(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("network", "event_manager", "get_event_type_prefixes"): [
-                {"key": "EVT_AP", "label": "Access Point Events"},
-                {"key": "EVT_GW", "label": "Gateway Events"},
+            ("network", "event_manager", "get_event_types"): [
+                {
+                    "key": "CLIENT_CONNECTED_WIRELESS_2",
+                    "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+                    "description": "Exact event key observed in the sample",
+                    "observed_count": 4,
+                },
+                {
+                    "key": "CLIENT_ROAMED_2",
+                    "prefix": "CLIENT_ROAMED_2",
+                    "description": "Exact event key observed in the sample",
+                    "observed_count": 9,
+                },
             ],
         },
     )
@@ -255,7 +265,20 @@ async def test_event_types(tmp_path, monkeypatch):
     assert body.get("errors") is None, body
     et = body["data"]["network"]["eventTypes"]
     assert et is not None
-    assert len(et["eventTypes"]) == 2
+    assert et["eventTypes"] == [
+        {
+            "key": "CLIENT_CONNECTED_WIRELESS_2",
+            "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+            "description": "Exact event key observed in the sample",
+            "observed_count": 4,
+        },
+        {
+            "key": "CLIENT_ROAMED_2",
+            "prefix": "CLIENT_ROAMED_2",
+            "description": "Exact event key observed in the sample",
+            "observed_count": 9,
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/routes/resources/test_network_stats_events_system.py
+++ b/apps/api/tests/routes/resources/test_network_stats_events_system.py
@@ -589,17 +589,24 @@ async def test_get_speedtest_results_list(tmp_path, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_get_event_types_detail(tmp_path, monkeypatch) -> None:
-    """event-types: event_manager.get_event_type_prefixes (synchronous, returns list)."""
+    """event-types: event_manager.get_event_types (async, returns exact keys)."""
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)
     _stub_connection(app, cid)
 
-    def fake_get(self):
-        return [{"prefix": "EVT_WU_", "description": "Wireless user"}]
+    async def fake_get(self):
+        return [
+            {
+                "key": "CLIENT_CONNECTED_WIRELESS_2",
+                "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+                "description": "Exact event key observed in the sample",
+                "observed_count": 4,
+            }
+        ]
 
     from unifi_core.network.managers.event_manager import EventManager
 
-    monkeypatch.setattr(EventManager, "get_event_type_prefixes", fake_get)
+    monkeypatch.setattr(EventManager, "get_event_types", fake_get)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(
@@ -607,7 +614,16 @@ async def test_get_event_types_detail(tmp_path, monkeypatch) -> None:
             headers={"Authorization": f"Bearer {key}"},
         )
     assert r.status_code == 200, r.text
-    assert r.json()["render_hint"]["kind"] == "detail"
+    body = r.json()
+    assert body["render_hint"]["kind"] == "detail"
+    assert body["data"]["event_types"] == [
+        {
+            "key": "CLIENT_CONNECTED_WIRELESS_2",
+            "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+            "description": "Exact event key observed in the sample",
+            "observed_count": 4,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/serializers/test_network_system.py
+++ b/apps/api/tests/serializers/test_network_system.py
@@ -160,13 +160,22 @@ def test_snmp_settings_detail_first_item_unwrap() -> None:
 
 def test_event_types_detail_serializer_shape() -> None:
     sample = [
-        {"prefix": "EVT_WU_", "description": "Wireless user events"},
-        {"prefix": "EVT_SW_", "description": "Switch events"},
+        {
+            "key": "CLIENT_CONNECTED_WIRELESS_2",
+            "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+            "description": "Exact event key observed in the sample",
+            "observed_count": 4,
+        },
+        {
+            "key": "CLIENT_ROAMED_2",
+            "prefix": "CLIENT_ROAMED_2",
+            "description": "Exact event key observed in the sample",
+            "observed_count": 9,
+        },
     ]
     out = EventTypes.from_manager_output(sample).to_dict()
     assert EventTypes.render_hint("detail")["kind"] == "detail"
-    assert out["event_types"][0]["prefix"] == "EVT_WU_"
-    assert out["event_types"][1]["prefix"] == "EVT_SW_"
+    assert out["event_types"] == sample
 
 
 # ---- Auto-backup settings ----

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -37,18 +37,26 @@ def _registry_with(tool: ToolEntry) -> ManifestRegistry:
 
 
 @pytest.mark.asyncio
-async def test_catalog_binding_is_authoritative_and_accepts_sync_result() -> None:
+async def test_catalog_binding_is_authoritative_and_awaits_event_types() -> None:
     entry = ToolEntry(
         name="unifi_get_event_types",
         product="network",
         category="events",
         manager="event_manager",
-        method="get_event_type_prefixes",
+        method="get_event_types",
         permission_action="read",
         read_only_hint=True,
     )
+    event_types = [
+        {
+            "key": "CLIENT_CONNECTED_WIRELESS_2",
+            "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+            "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+            "observed_count": 2,
+        }
+    ]
     manager = MagicMock()
-    manager.get_event_type_prefixes.return_value = {"EVT_WU_": "wireless"}
+    manager.get_event_types = AsyncMock(return_value=event_types)
     factory = MagicMock()
     factory.get_domain_manager = AsyncMock(return_value=manager)
     connection = MagicMock(site="default")
@@ -67,7 +75,7 @@ async def test_catalog_binding_is_authoritative_and_accepts_sync_result() -> Non
         confirm=False,
     )
 
-    assert result == {"EVT_WU_": "wireless"}
+    assert result == event_types
     factory.get_domain_manager.assert_awaited_once_with(
         session=session,
         controller_id="cid",
@@ -75,7 +83,7 @@ async def test_catalog_binding_is_authoritative_and_accepts_sync_result() -> Non
         attr_name="event_manager",
         site="default",
     )
-    manager.get_event_type_prefixes.assert_called_once_with()
+    manager.get_event_types.assert_awaited_once_with()
 
 
 def _dispatchable_entries() -> list[tuple[str, ToolEntry]]:

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -199,7 +199,7 @@ Gateway-wide security / NAT / connection-tracking settings (the controller's `us
 - `unifi_list_alarms` — List active alarms
 - `unifi_archive_alarm` — Archive a specific alarm
 - `unifi_archive_all_alarms` — Archive all active alarms
-- `unifi_get_event_types` — Get known event type prefixes
+- `unifi_get_event_types` — Get exact event keys observed in the 1,000 most recent events within the last 7 days
 
 ## Routing (5 tools)
 

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -12,8 +12,9 @@ dependencies = [
     # WAN delegation validation requires Core 0.4.30. Firewall-zone CRUD
     # requires the dual-API bridge added in Core 0.4.32. WLAN schedule-window
     # validation requires Core 0.4.34. Traffic-flow DPI name enrichment
-    # requires Core 0.4.36.
-    "unifi-core[network]>=0.4.36,<0.5",
+    # requires Core 0.4.36. Exact event-key filtering and discovery require
+    # Core 0.4.37.
+    "unifi-core[network]>=0.4.37,<0.5",
     "mcp[cli]>=1.28.1,<2",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -38,8 +38,8 @@ def _get_event_manager():
     description=(
         "Returns timestamped event log entries (client connects/disconnects, device "
         "state changes, firmware updates, config changes) sorted newest-first. "
-        "Filter by within_hours (default 24), event_type prefix (use unifi_get_event_types "
-        "for valid prefixes), and paginate with start/limit. "
+        "Filter by within_hours (default 24), an exact event_type key (use "
+        "unifi_get_event_types for recently observed keys), and paginate with start/limit. "
         "For critical alerts specifically, use unifi_list_alarms instead."
     ),
 )
@@ -50,7 +50,7 @@ async def list_events(
     event_type: Annotated[
         Optional[str],
         Field(
-            description="Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events, 'EVT_SW_' for switch events). Use unifi_get_event_types to see valid prefixes"
+            description="Filter by an exact event key (for example 'CLIENT_DISCONNECTED_WIRELESS_2'). Use unifi_get_event_types to see recently observed keys"
         ),
     ] = None,
 ) -> Dict[str, Any]:
@@ -124,7 +124,7 @@ async def list_alarms(
     description=(
         "Get recent events from the in-memory websocket buffer. This is fast "
         "(no API call) and returns events received via the real-time websocket "
-        "stream. Supports filtering by event_type prefix, client/device mac, "
+        "stream. Supports filtering by exact event_type key, client/device mac, "
         "and limit. Use this for real-time monitoring; use unifi_list_events "
         "for historical queries."
     ),
@@ -134,7 +134,7 @@ async def unifi_recent_events(
     event_type: Annotated[
         Optional[str],
         Field(
-            description="Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events). Use unifi_get_event_types for valid prefixes."
+            description="Filter by an exact event key (for example 'CLIENT_CONNECTED_WIRELESS_2'). Use unifi_get_event_types for recently observed keys."
         ),
     ] = None,
     mac: Annotated[
@@ -181,22 +181,25 @@ async def unifi_subscribe_events() -> Dict[str, Any]:
 
 @server.tool(
     name="unifi_get_event_types",
-    description="""Get a list of known event type prefixes for filtering events.
+    description="""Get recently observed exact event keys for filtering events.
 
-Use these prefixes with unifi_list_events event_type parameter to filter specific event categories.""",
+Use a returned key with the unifi_list_events event_type parameter. Keys are sampled from the 1,000 most recent events within the last 7 days, so event types absent from that sample are not included.""",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
 async def get_event_types() -> Dict[str, Any]:
-    """Get list of event type prefixes."""
+    """Get recently observed exact event keys."""
     try:
         event_manager = _get_event_manager()
-        prefixes = event_manager.get_event_type_prefixes()
-        shaped = event_types_from_controller(prefixes)
+        event_types = await event_manager.get_event_types()
+        shaped = event_types_from_controller(event_types)
 
         return {
             "success": True,
             "event_types": shaped.event_types,
-            "usage": "Use prefix value with unifi_list_events event_type parameter",
+            "usage": (
+                "Use a key value with the unifi_list_events event_type parameter. "
+                "Keys are sampled from the 1,000 most recent events within the last 7 days."
+            ),
         }
     except Exception as e:
         logger.error("Error getting event types: %s", e, exc_info=True)

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -6942,7 +6942,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get a list of known event type prefixes for filtering events.\n\nUse these prefixes with unifi_list_events event_type parameter to filter specific event categories.",
+      "description": "Get recently observed exact event keys for filtering events.\n\nUse a returned key with the unifi_list_events event_type parameter. Keys are sampled from the 1,000 most recent events within the last 7 days, so event types absent from that sample are not included.",
       "name": "unifi_get_event_types",
       "schema": {
         "input": {
@@ -11628,13 +11628,13 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), event_type prefix (use unifi_get_event_types for valid prefixes), and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
+      "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), an exact event_type key (use unifi_get_event_types for recently observed keys), and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
       "name": "unifi_list_events",
       "schema": {
         "input": {
           "properties": {
             "event_type": {
-              "description": "Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events, 'EVT_SW_' for switch events). Use unifi_get_event_types to see valid prefixes",
+              "description": "Filter by an exact event key (for example 'CLIENT_DISCONNECTED_WIRELESS_2'). Use unifi_get_event_types to see recently observed keys",
               "type": "string"
             },
             "limit": {
@@ -13690,13 +13690,13 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by event_type prefix, client/device mac, and limit. Use this for real-time monitoring; use unifi_list_events for historical queries.",
+      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by exact event_type key, client/device mac, and limit. Use this for real-time monitoring; use unifi_list_events for historical queries.",
       "name": "unifi_recent_events",
       "schema": {
         "input": {
           "properties": {
             "event_type": {
-              "description": "Filter by event type prefix (e.g., 'EVT_WU_' for wireless user events). Use unifi_get_event_types for valid prefixes.",
+              "description": "Filter by an exact event key (for example 'CLIENT_CONNECTED_WIRELESS_2'). Use unifi_get_event_types for recently observed keys.",
               "type": "string"
             },
             "limit": {

--- a/apps/network/tests/unit/test_event_tools.py
+++ b/apps/network/tests/unit/test_event_tools.py
@@ -50,6 +50,9 @@ class _StubEventManager:
     async def get_events(self, **_kwargs):
         return self._records
 
+    async def get_event_types(self):
+        return self._records
+
 
 _V2_RECORD = {
     "id": "evt-0001",
@@ -115,3 +118,51 @@ async def test_list_events_still_maps_legacy_records(monkeypatch):
     assert event["mac"] == "aa:bb:cc:00:00:09"
     assert event["ip"] == "192.0.2.50"
     assert event["msg"] == "Client disconnected"
+
+
+@pytest.mark.asyncio
+async def test_get_event_types_returns_observed_exact_keys(monkeypatch):
+    from unifi_network_mcp.tools import events as events_module
+
+    observed = [
+        {
+            "key": "CLIENT_CONNECTED_WIRELESS_2",
+            "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+            "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+            "observed_count": 4,
+        }
+    ]
+    monkeypatch.setattr(
+        events_module,
+        "_get_event_manager",
+        lambda: _StubEventManager(observed),
+    )
+
+    result = await events_module.get_event_types()
+
+    assert result["success"] is True
+    assert result["event_types"] == observed
+    assert result["usage"] == (
+        "Use a key value with the unifi_list_events event_type parameter. "
+        "Keys are sampled from the 1,000 most recent events within the last 7 days."
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_event_types_returns_standard_error_when_discovery_fails(monkeypatch):
+    from unifi_network_mcp.tools import events as events_module
+
+    manager = _StubEventManager([])
+
+    async def fail_discovery():
+        raise RuntimeError("controller event query failed")
+
+    manager.get_event_types = fail_discovery
+    monkeypatch.setattr(events_module, "_get_event_manager", lambda: manager)
+
+    result = await events_module.get_event_types()
+
+    assert result == {
+        "success": False,
+        "error": "Failed to get event types: controller event query failed",
+    }

--- a/plugins/unifi-network/skills/network-health-check/references/alarm-types.md
+++ b/plugins/unifi-network/skills/network-health-check/references/alarm-types.md
@@ -1,20 +1,19 @@
 # Alarm & Event Types Reference
 
-## Event Type Prefixes
+## Exact Event Keys
 
-Use with `unifi_list_events` `event_type` filter parameter.
+Call `unifi_get_event_types` to discover exact event keys observed recently on
+the controller. Pass a returned `key` unchanged to the `event_type` parameter of
+`unifi_list_events`.
 
-| Prefix | Category | Examples |
-|--------|----------|----------|
-| `EVT_SW_` | Switch | Connected, Lost_Contact, STP changes, port events |
-| `EVT_AP_` | Access Point | Connected, Lost_Contact, channel changes, radar detected |
-| `EVT_GW_` | Gateway | WAN transitions, failover, firmware updates |
-| `EVT_LAN_` | LAN | New device, IP conflict, DHCP events |
-| `EVT_WU_` | WLAN User | Client connect, disconnect, roam |
-| `EVT_WG_` | WLAN Guest | Guest client events |
-| `EVT_IPS_` | IPS/IDS | Blocked threats, anomalous traffic, security alerts |
-| `EVT_AD_` | Admin | Login, configuration changes, firmware updates |
-| `EVT_DPI_` | DPI | Deep Packet Inspection events |
+Do not pass legacy `EVT_*` prefixes, partial keys, or wildcard patterns. Modern
+controllers validate this parameter as an exact enum value. Available keys vary
+by controller version, features, and recent activity.
+
+Representative keys include `CLIENT_CONNECTED_WIRELESS_2`,
+`CLIENT_DISCONNECTED_WIRELESS_2`, `DEVICE_UNREACHABLE`,
+`NETWORK_WAN_FAILED_2`, and `THREAT_DETECTED_V3`. Treat these as examples only;
+use a key returned by `unifi_get_event_types` for the controller being checked.
 
 ## Alarm Severity Levels
 
@@ -28,15 +27,15 @@ Use with `unifi_list_events` `event_type` filter parameter.
 
 | Type | Severity | What It Means | What To Do |
 |------|----------|---------------|-----------|
-| `EVT_AP_Lost_Contact` | critical | AP stopped responding | Check power and uplink connectivity |
-| `EVT_AP_Connected` | info | AP came back online | Verify clients reconnected |
-| `EVT_SW_Lost_Contact` | critical | Switch offline | Check power, uplink, STP topology |
-| `EVT_SW_Connected` | info | Switch back online | Verify ports and VLANs recovered |
-| `EVT_GW_WANTransition` | warning | WAN failover or recovery | Check ISP status, failover config |
-| `EVT_IPS_*` | varies | Security event detected | Review threat details, check source |
+| `DEVICE_UNREACHABLE` | critical | A UniFi device stopped responding | Check power and uplink connectivity |
+| `DEVICE_RECONNECTED` | info | A UniFi device came back online | Verify clients and downlinks recovered |
+| `NETWORK_WAN_FAILED_2` | warning | WAN connectivity failed | Check ISP status and failover configuration |
+| `NETWORK_WAN_RESTORED_2` | info | WAN connectivity recovered | Verify primary-path stability |
+| `THREAT_DETECTED_V3` | varies | A security threat was detected | Review threat details and the source |
+| `TRAFFIC_BLOCKED_KNOWN_SOURCE_CLIENT` | varies | Traffic from a known client was blocked | Review the client and blocking policy |
 
 ## Response Fields
 
 **Alarms** (`unifi_list_alarms`): `_id`, `msg`, `severity`, `type`, `timestamp`, device/client MAC
 
-**Events** (`unifi_list_events`): `_id`, `msg`, `time` (Unix timestamp), `type`
+**Events** (`unifi_list_events`): `_id`, `key`, `msg`, `time` (Unix timestamp), `severity`

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -467,7 +467,7 @@ Manage the controller's native Dynamic DNS provider entries (Settings → Intern
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `unifi_get_event_types` | Read | Get a list of known event type prefixes for filtering events. |
+| `unifi_get_event_types` | Read | Get recently observed exact event keys for filtering events. |
 | `unifi_list_alarms` | Read | Returns active alarms (security alerts, connectivity issues, firmware warnings). |
 | `unifi_list_events` | Read | Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest... |
 | `unifi_recent_events` | Read | Get recent events from the in-memory websocket buffer. |

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -217,7 +217,7 @@ print(f"validated {len(registry)} catalog bindings against installed Core floor"
 """
 
 _NETWORK_CORE_FLOOR_CONTRACT = """
-import ast, json
+import ast, asyncio, json
 from importlib.resources import files
 from unifi_network_mcp import runtime
 
@@ -256,6 +256,32 @@ if not checked:
     failures.append("no direct Core manager call sites were discovered")
 if runtime.traffic_flow_manager._dpi_manager is not runtime.dpi_manager:
     failures.append("traffic_flow_manager is not wired to the runtime DPI catalogue manager")
+async def fake_get_events(*, within, limit, **kwargs):
+    if within != 168 or limit != 1000:
+        raise AssertionError(f"event catalog sampled within={within}, limit={limit}")
+    return [
+        {"key": "CLIENT_CONNECTED_WIRELESS_2"},
+        {"key": "CLIENT_CONNECTED_WIRELESS_2"},
+        {"event": "CLIENT_ROAMED_2"},
+    ]
+runtime.event_manager.get_events = fake_get_events
+catalog = asyncio.run(runtime.event_manager.get_event_types())
+expected_catalog = [
+    {
+        "key": "CLIENT_CONNECTED_WIRELESS_2",
+        "prefix": "CLIENT_CONNECTED_WIRELESS_2",
+        "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+        "observed_count": 2,
+    },
+    {
+        "key": "CLIENT_ROAMED_2",
+        "prefix": "CLIENT_ROAMED_2",
+        "description": "Exact event key observed in the 1,000 most recent events within the last 7 days",
+        "observed_count": 1,
+    },
+]
+if catalog != expected_catalog:
+    failures.append(f"event_manager.get_event_types returned {catalog!r}")
 if failures:
     raise SystemExit("\\n".join(failures))
 print(f"validated {len(checked)} direct Core manager call sites against installed Core floor")

--- a/tests/test_generate_api_action_catalog.py
+++ b/tests/test_generate_api_action_catalog.py
@@ -336,7 +336,7 @@ def test_repository_catalog_is_complete_with_only_streaming_exclusions() -> None
         "get_alarms",
     )
     assert by_name["unifi_recent_events"]["manager_method"] == "get_recent_from_buffer"
-    assert by_name["unifi_get_event_types"]["manager_method"] == "get_event_type_prefixes"
+    assert by_name["unifi_get_event_types"]["manager_method"] == "get_event_types"
     assert by_name["unifi_archive_alarm"]["manager_method"] == "archive_alarm"
     assert by_name["unifi_archive_all_alarms"]["manager_method"] == "archive_all_alarms"
     assert (


### PR DESCRIPTION
## Summary

- use exact controller event keys instead of rendered-message search
- discover recently observed exact keys for MCP, REST, and GraphQL consumers
- preserve compatibility for published Network versions while requiring Core 0.4.37
- paginate the v2 system log beyond its 100-event page cap
- add an exact published-Core floor gate to the Network release workflow

Closes #579

## Validation

- make pre-commit
- published Core floor checks for Network and API
- focused controller smoke for unifi_get_event_types and unifi_list_events
- live exact-key proof: 150/150 paginated CLIENT_ROAMED_2 events matched; partial key rejected
- live API actions, resources, and streams smoke

No controller mutations were performed.