### PR TITLE
feat: migrate MCP runtime to SDK 2.x

### DIFF
--- a/.github/workflows/check-pin-alignment.yml
+++ b/.github/workflows/check-pin-alignment.yml
@@ -28,10 +28,6 @@ on:
       - "scripts/check_pin_alignment.py"
       - ".github/workflows/check-pin-alignment.yml"
 
-env:
-  # hatch-vcs fallback for branches without an upstream-package tag in ancestry.
-  SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev0"
-
 permissions:
   contents: read
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ relay-test:
 	uv run --package unifi-mcp-relay pytest packages/unifi-mcp-relay/tests -v
 
 protocol-smoke:
-	uv run --package unifi-network-mcp python scripts/smoke_mcp_metadata.py --server all --registration-mode all
+	uv run --package unifi-network-mcp python scripts/smoke_mcp_metadata.py --server all --registration-mode all --client-mode all
 
 worker-install:
 	npm ci --prefix apps/worker

--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # declaring py-unifi-access here directly. Access system-log event
     # normalization and websocket topics require Core 0.4.33.
     "unifi-core[access]>=0.4.33,<0.5",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.
     "cryptography>=50.0.1",

--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Access MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.7,<0.7",
+    "unifi-mcp-shared>=0.6.10,<0.7",
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly. Access system-log event

--- a/apps/access/tests/integration/test_strict_dispatch.py
+++ b/apps/access/tests/integration/test_strict_dispatch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from unifi_mcp_shared.server import UniFiMCPServer
 from unifi_mcp_shared.strict_dispatch import StrictKwargFastMCP

--- a/apps/network/devtools/dev_console.py
+++ b/apps/network/devtools/dev_console.py
@@ -178,7 +178,7 @@ async def _invoke_tool(server, tool) -> None:
     name = tool.name
     desc = tool.description or ""
     # FastMCP uses inputSchema, not parameters
-    input_schema = getattr(tool, "inputSchema", None) or {}
+    input_schema = getattr(tool, "input_schema", None) or {}
     schema_props = input_schema.get("properties", {}) if isinstance(input_schema, dict) else {}
     _print("Tool", {"name": name, "description": desc})
 

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # requires Core 0.4.36. Exact event-key filtering and discovery require
     # Core 0.4.37.
     "unifi-core[network]>=0.4.37,<0.5",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.
     "cryptography>=50.0.1",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -5,7 +5,7 @@ description = "Unifi Network MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.7,<0.7",
+    "unifi-mcp-shared>=0.6.10,<0.7",
     # Network managers in unifi-core import aiounifi; pull it in via the
     # [network] extra rather than declaring aiounifi here directly so
     # there's one source of truth.

--- a/apps/network/tests/integration/test_strict_dispatch.py
+++ b/apps/network/tests/integration/test_strict_dispatch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from unifi_mcp_shared.server import UniFiMCPServer
 from unifi_mcp_shared.strict_dispatch import StrictKwargFastMCP

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -5,7 +5,7 @@ description = "UniFi Protect MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-mcp-shared>=0.6.7,<0.7",
+    "unifi-mcp-shared>=0.6.10,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly. Camera
     # detail fields require Core 0.4.35.

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # [protect] extra rather than declaring uiprotect here directly. Camera
     # detail fields require Core 0.4.35.
     "unifi-core[protect]>=0.4.35,<0.5",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.
     "cryptography>=50.0.1",

--- a/apps/protect/tests/integration/test_strict_dispatch.py
+++ b/apps/protect/tests/integration/test_strict_dispatch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError
 
 from unifi_mcp_shared.server import UniFiMCPServer
 from unifi_mcp_shared.strict_dispatch import StrictKwargFastMCP

--- a/apps/protect/tests/unit/test_detection_search_tools.py
+++ b/apps/protect/tests/unit/test_detection_search_tools.py
@@ -188,8 +188,8 @@ class TestProtectSearchDetections:
         from unifi_protect_mcp.runtime import server
 
         tools = {tool.name: tool for tool in await server.list_tools()}
-        assert tools["protect_search_detections"].annotations.readOnlyHint is True
-        assert tools["protect_search_detections"].annotations.openWorldHint is False
+        assert tools["protect_search_detections"].annotations.read_only_hint is True
+        assert tools["protect_search_detections"].annotations.open_world_hint is False
 
 
 # ---------------------------------------------------------------------------
@@ -245,5 +245,5 @@ class TestProtectDetectionSearchLabels:
         from unifi_protect_mcp.runtime import server
 
         tools = {tool.name: tool for tool in await server.list_tools()}
-        assert tools["protect_detection_search_labels"].annotations.readOnlyHint is True
-        assert tools["protect_detection_search_labels"].annotations.openWorldHint is False
+        assert tools["protect_detection_search_labels"].annotations.read_only_hint is True
+        assert tools["protect_detection_search_labels"].annotations.open_world_hint is False

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,9 @@ Used by: `apps/network`, `apps/protect`, `apps/access`, `apps/api`.
 
 ### unifi-mcp-shared
 
-Shared MCP server patterns. Depends on `mcp` SDK and `omegaconf`.
+Shared MCP server patterns. Depends on MCP SDK 2.x and `omegaconf`. The shared
+server negotiates the current Discover-era and legacy Initialize-era protocols
+per connection, so one process can serve clients at either migration state.
 
 | Module | Purpose |
 |--------|---------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,12 @@ Complete documentation for the UniFi MCP ecosystem.
 
 ## MCP Discovery and Lazy Tool Loading
 
+The Python servers run on MCP SDK 2.x and negotiate per connection. Current
+clients use the Discover-era protocol (`2026-07-28`), while clients that still
+use the Initialize handshake continue to negotiate the legacy protocol
+(`2025-11-25`) against the same server process. No process-level protocol
+switch is required.
+
 Standard MCP discovery is still `tools/list` followed by `tools/call`. The
 UniFi `*_tool_index`, `*_execute`, `*_batch`, and `*_load_tools` surfaces are
 optional lazy-loading extensions for filtered discovery and indirect execution, not replacements

--- a/packages/unifi-core/src/unifi_core/manifest_helpers.py
+++ b/packages/unifi-core/src/unifi_core/manifest_helpers.py
@@ -42,12 +42,21 @@ def get_tool_annotations(server: Any) -> dict[str, dict[str, Any]]:
             if tool_annotations is None:
                 continue
 
-            # ToolAnnotations is a pydantic BaseModel; serialize only non-None fields
-            ann_dict = {}
-            for field_name in ("title", "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"):
-                value = getattr(tool_annotations, field_name, None)
-                if value is not None:
-                    ann_dict[field_name] = value
+            # Preserve MCP wire aliases while excluding SDK defaults the tool did not declare.
+            if hasattr(tool_annotations, "model_dump"):
+                ann_dict = tool_annotations.model_dump(by_alias=True, exclude_none=True, exclude_unset=True)
+            else:
+                ann_dict = {
+                    field_name: value
+                    for field_name in (
+                        "title",
+                        "readOnlyHint",
+                        "destructiveHint",
+                        "idempotentHint",
+                        "openWorldHint",
+                    )
+                    if (value := getattr(tool_annotations, field_name, None)) is not None
+                }
 
             if ann_dict:
                 annotations_map[tool_name] = ann_dict

--- a/packages/unifi-core/src/unifi_core/manifest_helpers.py
+++ b/packages/unifi-core/src/unifi_core/manifest_helpers.py
@@ -42,21 +42,12 @@ def get_tool_annotations(server: Any) -> dict[str, dict[str, Any]]:
             if tool_annotations is None:
                 continue
 
-            # Preserve MCP wire aliases while excluding SDK defaults the tool did not declare.
-            if hasattr(tool_annotations, "model_dump"):
-                ann_dict = tool_annotations.model_dump(by_alias=True, exclude_none=True, exclude_unset=True)
-            else:
-                ann_dict = {
-                    field_name: value
-                    for field_name in (
-                        "title",
-                        "readOnlyHint",
-                        "destructiveHint",
-                        "idempotentHint",
-                        "openWorldHint",
-                    )
-                    if (value := getattr(tool_annotations, field_name, None)) is not None
-                }
+            # ToolAnnotations is a pydantic BaseModel; serialize only non-None fields
+            ann_dict = {}
+            for field_name in ("title", "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint"):
+                value = getattr(tool_annotations, field_name, None)
+                if value is not None:
+                    ann_dict[field_name] = value
 
             if ann_dict:
                 annotations_map[tool_name] = ann_dict

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "click>=8.3.3",
     "aiohttp>=3.14.3",
     "python-dotenv>=1.2.2",
-    "unifi-mcp-shared>=0.6.7,<0.7",
+    "unifi-mcp-shared>=0.6.10,<0.7",
     # location_timeline.py imports unifi_core.event_timeline directly. This resolves
     # today only as a transitive of unifi-mcp-shared; declare it so it does not.
     "unifi-core>=0.4.21,<0.5",

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP relay: bridges local MCP servers to a Cloudflare Worker gatew
 requires-python = ">=3.13"
 dependencies = [
     "websockets>=17.0.1",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.
     "cryptography>=50.0.1",

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
@@ -221,7 +221,7 @@ def _relay_client_info() -> dict:
         "title": "UniFi MCP Relay",
         "version": _relay_version(),
         "websiteUrl": PROJECT_WEBSITE_URL,
-        "icons": [icon.model_dump(exclude_none=True) for icon in mcp_icons_for_server("relay")],
+        "icons": [icon.model_dump(by_alias=True, exclude_none=True) for icon in mcp_icons_for_server("relay")],
     }
 
 

--- a/packages/unifi-mcp-relay/tests/test_sdk_v2_server.py
+++ b/packages/unifi-mcp-relay/tests/test_sdk_v2_server.py
@@ -1,0 +1,80 @@
+"""Relay interoperability with a real MCP SDK 2.x HTTP server."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import pytest
+import uvicorn
+from mcp.server.mcpserver import MCPServer
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ToolAnnotations
+from unifi_mcp_relay.discovery import discover_tools
+from unifi_mcp_relay.forwarder import ToolForwarder
+from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
+
+
+@asynccontextmanager
+async def running_sdk_v2_server() -> AsyncIterator[str]:
+    mcp_server = MCPServer("relay-sdk-v2-test", version="2.1.1")
+
+    @mcp_server.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            openWorldHint=False,
+        )
+    )
+    async def relay_sdk_v2_echo(value: str) -> dict:
+        """Echo a value through a structured MCP tool result."""
+        return {"success": True, "data": {"value": value}}
+
+    app = mcp_server.streamable_http_app(
+        json_response=True,
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    )
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen()
+    port = sock.getsockname()[1]
+
+    http_server = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="on"))
+    task = asyncio.create_task(http_server.serve(sockets=[sock]))
+    try:
+        for _ in range(100):
+            if http_server.started:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise RuntimeError("SDK v2 test server did not start")
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        http_server.should_exit = True
+        await task
+        sock.close()
+
+
+@pytest.mark.asyncio
+async def test_relay_discovers_and_forwards_to_sdk_v2_server() -> None:
+    async with running_sdk_v2_server() as server_url:
+        info = await discover_tools(server_url)
+
+        assert info is not None
+        assert info.name == "relay-sdk-v2-test"
+        assert info.protocol_version == DEFAULT_MCP_PROTOCOL_REVISION
+        assert [tool.name for tool in info.tools] == ["relay_sdk_v2_echo"]
+        assert info.tools[0].annotations == {
+            "readOnlyHint": True,
+            "openWorldHint": False,
+        }
+
+        forwarder = ToolForwarder([info])
+        try:
+            result = await forwarder.forward("relay_sdk_v2_echo", {"value": "ready"})
+        finally:
+            await forwarder.close()
+
+        assert result == {"success": True, "data": {"value": "ready"}}

--- a/packages/unifi-mcp-shared/pyproject.toml
+++ b/packages/unifi-mcp-shared/pyproject.toml
@@ -5,7 +5,7 @@ description = "Shared MCP server patterns: permissions, confirmation, lazy loadi
 requires-python = ">=3.13"
 dependencies = [
     "unifi-core>=0.4.22,<0.5",
-    "mcp[cli]>=1.28.1,<2",
+    "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.
     "cryptography>=50.0.1",

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
@@ -11,7 +11,6 @@ from unifi_core.confirmation import (
 )
 from unifi_core.formatting import error_response, success_response
 from unifi_core.jobs import JOBS, JobStore, get_job_status, start_async_tool
-from unifi_core.manifest_helpers import get_tool_annotations
 from unifi_core.policy_gate import PolicyGateChecker
 from unifi_core.validators import ResourceValidator, create_response
 
@@ -20,6 +19,7 @@ from unifi_mcp_shared.lazy_tools import (
     build_tool_module_map,
     setup_lazy_loading,
 )
+from unifi_mcp_shared.manifest_helpers import get_tool_annotations
 from unifi_mcp_shared.meta_tools import register_load_tools, register_meta_tools
 from unifi_mcp_shared.server import UniFiMCPServer
 from unifi_mcp_shared.tasks import (

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/lazy_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/lazy_tools.py
@@ -180,7 +180,13 @@ class LazyToolLoader:
         finally:
             self._loading = False
 
-    async def intercept_call_tool(self, original_call_tool: Callable, name: str, arguments: dict) -> Any:
+    async def intercept_call_tool(
+        self,
+        original_call_tool: Callable,
+        name: str,
+        arguments: dict,
+        context: Any | None = None,
+    ) -> Any:
         """Intercept tool calls to load tools on-demand.
 
         Args:
@@ -198,7 +204,7 @@ class LazyToolLoader:
                 raise ValueError(f"Failed to load tool '{name}'")
 
         # Call the original method
-        return await original_call_tool(name, arguments)
+        return await original_call_tool(name, arguments, context=context)
 
 
 def setup_lazy_loading(server, tool_decorator: Callable, tool_module_map: Dict[str, str]) -> LazyToolLoader:
@@ -218,8 +224,8 @@ def setup_lazy_loading(server, tool_decorator: Callable, tool_module_map: Dict[s
     original_call_tool = server.call_tool
 
     @wraps(original_call_tool)
-    async def lazy_call_tool(name: str, arguments: dict):
-        return await loader.intercept_call_tool(original_call_tool, name, arguments)
+    async def lazy_call_tool(name: str, arguments: dict, context: Any | None = None):
+        return await loader.intercept_call_tool(original_call_tool, name, arguments, context=context)
 
     server.call_tool = lazy_call_tool
 

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/manifest_generator.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/manifest_generator.py
@@ -19,8 +19,7 @@ import traceback
 from pathlib import Path
 from typing import Any
 
-from unifi_core.manifest_helpers import get_tool_annotations
-
+from unifi_mcp_shared.manifest_helpers import get_tool_annotations
 from unifi_mcp_shared.meta_tools import register_load_tools, register_meta_tools
 from unifi_mcp_shared.tool_loader import auto_load_tools
 

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/manifest_helpers.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/manifest_helpers.py
@@ -1,0 +1,55 @@
+"""MCP-specific helpers for tool manifest generation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def get_tool_annotations(server: Any) -> dict[str, dict[str, Any]]:
+    """Extract explicitly declared ToolAnnotations using their MCP wire names."""
+    annotations_map: dict[str, dict[str, Any]] = {}
+
+    try:
+        tool_manager = getattr(server, "_tool_manager", None)
+        if tool_manager is None:
+            logger.warning("   server._tool_manager not found; skipping annotations")
+            return annotations_map
+
+        internal_tools = getattr(tool_manager, "_tools", None)
+        if internal_tools is None:
+            logger.warning("   server._tool_manager._tools not found; skipping annotations")
+            return annotations_map
+
+        for tool_name, tool_obj in internal_tools.items():
+            tool_annotations = getattr(tool_obj, "annotations", None)
+            if tool_annotations is None:
+                continue
+
+            if hasattr(tool_annotations, "model_dump"):
+                annotation_data = tool_annotations.model_dump(
+                    by_alias=True,
+                    exclude_none=True,
+                    exclude_unset=True,
+                )
+            else:
+                annotation_data = {
+                    field_name: value
+                    for field_name in (
+                        "title",
+                        "readOnlyHint",
+                        "destructiveHint",
+                        "idempotentHint",
+                        "openWorldHint",
+                    )
+                    if (value := getattr(tool_annotations, field_name, None)) is not None
+                }
+
+            if annotation_data:
+                annotations_map[tool_name] = annotation_data
+    except Exception as exc:
+        logger.warning("   Failed to extract tool annotations: %s", exc)
+
+    return annotations_map

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -16,6 +16,7 @@ servers are loaded simultaneously:
 import logging
 from typing import TYPE_CHECKING, Callable, List
 
+from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
 
 from unifi_mcp_shared.response_serialization import normalize_call_tool_result
@@ -206,13 +207,13 @@ def register_meta_tools(
         ),
         annotations=action_annotations,
     )
-    async def execute_handler(tool: str, arguments: dict = None) -> dict:
+    async def execute_handler(tool: str, arguments: dict = None, ctx: Context | None = None) -> dict:
         """Execute a tool synchronously."""
         if arguments is None:
             arguments = {}
 
         try:
-            result = await server.call_tool(tool, arguments)
+            result = await server.call_tool(tool, arguments, context=ctx)
             return normalize_call_tool_result(result)
         except Exception as e:
             logger.error("Error executing tool '%s': %s", tool, e, exc_info=True)
@@ -257,7 +258,7 @@ def register_meta_tools(
         ),
         annotations=action_annotations,
     )
-    async def batch_handler(operations: List[dict]) -> dict:
+    async def batch_handler(operations: List[dict], ctx: Context | None = None) -> dict:
         """Execute multiple operations in parallel."""
         if not operations:
             return {"error": "No operations specified", "jobs": []}
@@ -277,7 +278,7 @@ def register_meta_tools(
                 # Create a closure that captures the current tool and arguments
                 async def _make_executor(t, a):
                     async def _execute():
-                        result = await server.call_tool(t, a)
+                        result = await server.call_tool(t, a, context=ctx)
                         return normalize_call_tool_result(result)
 
                     return _execute
@@ -460,8 +461,6 @@ def register_load_tools(
         server_label: Human-readable server name for descriptions.
         domain_hint: Short description of the tool domain for LLM context.
     """
-    from mcp.server.fastmcp import Context
-
     load_name = f"{prefix}_load_tools"
     exec_name = f"{prefix}_execute"
     hint = domain_hint or _DEFAULT_DOMAIN_HINTS.get(prefix, "controller management")
@@ -509,7 +508,7 @@ def register_load_tools(
 
         if loaded:
             try:
-                await ctx.session.send_tool_list_changed()
+                await ctx.notify_tools_changed()
                 logger.info("Sent notifications/tools/list_changed after loading: %s", loaded)
             except Exception as e:
                 logger.warning("Failed to send tool_list_changed notification: %s", e)

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/metadata.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/metadata.py
@@ -84,8 +84,8 @@ def configure_mcp_server_metadata(
     website_url: str = PROJECT_WEBSITE_URL,
     icon_family: str | None = None,
 ) -> None:
-    """Attach app package metadata to FastMCP's underlying initialize response."""
-    mcp_server = getattr(server, "_mcp_server", None)
+    """Attach app package metadata to MCPServer's initialize/discover responses."""
+    mcp_server = getattr(server, "_lowlevel_server", None)
     if mcp_server is None:
         return
 

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/protocol.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/protocol.py
@@ -89,16 +89,12 @@ def structured_content_supported(protocol_revision: str | None) -> bool:
         return False
 
 
-def get_request_protocol_revision(server: Any) -> str | None:
-    """Read the negotiated revision for the current SDK-v1 request, if any.
-
-    This is the only SDK-v1-specific session metadata read. Replace this helper
-    when SDK v2 exposes protocol metadata through per-request envelopes.
-    """
+def get_request_protocol_revision(context: Any | None) -> str | None:
+    """Read the protocol revision negotiated for the current SDK v2 request."""
+    if context is None:
+        return None
     try:
-        context = server.get_context()
-        client_params = context.session.client_params
-        revision = client_params.protocolVersion if client_params is not None else None
+        revision = context.request_context.protocol_version
         return str(revision) if revision else None
     except (AttributeError, LookupError, RuntimeError, ValueError):
         return None
@@ -127,14 +123,15 @@ def create_mcp_tool_adapter(
     else:
         revision = get_protocol_revision()
 
-    if revision not in _KNOWN_REVISIONS:
-        raise ValueError(
-            f"Unsupported MCP protocol revision: '{revision}'. Known revisions: {sorted(_KNOWN_REVISIONS)}"
+    if revision not in _KNOWN_PROTOCOL_TARGETS:
+        logger.warning(
+            "[protocol] Ignoring legacy process-level MCP protocol target %s; "
+            "SDK v2 negotiates the protocol per client",
+            revision,
         )
-
-    if revision == DEFAULT_MCP_PROTOCOL_REVISION:
-        logger.debug("[protocol] Using MCP %s adapter (passthrough)", revision)
-        return fastmcp_tool_decorator
-
-    # Unreachable, but satisfies type checkers
-    raise ValueError(f"Unhandled MCP protocol revision: {revision}")
+    else:
+        logger.debug(
+            "[protocol] Legacy process-level MCP protocol target %s is informational; SDK v2 negotiates per client",
+            revision,
+        )
+    return fastmcp_tool_decorator

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/response_serialization.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/response_serialization.py
@@ -25,8 +25,8 @@ def _json_text_content(result: Any) -> Any:
 def normalize_call_tool_result(result: Any) -> Any:
     """Unwrap canonical MCP result envelopes without changing domain data."""
     if isinstance(result, CallToolResult):
-        if result.structuredContent is not None:
-            return result.structuredContent
+        if result.structured_content is not None:
+            return result.structured_content
         return _json_text_content(result.content)
     if isinstance(result, tuple) and len(result) == 2:
         content, structured = result
@@ -101,7 +101,7 @@ def serialize_call_tool_result(
         return result
 
     if isinstance(result, CallToolResult):
-        structured = result.structuredContent
+        structured = result.structured_content
         if structured is None:
             return result
         return result.model_copy(update={"content": _compact_content(result.content, structured, tool_name=tool_name)})
@@ -110,6 +110,6 @@ def serialize_call_tool_result(
         content, structured = result
         return CallToolResult(
             content=_compact_content(content, structured, tool_name=tool_name),
-            structuredContent=structured,
+            structured_content=structured,
         )
     return result

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/server.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/server.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from mcp.server.mcpserver import Context
+from mcp.server.transport_security import TransportSecuritySettings
+
 from unifi_mcp_shared.protocol import get_request_protocol_revision
 from unifi_mcp_shared.response_policy import MCPContentMode
 from unifi_mcp_shared.response_serialization import serialize_call_tool_result
@@ -19,14 +22,45 @@ class UniFiMCPServer(StrictKwargFastMCP):
         mcp_content_mode: MCPContentMode = "adaptive",
         **kwargs: Any,
     ) -> None:
+        transport_security = kwargs.pop("transport_security", None)
         super().__init__(*args, **kwargs)
         self._mcp_content_mode = mcp_content_mode
+        self.transport_security = _normalize_transport_security(transport_security)
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
-        result = await super().call_tool(name, arguments)
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Context | None = None,
+    ) -> Any:
+        result = await super().call_tool(name, arguments, context=context)
         return serialize_call_tool_result(
             result,
             mode=self._mcp_content_mode,
-            protocol_revision=get_request_protocol_revision(self),
+            protocol_revision=get_request_protocol_revision(context),
             tool_name=name,
         )
+
+
+def _normalize_transport_security(
+    settings: TransportSecuritySettings | None,
+) -> TransportSecuritySettings | None:
+    """Normalize v1-style bare hosts for the SDK v2 host-and-port matcher."""
+    if settings is None:
+        return None
+
+    allowed_hosts = [_normalize_allowed_host(host) for host in settings.allowed_hosts]
+    return settings.model_copy(update={"allowed_hosts": allowed_hosts})
+
+
+def _normalize_allowed_host(host: str) -> str:
+    value = host.strip()
+    if not value or value == "*":
+        return value
+    if value.startswith("["):
+        return value if "]:" in value else f"{value}:*"
+    if value.count(":") > 1:
+        return f"[{value}]:*"
+    if ":" in value:
+        return value
+    return f"{value}:*"

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/strict_dispatch.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/strict_dispatch.py
@@ -20,22 +20,21 @@ from __future__ import annotations
 import json
 import logging
 import pathlib
-from typing import Any, Sequence
+from typing import Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import ContentBlock
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from unifi_core.redaction import redaction_marker_paths
 
 logger = logging.getLogger(__name__)
 
 
-class StrictKwargFastMCP(FastMCP):
+class StrictKwargFastMCP(MCPServer):
     """FastMCP subclass that rejects unknown top-level kwargs at dispatch time.
 
     Reads ``tools_manifest.json`` once at construction and caches the allowed
     top-level argument names per tool. Unknown keys at ``call_tool`` time
-    raise :class:`mcp.server.fastmcp.exceptions.ToolError` with a structured,
+    raise :class:`mcp.server.mcpserver.exceptions.ToolError` with a structured,
     human-readable message.
 
     Note: only top-level kwargs are checked. Inner dict shapes (e.g. a
@@ -57,7 +56,8 @@ class StrictKwargFastMCP(FastMCP):
         self,
         name: str,
         arguments: dict[str, Any],
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        context: Context | None = None,
+    ) -> Any:
         """Dispatch a tool call after validating top-level kwargs.
 
         - Tools not present in the manifest cache (stale manifest, dynamically
@@ -92,7 +92,7 @@ class StrictKwargFastMCP(FastMCP):
                 f"Invalid params for '{name}': {field} is the redaction marker, not a real value. "
                 f"Omit {field} to keep the current value."
             )
-        return await super().call_tool(name, arguments)
+        return await super().call_tool(name, arguments, context=context)
 
 
 def _load_allowed_kwargs(manifest_path: pathlib.Path) -> dict[str, frozenset[str]]:

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tasks.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tasks.py
@@ -46,6 +46,10 @@ def _timestamp_to_datetime(value: Any, *, fallback: datetime | None = None) -> d
     return datetime.now(timezone.utc)
 
 
+def _datetime_to_protocol_timestamp(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
 def _status_message(job_status: dict[str, Any], task_status: TaskStatus) -> str:
     if task_status == "failed":
         return str(job_status.get("error") or "Operation failed.")
@@ -68,8 +72,8 @@ def task_from_job_status(
         taskId=job_id,
         status=task_status,
         statusMessage=_status_message(job_status, task_status),
-        createdAt=created_at,
-        lastUpdatedAt=last_updated_at,
+        createdAt=_datetime_to_protocol_timestamp(created_at),
+        lastUpdatedAt=_datetime_to_protocol_timestamp(last_updated_at),
         ttl=ttl_ms,
         pollInterval=poll_interval_ms,
     )

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/testing.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/testing.py
@@ -16,12 +16,12 @@ def assert_server_initialization_metadata(server: Any, *, package_name: str) -> 
     instance so the project-wide initialize-response contract is asserted in
     exactly one place.
     """
-    options = server._mcp_server.create_initialization_options()
+    options = server._lowlevel_server.create_initialization_options()
     assert options.server_name == package_name
     assert options.server_version == version(package_name)
     assert options.website_url == PROJECT_WEBSITE_URL
     assert options.icons is not None
     assert [icon.sizes for icon in options.icons] == [["48x48"], ["96x96"], ["192x192"]]
-    assert {icon.mimeType for icon in options.icons} == {"image/png"}
+    assert {icon.mime_type for icon in options.icons} == {"image/png"}
     decoded = base64.b64decode(options.icons[0].src.removeprefix("data:image/png;base64,"))
     assert decoded.startswith(b"\x89PNG\r\n\x1a\n")

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
@@ -101,11 +101,12 @@ def normalize_tool_annotations(annotations: Any | None) -> Dict[str, Any] | None
     if annotations is None:
         return None
 
-    source = (
-        annotations
-        if isinstance(annotations, dict)
-        else {field_name: getattr(annotations, field_name, None) for field_name in _ANNOTATION_FIELDS}
-    )
+    if isinstance(annotations, dict):
+        source = annotations
+    elif hasattr(annotations, "model_dump"):
+        source = annotations.model_dump(by_alias=True, exclude_none=True, exclude_unset=True)
+    else:
+        source = {field_name: getattr(annotations, field_name, None) for field_name in _ANNOTATION_FIELDS}
     normalized = {
         field_name: source[field_name]
         for field_name in _ANNOTATION_FIELDS

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/transport.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 from unifi_core.config_helpers import parse_config_bool
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
 VALID_HTTP_TRANSPORTS = {"streamable-http", "sse"}
 _TRANSPORT_LABELS = {"streamable-http": "Streamable HTTP", "sse": "HTTP SSE"}
@@ -72,7 +72,7 @@ def resolve_http_config(
 
 async def run_transports(
     *,
-    server: FastMCP,
+    server: MCPServer,
     http_enabled: bool,
     host: str,
     port: int,
@@ -109,9 +109,6 @@ async def run_transports(
     async def run_http() -> None:
         try:
             logger.info("Starting FastMCP %s server on %s:%s ...", transport_label, host, port)
-            server.settings.host = host
-            server.settings.port = port
-
             # Redirect uvicorn access logs to stderr to prevent stdout conflicts
             # when running alongside stdio transport (stdout is used for JSON-RPC)
             import uvicorn.config
@@ -119,9 +116,17 @@ async def run_transports(
             uvicorn.config.LOGGING_CONFIG["handlers"]["access"]["stream"] = "ext://sys.stderr"
 
             if http_transport == "streamable-http":
-                await server.run_streamable_http_async()
+                await server.run_streamable_http_async(
+                    host=host,
+                    port=port,
+                    transport_security=getattr(server, "transport_security", None),
+                )
             else:
-                await server.run_sse_async()
+                await server.run_sse_async(
+                    host=host,
+                    port=port,
+                    transport_security=getattr(server, "transport_security", None),
+                )
             logger.info("%s server exited.", transport_label)
         except SystemExit as se:
             logger.error(

--- a/packages/unifi-mcp-shared/tests/test_manifest_helpers.py
+++ b/packages/unifi-mcp-shared/tests/test_manifest_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from unifi_core.manifest_helpers import get_tool_annotations
+from unifi_mcp_shared.manifest_helpers import get_tool_annotations
 
 
 def _make_server(tools: dict | None = None, *, has_manager: bool = True) -> SimpleNamespace:

--- a/packages/unifi-mcp-shared/tests/test_meta_tools.py
+++ b/packages/unifi-mcp-shared/tests/test_meta_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer as FastMCP
 from mcp.types import (
     AudioContent,
     EmbeddedResource,
@@ -43,7 +43,7 @@ def _capture_tools():
 
 
 def _context():
-    return SimpleNamespace(session=SimpleNamespace(send_tool_list_changed=AsyncMock()))
+    return SimpleNamespace(notify_tools_changed=AsyncMock())
 
 
 def _register_test_meta_tools(*, server, prefix, start_async_tool=None, get_job_status=None):
@@ -252,14 +252,13 @@ async def test_fastmcp_execute_and_batch_expose_domain_payload(prefix):
         f"{prefix}_execute",
         {"tool": f"{prefix}_inner", "arguments": {}},
     )
-    assert len(execute) == 1
-    assert json.loads(execute[0].text) == payload
+    assert json.loads(execute.content[0].text) == payload
 
     batch = await server.call_tool(
         f"{prefix}_batch",
         {"operations": [{"tool": f"{prefix}_inner", "arguments": {}}]},
     )
-    job_id = json.loads(batch[0].text)["jobs"][0]["jobId"]
+    job_id = json.loads(batch.content[0].text)["jobs"][0]["jobId"]
 
     for _ in range(10):
         if (await store.status(job_id))["status"] == "done":
@@ -267,7 +266,7 @@ async def test_fastmcp_execute_and_batch_expose_domain_payload(prefix):
         await asyncio.sleep(0)
 
     status = await server.call_tool(f"{prefix}_batch_status", {"jobId": job_id})
-    status_payload = json.loads(status[0].text)
+    status_payload = json.loads(status.content[0].text)
     assert status_payload["status"] == "done"
     assert status_payload["result"] == payload
 
@@ -295,7 +294,7 @@ class TestRegisterLoadTools:
         assert result["loaded"] == ["unifi_list_clients"]
         assert result["errors"] is None
         lazy_loader.load_tool.assert_awaited_once_with("unifi_list_clients")
-        ctx.session.send_tool_list_changed.assert_awaited_once()
+        ctx.notify_tools_changed.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unknown_tools_do_not_send_list_changed_notification(self):
@@ -316,7 +315,7 @@ class TestRegisterLoadTools:
         assert result["loaded"] == []
         assert result["errors"] == [{"tool": "unifi_unknown", "error": "Unknown tool"}]
         lazy_loader.load_tool.assert_not_awaited()
-        ctx.session.send_tool_list_changed.assert_not_awaited()
+        ctx.notify_tools_changed.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_failed_load_does_not_send_list_changed_notification(self):
@@ -336,7 +335,7 @@ class TestRegisterLoadTools:
 
         assert result["loaded"] == []
         assert result["errors"] == [{"tool": "unifi_list_clients", "error": "Failed to load"}]
-        ctx.session.send_tool_list_changed.assert_not_awaited()
+        ctx.notify_tools_changed.assert_not_awaited()
 
     def test_load_tools_description_uses_standard_notification_name(self):
         registered, tool_decorator = _capture_tools()

--- a/packages/unifi-mcp-shared/tests/test_metadata.py
+++ b/packages/unifi-mcp-shared/tests/test_metadata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer as FastMCP
 from unifi_mcp_shared.metadata import (
     PROJECT_WEBSITE_URL,
     configure_mcp_server_metadata,
@@ -28,7 +28,7 @@ def test_mcp_icons_for_server_returns_packaged_png_data_uris() -> None:
     icons = mcp_icons_for_server("network")
 
     assert [icon.sizes for icon in icons] == [["48x48"], ["96x96"], ["192x192"]]
-    assert {icon.mimeType for icon in icons} == {"image/png"}
+    assert {icon.mime_type for icon in icons} == {"image/png"}
     for icon in icons:
         data = _decode_icon_src(icon.src)
         assert data.startswith(b"\x89PNG\r\n\x1a\n")
@@ -48,7 +48,7 @@ def test_configure_mcp_server_metadata_attaches_icons() -> None:
 
     configure_mcp_server_metadata(server, package_name="unifi-mcp-shared", icon_family="access")
 
-    options = server._mcp_server.create_initialization_options()
+    options = server._lowlevel_server.create_initialization_options()
     assert options.website_url == PROJECT_WEBSITE_URL
     assert options.icons is not None
     assert options.icons[0].sizes == ["48x48"]

--- a/packages/unifi-mcp-shared/tests/test_permissioned_tool.py
+++ b/packages/unifi-mcp-shared/tests/test_permissioned_tool.py
@@ -7,7 +7,7 @@ from typing import Annotated, Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer as FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import Field
 from unifi_mcp_shared.output_schema import (
@@ -257,12 +257,12 @@ class TestCreatePermissionedTool:
         tools = await server.list_tools()
         tool = next(t for t in tools if t.name == "fastmcp_schema_tool")
         assert tool.title == "FastMCP Schema Tool"
-        assert tool.outputSchema == get_unifi_tool_response_output_schema()
+        assert tool.output_schema == get_unifi_tool_response_output_schema()
 
-        content, structured_content = await server.call_tool("fastmcp_schema_tool", {})
-        assert content[0].type == "text"
-        assert '"success": true' in content[0].text
-        assert structured_content == {"success": True, "data": {"id": "abc"}}
+        result = await server.call_tool("fastmcp_schema_tool", {})
+        assert result.content[0].type == "text"
+        assert '"success": true' in result.content[0].text
+        assert result.structured_content == {"success": True, "data": {"id": "abc"}}
 
     def test_uses_function_name_when_no_name_given(self, mock_deps):
         pt = _create_pt(mock_deps)

--- a/packages/unifi-mcp-shared/tests/test_protocol.py
+++ b/packages/unifi-mcp-shared/tests/test_protocol.py
@@ -30,15 +30,13 @@ def test_structured_content_not_assumed_for_old_or_unknown_revisions(revision):
 
 
 def test_request_protocol_revision_reads_current_sdk_session():
-    server = MagicMock()
-    server.get_context.return_value.session.client_params.protocolVersion = "2025-11-25"
-    assert get_request_protocol_revision(server) == "2025-11-25"
+    context = MagicMock()
+    context.request_context.protocol_version = "2025-11-25"
+    assert get_request_protocol_revision(context) == "2025-11-25"
 
 
 def test_request_protocol_revision_returns_none_outside_request():
-    server = MagicMock()
-    server.get_context.side_effect = ValueError("Context is not available outside of a request")
-    assert get_request_protocol_revision(server) is None
+    assert get_request_protocol_revision(None) is None
 
 
 class TestGetProtocolRevision:
@@ -85,15 +83,16 @@ class TestCreateMcpToolAdapter:
         adapter = create_mcp_tool_adapter(mock_decorator, protocol_revision="v1")
         assert adapter is mock_decorator
 
-    def test_unsupported_revision_raises(self):
+    def test_unknown_revision_is_ignored_for_per_client_negotiation(self, caplog):
         mock_decorator = MagicMock()
-        with pytest.raises(ValueError, match="Unsupported MCP protocol revision"):
-            create_mcp_tool_adapter(mock_decorator, protocol_revision="2026-06-18")
+        adapter = create_mcp_tool_adapter(mock_decorator, protocol_revision="2026-06-18")
+        assert adapter is mock_decorator
+        assert "negotiates the protocol per client" in caplog.text
 
-    def test_future_target_revision_is_not_runtime_supported(self):
+    def test_future_target_revision_uses_same_negotiated_adapter(self):
         mock_decorator = MagicMock()
-        with pytest.raises(ValueError, match="Unsupported MCP protocol revision"):
-            create_mcp_tool_adapter(mock_decorator, protocol_revision="2026-07-28")
+        adapter = create_mcp_tool_adapter(mock_decorator, protocol_revision="2026-07-28")
+        assert adapter is mock_decorator
 
     def test_v2_revision_alias_raises(self):
         mock_decorator = MagicMock()

--- a/packages/unifi-mcp-shared/tests/test_response_serialization.py
+++ b/packages/unifi-mcp-shared/tests/test_response_serialization.py
@@ -41,7 +41,7 @@ def _assert_mixed_content_compacted(compact, structured, explanatory_text, image
     summary = compact_content_text(structured, tool_name="unifi_test")
 
     assert isinstance(compact, CallToolResult)
-    assert compact.structuredContent == structured
+    assert compact.structured_content == structured
     assert len(compact.content) == 3
     assert isinstance(compact.content[0], TextContent)
     assert compact.content[0].text == summary
@@ -74,7 +74,7 @@ def _assert_non_identical_json_compacted(compact, structured, explanatory_text, 
     summary = compact_content_text(structured, tool_name="unifi_list_records")
 
     assert isinstance(compact, CallToolResult)
-    assert compact.structuredContent == structured
+    assert compact.structured_content == structured
     assert len(compact.content) == 3
     assert isinstance(compact.content[0], TextContent)
     assert compact.content[0].text == summary
@@ -126,7 +126,7 @@ def test_adaptive_compacts_supported_revision():
         tool_name="unifi_list_records",
     )
     assert isinstance(compact, CallToolResult)
-    assert compact.structuredContent["count"] == 250
+    assert compact.structured_content["count"] == 250
     assert compact.content
     assert "250" in compact.content[0].text
     assert "items" not in compact.content[0].text
@@ -166,7 +166,7 @@ def test_compact_override_works_without_revision():
         protocol_revision=None,
         tool_name="unifi_test",
     )
-    assert result.structuredContent["success"] is False
+    assert result.structured_content["success"] is False
     assert result.content
     assert "controller unavailable" in result.content[0].text
 
@@ -268,10 +268,10 @@ def test_compacting_direct_result_preserves_meta_and_error_status():
 
     assert compact is not original
     assert compact.meta == {"request_id": "req-123"}
-    assert compact.isError is True
-    assert compact.structuredContent == original.structuredContent
+    assert compact.is_error is True
+    assert compact.structured_content == original.structured_content
     assert compact.content
     assert compact.content[0].text == compact_content_text(
-        original.structuredContent,
+        original.structured_content,
         tool_name="unifi_test",
     )

--- a/packages/unifi-mcp-shared/tests/test_sdk_v2_compatibility.py
+++ b/packages/unifi-mcp-shared/tests/test_sdk_v2_compatibility.py
@@ -1,0 +1,88 @@
+"""Compatibility contract for MCP SDK 2.x modern and handshake-era clients."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from mcp.client import Client
+from mcp.server.mcpserver import Context
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ToolAnnotations
+from pydantic import BaseModel
+from unifi_mcp_shared.server import UniFiMCPServer
+
+
+class NegotiatedResult(BaseModel):
+    success: bool
+    protocol_version: str
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_revision"),
+    [("auto", "2026-07-28"), ("legacy", "2025-11-25")],
+)
+async def test_one_server_supports_modern_and_legacy_clients(mode: str, expected_revision: str) -> None:
+    server = UniFiMCPServer("compatibility-test", version="1.0.0")
+
+    @server.tool(
+        name="negotiated_tool",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+        structured_output=True,
+    )
+    async def negotiated_tool(ctx: Context) -> NegotiatedResult:
+        return NegotiatedResult(
+            success=True,
+            protocol_version=ctx.request_context.protocol_version,
+        )
+
+    async with Client(server, mode=mode) as client:
+        assert client.protocol_version == expected_revision
+
+        listed = await client.list_tools()
+        tool = next(item for item in listed.tools if item.name == "negotiated_tool")
+        assert tool.annotations is not None
+        assert tool.annotations.read_only_hint is True
+        assert tool.annotations.open_world_hint is False
+        assert tool.input_schema["type"] == "object"
+
+        result = await client.call_tool("negotiated_tool", {})
+
+    assert result.is_error is False
+    assert result.structured_content == {
+        "success": True,
+        "protocol_version": expected_revision,
+    }
+
+
+async def test_bare_allowed_hosts_accept_real_host_headers_with_ports() -> None:
+    server = UniFiMCPServer(
+        "host-pattern-test",
+        transport_security=TransportSecuritySettings(
+            allowed_hosts=["localhost", "127.0.0.1", "[::1]"],
+        ),
+    )
+    assert server.transport_security is not None
+    assert server.transport_security.allowed_hosts == ["localhost:*", "127.0.0.1:*", "[::1]:*"]
+
+    app = server.streamable_http_app(
+        transport_security=server.transport_security,
+        host="127.0.0.1",
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://127.0.0.1:34567",
+        ) as client:
+            response = await client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "server/discover", "params": {}},
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "MCP-Protocol-Version": "2026-07-28",
+                },
+            )
+
+    # The deliberately incomplete discover envelope is rejected after host
+    # validation. SDK v2 returned 421 here before bare hosts were normalized.
+    assert response.status_code == 400

--- a/packages/unifi-mcp-shared/tests/test_server.py
+++ b/packages/unifi-mcp-shared/tests/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from mcp.types import CallToolResult
@@ -26,7 +27,7 @@ async def test_adaptive_server_compacts_supported_client(monkeypatch):
     result = await server.call_tool("unifi_test", {})
 
     assert isinstance(result, CallToolResult)
-    assert result.structuredContent == {"success": True, "data": {"rows": [{"id": 1}]}}
+    assert result.structured_content == {"success": True, "data": {"rows": [{"id": 1}]}}
     assert result.content
     assert "rows" not in result.content[0].text
 
@@ -41,7 +42,8 @@ async def test_adaptive_server_preserves_old_client(monkeypatch):
 
     result = await server.call_tool("unifi_test", {})
 
-    assert isinstance(result, tuple)
+    assert isinstance(result, CallToolResult)
+    assert json.loads(result.content[0].text) == {"success": True, "data": {}}
 
 
 def test_unifi_server_retains_strict_dispatch_contract():

--- a/packages/unifi-mcp-shared/tests/test_strict_dispatch.py
+++ b/packages/unifi-mcp-shared/tests/test_strict_dispatch.py
@@ -7,8 +7,8 @@ import pathlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import MCPServer as FastMCP
+from mcp.server.mcpserver.exceptions import ToolError
 from unifi_core.redaction import REDACTED
 from unifi_mcp_shared.strict_dispatch import StrictKwargFastMCP, _load_allowed_kwargs
 
@@ -97,6 +97,7 @@ async def test_known_kwargs_pass_through(acl_manifest: pathlib.Path) -> None:
     super_mock.assert_awaited_once_with(
         "unifi_create_acl_rule",
         {"name": "rule", "action": "REJECT", "enabled": True},
+        context=None,
     )
 
 
@@ -106,7 +107,7 @@ async def test_empty_kwargs_pass_through(acl_manifest: pathlib.Path) -> None:
     with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=sentinel)) as super_mock:
         result = await server.call_tool("unifi_list_devices", {})
     assert result is sentinel
-    super_mock.assert_awaited_once_with("unifi_list_devices", {})
+    super_mock.assert_awaited_once_with("unifi_list_devices", {}, context=None)
 
 
 async def test_no_args_tool_pass_through(acl_manifest: pathlib.Path) -> None:
@@ -116,7 +117,7 @@ async def test_no_args_tool_pass_through(acl_manifest: pathlib.Path) -> None:
     with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=sentinel)) as super_mock:
         result = await server.call_tool("unifi_no_args_tool", {})
     assert result is sentinel
-    super_mock.assert_awaited_once_with("unifi_no_args_tool", {})
+    super_mock.assert_awaited_once_with("unifi_no_args_tool", {}, context=None)
 
 
 async def test_no_args_tool_rejects_unknown_kwargs(acl_manifest: pathlib.Path) -> None:
@@ -136,7 +137,7 @@ async def test_dict_param_doesnt_recurse(acl_manifest: pathlib.Path) -> None:
     with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=sentinel)) as super_mock:
         result = await server.call_tool("unifi_update_policy", args)
     assert result is sentinel
-    super_mock.assert_awaited_once_with("unifi_update_policy", args)
+    super_mock.assert_awaited_once_with("unifi_update_policy", args, context=None)
 
 
 async def test_unknown_tool_delegates_to_super(acl_manifest: pathlib.Path) -> None:
@@ -146,7 +147,7 @@ async def test_unknown_tool_delegates_to_super(acl_manifest: pathlib.Path) -> No
     with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=sentinel)) as super_mock:
         result = await server.call_tool("unifi_not_in_manifest", {"anything": 1})
     assert result is sentinel
-    super_mock.assert_awaited_once_with("unifi_not_in_manifest", {"anything": 1})
+    super_mock.assert_awaited_once_with("unifi_not_in_manifest", {"anything": 1}, context=None)
 
 
 async def test_missing_required_not_double_reported(acl_manifest: pathlib.Path) -> None:
@@ -157,7 +158,7 @@ async def test_missing_required_not_double_reported(acl_manifest: pathlib.Path) 
     with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=sentinel)) as super_mock:
         result = await server.call_tool("unifi_create_acl_rule", {"name": "rule"})
     assert result is sentinel
-    super_mock.assert_awaited_once_with("unifi_create_acl_rule", {"name": "rule"})
+    super_mock.assert_awaited_once_with("unifi_create_acl_rule", {"name": "rule"}, context=None)
 
 
 # -----------------------------
@@ -199,7 +200,7 @@ async def test_marker_guard_allows_non_sensitive_field_equal_to_marker(acl_manif
     with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=sentinel)) as super_mock:
         result = await server.call_tool("unifi_create_acl_rule", args)
     assert result is sentinel
-    super_mock.assert_awaited_once_with("unifi_create_acl_rule", args)
+    super_mock.assert_awaited_once_with("unifi_create_acl_rule", args, context=None)
 
 
 async def test_marker_guard_runs_for_unknown_tools(tmp_path: pathlib.Path) -> None:

--- a/packages/unifi-mcp-shared/tests/test_tasks.py
+++ b/packages/unifi-mcp-shared/tests/test_tasks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 from mcp.types import CreateTaskResult, Task
 from unifi_mcp_shared.tasks import (
     DEFAULT_TASK_POLL_INTERVAL_MS,
@@ -29,13 +27,13 @@ def test_task_from_running_job_status():
     )
 
     assert isinstance(task, Task)
-    assert task.taskId == "job-123"
+    assert task.task_id == "job-123"
     assert task.status == "working"
-    assert task.statusMessage == "Operation is in progress."
-    assert task.createdAt == datetime.fromtimestamp(1_700_000_000, tz=timezone.utc)
-    assert task.lastUpdatedAt == task.createdAt
+    assert task.status_message == "Operation is in progress."
+    assert task.created_at == "2023-11-14T22:13:20Z"
+    assert task.last_updated_at == task.created_at
     assert task.ttl == DEFAULT_TASK_TTL_MS
-    assert task.pollInterval == DEFAULT_TASK_POLL_INTERVAL_MS
+    assert task.poll_interval == DEFAULT_TASK_POLL_INTERVAL_MS
 
 
 def test_task_from_completed_job_status_uses_completion_timestamp():
@@ -53,11 +51,11 @@ def test_task_from_completed_job_status_uses_completion_timestamp():
     )
 
     assert task.status == "completed"
-    assert task.statusMessage == "Operation completed."
-    assert task.createdAt == datetime.fromtimestamp(1_700_000_000, tz=timezone.utc)
-    assert task.lastUpdatedAt == datetime.fromtimestamp(1_700_000_030, tz=timezone.utc)
+    assert task.status_message == "Operation completed."
+    assert task.created_at == "2023-11-14T22:13:20Z"
+    assert task.last_updated_at == "2023-11-14T22:13:50Z"
     assert task.ttl is None
-    assert task.pollInterval is None
+    assert task.poll_interval is None
 
 
 def test_task_from_failed_job_status_uses_error_message():
@@ -73,14 +71,14 @@ def test_task_from_failed_job_status_uses_error_message():
     )
 
     assert task.status == "failed"
-    assert task.statusMessage == "Controller rejected request"
+    assert task.status_message == "Controller rejected request"
 
 
 def test_unknown_job_status_maps_to_failed_task():
     task = task_from_job_status("missing", {"status": "unknown"})
 
     assert task.status == "failed"
-    assert task.statusMessage == "Operation failed."
+    assert task.status_message == "Operation failed."
 
 
 def test_task_to_dict_uses_protocol_field_names():
@@ -116,7 +114,7 @@ def test_create_task_result_from_job_validates_against_sdk_model():
     )
 
     parsed = CreateTaskResult.model_validate(payload)
-    assert parsed.task.taskId == "job-123"
+    assert parsed.task.task_id == "job-123"
     assert parsed.task.status == "working"
     assert payload["_meta"] == {MCP_MODEL_IMMEDIATE_RESPONSE_META: "Started operation. Poll tasks/get for status."}
 

--- a/packages/unifi-mcp-shared/tests/test_transport.py
+++ b/packages/unifi-mcp-shared/tests/test_transport.py
@@ -2,10 +2,28 @@
 
 import asyncio
 import logging
+import socket
+from contextlib import suppress
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import uvicorn
+from mcp.client import Client
+from mcp.client.sse import sse_client
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ToolAnnotations
+from pydantic import BaseModel
+from unifi_mcp_shared.server import UniFiMCPServer
 from unifi_mcp_shared.transport import resolve_http_config, run_transports
+
+
+class SSEEchoData(BaseModel):
+    value: str
+
+
+class SSEEchoResult(BaseModel):
+    success: bool
+    data: SSEEchoData
 
 
 class TestResolveHttpConfig:
@@ -194,3 +212,78 @@ class TestRunTransports:
 
         assert http_started.is_set(), "HTTP transport never started"
         assert http_was_cancelled, "HTTP transport was not cancelled when stdio exited"
+
+
+@pytest.mark.asyncio
+async def test_real_sdk_v2_sse_transport_completes_handshake() -> None:
+    """Exercise the production SSE branch against the SDK's real client."""
+    server = UniFiMCPServer(
+        "sse-transport-test",
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    )
+
+    @server.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+        structured_output=True,
+    )
+    async def sse_echo(value: str) -> SSEEchoResult:
+        return SSEEchoResult(success=True, data=SSEEchoData(value=value))
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    real_uvicorn_server = uvicorn.Server
+    http_server: uvicorn.Server | None = None
+
+    def capture_uvicorn_server(config: uvicorn.Config) -> uvicorn.Server:
+        nonlocal http_server
+        http_server = real_uvicorn_server(config)
+        return http_server
+
+    with (
+        patch("unifi_mcp_shared.transport.os.getpid", return_value=1),
+        patch("uvicorn.Server", side_effect=capture_uvicorn_server),
+    ):
+        transport_task = asyncio.create_task(
+            run_transports(
+                server=server,
+                http_enabled=True,
+                host="127.0.0.1",
+                port=port,
+                http_transport="sse",
+                logger=logging.getLogger("test"),
+            )
+        )
+        try:
+            for _ in range(100):
+                try:
+                    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+                except OSError:
+                    await asyncio.sleep(0.01)
+                    continue
+                writer.close()
+                await writer.wait_closed()
+                del reader
+                break
+            else:
+                raise RuntimeError("SDK v2 SSE test server did not start")
+
+            async with Client(sse_client(f"http://127.0.0.1:{port}/sse")) as client:
+                assert client.protocol_version == "2026-07-28"
+                listed = await client.list_tools()
+                assert [tool.name for tool in listed.tools] == ["sse_echo"]
+                result = await client.call_tool("sse_echo", {"value": "ready"})
+                assert result.structured_content == {
+                    "success": True,
+                    "data": {"value": "ready"},
+                }
+        finally:
+            if http_server is not None:
+                http_server.should_exit = True
+            try:
+                await asyncio.wait_for(transport_task, timeout=3.0)
+            except TimeoutError:
+                transport_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await transport_task

--- a/packages/unifi-mcp-shared/tests/test_transport.py
+++ b/packages/unifi-mcp-shared/tests/test_transport.py
@@ -167,7 +167,7 @@ class TestRunTransports:
         http_started = asyncio.Event()
         http_was_cancelled = False
 
-        async def long_running_http():
+        async def long_running_http(**_kwargs):
             nonlocal http_was_cancelled
             http_started.set()
             try:

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -26,10 +26,9 @@ How this script catches it
 1. Build a workspace wheel for every upstream and downstream package.
 2. For each downstream wheel, create a clean venv with no workspace context.
 3. ``pip install`` the downstream wheel with ``--find-links`` pointing at the
-   workspace upstream wheels and ``--index-url`` set to PyPI. This is the exact
-   resolution path a user hits, except that workspace upstream wheels are
-   available as an additional source so coordinated upstream-downstream PRs do
-   not falsely fail.
+   workspace upstream wheels and ``--index-url`` set to PyPI. Only upstreams
+   being released by the change are explicit install targets; other dependencies
+   must resolve to published versions allowed by the downstream metadata.
 4. Assert every built wheel explicitly declares the advisory-safe floors for
    vulnerable transitives exposed at its published install boundary.
 5. Preinstall the prior vulnerable workspace resolutions before every wheel,
@@ -356,6 +355,12 @@ def wheel_dependency_names(wheel: Path) -> set[str]:
         except InvalidRequirement:
             continue
     return names
+
+
+def release_candidate_wheels(upstream_wheels: dict[str, Path]) -> tuple[Path, ...]:
+    """Return only upstream wheels intentionally published by this release train."""
+    shared_wheel = upstream_wheels.get("unifi-mcp-shared")
+    return () if shared_wheel is None else (shared_wheel,)
 
 
 def _requirement_enforces_floor(requirement: Requirement, floor: str, allowed_marker: str | None) -> bool:
@@ -690,6 +695,7 @@ def main() -> int:
 
         print()
         print("Checking each downstream wheel over a vulnerable baseline against PyPI")
+        candidate_wheels = release_candidate_wheels(upstream_wheels)
         for pkg in DOWNSTREAM_PACKAGES:
             wheel = build_wheel(pkg.src, tmp_path / "downstream" / pkg.dist_name)
             downstream_wheels[pkg.dist_name] = wheel
@@ -704,7 +710,7 @@ def main() -> int:
                 wheel,
                 find_links,
                 venv_dir,
-                tuple(upstream_wheels.values()),
+                candidate_wheels,
             )
             status = "PASS" if ok else "FAIL"
             print(f"  [{status}] {pkg.dist_name} ({wheel.name}) — {metadata_msg}")

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -49,6 +49,7 @@ stdout and is intended to be read directly from the CI log.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -292,13 +293,42 @@ def run_capture(args: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, check=True, capture_output=True, text=True, **kwargs)
 
 
-def build_wheel(src: Path, out_dir: Path) -> Path:
+def build_wheel(src: Path, out_dir: Path, *, pretend_version: str | None = None) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
-    run_capture(["uv", "build", "--wheel", str(src), "--out-dir", str(out_dir)])
+    env = os.environ.copy()
+    if pretend_version is not None:
+        env["SETUPTOOLS_SCM_PRETEND_VERSION"] = pretend_version
+    run_capture(
+        ["uv", "build", "--wheel", str(src), "--out-dir", str(out_dir)],
+        env=env,
+    )
     wheels = sorted(out_dir.glob("*.whl"), key=lambda p: p.stat().st_mtime)
     if not wheels:
         raise RuntimeError(f"uv build produced no wheel for {src}")
     return wheels[-1]
+
+
+def wheel_version(wheel: Path) -> Version:
+    """Read a wheel's distribution version from its metadata."""
+    with zipfile.ZipFile(wheel) as archive:
+        metadata_name = next(name for name in archive.namelist() if name.endswith(".dist-info/METADATA"))
+        metadata = archive.read(metadata_name).decode()
+    raw_version = next(
+        line.split(":", 1)[1].strip() for line in metadata.splitlines() if line.lower().startswith("version:")
+    )
+    return Version(raw_version)
+
+
+def build_release_candidate_wheel(src: Path, out_dir: Path) -> Path:
+    """Build branch code with the exact next stable version it will publish as."""
+    development_wheel = build_wheel(src, out_dir)
+    development_version = wheel_version(development_wheel)
+    if not development_version.is_prerelease and not development_version.is_devrelease:
+        return development_wheel
+
+    candidate_version = development_version.base_version
+    development_wheel.unlink()
+    return build_wheel(src, out_dir, pretend_version=candidate_version)
 
 
 def _normalize_distribution_name(name: str) -> str:
@@ -315,6 +345,17 @@ def wheel_requirements(wheel: Path) -> list[str]:
         metadata = archive.read(metadata_name).decode()
     prefix = "requires-dist:"
     return [line.split(":", 1)[1].strip() for line in metadata.splitlines() if line.lower().startswith(prefix)]
+
+
+def wheel_dependency_names(wheel: Path) -> set[str]:
+    """Return normalized direct dependency names declared by a wheel."""
+    names: set[str] = set()
+    for raw_requirement in wheel_requirements(wheel):
+        try:
+            names.add(_normalize_distribution_name(Requirement(raw_requirement).name))
+        except InvalidRequirement:
+            continue
+    return names
 
 
 def _requirement_enforces_floor(requirement: Requirement, floor: str, allowed_marker: str | None) -> bool:
@@ -436,6 +477,7 @@ def check_downstream(
     venv_dir: Path,
     upstream_wheels: tuple[Path, ...],
 ) -> tuple[bool, str]:
+    declared_dependencies = wheel_dependency_names(downstream_wheel)
     upgrade_ok, upgrade_message, py = install_security_upgrade(
         pkg.dist_name,
         str(downstream_wheel),
@@ -446,7 +488,11 @@ def check_downstream(
         # exposing prerelease wheels through --find-links lets pip prefer the
         # latest stable PyPI release, which falsely rejects coordinated
         # upstream/downstream dependency migrations.
-        additional_targets=tuple(str(wheel) for wheel in upstream_wheels),
+        additional_targets=tuple(
+            str(wheel)
+            for wheel in upstream_wheels
+            if _normalize_distribution_name(wheel.stem.split("-")[0]) in declared_dependencies
+        ),
     )
     if not upgrade_ok:
         return False, upgrade_message
@@ -547,12 +593,7 @@ def check_core_floor_contract(
     return True, f"Core floor {floor}: {(result.stdout or '').strip()}"
 
 
-def check_api_core_floor(
-    api_wheel: Path,
-    venv_dir: Path,
-    *,
-    shared_wheel: Path | None = None,
-) -> tuple[bool, str]:
+def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
     """Install and contract-check the API against exactly its published Core floor."""
     return check_core_floor_contract(
         api_wheel,
@@ -560,7 +601,6 @@ def check_api_core_floor(
         package_label="API",
         core_extras="network,protect,access",
         contract=_API_CATALOG_FLOOR_CONTRACT,
-        additional_targets=(() if shared_wheel is None else (str(shared_wheel),)),
     )
 
 
@@ -620,7 +660,11 @@ def main() -> int:
         downstream_wheels: dict[str, Path] = {}
         print("Building upstream wheels (workspace) -> --find-links source")
         for name, path in UPSTREAM_PACKAGES.items():
-            wheel = build_wheel(path, find_links)
+            wheel = (
+                build_release_candidate_wheel(path, find_links)
+                if name == "unifi-mcp-shared"
+                else build_wheel(path, find_links)
+            )
             upstream_wheels[name] = wheel
             metadata_ok, metadata_msg = check_security_floors(name, wheel)
             print(f"  [{'PASS' if metadata_ok else 'FAIL'}] {name}: {wheel.name} — {metadata_msg}")
@@ -718,11 +762,7 @@ def main() -> int:
             return 1
 
         api_wheel = downstream_wheels["unifi-api-server"]
-        floor_ok, floor_message = check_api_core_floor(
-            api_wheel,
-            tmp_path / "api-floor-venv",
-            shared_wheel=upstream_wheels["unifi-mcp-shared"],
-        )
+        floor_ok, floor_message = check_api_core_floor(api_wheel, tmp_path / "api-floor-venv")
         print()
         print(f"  [{'PASS' if floor_ok else 'FAIL'}] API catalog against published Core floor")
         print(f"  {floor_message}")

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -368,6 +368,8 @@ def install_security_upgrade(
     install_target: str,
     find_links: Path,
     venv_dir: Path,
+    *,
+    additional_targets: tuple[str, ...] = (),
 ) -> tuple[bool, str, Path]:
     venv.create(venv_dir, with_pip=True, clear=True, symlinks=True)
     py = venv_dir / "bin" / "python"
@@ -399,6 +401,7 @@ def install_security_upgrade(
                 "--index-url",
                 "https://pypi.org/simple",
                 install_target,
+                *additional_targets,
             ]
         )
     except subprocess.CalledProcessError as exc:
@@ -426,12 +429,24 @@ def install_security_upgrade(
     return True, "vulnerable baseline upgraded to advisory-safe versions", py
 
 
-def check_downstream(pkg: Downstream, downstream_wheel: Path, find_links: Path, venv_dir: Path) -> tuple[bool, str]:
+def check_downstream(
+    pkg: Downstream,
+    downstream_wheel: Path,
+    find_links: Path,
+    venv_dir: Path,
+    upstream_wheels: tuple[Path, ...],
+) -> tuple[bool, str]:
     upgrade_ok, upgrade_message, py = install_security_upgrade(
         pkg.dist_name,
         str(downstream_wheel),
         find_links,
         venv_dir,
+        # Passing the branch-built upstream wheels as explicit install targets
+        # makes pip validate them against the downstream metadata. Merely
+        # exposing prerelease wheels through --find-links lets pip prefer the
+        # latest stable PyPI release, which falsely rejects coordinated
+        # upstream/downstream dependency migrations.
+        additional_targets=tuple(str(wheel) for wheel in upstream_wheels),
     )
     if not upgrade_ok:
         return False, upgrade_message
@@ -499,6 +514,7 @@ def check_core_floor_contract(
     package_label: str,
     core_extras: str,
     contract: str,
+    additional_targets: tuple[str, ...] = (),
 ) -> tuple[bool, str]:
     """Install and contract-check a wheel against exactly its published Core floor."""
     floor = core_floor_from_wheel(wheel, package_label)
@@ -517,6 +533,7 @@ def check_core_floor_contract(
                 "https://pypi.org/simple",
                 f"unifi-core[{core_extras}]=={floor}",
                 str(wheel),
+                *additional_targets,
             ]
         )
         run_capture([str(py), "-m", "pip", "check"])
@@ -530,7 +547,12 @@ def check_core_floor_contract(
     return True, f"Core floor {floor}: {(result.stdout or '').strip()}"
 
 
-def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
+def check_api_core_floor(
+    api_wheel: Path,
+    venv_dir: Path,
+    *,
+    shared_wheel: Path | None = None,
+) -> tuple[bool, str]:
     """Install and contract-check the API against exactly its published Core floor."""
     return check_core_floor_contract(
         api_wheel,
@@ -538,10 +560,16 @@ def check_api_core_floor(api_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
         package_label="API",
         core_extras="network,protect,access",
         contract=_API_CATALOG_FLOOR_CONTRACT,
+        additional_targets=(() if shared_wheel is None else (str(shared_wheel),)),
     )
 
 
-def check_network_core_floor(network_wheel: Path, venv_dir: Path) -> tuple[bool, str]:
+def check_network_core_floor(
+    network_wheel: Path,
+    venv_dir: Path,
+    *,
+    shared_wheel: Path | None = None,
+) -> tuple[bool, str]:
     """Install and contract-check Network against exactly its published Core floor."""
     return check_core_floor_contract(
         network_wheel,
@@ -549,6 +577,7 @@ def check_network_core_floor(network_wheel: Path, venv_dir: Path) -> tuple[bool,
         package_label="Network",
         core_extras="network",
         contract=_NETWORK_CORE_FLOOR_CONTRACT,
+        additional_targets=(() if shared_wheel is None else (str(shared_wheel),)),
     )
 
 
@@ -626,7 +655,13 @@ def main() -> int:
                 failures.append((pkg.dist_name, metadata_msg))
                 continue
             venv_dir = tmp_path / "venvs" / pkg.dist_name
-            ok, msg = check_downstream(pkg, wheel, find_links, venv_dir)
+            ok, msg = check_downstream(
+                pkg,
+                wheel,
+                find_links,
+                venv_dir,
+                tuple(upstream_wheels.values()),
+            )
             status = "PASS" if ok else "FAIL"
             print(f"  [{status}] {pkg.dist_name} ({wheel.name}) — {metadata_msg}")
             if not ok:
@@ -672,7 +707,9 @@ def main() -> int:
 
         network_wheel = downstream_wheels["unifi-network-mcp"]
         network_floor_ok, network_floor_message = check_network_core_floor(
-            network_wheel, tmp_path / "network-floor-venv"
+            network_wheel,
+            tmp_path / "network-floor-venv",
+            shared_wheel=upstream_wheels["unifi-mcp-shared"],
         )
         print()
         print(f"  [{'PASS' if network_floor_ok else 'FAIL'}] Network tools against published Core floor")
@@ -681,7 +718,11 @@ def main() -> int:
             return 1
 
         api_wheel = downstream_wheels["unifi-api-server"]
-        floor_ok, floor_message = check_api_core_floor(api_wheel, tmp_path / "api-floor-venv")
+        floor_ok, floor_message = check_api_core_floor(
+            api_wheel,
+            tmp_path / "api-floor-venv",
+            shared_wheel=upstream_wheels["unifi-mcp-shared"],
+        )
         print()
         print(f"  [{'PASS' if floor_ok else 'FAIL'}] API catalog against published Core floor")
         print(f"  {floor_message}")

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -164,7 +164,7 @@ def measure_tool_result_sizes(raw: Any) -> dict[str, int]:
     """Measure content and structured result sizes without altering the result."""
     if isinstance(raw, CallToolResult):
         content = raw.content
-        structured = raw.structuredContent
+        structured = raw.structured_content
     elif isinstance(raw, tuple) and len(raw) == 2:
         content, structured = raw
     else:
@@ -567,9 +567,9 @@ class LiveSmokeRunner:
 
     def unwrap_result(self, raw: Any) -> dict[str, Any]:
         if isinstance(raw, CallToolResult):
-            if isinstance(raw.structuredContent, dict):
-                meta_result = raw.structuredContent.get("result")
-                return meta_result if isinstance(meta_result, dict) else raw.structuredContent
+            if isinstance(raw.structured_content, dict):
+                meta_result = raw.structured_content.get("result")
+                return meta_result if isinstance(meta_result, dict) else raw.structured_content
             content = raw.content
         else:
             content = raw[0] if isinstance(raw, tuple) and raw else raw

--- a/scripts/smoke_mcp_metadata.py
+++ b/scripts/smoke_mcp_metadata.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Smoke test MCP standard surfaces over the real stdio transport.
 
-This validates the MCP protocol surface without invoking controller operations:
-``initialize`` and ``tools/list`` plus the read-only tool-index and lazy-loader
-meta-tools across the supported registration modes.
+This validates both current Discover negotiation and the legacy Initialize
+handshake without invoking controller operations: ``tools/list`` plus the
+read-only tool-index and lazy-loader meta-tools across the supported
+registration modes.
 """
 
 from __future__ import annotations
@@ -17,13 +18,15 @@ from pathlib import Path
 from typing import Any
 
 import anyio
-from mcp.client.session import ClientSession
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client import Client
+from mcp.client.stdio import StdioServerParameters
+from mcp.types import LATEST_PROTOCOL_VERSION
 from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL
 from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REGISTRATION_MODES = ("lazy", "eager", "meta_only")
+CLIENT_MODES = ("auto", "legacy")
 
 
 class MetadataSmokeError(AssertionError):
@@ -78,7 +81,12 @@ OFFLINE_SERVER_NAMES = ("network", "protect")
 def _field(obj: Any, name: str) -> Any:
     if isinstance(obj, dict):
         return obj.get(name)
-    return getattr(obj, name, None)
+    value = getattr(obj, name, None)
+    if value is not None:
+        return value
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(by_alias=True).get(name)
+    return None
 
 
 def _tool_by_name(tools: list[Any]) -> dict[str, Any]:
@@ -110,21 +118,21 @@ def validate_icons(icons: list[Any] | None, *, label: str) -> None:
             raise MetadataSmokeError(f"{label}: icon src is not PNG data")
 
 
-def validate_initialize_result(spec: ServerSpec, init: Any) -> None:
-    """Validate initialize negotiation and server metadata."""
-    protocol_version = _field(init, "protocolVersion")
-    if protocol_version != DEFAULT_MCP_PROTOCOL_REVISION:
+def validate_connection(spec: ServerSpec, client: Client, *, client_mode: str) -> None:
+    """Validate negotiated protocol and server metadata for either handshake."""
+    expected_protocol = LATEST_PROTOCOL_VERSION if client_mode == "auto" else DEFAULT_MCP_PROTOCOL_REVISION
+    protocol_version = client.protocol_version
+    if protocol_version != expected_protocol:
         raise MetadataSmokeError(
-            f"{spec.expected_name}: expected protocolVersion {DEFAULT_MCP_PROTOCOL_REVISION!r}, "
-            f"got {protocol_version!r}"
+            f"{spec.expected_name}: expected protocolVersion {expected_protocol!r}, got {protocol_version!r}"
         )
 
-    capabilities = _field(init, "capabilities")
+    capabilities = client.server_capabilities
     tools_capability = _field(capabilities, "tools")
     if tools_capability is None:
-        raise MetadataSmokeError(f"{spec.expected_name}: initialize result did not advertise tools capability")
+        raise MetadataSmokeError(f"{spec.expected_name}: server did not advertise tools capability")
 
-    validate_server_metadata(spec, init.serverInfo)
+    validate_server_metadata(spec, client.server_info)
 
 
 def validate_server_metadata(spec: ServerSpec, server_info: Any) -> None:
@@ -339,7 +347,13 @@ def selected_server_names(*, server: str, use_current_env: bool) -> list[str]:
     return list(OFFLINE_SERVER_NAMES)
 
 
-async def smoke_server(spec: ServerSpec, *, registration_mode: str, use_current_env: bool = False) -> str:
+async def smoke_server(
+    spec: ServerSpec,
+    *,
+    registration_mode: str,
+    client_mode: str,
+    use_current_env: bool = False,
+) -> str:
     """Run the stdio MCP smoke for one server and return a one-line summary."""
     env = smoke_env(registration_mode=registration_mode, use_current_env=use_current_env)
 
@@ -350,61 +364,61 @@ async def smoke_server(spec: ServerSpec, *, registration_mode: str, use_current_
         env=env,
     )
 
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            init = await session.initialize()
-            validate_initialize_result(spec, init)
+    async with Client(params, mode=client_mode) as client:
+        validate_connection(spec, client, client_mode=client_mode)
 
-            tools_result = await session.list_tools()
-            validate_meta_tool_surface(spec, tools_result.tools)
-            validate_mode_tools(spec, tools_result.tools, registration_mode=registration_mode)
+        tools_result = await client.list_tools()
+        validate_meta_tool_surface(spec, tools_result.tools)
+        validate_mode_tools(spec, tools_result.tools, registration_mode=registration_mode)
 
-            index_result = await session.call_tool(spec.index_tool, {"include_schemas": True})
-            index_payload = parse_meta_tool_result(
-                index_result,
-                label=f"{spec.expected_name}:{spec.index_tool}",
-            )
-            validate_index_catalog(spec, index_payload, registration_mode=registration_mode)
+        index_result = await client.call_tool(spec.index_tool, {"include_schemas": True})
+        index_payload = parse_meta_tool_result(
+            index_result,
+            label=f"{spec.expected_name}:{spec.index_tool}",
+        )
+        validate_index_catalog(spec, index_payload, registration_mode=registration_mode)
 
-            if registration_mode == "lazy":
-                load_tool_name = f"{spec.prefix}_load_tools"
-                load_result = await session.call_tool(load_tool_name, {"tools": [spec.representative_tool]})
-                if _field(load_result, "isError"):
-                    raise MetadataSmokeError(
-                        f"{spec.expected_name}: failed to warm lazy catalog with {spec.representative_tool}"
-                    )
-                warmed_tools = await session.list_tools()
-                warmed_by_name = _tool_by_name(warmed_tools.tools)
-                representative = warmed_by_name.get(spec.representative_tool)
-                if representative is None:
-                    raise MetadataSmokeError(
-                        f"{spec.expected_name}: warmed lazy tools/list missing {spec.representative_tool}"
-                    )
-                annotations = _field(representative, "annotations")
-                if _field(annotations, "openWorldHint") is not False:
-                    raise MetadataSmokeError(
-                        f"{spec.expected_name}: warmed {spec.representative_tool} missing closed-world annotation"
-                    )
-                warmed_index_result = await session.call_tool(spec.index_tool, {"include_schemas": True})
-                warmed_index_payload = parse_meta_tool_result(
-                    warmed_index_result,
-                    label=f"{spec.expected_name}:{spec.index_tool}:warmed",
+        if registration_mode == "lazy":
+            load_tool_name = f"{spec.prefix}_load_tools"
+            load_result = await client.call_tool(load_tool_name, {"tools": [spec.representative_tool]})
+            if _field(load_result, "isError"):
+                raise MetadataSmokeError(
+                    f"{spec.expected_name}: failed to warm lazy catalog with {spec.representative_tool}"
                 )
-                validate_index_catalog(spec, warmed_index_payload, registration_mode=registration_mode)
-                if warmed_index_payload.get("count") != index_payload.get("count"):
-                    raise MetadataSmokeError(
-                        f"{spec.expected_name}: warmed lazy index changed catalog size "
-                        f"from {index_payload.get('count')} to {warmed_index_payload.get('count')}"
-                    )
-
-            return (
-                f"{spec.expected_name} "
-                f"mode={registration_mode} "
-                f"{init.serverInfo.version} "
-                f"{spec.expected_index_title} "
-                f"tools={len(tools_result.tools)} "
-                f"icons={len(init.serverInfo.icons or [])}"
+            warmed_tools = await client.list_tools(cache_mode="refresh")
+            warmed_by_name = _tool_by_name(warmed_tools.tools)
+            representative = warmed_by_name.get(spec.representative_tool)
+            if representative is None:
+                raise MetadataSmokeError(
+                    f"{spec.expected_name}: warmed lazy tools/list missing {spec.representative_tool}"
+                )
+            annotations = _field(representative, "annotations")
+            if _field(annotations, "openWorldHint") is not False:
+                raise MetadataSmokeError(
+                    f"{spec.expected_name}: warmed {spec.representative_tool} missing closed-world annotation"
+                )
+            warmed_index_result = await client.call_tool(spec.index_tool, {"include_schemas": True})
+            warmed_index_payload = parse_meta_tool_result(
+                warmed_index_result,
+                label=f"{spec.expected_name}:{spec.index_tool}:warmed",
             )
+            validate_index_catalog(spec, warmed_index_payload, registration_mode=registration_mode)
+            if warmed_index_payload.get("count") != index_payload.get("count"):
+                raise MetadataSmokeError(
+                    f"{spec.expected_name}: warmed lazy index changed catalog size "
+                    f"from {index_payload.get('count')} to {warmed_index_payload.get('count')}"
+                )
+
+        return (
+            f"{spec.expected_name} "
+            f"client={client_mode} "
+            f"protocol={client.protocol_version} "
+            f"mode={registration_mode} "
+            f"{client.server_info.version} "
+            f"{spec.expected_index_title} "
+            f"tools={len(tools_result.tools)} "
+            f"icons={len(client.server_info.icons or [])}"
+        )
 
 
 def parse_args() -> argparse.Namespace:
@@ -429,6 +443,12 @@ def parse_args() -> argparse.Namespace:
         default="lazy",
         help="Registration mode to smoke test. Use 'all' to cover lazy, eager, and meta_only.",
     )
+    parser.add_argument(
+        "--client-mode",
+        choices=[*CLIENT_MODES, "all"],
+        default="all",
+        help="Handshake mode to smoke test. Defaults to current auto negotiation and legacy Initialize.",
+    )
     return parser.parse_args()
 
 
@@ -436,15 +456,18 @@ async def main_async() -> None:
     args = parse_args()
     server_names = selected_server_names(server=args.server, use_current_env=args.use_current_env)
     registration_modes = list(REGISTRATION_MODES) if args.registration_mode == "all" else [args.registration_mode]
+    client_modes = list(CLIENT_MODES) if args.client_mode == "all" else [args.client_mode]
     for server_name in server_names:
         for registration_mode in registration_modes:
-            print(
-                await smoke_server(
-                    SERVER_SPECS[server_name],
-                    registration_mode=registration_mode,
-                    use_current_env=args.use_current_env,
+            for client_mode in client_modes:
+                print(
+                    await smoke_server(
+                        SERVER_SPECS[server_name],
+                        registration_mode=registration_mode,
+                        client_mode=client_mode,
+                        use_current_env=args.use_current_env,
+                    )
                 )
-            )
 
 
 def main() -> None:

--- a/tests/test_check_pin_alignment.py
+++ b/tests/test_check_pin_alignment.py
@@ -222,6 +222,19 @@ def test_dependency_names_are_read_from_wheel_metadata(tmp_path: Path) -> None:
     }
 
 
+def test_release_candidate_wheels_exclude_unpublished_core(tmp_path: Path) -> None:
+    module = _module()
+    shared = tmp_path / "unifi_mcp_shared-0.6.10-py3-none-any.whl"
+    core = tmp_path / "unifi_core-0.4.38.dev1-py3-none-any.whl"
+
+    assert module.release_candidate_wheels(
+        {
+            "unifi-mcp-shared": shared,
+            "unifi-core": core,
+        }
+    ) == (shared,)
+
+
 def test_core_floor_contract_installs_branch_shared_wheel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     module = _module()
     commands: list[list[str]] = []

--- a/tests/test_check_pin_alignment.py
+++ b/tests/test_check_pin_alignment.py
@@ -20,9 +20,14 @@ def _module():
     return module
 
 
-def _wheel_with_requirements(tmp_path: Path, requirements: list[str]) -> Path:
+def _wheel_with_requirements(
+    tmp_path: Path,
+    requirements: list[str],
+    *,
+    version: str = "1.0.0",
+) -> Path:
     wheel = tmp_path / "unifi_api_server-1.0.0-py3-none-any.whl"
-    lines = ["Metadata-Version: 2.4", "Name: unifi-api-server", "Version: 1.0.0"]
+    lines = ["Metadata-Version: 2.4", "Name: unifi-api-server", f"Version: {version}"]
     lines.extend(f"Requires-Dist: {requirement}" for requirement in requirements)
     with zipfile.ZipFile(wheel, "w") as archive:
         archive.writestr("unifi_api_server-1.0.0.dist-info/METADATA", "\n".join(lines) + "\n")
@@ -179,6 +184,42 @@ def test_security_upgrade_installs_additional_workspace_targets(
         "/tmp/shared.whl",
         "/tmp/core.whl",
     ]
+
+
+def test_release_candidate_wheel_rebuilds_dev_version_as_stable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = _module()
+    development = _wheel_with_requirements(tmp_path, [], version="0.6.10.dev5+gabc123")
+    stable = tmp_path / "unifi_mcp_shared-0.6.10-py3-none-any.whl"
+    calls: list[str | None] = []
+
+    def fake_build_wheel(src: Path, out_dir: Path, *, pretend_version: str | None = None) -> Path:
+        calls.append(pretend_version)
+        if pretend_version is None:
+            return development
+        stable.touch()
+        return stable
+
+    monkeypatch.setattr(module, "build_wheel", fake_build_wheel)
+
+    result = module.build_release_candidate_wheel(tmp_path / "shared", tmp_path)
+
+    assert result == stable
+    assert calls == [None, "0.6.10"]
+
+
+def test_dependency_names_are_read_from_wheel_metadata(tmp_path: Path) -> None:
+    module = _module()
+    wheel = _wheel_with_requirements(
+        tmp_path,
+        ["unifi-mcp-shared>=0.6.10,<0.7", "unifi-core[network]>=0.4.37,<0.5"],
+    )
+
+    assert module.wheel_dependency_names(wheel) == {
+        "unifi-mcp-shared",
+        "unifi-core",
+    }
 
 
 def test_core_floor_contract_installs_branch_shared_wheel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_check_pin_alignment.py
+++ b/tests/test_check_pin_alignment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -142,3 +143,68 @@ def test_security_floor_check_rejects_prerelease_below_final_floor(tmp_path: Pat
 
     assert ok is False
     assert "cryptography>=50.0.0" in message
+
+
+def test_security_upgrade_installs_additional_workspace_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    module = _module()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(module.venv, "create", lambda *args, **kwargs: None)
+
+    def fake_run_capture(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if len(command) >= 2 and command[-2] == "-c" and "importlib.metadata" in command[-1]:
+            versions = "\n".join(
+                f"{name}={floor}" for name, floor in module.SECURITY_FLOORS["unifi-network-mcp"].items()
+            )
+            return subprocess.CompletedProcess(command, 0, stdout=versions, stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "run_capture", fake_run_capture)
+
+    ok, _, _ = module.install_security_upgrade(
+        "unifi-network-mcp",
+        "/tmp/network.whl",
+        tmp_path,
+        tmp_path / "venv",
+        additional_targets=("/tmp/shared.whl", "/tmp/core.whl"),
+    )
+
+    assert ok is True
+    install_command = commands[1]
+    assert install_command[-3:] == [
+        "/tmp/network.whl",
+        "/tmp/shared.whl",
+        "/tmp/core.whl",
+    ]
+
+
+def test_core_floor_contract_installs_branch_shared_wheel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    module = _module()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(module.venv, "create", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "core_floor_from_wheel", lambda *args: "0.4.37")
+
+    def fake_run_capture(command: list[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="contract passed", stderr="")
+
+    monkeypatch.setattr(module, "run_capture", fake_run_capture)
+
+    ok, _ = module.check_core_floor_contract(
+        tmp_path / "network.whl",
+        tmp_path / "venv",
+        package_label="Network",
+        core_extras="network",
+        contract="print('contract passed')",
+        additional_targets=("/tmp/shared.whl",),
+    )
+
+    assert ok is True
+    assert commands[0][-2:] == [
+        str(tmp_path / "network.whl"),
+        "/tmp/shared.whl",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -705,6 +705,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -749,21 +762,37 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -892,15 +921,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -910,15 +939,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -1022,6 +1064,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl", hash = "sha256:3d701d14e9a8828f1edd28bb70b725908b34277cdd72cf7d6a83f94dadc6b6a0", size = 79502, upload-time = "2026-06-11T05:05:09.954Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1682,6 +1736,15 @@ fastapi = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1787,7 +1850,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.1" },
     { name = "jsonschema", specifier = ">=4.17.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.1.1,<3" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -1961,7 +2024,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.1.1,<3" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -2009,7 +2072,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.1" },
     { name = "jsonschema", specifier = ">=4.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.1.1,<3" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -2063,7 +2126,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.1" },
     { name = "jsonschema", specifier = ">=4.17.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.1.1,<3" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -2123,7 +2186,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.1" },
     { name = "jsonschema", specifier = ">=4.17.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.1.1,<3" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },


### PR DESCRIPTION
## Summary

- upgrade the shared runtime, Network, Protect, Access, and Relay to `mcp[cli]>=2.1.1,<3`
- migrate server, context, transport, result, annotation, task, and metadata integration points to the SDK 2.x APIs
- negotiate the current 2026-07-28 Discover protocol and legacy 2025-11-25 Initialize protocol per connection from the same server process
- extend the protocol harness across both client modes and all lazy/eager/meta-only registration modes
- add real Relay interoperability coverage against an SDK 2.x Streamable HTTP server
- require `unifi-mcp-shared>=0.6.10,<0.7` from all MCP consumers and validate coordinated branch wheels at their intended stable release version

Supersedes #496. Merging this PR should allow Dependabot to close its dependency-only update automatically.

## Release order

Publish and verify `shared/v0.6.10` first. Then publish Network, Protect, Access, and Relay individually in dependency order. The downstream wheels deliberately require shared 0.6.10, so none can resolve against the pre-migration MCP 1.x shared runtime.

## Verification

- `make pre-commit`
- full live MCP inventory and read-only smoke for Network, Protect, and Access: 199 successful checks, 13 intentional skips, 0 failures
- safe live lifecycle smoke: 3 Network resources, 1 Protect alarm rule, and 1 Access visitor created and matched in cleanup; reversible Network settings restored; 0 failures
- live API action, REST resource-parity, and Network/Protect/Access SSE stream phases
- Compose build and startup for all three MCP servers plus Relay
- container HTTP negotiation in auto/current and legacy modes for all three servers, including `tools/list` and tool-index calls
- live Relay discovery of all 289 tools, Worker registration, and successful read-only forwarding to Network, Protect, and Access
- release-candidate wheel simulation for `unifi-mcp-shared==0.6.10` plus all downstream wheels, including security floors and fresh imports
- Compose stack removed after verification
