### PR TITLE
chore(deps): require unifi-core 0.4.39

### DIFF
--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -9,8 +9,9 @@ dependencies = [
     # Access managers in unifi-core import unifi_access_api (PyPI name
     # py-unifi-access); pull it in via the [access] extra rather than
     # declaring py-unifi-access here directly. Access system-log event
-    # normalization and websocket topics require Core 0.4.33.
-    "unifi-core[access]>=0.4.33,<0.5",
+    # normalization and websocket topics require Core 0.4.33; explicit zero
+    # event limits require Core 0.4.39.
+    "unifi-core[access]>=0.4.39,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -14,8 +14,9 @@ dependencies = [
     # requires Core 0.4.33; WLAN schedule-window projection requires Core
     # 0.4.34; Protect camera detail fields require Core 0.4.35; traffic-flow
     # DPI name enrichment requires Core 0.4.36; exact Network event-key
-    # filtering and discovery require Core 0.4.37.
-    "unifi-core[network,protect,access]>=0.4.37,<0.5",
+    # filtering and discovery require Core 0.4.37; explicit zero event limits
+    # require Core 0.4.39.
+    "unifi-core[network,protect,access]>=0.4.39,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     # requires the dual-API bridge added in Core 0.4.32. WLAN schedule-window
     # validation requires Core 0.4.34. Traffic-flow DPI name enrichment
     # requires Core 0.4.36. Exact event-key filtering and discovery require
-    # Core 0.4.37.
-    "unifi-core[network]>=0.4.37,<0.5",
+    # Core 0.4.37; explicit zero event limits require Core 0.4.39.
+    "unifi-core[network]>=0.4.39,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -8,8 +8,9 @@ dependencies = [
     "unifi-mcp-shared>=0.6.10,<0.7",
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly. Camera
-    # detail fields require Core 0.4.35.
-    "unifi-core[protect]>=0.4.35,<0.5",
+    # detail fields require Core 0.4.35; explicit zero event limits require
+    # Core 0.4.39.
+    "unifi-core[protect]>=0.4.39,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
## Summary

- raise the Network, Protect, Access, and API Core floor to `0.4.39`
- ensure upgrades of each product package pick up the `limit=0` event-manager fix from #614
- keep Shared and Relay unchanged because they do not consume the affected managers

## Verification

- `uv run python scripts/check_pin_alignment.py`
- `make pre-commit`
- pre-release Network, Protect, Access, API action, API resource, and API stream live smoke already passed for Core 0.4.39
