### PR TITLE
fix(shared): accept null execute arguments

### DIFF
--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -520,7 +520,10 @@
           "properties": {
             "arguments": {
               "description": "Tool parameters matching the schema from the tool index",
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "tool": {
               "description": "Tool name from access_tool_index (e.g. 'access_list_*')",

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -4844,7 +4844,10 @@
           "properties": {
             "arguments": {
               "description": "Tool parameters matching the schema from the tool index",
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "tool": {
               "description": "Tool name from unifi_tool_index (e.g. 'unifi_list_*')",

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -1732,7 +1732,10 @@
           "properties": {
             "arguments": {
               "description": "Tool parameters matching the schema from the tool index",
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "tool": {
               "description": "Tool name from protect_tool_index (e.g. 'protect_list_*')",

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -207,7 +207,7 @@ def register_meta_tools(
         ),
         annotations=action_annotations,
     )
-    async def execute_handler(tool: str, arguments: dict = None, ctx: Context | None = None) -> dict:
+    async def execute_handler(tool: str, arguments: dict | None = None, ctx: Context | None = None) -> dict:
         """Execute a tool synchronously."""
         if arguments is None:
             arguments = {}
@@ -232,7 +232,7 @@ def register_meta_tools(
                     "description": f"Tool name from {idx_name} (e.g. '{prefix}_list_*')",
                 },
                 "arguments": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "description": "Tool parameters matching the schema from the tool index",
                 },
             },

--- a/packages/unifi-mcp-shared/tests/test_meta_tools.py
+++ b/packages/unifi-mcp-shared/tests/test_meta_tools.py
@@ -79,6 +79,23 @@ def test_tool_index_schema_describes_ranked_token_search():
     assert "no usable terms returns no tools" in description
 
 
+def test_execute_tool_index_schema_accepts_null_arguments():
+    register_tool = Mock()
+    register_meta_tools(
+        server=SimpleNamespace(),
+        tool_decorator=_capture_tools()[1],
+        tool_index_handler=AsyncMock(return_value={}),
+        start_async_tool=AsyncMock(),
+        get_job_status=AsyncMock(),
+        register_tool=register_tool,
+        prefix="unifi",
+    )
+
+    execute_call = next(call for call in register_tool.call_args_list if call.kwargs["name"] == "unifi_execute")
+    arguments_schema = execute_call.kwargs["input_schema"]["properties"]["arguments"]
+    assert arguments_schema["type"] == ["object", "null"]
+
+
 def test_meta_tool_index_objects_contain_declared_annotations():
     TOOL_REGISTRY.clear()
     try:
@@ -269,6 +286,33 @@ async def test_fastmcp_execute_and_batch_expose_domain_payload(prefix):
     status_payload = json.loads(status.content[0].text)
     assert status_payload["status"] == "done"
     assert status_payload["result"] == payload
+
+
+@pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
+async def test_fastmcp_execute_accepts_null_arguments(prefix):
+    payload = {"success": True, "data": {"id": "abc"}}
+    server = FastMCP(f"{prefix}-test")
+
+    @server.tool(name=f"{prefix}_inner", structured_output=True)
+    async def structured_inner() -> StructuredInnerResult:
+        return StructuredInnerResult(**payload)
+
+    register_meta_tools(
+        server=server,
+        tool_decorator=server.tool,
+        tool_index_handler=AsyncMock(return_value={}),
+        start_async_tool=AsyncMock(),
+        get_job_status=AsyncMock(),
+        register_tool=Mock(),
+        prefix=prefix,
+    )
+
+    execute = await server.call_tool(
+        f"{prefix}_execute",
+        {"tool": f"{prefix}_inner", "arguments": None},
+    )
+
+    assert json.loads(execute.content[0].text) == payload
 
 
 class TestRegisterLoadTools:


### PR DESCRIPTION
## Summary

- allow `arguments: null` for the shared `*_execute` meta-tools so clients that serialize unset optional values can reach the handler
- normalize explicit null to the existing empty-arguments behavior
- advertise the nullable shape in the Network, Protect, and Access tool manifests
- add SDK-level regression coverage across all three server prefixes

Closes #616.

## Type of change

- [x] fix: bug fix
- [ ] feat: new feature
- [ ] docs: documentation only
- [ ] refactor: code change that neither fixes a bug nor adds a feature
- [x] test: adding or updating tests
- [ ] chore: maintenance, dependencies, CI, or configuration

## Scope

- [x] Network MCP server
- [x] Protect MCP server
- [x] Access MCP server
- [x] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [x] Shared packages
- [x] Plugin packaging
- [ ] Documentation

## Verification

- reproduced the reported SDK/Pydantic validation failure with omitted, object, and explicit-null argument variants
- focused null-argument regression: 4 passed
- shared package suite: 371 passed
- original three-way transport repro: omitted, `{}`, and `null` all pass after the fix
- `make pre-commit`
- `uv run python scripts/check_pin_alignment.py`
- shared/core reverse-import checks: clean
- relay sync review: no relay protocol change required; this only changes shared meta-tool argument validation and advertised input schema

## Release plan

After merge, verify scope from the merged diff, then publish Shared first followed by Network, Protect, Access, and Relay individually.
