### PR TITLE
fix(protect): expose v2 alarm profiles

### DIFF
--- a/apps/api/docs/graphql-reference.md
+++ b/apps/api/docs/graphql-reference.md
@@ -234,6 +234,12 @@ type AlarmPage {
 type AlarmProfileList {
   profiles: JSON
   count: Int
+
+  """Whether the result has complete Alarm Manager v2 coverage."""
+  complete: Boolean
+
+  """Explains missing v2-only profile fields when complete is false."""
+  coverageNotice: String
 }
 
 """A UniFi Protect alarm rule (normalized; includes AI-powered alarms)."""
@@ -1630,7 +1636,9 @@ type ProtectQuery {
   """Get the alarm system arm-state snapshot."""
   alarmStatus(controller: ID!): AlarmStatus
 
-  """List configured alarm profiles ({profiles, count})."""
+  """
+  List configured alarm profiles ({profiles, count, complete, coverageNotice}), including each profile's state and state_set_at timestamp. Alarm Manager v2 profile IDs are scoped to this read family; use arm_compatible to determine whether a profile can be passed to legacy arm actions.
+  """
   alarmProfiles(controller: ID!): AlarmProfileList
 
   """
@@ -2407,7 +2415,7 @@ Read-only access to UniFi Protect resources.
 
 **Fields:**
 
-- `alarmProfiles: AlarmProfileList`  — List configured alarm profiles ({profiles, count}).
+- `alarmProfiles: AlarmProfileList`  — List configured alarm profiles ({profiles, count, complete, coverageNotice}), including each profile's state and state_set_at timestamp. Alarm Manager v2 profile IDs are scoped to this read family; use arm_compatible to determine whether a profile can be passed to legacy arm actions.
 - `alarmRule: AlarmRule`  — Fetch a single alarm rule (automation) by id.
 - `alarmRules: AlarmRuleList`  — List configured alarm rules / Alarm Manager automations ({rules, count}).
 - `alarmStatus: AlarmStatus`  — Get the alarm system arm-state snapshot.

--- a/apps/api/docs/openapi-reference.md
+++ b/apps/api/docs/openapi-reference.md
@@ -1908,6 +1908,9 @@ No native ``protect_get_sensor`` tool exists — filter from LIST.
 ### `GET /v1/sites/{site_id}/alarm-profiles` — Alarm List Profiles
 
 
+List configured alarm profiles, including each profile's state and state_set_at timestamp. Alarm Manager v2 profile IDs are scoped to this read family; use arm_compatible to determine whether a profile can be passed to legacy arm actions.
+
+
 **Parameters:**
 
 - `site_id` (path) (required)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -10721,6 +10721,7 @@
     },
     "/v1/sites/{site_id}/alarm-profiles": {
       "get": {
+        "description": "List configured alarm profiles, including each profile's state and state_set_at timestamp. Alarm Manager v2 profile IDs are scoped to this read family; use arm_compatible to determine whether a profile can be passed to legacy arm actions.",
         "operationId": "alarm_list_profiles_v1_sites__site_id__alarm_profiles_get",
         "parameters": [
           {

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # DPI name enrichment requires Core 0.4.36; exact Network event-key
     # filtering and discovery require Core 0.4.37; explicit zero event limits
     # require Core 0.4.39.
-    "unifi-core[network,protect,access]>=0.4.39,<0.5",
+    "unifi-core[network,protect,access]>=0.4.40,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -724,7 +724,7 @@
       "input_schema": {
         "properties": {
           "profile_id": {
-            "description": "Arm profile UUID from protect_alarm_list_profiles. Omit to use the currently selected profile.",
+            "description": "Legacy Protect arm profile id. Do not pass Alarm Manager v2 UUIDs from protect_alarm_list_profiles; omit to use the currently selected legacy profile.",
             "type": "string"
           }
         },
@@ -832,8 +832,8 @@
       "category": "alarm",
       "permission_action": "read",
       "read_only_hint": true,
-      "manager_attr": "alarm_manager",
-      "manager_method": "list_arm_profiles",
+      "manager_attr": "alarm_facade",
+      "manager_method": "list_profiles",
       "input_schema": {
         "properties": {},
         "type": "object",

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -442,14 +442,28 @@ async def _fetch_alarm_profiles(ctx: GraphQLContext, controller: str) -> Any:
                 session,
                 controller,
                 "protect",
-                "alarm_manager",
+                "alarm_facade",
             )
             await ctx.manager_factory.get_connection_manager(
                 session,
                 controller,
                 "protect",
             )
-            return await mgr.list_arm_profiles()
+            profiles, complete = await mgr.list_profiles()
+            return {
+                "profiles": profiles,
+                "count": len(profiles),
+                "complete": complete,
+                "coverage_notice": (
+                    None
+                    if complete
+                    else (
+                        "Showing legacy Protect arm profiles: the UniFi-OS Alarm Manager "
+                        "(/api/v2/alarms) returned no profiles or is unavailable on this console, "
+                        "so v2-only profile fields such as state and state_set_at are not included."
+                    )
+                ),
+            }
 
     return await ctx.cache.get_or_fetch(key, _do)
 
@@ -1223,7 +1237,12 @@ class ProtectQuery:
 
     @strawberry.field(
         permission_classes=[IsRead],
-        description="List configured alarm profiles ({profiles, count}).",
+        description=(
+            "List configured alarm profiles ({profiles, count, complete, coverageNotice}), including each "
+            "profile's state and state_set_at timestamp. Alarm Manager v2 profile "
+            "IDs are scoped to this read family; use arm_compatible to determine "
+            "whether a profile can be passed to legacy arm actions."
+        ),
     )
     async def alarm_profiles(
         self,

--- a/apps/api/src/unifi_api/graphql/schema.graphql
+++ b/apps/api/src/unifi_api/graphql/schema.graphql
@@ -223,6 +223,12 @@ type AlarmPage {
 type AlarmProfileList {
   profiles: JSON
   count: Int
+
+  """Whether the result has complete Alarm Manager v2 coverage."""
+  complete: Boolean
+
+  """Explains missing v2-only profile fields when complete is false."""
+  coverageNotice: String
 }
 
 """A UniFi Protect alarm rule (normalized; includes AI-powered alarms)."""
@@ -1619,7 +1625,9 @@ type ProtectQuery {
   """Get the alarm system arm-state snapshot."""
   alarmStatus(controller: ID!): AlarmStatus
 
-  """List configured alarm profiles ({profiles, count})."""
+  """
+  List configured alarm profiles ({profiles, count, complete, coverageNotice}), including each profile's state and state_set_at timestamp. Alarm Manager v2 profile IDs are scoped to this read family; use arm_compatible to determine whether a profile can be passed to legacy arm actions.
+  """
   alarmProfiles(controller: ID!): AlarmProfileList
 
   """

--- a/apps/api/src/unifi_api/graphql/types/protect/alarms.py
+++ b/apps/api/src/unifi_api/graphql/types/protect/alarms.py
@@ -135,6 +135,8 @@ class AlarmProfile:
     activation_delay_ms: int | None
     schedule_count: int | None
     automation_count: int | None
+    id_family: str | None
+    arm_compatible: bool | None
 
     _raw: strawberry.Private[dict[str, Any] | None] = None
 
@@ -143,7 +145,7 @@ class AlarmProfile:
         return {
             "kind": kind,
             "primary_key": "id",
-            "display_columns": ["name", "record_everything", "schedule_count"],
+            "display_columns": ["name", "id_family", "arm_compatible", "schedule_count"],
         }
 
     @classmethod
@@ -156,6 +158,8 @@ class AlarmProfile:
                 activation_delay_ms=obj.get("activation_delay_ms"),
                 schedule_count=obj.get("schedule_count"),
                 automation_count=obj.get("automation_count"),
+                id_family=obj.get("id_family"),
+                arm_compatible=obj.get("arm_compatible"),
             )
             inst._raw = dict(obj)
             return inst
@@ -168,6 +172,8 @@ class AlarmProfile:
                 activation_delay_ms=dumped.get("activation_delay_ms"),
                 schedule_count=dumped.get("schedule_count"),
                 automation_count=dumped.get("automation_count"),
+                id_family=dumped.get("id_family"),
+                arm_compatible=dumped.get("arm_compatible"),
             )
             inst._raw = dict(dumped)
             return inst
@@ -178,6 +184,8 @@ class AlarmProfile:
             activation_delay_ms=None,
             schedule_count=None,
             automation_count=None,
+            id_family=None,
+            arm_compatible=None,
         )
         return inst
 
@@ -321,6 +329,10 @@ class AlarmProfileList:
 
     profiles: strawberry.scalars.JSON | None  # type: ignore[name-defined]
     count: int | None
+    complete: bool | None = strawberry.field(description="Whether the result has complete Alarm Manager v2 coverage.")
+    coverage_notice: str | None = strawberry.field(
+        description="Explains missing v2-only profile fields when complete is false."
+    )
 
     _raw: strawberry.Private[dict[str, Any] | None] = None
     _fallback: strawberry.Private[str | None] = None
@@ -335,12 +347,19 @@ class AlarmProfileList:
             inst = cls(
                 profiles=obj.get("profiles") or [],
                 count=obj.get("count"),
+                complete=obj.get("complete", True),
+                coverage_notice=obj.get("coverage_notice"),
             )
             inst._raw = dict(obj)
             return inst
         if isinstance(obj, list):
             wrapper = {"profiles": list(obj), "count": len(obj)}
-            inst = cls(profiles=wrapper["profiles"], count=wrapper["count"])
+            inst = cls(
+                profiles=wrapper["profiles"],
+                count=wrapper["count"],
+                complete=True,
+                coverage_notice=None,
+            )
             inst._raw = wrapper
             return inst
         if hasattr(obj, "model_dump"):
@@ -348,10 +367,12 @@ class AlarmProfileList:
             inst = cls(
                 profiles=dumped.get("profiles") or [],
                 count=dumped.get("count"),
+                complete=dumped.get("complete", True),
+                coverage_notice=dumped.get("coverage_notice"),
             )
             inst._raw = dict(dumped)
             return inst
-        inst = cls(profiles=None, count=None)
+        inst = cls(profiles=None, count=None, complete=None, coverage_notice=None)
         inst._fallback = str(obj)
         return inst
 

--- a/apps/api/src/unifi_api/routes/resources/protect/system.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/system.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.protect.managers.alarm_manager_service import AlarmManagerPermissionError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
@@ -144,6 +145,12 @@ async def alarm_get_status(
 
 @router.get(
     "/sites/{site_id}/alarm-profiles",
+    description=(
+        "List configured alarm profiles, including each profile's state and "
+        "state_set_at timestamp. Alarm Manager v2 profile IDs are scoped to this "
+        "read family; use arm_compatible to determine whether a profile can be "
+        "passed to legacy arm actions."
+    ),
     dependencies=[Depends(require_scope(Scope.READ))],
     tags=["protect/system"],
 )
@@ -162,11 +169,17 @@ async def alarm_list_profiles(
             session,
             controller.id,
             "protect",
-            "alarm_manager",
+            "alarm_facade",
         )
         cm = await factory.get_connection_manager(session, controller.id, "protect")
         await _maybe_set_site(cm, site_id)
-        items = await mgr.list_arm_profiles()
+        try:
+            items, complete = await mgr.list_profiles()
+        except AlarmManagerPermissionError as exc:
+            # v2 refused (non-SuperAdmin) and the legacy fallback had no
+            # profiles to serve. Surface the actionable remediation instead
+            # of letting it escape as a bare 500.
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     cursor_obj = _decode_cursor(cursor)
     page, next_cursor = paginate(
@@ -194,11 +207,23 @@ async def alarm_list_profiles(
         serializer = registry.serializer_for_tool("protect_alarm_list_profiles")
         rows = [serializer.serialize(p) for p in page]
         hint = registry.render_hint_for_tool("protect_alarm_list_profiles")
-    return {
+    result = {
         "items": rows,
         "next_cursor": next_cursor.encode() if next_cursor else None,
         "render_hint": hint,
     }
+    if not complete:
+        result["_meta"] = {
+            "com.github.sirkirby.unifi-mcp/alarm-coverage": {
+                "complete": False,
+                "reason": (
+                    "Showing legacy Protect arm profiles: the UniFi-OS Alarm Manager "
+                    "(/api/v2/alarms) returned no profiles or is unavailable on this console, "
+                    "so v2-only profile fields such as state and state_set_at are not included."
+                ),
+            }
+        }
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -575,6 +575,27 @@ def _alarm_facade_result(result: Any, _args: dict[str, Any], _manager: Any) -> d
     return out
 
 
+def _alarm_profile_list_result(result: Any, _args: dict[str, Any], _manager: Any) -> dict[str, Any]:
+    if not (
+        isinstance(result, tuple) and len(result) == 2 and isinstance(result[0], list) and isinstance(result[1], bool)
+    ):
+        raise ValueError("Alarm facade returned an invalid profile list result")
+    profiles, complete = result
+    out: dict[str, Any] = {"profiles": profiles, "count": len(profiles)}
+    if not complete:
+        out["_meta"] = {
+            "com.github.sirkirby.unifi-mcp/alarm-coverage": {
+                "complete": False,
+                "reason": (
+                    "Showing legacy Protect arm profiles: the UniFi-OS Alarm Manager "
+                    "(/api/v2/alarms) returned no profiles or is unavailable on this console, "
+                    "so v2-only profile fields such as state and state_set_at are not included."
+                ),
+            }
+        }
+    return out
+
+
 def _delete_recording_result(result: Any, _args: dict[str, Any], _manager: Any) -> Any:
     if isinstance(result, dict) and result.get("supported") is False:
         raise ValueError(str(result.get("message") or "Individual recording deletion is not supported"))
@@ -1476,6 +1497,7 @@ DISPATCH_DIRECT_RESULT_ADAPTERS: dict[str, DirectResultAdapter] = {
 DISPATCH_RESULT_ADAPTERS: dict[str, ResultAdapter] = {
     "protect_get_snapshot": _snapshot_result,
     "protect_recent_events": _recent_events_result,
+    "protect_alarm_list_profiles": _alarm_profile_list_result,
     "protect_alarm_create_rule": _alarm_facade_result,
     "protect_alarm_update_rule": _alarm_facade_result,
     "protect_alarm_delete_rule": _alarm_facade_result,

--- a/apps/api/tests/graphql/fixtures/protect/test_events.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_events.py
@@ -264,13 +264,27 @@ async def test_protect_alarm_list_profiles(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("protect", "alarm_manager", "list_arm_profiles"): {
-                "profiles": [
-                    {"id": "prof1", "name": "Away"},
-                    {"id": "prof2", "name": "Home"},
+            ("protect", "alarm_facade", "list_profiles"): (
+                [
+                    {
+                        "id": "prof1",
+                        "name": "Away",
+                        "state": "armed",
+                        "state_set_at": "2026-09-04T12:00:00Z",
+                        "id_family": "alarm_manager_v2",
+                        "arm_compatible": False,
+                    },
+                    {
+                        "id": "prof2",
+                        "name": "Home",
+                        "state": "disarmed",
+                        "state_set_at": "2026-09-04T13:00:00Z",
+                        "id_family": "alarm_manager_v2",
+                        "arm_compatible": False,
+                    },
                 ],
-                "count": 2,
-            },
+                True,
+            ),
         },
     )
     body = await graphql_query(
@@ -280,13 +294,49 @@ async def test_protect_alarm_list_profiles(tmp_path, monkeypatch):
         protect {{ alarmProfiles(controller: "{cid}") {{
             count
             profiles
+            complete
+            coverageNotice
         }} }}
     }}''',
     )
     assert body.get("errors") is None, body
     result = body["data"]["protect"]["alarmProfiles"]
     assert result["count"] == 2
+    assert result["complete"] is True
+    assert result["coverageNotice"] is None
     assert {p["id"] for p in result["profiles"]} == {"prof1", "prof2"}
+    away = next(p for p in result["profiles"] if p["id"] == "prof1")
+    assert away["state"] == "armed"
+    assert away["state_set_at"] == "2026-09-04T12:00:00Z"
+    assert away["id_family"] == "alarm_manager_v2"
+    assert away["arm_compatible"] is False
+
+
+@pytest.mark.asyncio
+async def test_protect_alarm_list_profiles_marks_incomplete_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await bootstrap(tmp_path, product="protect")
+    stub_managers(
+        monkeypatch,
+        {("protect", "alarm_facade", "list_profiles"): ([], False)},
+    )
+
+    body = await graphql_query(
+        app,
+        key,
+        f'''{{
+        protect {{ alarmProfiles(controller: "{cid}") {{
+            count profiles complete coverageNotice
+        }} }}
+    }}''',
+    )
+
+    assert body.get("errors") is None, body
+    result = body["data"]["protect"]["alarmProfiles"]
+    assert result["count"] == 0
+    assert result["profiles"] == []
+    assert result["complete"] is False
+    assert "v2-only profile fields" in result["coverageNotice"]
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/routes/resources/test_protect_events_system.py
+++ b/apps/api/tests/routes/resources/test_protect_events_system.py
@@ -508,16 +508,30 @@ async def test_alarm_list_profiles_happy_path(tmp_path, monkeypatch) -> None:
     _stub_connection(app, cid)
 
     fake_profiles = [
-        {"id": "p-1", "name": "Home"},
-        {"id": "p-2", "name": "Away"},
+        {
+            "id": "p-1",
+            "name": "Home",
+            "state": "armed",
+            "state_set_at": "2026-09-04T12:00:00Z",
+            "id_family": "alarm_manager_v2",
+            "arm_compatible": False,
+        },
+        {
+            "id": "p-2",
+            "name": "Away",
+            "state": "disarmed",
+            "state_set_at": "2026-09-04T13:00:00Z",
+            "id_family": "alarm_manager_v2",
+            "arm_compatible": False,
+        },
     ]
 
     async def fake(self):
-        return fake_profiles
+        return fake_profiles, True
 
-    from unifi_core.protect.managers.alarm_manager import AlarmManager
+    from unifi_core.protect.managers.alarm_facade import AlarmRulesFacade
 
-    monkeypatch.setattr(AlarmManager, "list_arm_profiles", fake)
+    monkeypatch.setattr(AlarmRulesFacade, "list_profiles", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(
@@ -527,6 +541,66 @@ async def test_alarm_list_profiles_happy_path(tmp_path, monkeypatch) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert len(body["items"]) == 2
+    assert {item["id"]: item for item in body["items"]} == {profile["id"]: profile for profile in fake_profiles}
+
+
+@pytest.mark.asyncio
+async def test_alarm_list_profiles_marks_incomplete_empty_fallback(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake(self):
+        return [], False
+
+    from unifi_core.protect.managers.alarm_facade import AlarmRulesFacade
+
+    monkeypatch.setattr(AlarmRulesFacade, "list_profiles", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        response = await c.get(
+            f"/v1/sites/default/alarm-profiles?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["items"] == []
+    assert body["_meta"]["com.github.sirkirby.unifi-mcp/alarm-coverage"]["complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_alarm_list_profiles_permission_error_maps_to_403(tmp_path, monkeypatch) -> None:
+    """Non-SuperAdmin on v2 + empty legacy fallback must surface as 403, not 500.
+
+    The facade re-raises ``AlarmManagerPermissionError`` so the actionable
+    remediation is not flattened into a misleading empty list. This route has
+    to translate it rather than let it escape as ``Internal Server Error``.
+    """
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    from unifi_core.protect.managers.alarm_facade import AlarmRulesFacade
+    from unifi_core.protect.managers.alarm_manager_service import (
+        AlarmManagerPermissionError,
+    )
+
+    detail = "Alarm Manager v2 requires a SuperAdmin local account."
+
+    async def fake(self):
+        raise AlarmManagerPermissionError(detail)
+
+    monkeypatch.setattr(AlarmRulesFacade, "list_profiles", fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get(
+            f"/v1/sites/default/alarm-profiles?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert r.status_code == 403, r.text
+    assert detail in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -29,6 +29,7 @@ async def _bootstrap(
     *,
     redact_sensitive_fields: bool = True,
     product_kinds: str = "network",
+    scopes: str = "write",
 ):
     config = _cfg(tmp_path, redact_sensitive_fields=redact_sensitive_fields)
     app = create_app(config)
@@ -45,7 +46,7 @@ async def _bootstrap(
                 id=str(uuid.uuid4()),
                 prefix=material.prefix,
                 hash=hash_key(material.plaintext),
-                scopes="write",
+                scopes=scopes,
                 name="t",
                 created_at=datetime.now(timezone.utc),
             )
@@ -132,6 +133,83 @@ async def test_action_endpoint_enforces_confirmation_before_manager_interaction(
         assert confirmed_response.status_code == 200
         assert confirmed_response.json()["success"] is True
         manager.apply_unlock_door.assert_awaited_once_with(door_id="door-1", duration=2)
+
+
+@pytest.mark.asyncio
+async def test_action_endpoint_unwraps_alarm_profile_facade_tuple(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, product_kinds="protect", scopes="admin")
+
+    manager = MagicMock()
+    manager.list_profiles = AsyncMock(
+        return_value=(
+            [
+                {
+                    "id": "01a06cca-1111-4222-8333-444444444444",
+                    "name": "Away",
+                    "state": "armed",
+                    "state_set_at": "2026-09-04T12:00:00Z",
+                    "id_family": "alarm_manager_v2",
+                    "arm_compatible": False,
+                }
+            ],
+            True,
+        )
+    )
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    app.state.manager_factory = factory
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/actions/protect_alarm_list_profiles",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {}, "confirm": False},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["data"] == {
+        "profiles": [
+            {
+                "id": "01a06cca-1111-4222-8333-444444444444",
+                "name": "Away",
+                "state": "armed",
+                "state_set_at": "2026-09-04T12:00:00Z",
+                "id_family": "alarm_manager_v2",
+                "arm_compatible": False,
+            }
+        ],
+        "count": 1,
+    }
+    assert "result" not in body["data"]
+    manager.list_profiles.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_action_endpoint_preserves_incomplete_alarm_profile_coverage(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, product_kinds="protect", scopes="admin")
+
+    manager = MagicMock()
+    manager.list_profiles = AsyncMock(return_value=([], False))
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    app.state.manager_factory = factory
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/actions/protect_alarm_list_profiles",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {}, "confirm": False},
+        )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["profiles"] == []
+    assert data["count"] == 0
+    assert data["_meta"]["com.github.sirkirby.unifi-mcp/alarm-coverage"]["complete"] is False
 
 
 @pytest.mark.parametrize(

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -3541,6 +3541,17 @@ def test_alarm_facade_result_adapter_unwraps_result_and_preserves_coverage() -> 
     assert fallback["_meta"]["com.github.sirkirby.unifi-mcp/alarm-coverage"]["complete"] is False
 
 
+def test_alarm_profile_result_adapter_preserves_incomplete_empty_fallback() -> None:
+    adapter = DISPATCH_RESULT_ADAPTERS["protect_alarm_list_profiles"]
+
+    assert adapter(([], True), {}, MagicMock()) == {"profiles": [], "count": 0}
+    fallback = adapter(([], False), {}, MagicMock())
+
+    assert fallback["profiles"] == []
+    assert fallback["count"] == 0
+    assert fallback["_meta"]["com.github.sirkirby.unifi-mcp/alarm-coverage"]["complete"] is False
+
+
 def test_delete_recording_result_adapter_rejects_unsupported_operation() -> None:
     adapter = DISPATCH_RESULT_ADAPTERS["protect_delete_recording"]
 

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # [protect] extra rather than declaring uiprotect here directly. Camera
     # detail fields require Core 0.4.35; explicit zero event limits require
     # Core 0.4.39.
-    "unifi-core[protect]>=0.4.39,<0.5",
+    "unifi-core[protect]>=0.4.40,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/protect/src/unifi_protect_mcp/tools/alarm.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/alarm.py
@@ -45,11 +45,18 @@ _ALARM_COVERAGE_NOTICE = (
     "returned no rules or is unavailable on this console, so AI-powered alarms "
     "(where supported) are not included."
 )
+_ALARM_PROFILE_COVERAGE_NOTICE = (
+    "Showing legacy Protect arm profiles: the UniFi-OS Alarm Manager "
+    "(/api/v2/alarms) returned no profiles or is unavailable on this console, "
+    "so v2-only profile fields such as state and state_set_at are not included."
+)
 
 
-def _with_alarm_coverage_meta(result: Dict[str, Any], complete: bool) -> Dict[str, Any]:
+def _with_alarm_coverage_meta(
+    result: Dict[str, Any], complete: bool, notice: str = _ALARM_COVERAGE_NOTICE
+) -> Dict[str, Any]:
     if not complete:
-        result["_meta"] = {_ALARM_COVERAGE_META: {"complete": False, "reason": _ALARM_COVERAGE_NOTICE}}
+        result["_meta"] = {_ALARM_COVERAGE_META: {"complete": False, "reason": notice}}
     return result
 
 
@@ -57,9 +64,13 @@ def _with_alarm_coverage_meta(result: Dict[str, Any], complete: bool) -> Dict[st
     name="protect_alarm_list_profiles",
     description=(
         "Lists all configured UniFi Protect Alarm Manager profiles with their id, "
-        "name, activation delay, schedule count, and automation count. Use this "
-        "to discover the arm profile id needed by protect_alarm_arm. Requires Protect "
-        "6.1+ with Alarm Manager configured in the web UI."
+        "name, state, state_set_at timestamp, activation delay, schedule count, "
+        "automation count, id_family, and arm_compatible flag. Alarm Manager v2 "
+        "profile IDs are scoped to this "
+        "read family and are not accepted by protect_alarm_arm; only profiles marked "
+        "arm_compatible can be used with that legacy arm action. Requires Protect "
+        "6.1+ with Alarm Manager configured in the web UI. Legacy fallback responses "
+        "include _meta with complete=false because v2-only fields are unavailable."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -67,16 +78,20 @@ async def protect_alarm_list_profiles() -> Dict[str, Any]:
     """List all arm profiles."""
     logger.info("protect_alarm_list_profiles tool called")
     try:
-        profiles = await alarm_manager.list_arm_profiles()
+        profiles, complete = await alarm_facade.list_profiles()
         raw = {"profiles": profiles, "count": len(profiles)}
         shaped_list = profile_list_from_controller(raw)
         shaped_profiles = [
             profile_from_controller(p).model_dump(exclude_none=True) for p in (shaped_list.profiles or [])
         ]
-        return {
-            "success": True,
-            "data": {**shaped_list.model_dump(exclude_none=True), "profiles": shaped_profiles},
-        }
+        return _with_alarm_coverage_meta(
+            {
+                "success": True,
+                "data": {**shaped_list.model_dump(exclude_none=True), "profiles": shaped_profiles},
+            },
+            complete,
+            _ALARM_PROFILE_COVERAGE_NOTICE,
+        )
     except Exception as e:
         logger.error("Error listing arm profiles: %s", e, exc_info=True)
         return {"success": False, "error": f"Failed to list arm profiles: {e}"}
@@ -125,7 +140,8 @@ async def protect_alarm_arm(
         Optional[str],
         Field(
             description=(
-                "Arm profile UUID from protect_alarm_list_profiles. Omit to use the currently selected profile."
+                "Legacy Protect arm profile id. Do not pass Alarm Manager v2 UUIDs "
+                "from protect_alarm_list_profiles; omit to use the currently selected legacy profile."
             )
         ),
     ] = None,

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -179,7 +179,7 @@
               "type": "boolean"
             },
             "profile_id": {
-              "description": "Arm profile UUID from protect_alarm_list_profiles. Omit to use the currently selected profile.",
+              "description": "Legacy Protect arm profile id. Do not pass Alarm Manager v2 UUIDs from protect_alarm_list_profiles; omit to use the currently selected legacy profile.",
               "type": "string"
             }
           },
@@ -731,7 +731,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Lists all configured UniFi Protect Alarm Manager profiles with their id, name, activation delay, schedule count, and automation count. Use this to discover the arm profile id needed by protect_alarm_arm. Requires Protect 6.1+ with Alarm Manager configured in the web UI.",
+      "description": "Lists all configured UniFi Protect Alarm Manager profiles with their id, name, state, state_set_at timestamp, activation delay, schedule count, automation count, id_family, and arm_compatible flag. Alarm Manager v2 profile IDs are scoped to this read family and are not accepted by protect_alarm_arm; only profiles marked arm_compatible can be used with that legacy arm action. Requires Protect 6.1+ with Alarm Manager configured in the web UI. Legacy fallback responses include _meta with complete=false because v2-only fields are unavailable.",
       "name": "protect_alarm_list_profiles",
       "schema": {
         "input": {

--- a/apps/protect/tests/unit/test_alarm_tools.py
+++ b/apps/protect/tests/unit/test_alarm_tools.py
@@ -6,6 +6,61 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_list_profiles_delegates_to_alarm_facade():
+    from unifi_protect_mcp.tools import alarm
+
+    facade = MagicMock()
+    profile = {
+        "id": "uuid-1",
+        "name": "Away",
+        "state": "armed",
+        "state_set_at": "2026-09-04T12:00:00Z",
+        "automation_count": 2,
+        "id_family": "alarm_manager_v2",
+        "arm_compatible": False,
+    }
+    facade.list_profiles = AsyncMock(return_value=([profile], True))
+    legacy = MagicMock()
+    legacy.list_arm_profiles = AsyncMock()
+
+    with (
+        patch("unifi_protect_mcp.tools.alarm.alarm_facade", facade),
+        patch("unifi_protect_mcp.tools.alarm.alarm_manager", legacy),
+    ):
+        result = await alarm.protect_alarm_list_profiles()
+
+    assert result == {
+        "success": True,
+        "data": {"profiles": [profile], "count": 1},
+    }
+    facade.list_profiles.assert_awaited_once_with()
+    legacy.list_arm_profiles.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_profiles_surfaces_coverage_meta_when_legacy_serves():
+    from unifi_protect_mcp.tools import alarm
+
+    facade = MagicMock()
+    facade.list_profiles = AsyncMock(
+        return_value=(
+            [{"id": "legacy-id", "name": "Away", "id_family": "legacy", "arm_compatible": True}],
+            False,
+        )
+    )
+
+    with patch("unifi_protect_mcp.tools.alarm.alarm_facade", facade):
+        result = await alarm.protect_alarm_list_profiles()
+
+    assert result["success"] is True
+    assert result["data"]["profiles"][0]["id"] == "legacy-id"
+    assert result["_meta"][alarm._ALARM_COVERAGE_META] == {
+        "complete": False,
+        "reason": alarm._ALARM_PROFILE_COVERAGE_NOTICE,
+    }
+
+
+@pytest.mark.asyncio
 async def test_update_rule_confirm_delegates_to_alarm_facade():
     from unifi_protect_mcp.tools import alarm
 

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -181,7 +181,7 @@ Controls the UniFi Protect Alarm Manager (Protect 6.1+). Requires arm profiles c
 |------|------|-------------|
 | `protect_alarm_get_rule` | Read | Fetches a single UniFi Protect alarm rule by id (normalized: id, title, enabled, triggers, actions, scope, stats), including AI-powered a... |
 | `protect_alarm_get_status` | Read | Returns the current armed/disarmed state of the UniFi Protect Alarm Manager, including the active profile, raw status string, armed-at ti... |
-| `protect_alarm_list_profiles` | Read | Lists all configured UniFi Protect Alarm Manager profiles with their id, name, activation delay, schedule count, and automation count. |
+| `protect_alarm_list_profiles` | Read | Lists all configured UniFi Protect Alarm Manager profiles with their id, name, state, state_set_at timestamp, activation delay, schedule ... |
 | `protect_alarm_list_rules` | Read | Lists every UniFi Protect alarm rule, including AI-powered alarms (e.g. |
 | `protect_alarm_arm` | Mutate | Arms the UniFi Protect Alarm Manager. |
 | `protect_alarm_create_rule` | Mutate | Creates a new alarm rule via POST. |


### PR DESCRIPTION
## Summary

Refs #619 and follows the Core-first merge from #620.

Now that `unifi-core==0.4.40` is published, this restores the reviewed downstream behavior:

- route `protect_alarm_list_profiles` through `AlarmRulesFacade.list_profiles()`
- expose Alarm Manager v2 profile state, ID-family provenance, and `arm_compatible`
- bind the API action, GraphQL query, and REST resource to the facade
- map the actionable non-SuperAdmin Alarm Manager error to REST 403
- raise Protect and API Core floors to `>=0.4.40`
- regenerate the Protect manifest, API catalog, SDL, OpenAPI, and both reference docs

The legacy arm action remains explicitly scoped to legacy-compatible profile IDs. This PR does not change `protect_alarm_get_status`; that can remain a separate follow-up from #619.

## Validation

- `make pre-commit` — passed
- Protect — 508 passed
- API — 1,362 passed
- clean-wheel pin alignment — passed; API validated 271 bindings against published Core 0.4.40
- live MCP `protect_alarm_list_profiles` — passed
- live API action `protect_alarm_list_profiles` — HTTP 200, parity passed
- live REST `/v1/sites/default/alarm-profiles` — HTTP 200, action/resource parity passed

Alex remains the commit author; the maintainer changes here are the dependency-ordered split, released floors, REST error mapping, and regenerated artifacts.
