### PR TITLE
fix(core): add Alarm Manager v2 profile bridge

### DIFF
--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
@@ -30,6 +30,7 @@ from unifi_core.protect.models.alarm_rules import (
     alarm_rule_to_legacy_create_body,
     alarm_rule_to_v2_body,
 )
+from unifi_core.protect.models.alarms import profile_from_controller
 
 _UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
@@ -66,6 +67,48 @@ class AlarmRulesFacade:
             return rules, True
         raw = await self._legacy.list_rules()
         return [alarm_rule_from_legacy(rule).model_dump(exclude_none=True) for rule in raw], False
+
+    async def list_profiles(self) -> tuple[list[dict[str, Any]], bool]:
+        """Return ``(profiles, complete)``.
+
+        Prefer the v2 Alarm Manager profile API, but fall back to the legacy
+        arm-profile API whenever v2 cannot serve profiles on this console — that
+        is, when it returns an empty list or rejects the request. ``complete`` is
+        True only when v2 actually served the profiles.
+
+        Transient/server failures (5xx, timeouts -> ``NvrError``) are NOT masked:
+        they propagate so a real v2 outage is never silently hidden behind legacy.
+        """
+        permission_error: AlarmManagerPermissionError | None = None
+        try:
+            profiles = await self._service.list_profiles()
+        except AlarmManagerPermissionError as exc:
+            permission_error = exc
+            profiles = None
+        except BadRequest:
+            profiles = None
+        if profiles:
+            shaped = []
+            for profile in profiles:
+                if not isinstance(profile, dict):
+                    continue
+                item = profile_from_controller(
+                    {**profile, "id_family": "alarm_manager_v2", "arm_compatible": False}
+                ).model_dump(exclude_none=True)
+                shaped.append(item)
+            return shaped, True
+        raw = await self._legacy.list_arm_profiles()
+        if raw:
+            return [
+                profile_from_controller({**profile, "id_family": "legacy_arm", "arm_compatible": True}).model_dump(
+                    exclude_none=True
+                )
+                for profile in raw
+                if isinstance(profile, dict)
+            ], False
+        if permission_error is not None:
+            raise permission_error
+        return [], False
 
     async def get_rule(self, rule_id: str) -> tuple[dict[str, Any], bool]:
         """Return ``(rule, complete)`` for one rule by id.

--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_manager.py
@@ -50,6 +50,8 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from uiprotect.exceptions import BadRequest
+
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
 
@@ -57,6 +59,13 @@ logger = logging.getLogger(__name__)
 
 # Values of ``nvr.armMode.status`` that mean "not armed".
 _DISARMED_STATUSES = {"disabled", "disarmed", "off", "inactive"}
+_LEGACY_PROFILE_ID_NOT_FOUND_ERROR = (
+    "The legacy Protect arm endpoint did not recognize this profile_id. Alarm Manager "
+    "v2 ids returned by protect_alarm_list_profiles are not accepted by that endpoint; "
+    "use a profile marked arm_compatible=true, or omit profile_id to use the currently "
+    "selected legacy profile. A v2 arming endpoint is not implemented because its "
+    "contract has not been verified."
+)
 
 
 class AlarmManager:
@@ -172,11 +181,16 @@ class AlarmManager:
 
     async def _select_profile(self, profile_id: str) -> None:
         """PATCH ``arm`` to set which profile is active."""
-        await self._cm.client.api_request(
-            "arm",
-            method="patch",
-            json={"armProfileId": profile_id},
-        )
+        try:
+            await self._cm.client.api_request(
+                "arm",
+                method="patch",
+                json={"armProfileId": profile_id},
+            )
+        except BadRequest as exc:
+            if _is_arm_profile_not_found(exc):
+                raise ValueError(_LEGACY_PROFILE_ID_NOT_FOUND_ERROR) from exc
+            raise
 
     # ------------------------------------------------------------------
     # Preview (for confirm=false tool responses)
@@ -442,6 +456,25 @@ def _ms_to_iso(value: Any) -> Optional[str]:
     if ms <= 0:
         return None
     return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+
+
+def _is_arm_profile_not_found(exc: BaseException) -> bool:
+    """Return true when Protect rejected a legacy arm profile selection."""
+    if any(_payload_is_arm_profile_not_found(arg) for arg in exc.args):
+        return True
+    text = str(exc)
+    return "armProfile" in text and ("NOT_FOUND" in text or "Status: 404" in text or "not found" in text.lower())
+
+
+def _payload_is_arm_profile_not_found(value: Any) -> bool:
+    if isinstance(value, dict):
+        entity = value.get("entity")
+        name = value.get("name")
+        error = str(value.get("error") or "")
+        return entity == "armProfile" and (name == "NOT_FOUND" or "not found" in error.lower())
+    if isinstance(value, (list, tuple)):
+        return any(_payload_is_arm_profile_not_found(item) for item in value)
+    return False
 
 
 def _require_rule_id(rule_id: Any) -> str:

--- a/packages/unifi-core/src/unifi_core/protect/models/alarms.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/alarms.py
@@ -88,6 +88,30 @@ class AlarmProfile(BaseModel):
         description="Number of automations associated with this profile",
         json_schema_extra={"mutable": False},
     )
+    state: Optional[str] = Field(
+        default=None,
+        description=(
+            "Raw v2 arm state for this profile. Observed values: 'disarmed', 'arming' "
+            "(during a profile activation delay), 'armed', 'breached'. "
+            "Kept as a free-form string because the controller may report values not seen here."
+        ),
+        json_schema_extra={"mutable": False},
+    )
+    state_set_at: Optional[str] = Field(
+        default=None,
+        description="ISO timestamp when this profile state was set",
+        json_schema_extra={"mutable": False},
+    )
+    id_family: Optional[str] = Field(
+        default=None,
+        description="Profile ID namespace: alarm_manager_v2 or legacy_arm",
+        json_schema_extra={"mutable": False},
+    )
+    arm_compatible: Optional[bool] = Field(
+        default=None,
+        description="Whether this profile ID can be passed to protect_alarm_arm",
+        json_schema_extra={"mutable": False},
+    )
 
 
 class AlarmProfileList(BaseModel):
@@ -319,13 +343,18 @@ def status_from_controller(raw: Any) -> AlarmStatus:
 
 def profile_from_controller(raw: Any) -> AlarmProfile:
     """Build an AlarmProfile from a manager dict or object."""
+    alarm_ids = _get(raw, "alarm_ids")
     return AlarmProfile(
         id=_get(raw, "id"),
-        name=_get(raw, "name"),
+        name=_get(raw, "name") or _get(raw, "title"),
         record_everything=_get(raw, "record_everything"),
         activation_delay_ms=_get(raw, "activation_delay_ms"),
         schedule_count=_get(raw, "schedule_count"),
-        automation_count=_get(raw, "automation_count"),
+        automation_count=_get(raw, "automation_count", len(alarm_ids) if isinstance(alarm_ids, list) else None),
+        state=_get(raw, "state"),
+        state_set_at=_stringify_dt(_get(raw, "state_set_at")),
+        id_family=_get(raw, "id_family"),
+        arm_compatible=_get(raw, "arm_compatible"),
     )
 
 

--- a/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
@@ -48,6 +48,23 @@ _RAW_LEGACY = {
     "conditions": [{"type": "motion"}],
     "actions": [{"type": "webhook"}],
 }
+_RAW_V2_PROFILE = {
+    "id": "019e9f9d-59a1-7ee3-8921-27f84a0086ea",
+    "title": "Away",
+    "state": "armed",
+    "state_set_at": "2026-09-04T09:00:00Z",
+    "alarm_ids": ["alarm-1", "alarm-2"],
+    "created_at": "2026-09-01T09:00:00Z",
+    "updated_at": "2026-09-04T09:00:00Z",
+}
+_RAW_LEGACY_PROFILE = {
+    "id": "66a5c92a0022f903e4000401",
+    "name": "Home",
+    "record_everything": False,
+    "activation_delay_ms": 30000,
+    "schedule_count": 1,
+    "automation_count": 3,
+}
 # A legacy automation whose controller-assigned id carries a `_new` suffix, and
 # whose condition has no `type` key (so the canonical trigger_id normalizes to
 # None and is dropped) — the shape that breaks update/create round-trips.
@@ -77,7 +94,7 @@ def _facade(
     # service_err is shorthand for a v2 403; list_exc/get_exc inject other v2 errors.
     # They are mutually exclusive — combining them would silently ignore service_err.
     assert not (service_err and (list_exc or get_exc)), "pass service_err OR list_exc/get_exc, not both"
-    _perm = AlarmManagerPermissionError("x") if service_err else None
+    _perm = AlarmManagerPermissionError("SuperAdmin is required for Alarm Manager v2") if service_err else None
     service.list_rules = AsyncMock(side_effect=list_exc or _perm, return_value=service_list)
     service.get_rule = AsyncMock(side_effect=get_exc or _perm, return_value=service_get)
     service.list_rules_raw = AsyncMock(side_effect=list_exc or _perm, return_value=service_list)
@@ -90,6 +107,8 @@ def _facade(
     legacy.create_rule = AsyncMock(return_value=_RAW_LEGACY)
     legacy.update_rule = AsyncMock(return_value=_RAW_LEGACY)
     legacy.delete_rule = AsyncMock(return_value={"deleted": True, "rule_id": "66a5c92a0022f903e4000400"})
+    service.list_profiles = AsyncMock(side_effect=list_exc or _perm, return_value=service_list)
+    legacy.list_arm_profiles = AsyncMock(return_value=legacy_list)
     return AlarmRulesFacade(service, legacy)
 
 
@@ -148,6 +167,77 @@ async def test_list_rules_propagates_v2_server_error():
     # v2 5xx (NvrError) is a real/transient outage -> surface it; do NOT mask with legacy.
     with pytest.raises(NvrError):
         await _facade(list_exc=NvrError("500"), legacy_list=[_RAW_LEGACY]).list_rules()
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_prefers_alarm_manager_profiles_and_reports_complete():
+    profiles, complete = await _facade(
+        service_list=[_RAW_V2_PROFILE], legacy_list=[_RAW_LEGACY_PROFILE]
+    ).list_profiles()
+
+    assert complete is True
+    assert profiles == [
+        {
+            "id": "019e9f9d-59a1-7ee3-8921-27f84a0086ea",
+            "name": "Away",
+            "automation_count": 2,
+            "state": "armed",
+            "state_set_at": "2026-09-04T09:00:00Z",
+            "id_family": "alarm_manager_v2",
+            "arm_compatible": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_falls_back_to_legacy_when_v2_empty():
+    profiles, complete = await _facade(service_list=[], legacy_list=[_RAW_LEGACY_PROFILE]).list_profiles()
+
+    assert complete is False
+    assert profiles[0]["id"] == "66a5c92a0022f903e4000401"
+    assert profiles[0]["name"] == "Home"
+    assert profiles[0]["automation_count"] == 3
+    assert profiles[0]["id_family"] == "legacy_arm"
+    assert profiles[0]["arm_compatible"] is True
+    assert "state" not in profiles[0]
+    assert "state_set_at" not in profiles[0]
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_falls_back_on_v2_client_error():
+    profiles, complete = await _facade(list_exc=BadRequest("404"), legacy_list=[_RAW_LEGACY_PROFILE]).list_profiles()
+
+    assert complete is False
+    assert profiles[0]["name"] == "Home"
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_preserves_empty_behavior_when_both_backends_empty():
+    profiles, complete = await _facade(service_list=[], legacy_list=[]).list_profiles()
+
+    assert complete is False
+    assert profiles == []
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_preserves_permission_error_when_legacy_has_no_profiles():
+    with pytest.raises(AlarmManagerPermissionError, match="SuperAdmin"):
+        await _facade(service_err=True, legacy_list=[]).list_profiles()
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_uses_legacy_profiles_after_permission_error_when_available():
+    profiles, complete = await _facade(service_err=True, legacy_list=[_RAW_LEGACY_PROFILE]).list_profiles()
+
+    assert complete is False
+    assert profiles[0]["id_family"] == "legacy_arm"
+    assert profiles[0]["arm_compatible"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_propagates_v2_server_error():
+    with pytest.raises(NvrError):
+        await _facade(list_exc=NvrError("500"), legacy_list=[_RAW_LEGACY_PROFILE]).list_profiles()
 
 
 @pytest.mark.asyncio

--- a/packages/unifi-core/tests/protect/managers/test_alarm_manager_profiles.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_manager_profiles.py
@@ -1,0 +1,116 @@
+"""Tests for legacy Protect alarm profile selection."""
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+from uiprotect.exceptions import BadRequest
+from unifi_core.protect.managers.alarm_manager import AlarmManager
+
+_PROFILES_RESPONSE = [
+    {
+        "id": "p-night",
+        "name": "Arm Night",
+        "recordEverything": False,
+        "activationDelay": 60000,
+        "schedules": [],
+        "automations": ["a1", "a2"],
+    }
+]
+
+
+def _nvr_response(*, status: str = "disabled", profile_id: str | None = None) -> dict:
+    return {
+        "mac": "AABBCCDDEEFF",
+        "name": "UNVR",
+        "armMode": {
+            "status": status,
+            "armProfileId": profile_id,
+            "armedAt": None,
+            "willBeArmedAt": None,
+            "breachDetectedAt": None,
+            "breachEventCount": 0,
+            "breachTriggerEventId": None,
+            "breachEventId": None,
+        },
+    }
+
+
+def _make_cm(responses: list[object]) -> MagicMock:
+    cm = MagicMock()
+    cm.client.api_request = AsyncMock(side_effect=responses)
+    return cm
+
+
+class TestLegacyProfileSelection:
+    @pytest.mark.asyncio
+    async def test_arm_translates_legacy_arm_profile_not_found(self) -> None:
+        profile_id = "01a06cca-1111-4222-8333-444444444444"
+        missing_profile = {
+            "error": "Entity 'armProfile' not found",
+            "name": "NOT_FOUND",
+            "entity": "armProfile",
+            "id": profile_id,
+            "idKey": "id",
+        }
+        cm = _make_cm(
+            [
+                _nvr_response(),
+                _PROFILES_RESPONSE,
+                BadRequest(missing_profile),
+            ]
+        )
+        manager = AlarmManager(cm)
+
+        with pytest.raises(ValueError, match="did not recognize this profile_id"):
+            await manager.arm(profile_id)
+
+        mutating_calls = [
+            item for item in cm.client.api_request.await_args_list if item.kwargs.get("method") in ("patch", "post")
+        ]
+        assert mutating_calls == [call("arm", method="patch", json={"armProfileId": profile_id})]
+
+    @pytest.mark.asyncio
+    async def test_arm_uuid_shaped_profile_id_reaches_legacy_endpoint_when_accepted(
+        self,
+    ) -> None:
+        profile_id = "01a06cca-1111-4222-8333-444444444444"
+        cm = _make_cm(
+            [
+                _nvr_response(),
+                _PROFILES_RESPONSE,
+                None,
+                None,
+            ]
+        )
+        manager = AlarmManager(cm)
+
+        result = await manager.arm(profile_id)
+
+        assert result == {
+            "armed": True,
+            "profile_id": profile_id,
+            "profile_name": None,
+        }
+        mutating_calls = [
+            item for item in cm.client.api_request.await_args_list if item.kwargs.get("method") in ("patch", "post")
+        ]
+        assert mutating_calls == [
+            call("arm", method="patch", json={"armProfileId": profile_id}),
+            call("arm/enable", method="post"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_preview_arm_accepts_unknown_profile_id_shape(self) -> None:
+        profile_id = "01a06cca-1111-4222-8333-444444444444"
+        cm = _make_cm(
+            [
+                _nvr_response(),
+                _PROFILES_RESPONSE,
+            ]
+        )
+        manager = AlarmManager(cm)
+
+        preview = await manager.preview_arm(profile_id)
+
+        assert preview["target_profile_id"] == profile_id
+        assert preview["target_profile_name"] is None

--- a/packages/unifi-core/tests/protect/models/test_alarms.py
+++ b/packages/unifi-core/tests/protect/models/test_alarms.py
@@ -168,6 +168,8 @@ class TestProfileFromController:
         assert profile.activation_delay_ms == 30000
         assert profile.schedule_count == 2
         assert profile.automation_count == 1
+        assert profile.state is None
+        assert profile.state_set_at is None
 
     def test_partial_dict(self) -> None:
         raw = {"id": "profile-002", "name": "Away"}
@@ -178,6 +180,8 @@ class TestProfileFromController:
         assert profile.activation_delay_ms is None
         assert profile.schedule_count is None
         assert profile.automation_count is None
+        assert profile.state is None
+        assert profile.state_set_at is None
 
     def test_empty_dict(self) -> None:
         profile = profile_from_controller({})
@@ -194,6 +198,34 @@ class TestProfileFromController:
         assert "schedule_count" in dumped
         assert "record_everything" not in dumped
         assert "activation_delay_ms" not in dumped
+
+    def test_v2_profile_shape_maps_supported_fields_only(self) -> None:
+        raw = {
+            "id": "019e9f9d-59a1-7ee3-8921-27f84a0086ea",
+            "title": "Away",
+            "state": "armed",
+            "state_set_at": "2026-09-04T09:00:00Z",
+            "alarm_ids": ["alarm-1", "alarm-2"],
+            "created_at": "2026-09-01T09:00:00Z",
+            "updated_at": "2026-09-04T09:00:00Z",
+        }
+
+        dumped = profile_from_controller(raw).model_dump(exclude_none=True)
+
+        assert dumped == {
+            "id": "019e9f9d-59a1-7ee3-8921-27f84a0086ea",
+            "name": "Away",
+            "automation_count": 2,
+            "state": "armed",
+            "state_set_at": "2026-09-04T09:00:00Z",
+        }
+
+    def test_v2_profile_unknown_state_passes_through(self) -> None:
+        raw = {"id": "profile-004", "title": "Away", "state": "arming"}
+
+        dumped = profile_from_controller(raw).model_dump(exclude_none=True)
+
+        assert dumped["state"] == "arming"
 
 
 class TestProfileListFromController:


### PR DESCRIPTION
## Summary

Refs #619.

This is the Core-first half of the Alarm Manager profile fix. It adds the reusable bridge required by the Protect and API surfaces without publishing downstream packages against an unreleased Core method:

- route profile discovery through Alarm Manager v2, with the legacy endpoint as the narrow compatibility fallback
- normalize v2 profile fields, including state and provenance
- translate legacy profile-selection 404s into the domain error
- preserve unknown controller state values
- cover facade, model, and legacy profile-ID behavior in Core tests

After this merges, maintainers will release `unifi-core==0.4.40` and restore the reviewed Protect/API surface in a follow-up pinned to `unifi-core>=0.4.40`.

## Testing

- `make pre-commit` — passed
- `unifi-core` — 1,799 passed
- full repository suites and generated-artifact drift checks — passed
- contributor live validation: Protect 7.2.105 on UNVR G2 in Global Alarm Manager mode; v2 returned the configured profiles and their current state

The original combined implementation is preserved for the downstream follow-up. No further contributor action is needed.
