### PR TITLE
fix(core): guard event limit on identity, not truthiness

### DIFF
--- a/apps/access/tests/unit/test_events.py
+++ b/apps/access/tests/unit/test_events.py
@@ -71,6 +71,13 @@ class TestEventBufferExtended:
         assert events[0]["seq"] == 4
         assert events[-1]["seq"] == 2
 
+    def test_buffer_limit_zero_returns_empty(self):
+        """An explicit limit=0 means zero results, not unlimited."""
+        buf = EventBuffer(max_size=10, ttl_seconds=300)
+        for i in range(5):
+            buf.add({"type": "test", "seq": i})
+        assert buf.get_recent(limit=0) == []
+
     def test_buffer_ttl_expiration(self):
         """Buffer skips events older than TTL."""
         buf = EventBuffer(max_size=10, ttl_seconds=1)
@@ -203,6 +210,16 @@ class TestEventManagerREST:
         assert body["start"] == "2026-03-01"
         assert body["end"] == "2026-03-17"
         assert "page_size=10" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    async def test_list_events_limit_zero_requests_zero_page_size(self, event_mgr_proxy, cm_proxy):
+        """An explicit limit=0 asks the controller for zero events, not the 30 default."""
+        with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
+            mock_req.return_value = {"data": {"events": []}}
+            await event_mgr_proxy.list_events(limit=0)
+
+        call_args = mock_req.call_args
+        assert "page_size=0" in call_args[0][1]
 
     @pytest.mark.asyncio
     async def test_list_events_no_proxy(self, event_mgr_none):

--- a/apps/access/tests/unit/test_events.py
+++ b/apps/access/tests/unit/test_events.py
@@ -212,14 +212,14 @@ class TestEventManagerREST:
         assert "page_size=10" in call_args[0][1]
 
     @pytest.mark.asyncio
-    async def test_list_events_limit_zero_requests_zero_page_size(self, event_mgr_proxy, cm_proxy):
-        """An explicit limit=0 asks the controller for zero events, not the 30 default."""
+    async def test_list_events_limit_zero_returns_empty_without_calling_controller(self, event_mgr_proxy, cm_proxy):
+        """An explicit limit=0 means zero results locally; page_size=0 is not trustworthy
+        across controllers (the reference Access controller treats it as uncapped)."""
         with patch.object(cm_proxy, "proxy_request", new_callable=AsyncMock) as mock_req:
-            mock_req.return_value = {"data": {"events": []}}
-            await event_mgr_proxy.list_events(limit=0)
+            events = await event_mgr_proxy.list_events(limit=0)
 
-        call_args = mock_req.call_args
-        assert "page_size=0" in call_args[0][1]
+        assert events == []
+        mock_req.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_list_events_no_proxy(self, event_mgr_none):

--- a/apps/protect/tests/unit/test_event_buffer.py
+++ b/apps/protect/tests/unit/test_event_buffer.py
@@ -89,6 +89,13 @@ class TestEventBufferGetRecent:
         assert len(results) == 3
         assert results[0]["index"] == 9  # newest first
 
+    def test_limit_zero_returns_empty(self):
+        """An explicit limit=0 means zero results, not unlimited."""
+        buf = EventBuffer()
+        for i in range(10):
+            buf.add({"type": "motion", "index": i})
+        assert buf.get_recent(limit=0) == []
+
 
 # ---------------------------------------------------------------------------
 # get_recent - filters

--- a/packages/unifi-core/src/unifi_core/access/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/event_manager.py
@@ -71,6 +71,8 @@ class EventBuffer:
         cutoff = time.time() - self._ttl
         results: list[dict[str, Any]] = []
         for event in reversed(self._buffer):
+            if limit is not None and len(results) >= limit:
+                break
             if event.get("_buffered_at", 0) < cutoff:
                 continue
             if event_type and event.get("type") != event_type:
@@ -78,8 +80,6 @@ class EventBuffer:
             if door_id and event.get("door_id") != door_id:
                 continue
             results.append(event)
-            if limit and len(results) >= limit:
-                break
         return results
 
     def clear(self) -> None:
@@ -385,7 +385,7 @@ class EventManager:
             if user_id:
                 body["user_id"] = user_id
 
-            page_size = limit or 30
+            page_size = limit
             path = f"insights/system_log/search?page_size={page_size}&page_num=1&isAccess"
 
             data = await self._cm.proxy_request("POST", path, json=body)

--- a/packages/unifi-core/src/unifi_core/access/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/event_manager.py
@@ -373,6 +373,9 @@ class EventManager:
         if not self._cm.has_proxy:
             raise UniFiConnectionError("No proxy session available for list_events")
 
+        if limit == 0:
+            return []
+
         try:
             # The system_log/search endpoint requires a ``topic`` field.
             body: dict[str, Any] = {"topic": topic}

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -49,6 +49,8 @@ class EventBuffer:
         cutoff = time.time() - self._ttl
         out: list[dict[str, Any]] = []
         for event in reversed(self._buffer):
+            if limit is not None and len(out) >= limit:
+                break
             if event.get("_buffered_at", 0) < cutoff:
                 continue
             if event_type and event.get("key") != event_type:
@@ -56,8 +58,6 @@ class EventBuffer:
             if mac and not mac_equal(event.get("mac"), mac):
                 continue
             out.append(event)
-            if limit and len(out) >= limit:
-                break
         return out
 
     def clear(self) -> None:

--- a/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
@@ -126,6 +126,8 @@ class EventBuffer:
         cutoff = time.time() - self._ttl
         results: list[dict[str, Any]] = []
         for event in reversed(self._buffer):
+            if limit is not None and len(results) >= limit:
+                break
             if event.get("_buffered_at", 0) < cutoff:
                 continue
             if event_type and event.get("type") != event_type:
@@ -135,8 +137,6 @@ class EventBuffer:
             if min_confidence is not None and event.get("score", 100) < min_confidence:
                 continue
             results.append(event)
-            if limit and len(results) >= limit:
-                break
         return results
 
     def clear(self) -> None:

--- a/packages/unifi-core/tests/network/managers/test_event_manager_buffer.py
+++ b/packages/unifi-core/tests/network/managers/test_event_manager_buffer.py
@@ -48,6 +48,14 @@ def test_buffer_event_type_filter_requires_exact_key() -> None:
     assert buf.get_recent(event_type="CLIENT_CONNECTED") == []
 
 
+def test_buffer_limit_zero_returns_empty() -> None:
+    """An explicit limit=0 means zero results, not unlimited."""
+    buf = EventBuffer(max_size=10, ttl_seconds=300)
+    buf.add({"id": "e1", "key": "EVT_LU_Connected"})
+    buf.add({"id": "e2", "key": "EVT_LU_Disconnected"})
+    assert buf.get_recent(limit=0) == []
+
+
 def test_buffer_clear() -> None:
     buf = EventBuffer(max_size=10, ttl_seconds=300)
     buf.add({"id": "e1"})


### PR DESCRIPTION
Refs #564. This covers the truthiness bug at all four sites the issue names; the issue's separate "also worth a look" note about negative limits is not part of this diff, so I'm not closing the issue with this PR.

## Root cause

Four sites test `limit` for truthiness instead of identity against `None`, so an explicit `limit=0` (a caller stating "return zero events") is read the same as "no limit given":

- `packages/unifi-core/src/unifi_core/access/managers/event_manager.py:81` and `:388` (`EventBuffer.get_recent` and `list_events`'s `page_size = limit or 30`)
- `packages/unifi-core/src/unifi_core/protect/managers/event_manager.py:138`
- `packages/unifi-core/src/unifi_core/network/managers/event_manager.py:59`

The three `EventBuffer.get_recent` sites share one more bug once the truthiness check is fixed: the `limit` guard ran *after* `results.append(event)`, so the very first eligible event was always appended before a `limit=0` guard could ever run. I moved the check to the top of the loop, before an event is filtered or appended, so it can actually stop at zero.

## Fix

Guard on `limit is not None` and check it before processing each event, at all three `EventBuffer.get_recent` sites. For Access's REST `list_events`, `limit` is already a non-optional `int` defaulting to 30. The zero case now returns `[]` locally before any controller request; positive limits are passed through as `page_size = limit`. This also brings the file in line with `network/managers/event_manager.py`'s own `_get_events_v2`, which already treats `limit <= 0` as "return `[]`" on its REST path.

Left the negative-limit case out of scope, as the reporter did: the REST path already fails safe there (the controller rejects a negative `page_size`), and the buffer path's existing behavior for a negative limit is unrelated to this bug.

## Verification

- Added regression tests at all four sites and ran them on Python 3.13: they fail on `main` and pass on this branch. Files: `apps/access/tests/unit/test_events.py` (buffer + REST `page_size`), `apps/protect/tests/unit/test_event_buffer.py`, `packages/unifi-core/tests/network/managers/test_event_manager_buffer.py`.
- Ran the full `access`, `protect`, and `network` app unit suites plus the full `unifi-core` package suite; all pass (2726 tests total).
- `ruff format --check` and `ruff check` are clean on the whole workspace.
- I haven't confirmed the `unifi-core` package suite runs in this PR's checks: `release-core.yml` is the only workflow that runs it, and it's tag-triggered, not PR-triggered, so I ran it by hand instead.

## Maintainer verification

I independently validated exact head `085a26a9` against the reference controllers.

<details>
<summary>Live validation result</summary>

```text
access_list_events(limit=0)
{"success": true, "count": 0, "events_len": 0, "has_error": false}

Full safe smoke: Network passed; Protect passed; Access passed.
Focused regressions: Access 22 passed; Protect 19 passed; Network buffer 7 passed.
Core suite: 1787 passed.
GitHub checks: 14 passed.
```

</details>
