### PR TITLE
fix(deps): pin network authentication runtime

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
     # DPI name enrichment requires Core 0.4.36; exact Network event-key
     # filtering and discovery require Core 0.4.37.
     "unifi-core[network,protect,access]>=0.4.37,<0.5",
+    # The API server is a deployable Network client too. Pin the authentication
+    # transport exactly so a released API version has a reproducible login stack
+    # even when installed from PyPI without the workspace uv.lock.
+    "aiounifi==95",
+    "aiohttp==3.14.3",
     "fastapi>=0.141.1",
     "uvicorn[standard]>=0.52.1",
     "sqlalchemy[asyncio]>=2.0.51",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -6,15 +6,17 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "unifi-mcp-shared>=0.6.10,<0.7",
-    # Network managers in unifi-core import aiounifi; pull it in via the
-    # [network] extra rather than declaring aiounifi here directly so
-    # there's one source of truth.
+    # Network managers in unifi-core import aiounifi; the [network] extra
+    # declares the compatibility floor for library consumers. This deployable
+    # app also pins the auth client exactly so one MCP release always resolves
+    # to one tested login stack for uvx/pip users (which do not consume uv.lock).
     # WAN delegation validation requires Core 0.4.30. Firewall-zone CRUD
     # requires the dual-API bridge added in Core 0.4.32. WLAN schedule-window
     # validation requires Core 0.4.34. Traffic-flow DPI name enrichment
     # requires Core 0.4.36. Exact event-key filtering and discovery require
     # Core 0.4.37.
     "unifi-core[network]>=0.4.37,<0.5",
+    "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.
@@ -24,7 +26,7 @@ dependencies = [
     "python-multipart>=0.0.31",
     "starlette>=1.3.1",
     "click>=8.3.3",
-    "aiohttp>=3.14.3",
+    "aiohttp==3.14.3",
     "pyyaml>=6.0",
     "python-dotenv>=1.2.2",
     "omegaconf>=2.3.0",

--- a/scripts/check_pin_alignment.py
+++ b/scripts/check_pin_alignment.py
@@ -31,13 +31,15 @@ How this script catches it
    must resolve to published versions allowed by the downstream metadata.
 4. Assert every built wheel explicitly declares the advisory-safe floors for
    vulnerable transitives exposed at its published install boundary.
-5. Preinstall the prior vulnerable workspace resolutions before every wheel,
+5. Assert deployable Network runtimes exactly pin ``aiounifi`` and ``aiohttp``
+   consistently, so a released app version identifies one authentication stack.
+6. Preinstall the prior vulnerable workspace resolutions before every wheel,
    then prove its metadata upgrades them to safe versions.
-6. Attempt a smoke import of the downstream's runtime entrypoint. If the import
+7. Attempt a smoke import of the downstream's runtime entrypoint. If the import
    succeeds, the declared pin permits a working upstream version. If it fails
    with ``ModuleNotFoundError`` (or pip itself fails with no matching version),
    the pin is stale and a fresh PyPI install would crash.
-7. Install the Network and API wheels against exactly their declared published
+8. Install the Network and API wheels against exactly their declared published
    ``unifi-core`` floors and validate their manager-call contracts. This catches
    newly used Core methods that ordinary imports do not execute.
 
@@ -92,6 +94,14 @@ SECURITY_FLOORS: dict[str, dict[str, str]] = {
         "starlette": "1.3.1",
         "click": "8.3.3",
     },
+}
+
+# Deployable applications must make the Network authentication stack
+# reproducible in their wheel metadata. Library packages intentionally retain
+# compatibility floors, but uvx/pip users do not consume the workspace lockfile.
+REPRODUCIBLE_RUNTIME_PINS: dict[str, tuple[str, ...]] = {
+    "unifi-network-mcp": ("aiounifi", "aiohttp"),
+    "unifi-api-server": ("aiounifi", "aiohttp"),
 }
 
 # These were the vulnerable workspace resolutions before the security update.
@@ -409,6 +419,45 @@ def check_security_floors(dist_name: str, wheel: Path) -> tuple[bool, str]:
     return True, "all advisory-safe Requires-Dist floors are explicit"
 
 
+def exact_runtime_pins(wheel: Path, names: tuple[str, ...]) -> tuple[bool, dict[str, str], str]:
+    """Return exact unconditional runtime pins declared by a wheel."""
+    declared: dict[str, list[Requirement]] = {}
+    for raw_requirement in wheel_requirements(wheel):
+        try:
+            requirement = Requirement(raw_requirement)
+        except InvalidRequirement:
+            continue
+        if requirement.marker is None:
+            declared.setdefault(_normalize_distribution_name(requirement.name), []).append(requirement)
+
+    pins: dict[str, str] = {}
+    failures: list[str] = []
+    for raw_name in names:
+        name = _normalize_distribution_name(raw_name)
+        requirements = declared.get(name, [])
+        exact_versions = {
+            specifier.version
+            for requirement in requirements
+            for specifier in requirement.specifier
+            if specifier.operator == "==" and "*" not in specifier.version
+        }
+        if len(requirements) != 1 or len(requirements[0].specifier) != 1 or len(exact_versions) != 1:
+            failures.append(f"{name} must have one unconditional exact == pin")
+            continue
+        version = exact_versions.pop()
+        try:
+            Version(version)
+        except InvalidVersion:
+            failures.append(f"{name} has invalid exact pin {version!r}")
+            continue
+        pins[name] = version
+
+    if failures:
+        return False, pins, "; ".join(failures)
+    rendered = ", ".join(f"{name}=={version}" for name, version in sorted(pins.items()))
+    return True, pins, f"reproducible runtime pins: {rendered}"
+
+
 def install_security_upgrade(
     dist_name: str,
     install_target: str,
@@ -717,6 +766,27 @@ def main() -> int:
             if not ok:
                 failures.append((pkg.dist_name, msg))
 
+        print()
+        print("Checking reproducible Network authentication runtime pins")
+        runtime_pin_sets: dict[str, dict[str, str]] = {}
+        for dist_name, names in REPRODUCIBLE_RUNTIME_PINS.items():
+            wheel = downstream_wheels[dist_name]
+            ok, pins, message = exact_runtime_pins(wheel, names)
+            print(f"  [{'PASS' if ok else 'FAIL'}] {dist_name} — {message}")
+            if ok:
+                runtime_pin_sets[dist_name] = pins
+            else:
+                failures.append((dist_name, message))
+
+        if len(runtime_pin_sets) == len(REPRODUCIBLE_RUNTIME_PINS):
+            distinct_pin_sets = {tuple(sorted(pins.items())) for pins in runtime_pin_sets.values()}
+            if len(distinct_pin_sets) != 1:
+                message = "Network and API wheels declare different aiounifi/aiohttp exact pins"
+                print(f"  [FAIL] cross-app alignment — {message}")
+                failures.append(("network-auth-runtime", message))
+            else:
+                print("  [PASS] cross-app alignment — Network and API pins match")
+
         if failures:
             print()
             print("=" * 70)
@@ -776,7 +846,7 @@ def main() -> int:
             return 1
 
         print()
-        print("All wheels enforce security floors; downstream upgrades, installs, and imports pass.")
+        print("All wheels enforce security floors and runtime pins; downstream upgrades, installs, and imports pass.")
         return 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ wheels = [
 
 [[package]]
 name = "aiounifi"
-version = "92"
+version = "95"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -161,9 +161,9 @@ dependencies = [
     { name = "pyotp" },
     { name = "segno" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/ab/a7066835ae47ec206707b5d0f467f19f1b7e3654900f91d1bc5f3004896b/aiounifi-92.tar.gz", hash = "sha256:773192640cb5a25b432ed8905bc08929b2403786bb8e9cc6ac7aac14e47555bb", size = 67171, upload-time = "2026-07-06T12:16:52.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/c9/ca2f96cc24a8f9ca02224bcb59a2c4e9c70dd6a0531db135389a80338a52/aiounifi-95.tar.gz", hash = "sha256:b6ace0dbb42ba5095c9aa7dd0bf882ae5240cad4ce88830c03a4fec69ab4c787", size = 67909, upload-time = "2026-08-28T17:15:44.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/e6/ffb077a9f91288b6c1c689746acd84ff4813ec075b2bce0577057ce8568d/aiounifi-92-py3-none-any.whl", hash = "sha256:016d85b306d62bb617d8f05706fb5e695655c7dc7a3671e06089a2829a8cf22e", size = 56616, upload-time = "2026-07-06T12:16:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8b/65ab9e3dad409374e3887a31c87c07f838e10e2cfa3944387b88616ca935/aiounifi-95-py3-none-any.whl", hash = "sha256:e4d02fc8eb91c9bd672b963c811211c7a3681b889f82ed33c5a4a7cf7750e767", size = 56821, upload-time = "2026-08-28T17:15:43.139Z" },
 ]
 
 [[package]]
@@ -1877,7 +1877,9 @@ dev = [
 name = "unifi-api-server"
 source = { editable = "apps/api" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "aiosqlite" },
+    { name = "aiounifi" },
     { name = "alembic" },
     { name = "argon2-cffi" },
     { name = "click" },
@@ -1910,7 +1912,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = "==3.14.3" },
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "aiounifi", specifier = "==95" },
     { name = "alembic", specifier = ">=1.19.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "click", specifier = ">=8.3.3" },
@@ -2094,6 +2098,7 @@ name = "unifi-network-mcp"
 source = { editable = "apps/network" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiounifi" },
     { name = "click" },
     { name = "cryptography" },
     { name = "jsonschema" },
@@ -2122,7 +2127,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "aiohttp", specifier = "==3.14.3" },
+    { name = "aiounifi", specifier = "==95" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.1" },
     { name = "jsonschema", specifier = ">=4.17.0" },


### PR DESCRIPTION
## Summary

- Pin aiounifi 95 and aiohttp 3.14.3 in the deployable Network MCP and API packages so a released application version identifies one tested authentication stack outside uv.lock.
- Keep unifi-core on compatibility floors for reusable library consumers.
- Extend the wheel metadata gate to require unconditional exact auth-runtime pins and matching Network/API versions.

Related to #521. This improves reproducibility and diagnosis; it does not claim the pins resolve the reporter-specific 403.

## Type of change

- [x] fix: bug fix
- [ ] feat: new feature
- [ ] docs: documentation only
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [ ] test: adding or updating tests
- [x] chore: maintenance, dependencies, CI, or configuration

## Scope

- [x] Network MCP server
- [ ] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [x] API server
- [ ] Shared packages
- [ ] Plugin packaging
- [ ] Documentation

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran make pre-commit.
- [ ] I updated generated manifests with make manifest when changing MCP tools. Not applicable: no MCP tools changed.
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-visible changes. Not applicable: package metadata and its enforcement gate are self-documenting.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- uv lock --check
- uv run scripts/check_pin_alignment.py
- make pre-commit
- Exact aiounifi 95 / aiohttp 3.14.3 login probe against UDM Pro SE on UniFi OS 5.1.31 / Network 10.6.101: passed
- Network read-only live smoke: 121 passed, 7 skipped, 0 failures

## Notes for reviewers

Exact pins live only at deployable application boundaries. unifi-core intentionally retains its aiounifi and aiohttp compatibility floors. The alignment gate inspects built wheel metadata, so future Network/API releases cannot silently diverge.