### PR TITLE
Add cross-server support bundle summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Leverage agents and agentic AI workflows to manage your UniFi deployment.
 
 | Server | Status | Tools | Package |
 |--------|--------|-------|---------|
-| [Network](apps/network/) | Stable | 192 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
-| [Protect](apps/protect/) | Stable | 61 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
-| [Access](apps/access/) | Stable | 36 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
+| [Network](apps/network/) | Stable | 193 | [`unifi-network-mcp`](https://pypi.org/project/unifi-network-mcp/) |
+| [Protect](apps/protect/) | Stable | 62 | [`unifi-protect-mcp`](https://pypi.org/project/unifi-protect-mcp/) |
+| [Access](apps/access/) | Stable | 37 | [`unifi-access-mcp`](https://pypi.org/project/unifi-access-mcp/) |
 
 ## Cloud Relay
 
@@ -251,9 +251,9 @@ This is a monorepo with shared packages:
 
 ```
 apps/
-  network/          # UniFi Network MCP server (stable, 192 tools)
-  protect/          # UniFi Protect MCP server (stable, 61 tools)
-  access/           # UniFi Access MCP server (stable, 36 tools)
+  network/          # UniFi Network MCP server (stable, 193 tools)
+  protect/          # UniFi Protect MCP server (stable, 62 tools)
+  access/           # UniFi Access MCP server (stable, 37 tools)
   api/              # Independent REST + GraphQL API server (beta)
   worker/           # Cloudflare Worker gateway + npm CLI
 packages/

--- a/apps/access/README.md
+++ b/apps/access/README.md
@@ -173,7 +173,7 @@ No additional configuration is required — if both plugins are active, the skil
 
 - [Configuration](docs/configuration.md) -- Full env var reference, YAML config, Access-specific options
 - [Permissions](docs/permissions.md) -- Permission system, category defaults, how to enable mutations
-- [Tool Catalog](docs/tools.md) -- All 36 tools organized by category
+- [Tool Catalog](docs/tools.md) -- All 37 tools organized by category
 - [Event Streaming](docs/events.md) -- Real-time event architecture, WebSocket buffer, polling
 - [Troubleshooting](docs/troubleshooting.md) -- Connection issues, dual auth debugging, missing tools
 

--- a/apps/access/devtools/dev_console.py
+++ b/apps/access/devtools/dev_console.py
@@ -195,9 +195,9 @@ async def main_async() -> None:
     logger.info("Access Developer console starting...")
 
     try:
-        import unifi_access_mcp.main  # noqa: F401, E402
+        import unifi_access_mcp.main as main_mod  # noqa: E402
         from unifi_access_mcp.jobs import get_job_status, start_async_tool  # noqa: E402
-        from unifi_access_mcp.runtime import connection_manager, server  # noqa: E402
+        from unifi_access_mcp.runtime import connection_manager, server, support_bundle_service  # noqa: E402
         from unifi_access_mcp.tool_index import register_tool, tool_index_handler  # noqa: E402
         from unifi_mcp_shared.meta_tools import register_meta_tools  # noqa: E402
         from unifi_mcp_shared.tool_loader import auto_load_tools  # noqa: E402
@@ -216,11 +216,12 @@ async def main_async() -> None:
 
         register_meta_tools(
             server=server,
-            tool_decorator=server.tool,
+            tool_decorator=main_mod._original_tool_decorator,
             tool_index_handler=tool_index_handler,
             start_async_tool=start_async_tool,
             get_job_status=get_job_status,
             register_tool=register_tool,
+            support_bundle_handler=support_bundle_service.generate,
             prefix="access",
             server_label="UniFi Access",
         )

--- a/apps/access/docs/tools.md
+++ b/apps/access/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Access MCP server exposes 36 tools, all prefixed with `access_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Access MCP server exposes 37 tools, all prefixed with `access_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy workflows, call the `access_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_access_mcp/tools_manifest.json`. In `meta_only` mode, the index initially contains only meta-tools; executing a known domain tool lazily registers its module, so later index results can include those loaded tools.
 

--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # declaring py-unifi-access here directly. Access system-log event
     # normalization and websocket topics require Core 0.4.33; explicit zero
     # event limits require Core 0.4.39.
-    "unifi-core[access]>=0.4.39,<0.5",
+    "unifi-core[access]>=0.4.41,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/access/src/unifi_access_mcp/main.py
+++ b/apps/access/src/unifi_access_mcp/main.py
@@ -20,6 +20,7 @@ from unifi_access_mcp.runtime import (
     connection_manager,
     event_manager,
     server,
+    support_bundle_service,
 )
 from unifi_access_mcp.tool_index import register_tool, tool_index_handler
 from unifi_access_mcp.utils.config_helpers import parse_config_bool
@@ -107,6 +108,7 @@ async def main_async():
         base_package="unifi_access_mcp.tools",
         config=config,
         logger=logger,
+        support_bundle_handler=support_bundle_service.generate,
         prefix="access",
         server_label="UniFi Access",
     )

--- a/apps/access/src/unifi_access_mcp/runtime.py
+++ b/apps/access/src/unifi_access_mcp/runtime.py
@@ -25,10 +25,17 @@ from typing import Any
 
 from mcp.server.transport_security import TransportSecuritySettings
 
-from unifi_access_mcp.bootstrap import load_config, logger
+from unifi_access_mcp.bootstrap import UNIFI_TOOL_REGISTRATION_MODE, load_config, logger
+from unifi_access_mcp.support import AccessSupportBundleAdapter
 from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL, configure_mcp_server_metadata
 from unifi_mcp_shared.response_policy import resolve_mcp_content_mode, should_redact_response_sensitive_fields
 from unifi_mcp_shared.server import UniFiMCPServer
+from unifi_mcp_shared.support_bundle import (
+    SupportBundleService,
+    configured_filter,
+    configured_transports,
+    fixed_manifest_reader,
+)
 
 _TOOLS_MANIFEST_PATH = Path(__file__).resolve().parent / "tools_manifest.json"
 from unifi_access_mcp.tool_index import TOOL_REGISTRY
@@ -212,6 +219,29 @@ def get_tool_registry() -> dict[str, Any]:
     return TOOL_REGISTRY
 
 
+@lru_cache
+def get_support_bundle_adapter() -> AccessSupportBundleAdapter:
+    """Create the Access adapter over existing safe runtime singletons."""
+    return AccessSupportBundleAdapter(get_connection_manager())
+
+
+@lru_cache
+def get_support_bundle_service() -> SupportBundleService:
+    """Create the process-wide Access support-bundle service."""
+    cfg = get_config()
+    return SupportBundleService(
+        adapter=get_support_bundle_adapter(),
+        registration_mode=UNIFI_TOOL_REGISTRATION_MODE,
+        content_mode=resolve_mcp_content_mode("access", config=cfg),
+        transports=configured_transports(cfg.server),
+        diagnostics_enabled=str(cfg.server.diagnostics.get("enabled", False)).lower() in {"true", "1", "yes"},
+        response_redaction_enabled=should_redact_response_sensitive_fields("access", cfg),
+        manifest_reader=fixed_manifest_reader(_TOOLS_MANIFEST_PATH),
+        enabled_categories=configured_filter(cfg.server.get("enabled_categories")),
+        enabled_tools=configured_filter(cfg.server.get("enabled_tools")),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shorthand aliases (import-time singletons) --------------------------------
 # ---------------------------------------------------------------------------
@@ -231,6 +261,8 @@ event_manager = get_event_manager()
 device_manager = get_device_manager()
 system_manager = get_system_manager()
 tool_registry = get_tool_registry()
+support_bundle_adapter = get_support_bundle_adapter()
+support_bundle_service = get_support_bundle_service()
 
 
 def should_redact_sensitive_fields() -> bool:

--- a/apps/access/src/unifi_access_mcp/support.py
+++ b/apps/access/src/unifi_access_mcp/support.py
@@ -1,0 +1,78 @@
+"""Privacy-bounded support-bundle adapter for UniFi Access."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from unifi_core.support_bundle import (
+    AccessCapabilities,
+    ConnectionSection,
+    ConnectivityProbe,
+    ControllerCapabilityFlag,
+    ControllerSection,
+    EvidenceStatus,
+    Product,
+    SanitizationSection,
+    SummaryProbe,
+)
+from unifi_mcp_shared.support_bundle import ProbeName, SupportBundleEvidence
+
+
+class AccessSupportBundleAdapter:
+    """Translate Access's public safe connection snapshot into Core types."""
+
+    product = Product.ACCESS
+
+    def __init__(self, connection_manager: Any) -> None:
+        self._connection_manager = connection_manager
+
+    async def collect(self, probe: ProbeName, resource: str | None) -> SupportBundleEvidence:
+        del resource
+        status = self._connection_manager.support_status()
+        connected = status["connected"] is True
+        developer_api_available = status["developer_api_available"] is True
+        proxy_available = status["proxy_session_available"] is True
+        if developer_api_available and proxy_available:
+            api_surface = "mixed"
+        elif developer_api_available:
+            api_surface = "integration"
+        elif proxy_available:
+            api_surface = "controller_v2"
+        else:
+            api_surface = "unknown"
+        probe_section = (
+            SummaryProbe(status=EvidenceStatus.AVAILABLE if connected else EvidenceStatus.UNAVAILABLE)
+            if probe == "summary"
+            else ConnectivityProbe(
+                status=EvidenceStatus.UNSUPPORTED,
+                duration_bucket="unknown",
+                outcome="unknown",
+            )
+        )
+        return SupportBundleEvidence(
+            controller=ControllerSection(
+                status=EvidenceStatus.AVAILABLE if connected else EvidenceStatus.NOT_CONNECTED,
+                api_surface=api_surface,
+                capability_flags=(ControllerCapabilityFlag.CACHED_STATE,) if connected else (),
+            ),
+            connection=ConnectionSection(
+                initialized=status["initialized"] is True,
+                connected=connected,
+                tls_verification_enabled=status["tls_verification_enabled"] is True,
+                last_attempt=status["last_attempt"],
+                capabilities=AccessCapabilities(
+                    developer_api_available=developer_api_available,
+                    proxy_session_available=proxy_available,
+                    api_token_configured=status["api_token_configured"] is True,
+                ),
+            ),
+            probe=probe_section,
+            sanitization=SanitizationSection(
+                values_suppressed=False,
+                dynamic_keys_suppressed=False,
+                errors_normalized=True,
+                variants_truncated=False,
+                nodes_truncated=False,
+                bytes_truncated=False,
+            ),
+        )

--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 36,
+  "count": 37,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "access_create_credential": "unifi_access_mcp.tools.credentials",
@@ -1380,6 +1380,57 @@
         }
       },
       "title": "Get Policy"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Generate sanitized UniFi Access support evidence for user review. Summary is local/cache-only; live probes are bounded and explicitly allowlisted.",
+      "name": "access_get_support_bundle",
+      "schema": {
+        "input": {
+          "properties": {
+            "probe": {
+              "default": "summary",
+              "enum": [
+                "summary",
+                "connectivity",
+                "resource_shape"
+              ],
+              "type": "string"
+            },
+            "resource": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "data": {
+              "type": "object"
+            },
+            "error": {
+              "type": "string"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ],
+          "type": "object"
+        }
+      },
+      "title": "UniFi Access Support Bundle"
     },
     {
       "annotations": {

--- a/apps/access/tests/unit/test_support.py
+++ b/apps/access/tests/unit/test_support.py
@@ -1,0 +1,43 @@
+"""Tests for the Access support-bundle adapter."""
+
+from types import SimpleNamespace
+
+from unifi_access_mcp.support import AccessSupportBundleAdapter
+from unifi_core.support_bundle import connection_attempt_succeeded
+
+
+def _manager(*, developer: bool, proxy: bool):
+    return SimpleNamespace(
+        support_status=lambda: {
+            "initialized": developer or proxy,
+            "connected": developer or proxy,
+            "tls_verification_enabled": True,
+            "last_attempt": connection_attempt_succeeded(),
+            "developer_api_available": developer,
+            "proxy_session_available": proxy,
+            "api_token_configured": True,
+            "developer_api_attempt": connection_attempt_succeeded(),
+            "proxy_session_attempt": connection_attempt_succeeded(),
+        }
+    )
+
+
+async def test_access_summary_reports_dual_auth_capabilities_without_attempt_extras():
+    evidence = await AccessSupportBundleAdapter(_manager(developer=True, proxy=True)).collect("summary", None)
+
+    assert evidence.connection.capabilities.model_dump(mode="json") == {
+        "product": "access",
+        "developer_api_available": True,
+        "proxy_session_available": True,
+        "api_token_configured": True,
+    }
+    assert evidence.controller.api_surface == "mixed"
+    assert "developer_api_attempt" not in repr(evidence)
+
+
+async def test_access_single_successful_auth_path_is_reported():
+    developer = await AccessSupportBundleAdapter(_manager(developer=True, proxy=False)).collect("summary", None)
+    proxy = await AccessSupportBundleAdapter(_manager(developer=False, proxy=True)).collect("summary", None)
+
+    assert developer.controller.api_surface == "integration"
+    assert proxy.controller.api_surface == "controller_v2"

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -5,7 +5,7 @@
   <img src="../../assets/hero-network.svg" alt="UniFi Network MCP Server" width="720">
 </p>
 
-MCP server exposing 192 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
+MCP server exposing 193 UniFi Network Controller tools for LLMs, agents, and automation platforms. Query clients, devices, firewall rules, VLANs, VPNs, Traffic Flows, stats, and more — with safe-by-default permissions and preview-before-confirm for all mutations.
 
 ## Install
 
@@ -229,7 +229,7 @@ Each device record now includes additional fields alongside the existing MAC, na
 
 - [Configuration](docs/configuration.md) — Full env var reference, YAML config, controller type detection
 - [Permissions](docs/permissions.md) — Permission system, category defaults, how to enable high-risk tools
-- [Tool Catalog](docs/tools.md) — All 192 tools organized by category
+- [Tool Catalog](docs/tools.md) — All 193 tools organized by category
 - [Transports](docs/transports.md) — stdio, Streamable HTTP, and SSE setup
 - [Troubleshooting](docs/troubleshooting.md) — Connection issues, SSL, missing tools
 

--- a/apps/network/devtools/dev_console.py
+++ b/apps/network/devtools/dev_console.py
@@ -265,11 +265,11 @@ async def main_async() -> None:
         # Import main to apply permissioned_tool wrapper to server.tool
         # This handles permission_category/permission_action kwargs that
         # FastMCP's native .tool() decorator doesn't understand
-        import unifi_network_mcp.main  # noqa: F401, E402
+        import unifi_network_mcp.main as main_mod  # noqa: E402
         from unifi_mcp_shared.meta_tools import register_meta_tools  # noqa: E402
         from unifi_mcp_shared.tool_loader import auto_load_tools  # noqa: E402
         from unifi_network_mcp.jobs import get_job_status, start_async_tool  # noqa: E402
-        from unifi_network_mcp.runtime import connection_manager, server  # noqa: E402
+        from unifi_network_mcp.runtime import connection_manager, server, support_bundle_service  # noqa: E402
         from unifi_network_mcp.tool_index import register_tool, tool_index_handler  # noqa: E402
     except ModuleNotFoundError as e:
         if str(e).startswith("No module named 'mcp'"):
@@ -287,11 +287,12 @@ async def main_async() -> None:
         # Register meta-tools (tool_index, execute, batch, batch_status) for dev console
         register_meta_tools(
             server=server,
-            tool_decorator=server.tool,
+            tool_decorator=main_mod._original_tool_decorator,
             tool_index_handler=tool_index_handler,
             start_async_tool=start_async_tool,
             get_job_status=get_job_status,
             register_tool=register_tool,
+            support_bundle_handler=support_bundle_service.generate,
         )
 
         if not await _ensure_connected(connection_manager):

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Network MCP server exposes 192 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Network MCP server exposes 193 tools, all prefixed with `unifi_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy workflows, call the `unifi_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_network_mcp/tools_manifest.json`. In `meta_only` mode, the index initially contains only meta-tools; executing a known domain tool lazily registers its module, so later index results can include those loaded tools.
 

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # validation requires Core 0.4.34. Traffic-flow DPI name enrichment
     # requires Core 0.4.36. Exact event-key filtering and discovery require
     # Core 0.4.37; explicit zero event limits require Core 0.4.39.
-    "unifi-core[network]>=0.4.39,<0.5",
+    "unifi-core[network]>=0.4.41,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security

--- a/apps/network/src/unifi_network_mcp/main.py
+++ b/apps/network/src/unifi_network_mcp/main.py
@@ -20,6 +20,7 @@ from unifi_network_mcp.runtime import (
     config,
     connection_manager,
     server,
+    support_bundle_service,
 )
 from unifi_network_mcp.tool_index import register_tool, tool_index_handler
 from unifi_network_mcp.utils.diagnostics import diagnostics_enabled, wrap_tool
@@ -77,6 +78,7 @@ async def main_async():
         base_package="unifi_network_mcp.tools",
         config=config,
         logger=logger,
+        support_bundle_handler=support_bundle_service.generate,
     )
 
     # ---- Start transports ----

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -29,7 +29,14 @@ from unifi_core.auth import UniFiAuth
 from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL, configure_mcp_server_metadata
 from unifi_mcp_shared.response_policy import resolve_mcp_content_mode, should_redact_response_sensitive_fields
 from unifi_mcp_shared.server import UniFiMCPServer
-from unifi_network_mcp.bootstrap import load_config, logger
+from unifi_mcp_shared.support_bundle import (
+    SupportBundleService,
+    configured_filter,
+    configured_transports,
+    fixed_manifest_reader,
+)
+from unifi_network_mcp.bootstrap import UNIFI_TOOL_REGISTRATION_MODE, load_config, logger
+from unifi_network_mcp.support import NetworkSupportBundleAdapter
 
 _TOOLS_MANIFEST_PATH = Path(__file__).resolve().parent / "tools_manifest.json"
 from unifi_core.network.managers.acl_manager import AclManager
@@ -291,6 +298,32 @@ def get_tool_registry() -> dict[str, Any]:
     return TOOL_REGISTRY
 
 
+@lru_cache
+def get_support_bundle_adapter() -> NetworkSupportBundleAdapter:
+    """Create the Network adapter over existing safe runtime singletons."""
+    return NetworkSupportBundleAdapter(
+        get_connection_manager(),
+        integration_api_key_configured=get_auth().has_api_key,
+    )
+
+
+@lru_cache
+def get_support_bundle_service() -> SupportBundleService:
+    """Create the process-wide Network support-bundle service."""
+    cfg = get_config()
+    return SupportBundleService(
+        adapter=get_support_bundle_adapter(),
+        registration_mode=UNIFI_TOOL_REGISTRATION_MODE,
+        content_mode=resolve_mcp_content_mode("network", config=cfg),
+        transports=configured_transports(cfg.server),
+        diagnostics_enabled=str(cfg.server.diagnostics.get("enabled", False)).lower() in {"true", "1", "yes"},
+        response_redaction_enabled=should_redact_response_sensitive_fields("network", cfg),
+        manifest_reader=fixed_manifest_reader(_TOOLS_MANIFEST_PATH),
+        enabled_categories=configured_filter(cfg.server.get("enabled_categories")),
+        enabled_tools=configured_filter(cfg.server.get("enabled_tools")),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shorthand aliases (import‑time singletons) --------------------------------
 # ---------------------------------------------------------------------------
@@ -326,6 +359,8 @@ routing_manager = get_routing_manager()
 traffic_flow_manager = get_traffic_flow_manager()
 traffic_route_manager = get_traffic_route_manager()
 tool_registry = get_tool_registry()
+support_bundle_adapter = get_support_bundle_adapter()
+support_bundle_service = get_support_bundle_service()
 
 
 def should_redact_sensitive_fields() -> bool:

--- a/apps/network/src/unifi_network_mcp/support.py
+++ b/apps/network/src/unifi_network_mcp/support.py
@@ -1,0 +1,80 @@
+"""Privacy-bounded support-bundle adapter for UniFi Network."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from unifi_core.support_bundle import (
+    ConnectionSection,
+    ConnectivityProbe,
+    ControllerCapabilityFlag,
+    ControllerSection,
+    EvidenceStatus,
+    NetworkCapabilities,
+    Product,
+    SanitizationSection,
+    SummaryProbe,
+)
+from unifi_mcp_shared.support_bundle import ProbeName, SupportBundleEvidence
+
+
+class NetworkSupportBundleAdapter:
+    """Translate Network's public safe connection snapshot into Core types."""
+
+    product = Product.NETWORK
+
+    def __init__(self, connection_manager: Any, *, integration_api_key_configured: bool) -> None:
+        self._connection_manager = connection_manager
+        self._integration_api_key_configured = integration_api_key_configured
+
+    async def collect(self, probe: ProbeName, resource: str | None) -> SupportBundleEvidence:
+        del resource
+        status = self._connection_manager.support_status()
+        connected = status["connected"] is True
+        controller_type = status["controller_type"]
+        session_available = status["session_available"] is True
+        if session_available and self._integration_api_key_configured:
+            api_surface = "mixed"
+        elif session_available:
+            api_surface = "controller_v2"
+        elif self._integration_api_key_configured:
+            api_surface = "integration"
+        else:
+            api_surface = "unknown"
+        probe_section = (
+            SummaryProbe(status=EvidenceStatus.AVAILABLE if connected else EvidenceStatus.UNAVAILABLE)
+            if probe == "summary"
+            else ConnectivityProbe(
+                status=EvidenceStatus.UNSUPPORTED,
+                duration_bucket="unknown",
+                outcome="unknown",
+            )
+        )
+        return SupportBundleEvidence(
+            controller=ControllerSection(
+                status=EvidenceStatus.AVAILABLE if connected else EvidenceStatus.NOT_CONNECTED,
+                api_surface=api_surface,
+                capability_flags=(ControllerCapabilityFlag.CACHED_STATE,) if connected else (),
+            ),
+            connection=ConnectionSection(
+                initialized=status["initialized"] is True,
+                connected=connected,
+                tls_verification_enabled=status["tls_verification_enabled"] is True,
+                last_attempt=status["last_attempt"],
+                capabilities=NetworkCapabilities(
+                    session_available=session_available,
+                    integration_api_key_configured=self._integration_api_key_configured,
+                    controller_type=controller_type,
+                    reconnect_circuit=status["reconnect_circuit"],
+                ),
+            ),
+            probe=probe_section,
+            sanitization=SanitizationSection(
+                values_suppressed=False,
+                dynamic_keys_suppressed=False,
+                errors_normalized=True,
+                variants_truncated=False,
+                nodes_truncated=False,
+                bytes_truncated=False,
+            ),
+        )

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 192,
+  "count": 193,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "unifi_adopt_device": "unifi_network_mcp.tools.devices",
@@ -9117,6 +9117,57 @@
         }
       },
       "title": "Get Speedtest Status"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Generate sanitized UniFi Network support evidence for user review. Summary is local/cache-only; live probes are bounded and explicitly allowlisted.",
+      "name": "unifi_get_support_bundle",
+      "schema": {
+        "input": {
+          "properties": {
+            "probe": {
+              "default": "summary",
+              "enum": [
+                "summary",
+                "connectivity",
+                "resource_shape"
+              ],
+              "type": "string"
+            },
+            "resource": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "data": {
+              "type": "object"
+            },
+            "error": {
+              "type": "string"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ],
+          "type": "object"
+        }
+      },
+      "title": "UniFi Network Support Bundle"
     },
     {
       "annotations": {

--- a/apps/network/tests/unit/test_support.py
+++ b/apps/network/tests/unit/test_support.py
@@ -1,0 +1,56 @@
+"""Tests for the Network support-bundle adapter."""
+
+from types import SimpleNamespace
+
+from unifi_core.support_bundle import connection_attempt_failed, connection_attempt_succeeded
+from unifi_network_mcp.support import NetworkSupportBundleAdapter
+
+
+async def test_network_summary_uses_only_public_safe_connection_status():
+    manager = SimpleNamespace(
+        support_status=lambda: {
+            "initialized": True,
+            "connected": True,
+            "tls_verification_enabled": True,
+            "last_attempt": connection_attempt_succeeded(),
+            "session_available": True,
+            "controller_type": "proxy",
+            "reconnect_circuit": "closed",
+            "host": "controller.example.invalid",
+        }
+    )
+    adapter = NetworkSupportBundleAdapter(manager, integration_api_key_configured=True)
+
+    evidence = await adapter.collect("summary", None)
+
+    assert evidence.connection.capabilities.model_dump(mode="json") == {
+        "product": "network",
+        "session_available": True,
+        "integration_api_key_configured": True,
+        "controller_type": "proxy",
+        "reconnect_circuit": "closed",
+    }
+    assert evidence.controller.api_surface == "mixed"
+    assert "controller.example.invalid" not in repr(evidence)
+
+
+async def test_network_failed_initialization_keeps_category_not_raw_error():
+    canary = "https://user:secret@controller.example.invalid"
+    manager = SimpleNamespace(
+        support_status=lambda: {
+            "initialized": False,
+            "connected": False,
+            "tls_verification_enabled": False,
+            "last_attempt": connection_attempt_failed(PermissionError(canary)),
+            "session_available": False,
+            "controller_type": "unknown",
+            "reconnect_circuit": "open",
+        }
+    )
+    adapter = NetworkSupportBundleAdapter(manager, integration_api_key_configured=False)
+
+    evidence = await adapter.collect("summary", None)
+
+    assert evidence.probe.status.value == "unavailable"
+    assert evidence.connection.last_attempt.error_category.value == "permission"
+    assert canary not in repr(evidence)

--- a/apps/network/tests/unit/test_tool_map_sync.py
+++ b/apps/network/tests/unit/test_tool_map_sync.py
@@ -30,15 +30,11 @@ class TestToolMapSync:
         return TOOL_MODULE_MAP
 
     @pytest.fixture
-    def meta_tools(self) -> set[str]:
+    def meta_tools(self, manifest_tools: set[str]) -> set[str]:
         """Meta-tools that are registered separately, not via TOOL_MODULE_MAP."""
-        return {
-            "unifi_tool_index",
-            "unifi_execute",
-            "unifi_batch",
-            "unifi_batch_status",
-            "unifi_load_tools",
-        }
+        from unifi_mcp_shared.meta_tools import is_meta_tool
+
+        return {name for name in manifest_tools if is_meta_tool(name)}
 
     def test_all_manifest_tools_in_map(
         self, manifest_tools: set[str], tool_module_map: dict[str, str], meta_tools: set[str]

--- a/apps/protect/README.md
+++ b/apps/protect/README.md
@@ -212,7 +212,7 @@ Compact mode is the recommended default when building summaries or feeding event
 
 - [Configuration](docs/configuration.md) -- Full env var reference, YAML config, Protect-specific options
 - [Permissions](docs/permissions.md) -- Permission system, category defaults, how to enable mutations
-- [Tool Catalog](docs/tools.md) -- All 61 tools organized by category
+- [Tool Catalog](docs/tools.md) -- All 62 tools organized by category
 - [Event Streaming](docs/events.md) -- Real-time event architecture, MCP resources, polling
 - [Troubleshooting](docs/troubleshooting.md) -- Connection issues, SSL, missing tools
 

--- a/apps/protect/devtools/dev_console.py
+++ b/apps/protect/devtools/dev_console.py
@@ -255,11 +255,11 @@ async def main_async() -> None:
         # Import main to apply permissioned_tool wrapper to server.tool
         # This handles permission_category/permission_action kwargs that
         # FastMCP's native .tool() decorator doesn't understand
-        import unifi_protect_mcp.main  # noqa: F401, E402
+        import unifi_protect_mcp.main as main_mod  # noqa: E402
         from unifi_mcp_shared.meta_tools import register_meta_tools  # noqa: E402
         from unifi_mcp_shared.tool_loader import auto_load_tools  # noqa: E402
         from unifi_protect_mcp.jobs import get_job_status, start_async_tool  # noqa: E402
-        from unifi_protect_mcp.runtime import connection_manager, server  # noqa: E402
+        from unifi_protect_mcp.runtime import connection_manager, server, support_bundle_service  # noqa: E402
         from unifi_protect_mcp.tool_index import register_tool, tool_index_handler  # noqa: E402
     except ModuleNotFoundError as e:
         if str(e).startswith("No module named 'mcp'"):
@@ -277,11 +277,12 @@ async def main_async() -> None:
         # Register meta-tools (tool_index, execute, batch, batch_status) for dev console
         register_meta_tools(
             server=server,
-            tool_decorator=server.tool,
+            tool_decorator=main_mod._original_tool_decorator,
             tool_index_handler=tool_index_handler,
             start_async_tool=start_async_tool,
             get_job_status=get_job_status,
             register_tool=register_tool,
+            support_bundle_handler=support_bundle_service.generate,
             prefix="protect",
             server_label="UniFi Protect",
         )

--- a/apps/protect/docs/tools.md
+++ b/apps/protect/docs/tools.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-The UniFi Protect MCP server exposes 61 tools (including 5 meta-tools), all prefixed with `protect_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
+The UniFi Protect MCP server exposes 62 tools (including 6 meta-tools), all prefixed with `protect_`. Read-only tools are always available. Mutating tools are controlled by the [permission system](permissions.md).
 
 Standard MCP clients should use `tools/list` for currently registered tools. For compact manifest-backed metadata in lazy workflows, call the `protect_tool_index` compatibility meta-tool at runtime, or inspect `src/unifi_protect_mcp/tools_manifest.json`. In `meta_only` mode, the index initially contains only meta-tools; executing a known domain tool lazily registers its module, so later index results can include those loaded tools.
 

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # [protect] extra rather than declaring uiprotect here directly. Camera
     # detail fields require Core 0.4.35; explicit zero event limits require
     # Core 0.4.39.
-    "unifi-core[protect]>=0.4.40,<0.5",
+    "unifi-core[protect]>=0.4.41,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/protect/src/unifi_protect_mcp/main.py
+++ b/apps/protect/src/unifi_protect_mcp/main.py
@@ -21,6 +21,7 @@ from unifi_protect_mcp.runtime import (
     connection_manager,
     event_manager,
     server,
+    support_bundle_service,
 )
 from unifi_protect_mcp.tool_index import register_tool, tool_index_handler
 from unifi_protect_mcp.utils.config_helpers import parse_config_bool
@@ -106,6 +107,7 @@ async def main_async():
         base_package="unifi_protect_mcp.tools",
         config=config,
         logger=logger,
+        support_bundle_handler=support_bundle_service.generate,
         prefix="protect",
         server_label="UniFi Protect",
     )

--- a/apps/protect/src/unifi_protect_mcp/runtime.py
+++ b/apps/protect/src/unifi_protect_mcp/runtime.py
@@ -29,7 +29,14 @@ from unifi_core.auth import UniFiAuth
 from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL, configure_mcp_server_metadata
 from unifi_mcp_shared.response_policy import resolve_mcp_content_mode, should_redact_response_sensitive_fields
 from unifi_mcp_shared.server import UniFiMCPServer
-from unifi_protect_mcp.bootstrap import load_config, logger
+from unifi_mcp_shared.support_bundle import (
+    SupportBundleService,
+    configured_filter,
+    configured_transports,
+    fixed_manifest_reader,
+)
+from unifi_protect_mcp.bootstrap import UNIFI_TOOL_REGISTRATION_MODE, load_config, logger
+from unifi_protect_mcp.support import ProtectSupportBundleAdapter
 
 _TOOLS_MANIFEST_PATH = Path(__file__).resolve().parent / "tools_manifest.json"
 from unifi_core.protect.managers.alarm_facade import AlarmRulesFacade
@@ -229,6 +236,29 @@ def get_tool_registry() -> dict[str, Any]:
     return TOOL_REGISTRY
 
 
+@lru_cache
+def get_support_bundle_adapter() -> ProtectSupportBundleAdapter:
+    """Create the Protect adapter over existing safe runtime singletons."""
+    return ProtectSupportBundleAdapter(get_connection_manager())
+
+
+@lru_cache
+def get_support_bundle_service() -> SupportBundleService:
+    """Create the process-wide Protect support-bundle service."""
+    cfg = get_config()
+    return SupportBundleService(
+        adapter=get_support_bundle_adapter(),
+        registration_mode=UNIFI_TOOL_REGISTRATION_MODE,
+        content_mode=resolve_mcp_content_mode("protect", config=cfg),
+        transports=configured_transports(cfg.server),
+        diagnostics_enabled=str(cfg.server.diagnostics.get("enabled", False)).lower() in {"true", "1", "yes"},
+        response_redaction_enabled=should_redact_response_sensitive_fields("protect", cfg),
+        manifest_reader=fixed_manifest_reader(_TOOLS_MANIFEST_PATH),
+        enabled_categories=configured_filter(cfg.server.get("enabled_categories")),
+        enabled_tools=configured_filter(cfg.server.get("enabled_tools")),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shorthand aliases (import-time singletons) --------------------------------
 # ---------------------------------------------------------------------------
@@ -252,6 +282,8 @@ system_manager = get_system_manager()
 alarm_manager = get_alarm_manager()
 alarm_facade = get_alarm_facade()
 tool_registry = get_tool_registry()
+support_bundle_adapter = get_support_bundle_adapter()
+support_bundle_service = get_support_bundle_service()
 
 
 def should_redact_sensitive_fields() -> bool:

--- a/apps/protect/src/unifi_protect_mcp/support.py
+++ b/apps/protect/src/unifi_protect_mcp/support.py
@@ -1,0 +1,83 @@
+"""Privacy-bounded support-bundle adapter for UniFi Protect."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from unifi_core.support_bundle import (
+    ConnectionSection,
+    ConnectivityProbe,
+    ControllerCapabilityFlag,
+    ControllerSection,
+    EvidenceStatus,
+    Product,
+    ProtectCapabilities,
+    ResourceShapeProbe,
+    SanitizationSection,
+    SummaryProbe,
+)
+from unifi_mcp_shared.support_bundle import ProbeName, SupportBundleEvidence
+
+
+class ProtectSupportBundleAdapter:
+    """Translate Protect's public safe connection snapshot into Core types."""
+
+    product = Product.PROTECT
+
+    def __init__(self, connection_manager: Any) -> None:
+        self._connection_manager = connection_manager
+
+    async def collect(self, probe: ProbeName, resource: str | None) -> SupportBundleEvidence:
+        status = self._connection_manager.support_status()
+        connected = status["connected"] is True
+        session_available = status["session_available"] is True
+        api_key_configured = status["public_api_key_configured"] is True
+        if session_available and api_key_configured:
+            api_surface = "mixed"
+        elif session_available:
+            api_surface = "controller_v2"
+        elif api_key_configured:
+            api_surface = "integration"
+        else:
+            api_surface = "unknown"
+        if probe == "summary":
+            probe_section = SummaryProbe(status=EvidenceStatus.AVAILABLE if connected else EvidenceStatus.UNAVAILABLE)
+        elif probe == "resource_shape":
+            probe_section = ResourceShapeProbe(
+                status=EvidenceStatus.UNSUPPORTED,
+                resource="sensors",
+            )
+        else:
+            probe_section = ConnectivityProbe(
+                status=EvidenceStatus.UNSUPPORTED,
+                duration_bucket="unknown",
+                outcome="unknown",
+            )
+        return SupportBundleEvidence(
+            controller=ControllerSection(
+                status=EvidenceStatus.AVAILABLE if connected else EvidenceStatus.NOT_CONNECTED,
+                api_surface=api_surface,
+                capability_flags=(ControllerCapabilityFlag.CACHED_STATE,) if connected else (),
+            ),
+            connection=ConnectionSection(
+                initialized=status["initialized"] is True,
+                connected=connected,
+                tls_verification_enabled=status["tls_verification_enabled"] is True,
+                last_attempt=status["last_attempt"],
+                capabilities=ProtectCapabilities(
+                    session_available=session_available,
+                    bootstrap_available=status["bootstrap_available"] is True,
+                    public_api_key_configured=api_key_configured,
+                    websocket_state=status["websocket_state"],
+                ),
+            ),
+            probe=probe_section,
+            sanitization=SanitizationSection(
+                values_suppressed=False,
+                dynamic_keys_suppressed=False,
+                errors_normalized=True,
+                variants_truncated=False,
+                nodes_truncated=False,
+                bytes_truncated=False,
+            ),
+        )

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 61,
+  "count": 62,
   "generated_by": "scripts/generate_tool_manifest.py",
   "module_map": {
     "protect_acknowledge_event": "unifi_protect_mcp.tools.events",
@@ -2696,6 +2696,57 @@
         }
       },
       "title": "Get Snapshot"
+    },
+    {
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+        "readOnlyHint": true
+      },
+      "description": "Generate sanitized UniFi Protect support evidence for user review. Summary is local/cache-only; live probes are bounded and explicitly allowlisted.",
+      "name": "protect_get_support_bundle",
+      "schema": {
+        "input": {
+          "properties": {
+            "probe": {
+              "default": "summary",
+              "enum": [
+                "summary",
+                "connectivity",
+                "resource_shape"
+              ],
+              "type": "string"
+            },
+            "resource": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "data": {
+              "type": "object"
+            },
+            "error": {
+              "type": "string"
+            },
+            "success": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "success"
+          ],
+          "type": "object"
+        }
+      },
+      "title": "UniFi Protect Support Bundle"
     },
     {
       "annotations": {

--- a/apps/protect/tests/unit/test_support.py
+++ b/apps/protect/tests/unit/test_support.py
@@ -1,0 +1,52 @@
+"""Tests for the Protect support-bundle adapter."""
+
+from types import SimpleNamespace
+
+from unifi_core.support_bundle import connection_attempt_succeeded
+from unifi_protect_mcp.support import ProtectSupportBundleAdapter
+
+
+def _manager(*, connected: bool = True):
+    return SimpleNamespace(
+        support_status=lambda: {
+            "initialized": connected,
+            "connected": connected,
+            "tls_verification_enabled": True,
+            "last_attempt": connection_attempt_succeeded(),
+            "session_available": connected,
+            "bootstrap_available": connected,
+            "public_api_key_configured": True,
+            "websocket_state": "connected" if connected else "unknown",
+        }
+    )
+
+
+async def test_protect_summary_reports_typed_cached_capabilities():
+    evidence = await ProtectSupportBundleAdapter(_manager()).collect("summary", None)
+
+    assert evidence.connection.capabilities.model_dump(mode="json") == {
+        "product": "protect",
+        "session_available": True,
+        "bootstrap_available": True,
+        "public_api_key_configured": True,
+        "websocket_state": "connected",
+    }
+    assert evidence.controller.api_surface == "mixed"
+
+
+async def test_protect_summary_remains_available_after_initialization_returns_false():
+    evidence = await ProtectSupportBundleAdapter(_manager(connected=False)).collect("summary", None)
+
+    assert evidence.connection.initialized is False
+    assert evidence.probe.status.value == "unavailable"
+
+
+async def test_protect_resource_shape_is_explicitly_unsupported_after_gate_zero():
+    evidence = await ProtectSupportBundleAdapter(_manager()).collect("resource_shape", "sensors")
+
+    assert evidence.probe.model_dump(mode="json") == {
+        "probe": "resource_shape",
+        "status": "unsupported",
+        "resource": "sensors",
+        "shape": None,
+    }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ Used by: `apps/network`, `apps/protect`, `apps/access`.
 
 ### apps/network
 
-The UniFi Network MCP server. 192 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
+The UniFi Network MCP server. 193 tools covering firewall, clients, devices, networks, VPNs, routing, stats, Traffic Flows, and more.
 
 - `src/unifi_network_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch
@@ -71,7 +71,7 @@ The UniFi Network MCP server. 192 tools covering firewall, clients, devices, net
 
 ### apps/protect
 
-The UniFi Protect MCP server. 61 tools across 8 categories covering cameras, events, Find Anything detection search, recordings, devices (lights/sensors/chimes), liveviews, system status, recognition (faces + license plates), and the Alarm Manager (including AI-powered alarms, which require a SuperAdmin credential). Connects via `uiprotect` (pyunifiprotect) for websocket-based real-time event streaming.
+The UniFi Protect MCP server. 62 tools across 8 categories covering cameras, events, Find Anything detection search, recordings, devices (lights/sensors/chimes), liveviews, system status, recognition (faces + license plates), and the Alarm Manager (including AI-powered alarms, which require a SuperAdmin credential). Connects via `uiprotect` (pyunifiprotect) for websocket-based real-time event streaming.
 
 - `src/unifi_protect_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch
@@ -87,7 +87,7 @@ The UniFi Protect MCP server. 61 tools across 8 categories covering cameras, eve
 
 ### apps/access
 
-The UniFi Access MCP server. 36 tools across 7 categories covering doors, policies, credentials, visitors, events, devices, and system. Uses a **dual-path authentication** model: API key auth on the dedicated Access port (12445) via `py-unifi-access`, and a local proxy session on port 443 for mutations.
+The UniFi Access MCP server. 37 tools across 7 categories covering doors, policies, credentials, visitors, events, devices, and system. Uses a **dual-path authentication** model: API key auth on the dedicated Access port (12445) via `py-unifi-access`, and a local proxy session on port 443 for mutations.
 
 - `src/unifi_access_mcp/` -- server code
   - `main.py` -- entry point, tool registration, transport dispatch

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,17 +119,17 @@
             </div>
           </div>
           <div class="server-list">
-            <div class="server-row network" data-product="network" data-tool-count="192">
+            <div class="server-row network" data-product="network" data-tool-count="193">
               <div><h4>Network <span>Stable</span></h4><p>Inventory, clients, routing, Wi-Fi, firewall policy, traffic, and controlled configuration.</p></div>
-              <div class="server-meta"><strong>192 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
+              <div class="server-meta"><strong>193 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/network">unifi-network-mcp</a></div>
             </div>
-            <div class="server-row protect" data-product="protect" data-tool-count="61">
+            <div class="server-row protect" data-product="protect" data-tool-count="62">
               <div><h4>Protect <span>Stable</span></h4><p>Cameras, events, detections, recordings, devices, and incident investigation workflows.</p></div>
-              <div class="server-meta"><strong>61 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/protect">unifi-protect-mcp</a></div>
+              <div class="server-meta"><strong>62 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/protect">unifi-protect-mcp</a></div>
             </div>
-            <div class="server-row access" data-product="access" data-tool-count="36">
+            <div class="server-row access" data-product="access" data-tool-count="37">
               <div><h4>Access <span>Stable</span></h4><p>Doors, visitors, credentials, policies, devices, and activity records.</p></div>
-              <div class="server-meta"><strong>36 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/access">unifi-access-mcp</a></div>
+              <div class="server-meta"><strong>37 tools</strong><a href="https://github.com/sirkirby/unifi-mcp/tree/main/apps/access">unifi-access-mcp</a></div>
             </div>
           </div>
         </article>

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/discovery.py
@@ -23,6 +23,7 @@ import aiohttp
 from unifi_mcp_shared.metadata import PROJECT_WEBSITE_URL, mcp_icons_for_server
 from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
 
+from unifi_mcp_relay.policy import filter_relay_tools
 from unifi_mcp_relay.protocol import ToolInfo
 
 logger = logging.getLogger("unifi-mcp-relay")
@@ -251,7 +252,7 @@ def _build_tools_from_index(index_result: dict, server_name: str) -> list[ToolIn
                 server_origin=server_name,
             )
         )
-    return tools
+    return filter_relay_tools(tools)
 
 
 def _build_tools_from_list(tools_list: list[dict], server_name: str) -> list[ToolInfo]:
@@ -268,7 +269,7 @@ def _build_tools_from_list(tools_list: list[dict], server_name: str) -> list[Too
                 server_origin=server_name,
             )
         )
-    return tools
+    return filter_relay_tools(tools)
 
 
 def _overlay_listed_metadata(

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
@@ -16,6 +16,9 @@ logger = logging.getLogger("unifi-mcp-relay")
 _MAX_RELAY_BATCH_JOBS = 1_000
 _RELAY_BATCH_STATUS_ERROR = "Batch status is available only for jobs started through this relay connection."
 
+# Scope provenance to the backend URL as well as the product status tool.
+type RelayBatchJobs = dict[tuple[str, str], dict[str, None]]
+
 
 class ToolForwarder:
     """Routes tool calls to the correct local MCP server.
@@ -24,13 +27,13 @@ class ToolForwarder:
     The routing table maps tool names to server URLs derived from discovery results.
     """
 
-    def __init__(self, server_infos: list[ServerInfo]) -> None:
+    def __init__(self, server_infos: list[ServerInfo], *, batch_jobs: RelayBatchJobs | None = None) -> None:
         self._tool_to_url: dict[str, str] = {}
         self._clients: dict[str, McpHttpClient] = {}
         self._lazy_load_tool_by_url: dict[str, str] = {}
         self._lazy_advertised_tools_by_url: dict[str, set[str]] = {}
         self._loaded_lazy_tools_by_url: dict[str, set[str]] = {}
-        self._relay_batch_jobs: dict[str, dict[str, None]] = {}
+        self._relay_batch_jobs: RelayBatchJobs = batch_jobs if batch_jobs is not None else {}
         for info in server_infos:
             for tool in filter_relay_tools(info.tools):
                 self._tool_to_url[tool.name] = info.url
@@ -187,7 +190,8 @@ class ToolForwarder:
         if not job_ids:
             return None
 
-        known = self._relay_batch_jobs.get(tool_name, {})
+        url = self.get_server_url(tool_name)
+        known = self._relay_batch_jobs.get((url, tool_name), {}) if url is not None else {}
         if any(not isinstance(job_id, str) or job_id not in known for job_id in job_ids):
             return _RELAY_BATCH_STATUS_ERROR
         return None
@@ -200,7 +204,10 @@ class ToolForwarder:
             return
 
         status_name = f"{tool_name[: -len('_batch')]}_batch_status"
-        known = self._relay_batch_jobs.setdefault(status_name, {})
+        url = self.get_server_url(tool_name)
+        if url is None:
+            return
+        known = self._relay_batch_jobs.setdefault((url, status_name), {})
         for job in jobs:
             if not isinstance(job, dict):
                 continue

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/forwarder.py
@@ -9,8 +9,12 @@ from typing import Any
 from unifi_mcp_shared.meta_tools import is_meta_tool as _is_meta_tool
 
 from unifi_mcp_relay.discovery import McpHttpClient, ServerInfo
+from unifi_mcp_relay.policy import filter_relay_tools, filter_tool_index_result, relay_call_rejection
 
 logger = logging.getLogger("unifi-mcp-relay")
+
+_MAX_RELAY_BATCH_JOBS = 1_000
+_RELAY_BATCH_STATUS_ERROR = "Batch status is available only for jobs started through this relay connection."
 
 
 class ToolForwarder:
@@ -26,8 +30,9 @@ class ToolForwarder:
         self._lazy_load_tool_by_url: dict[str, str] = {}
         self._lazy_advertised_tools_by_url: dict[str, set[str]] = {}
         self._loaded_lazy_tools_by_url: dict[str, set[str]] = {}
+        self._relay_batch_jobs: dict[str, dict[str, None]] = {}
         for info in server_infos:
-            for tool in info.tools:
+            for tool in filter_relay_tools(info.tools):
                 self._tool_to_url[tool.name] = info.url
             if info.lazy_load_tool_name:
                 self._lazy_load_tool_by_url[info.url] = info.lazy_load_tool_name
@@ -44,6 +49,8 @@ class ToolForwarder:
 
     def get_server_url(self, tool_name: str) -> str | None:
         """Return the server URL responsible for the given tool, or None if unknown."""
+        if relay_call_rejection(tool_name, {}) is not None:
+            return None
         return self._tool_to_url.get(tool_name)
 
     async def open(self) -> None:
@@ -77,7 +84,8 @@ class ToolForwarder:
         if not client:
             raise RuntimeError(f"No client for {server_url}")
         result = await client.request("tools/call", {"name": tool_name, "arguments": arguments})
-        return self._parse_tool_result(result, tool_name)
+        parsed = self._parse_tool_result(result, tool_name)
+        return filter_tool_index_result(parsed) if tool_name.endswith("_tool_index") else parsed
 
     def _parse_tool_result(self, result: dict, tool_name: str) -> Any:
         """Parse a tools/call result from current or legacy MCP response shapes."""
@@ -125,12 +133,16 @@ class ToolForwarder:
         Raises:
             Exception: Propagates any transport or protocol errors from the client.
         """
+        if self._call_rejection(tool_name, arguments) is not None:
+            return None
         url = self.get_server_url(tool_name)
         if not url:
             logger.warning("[forwarder] Unknown tool: %s", tool_name)
             return None
         await self._ensure_lazy_tool_loaded(url, tool_name)
-        return await self._call(url, tool_name, arguments)
+        result = await self._call(url, tool_name, arguments)
+        self._record_batch_jobs(tool_name, result)
+        return result
 
     async def forward_with_error(self, tool_name: str, arguments: dict) -> Any | str:
         """Forward a tool call, returning an error string on any failure.
@@ -145,12 +157,55 @@ class ToolForwarder:
         Returns:
             The tool result on success, or an error string on failure.
         """
+        rejection = self._call_rejection(tool_name, arguments)
+        if rejection is not None:
+            return rejection
         url = self.get_server_url(tool_name)
         if not url:
             return f"Unknown tool: {tool_name}"
         try:
             await self._ensure_lazy_tool_loaded(url, tool_name)
-            return await self._call(url, tool_name, arguments)
+            result = await self._call(url, tool_name, arguments)
+            self._record_batch_jobs(tool_name, result)
+            return result
         except Exception as e:
             logger.exception("[forwarder] Failed to forward %s to %s", tool_name, url)
             return str(e)
+
+    def _call_rejection(self, tool_name: str, arguments: dict) -> str | None:
+        rejection = relay_call_rejection(tool_name, arguments)
+        if rejection is not None:
+            return rejection
+        if not tool_name.endswith("_batch_status"):
+            return None
+
+        job_ids: list[object] = []
+        if arguments.get("jobId") is not None:
+            job_ids.append(arguments["jobId"])
+        if isinstance(arguments.get("jobIds"), list):
+            job_ids.extend(arguments["jobIds"])
+        if not job_ids:
+            return None
+
+        known = self._relay_batch_jobs.get(tool_name, {})
+        if any(not isinstance(job_id, str) or job_id not in known for job_id in job_ids):
+            return _RELAY_BATCH_STATUS_ERROR
+        return None
+
+    def _record_batch_jobs(self, tool_name: str, result: Any) -> None:
+        if not tool_name.endswith("_batch") or not isinstance(result, dict):
+            return
+        jobs = result.get("jobs")
+        if not isinstance(jobs, list):
+            return
+
+        status_name = f"{tool_name[: -len('_batch')]}_batch_status"
+        known = self._relay_batch_jobs.setdefault(status_name, {})
+        for job in jobs:
+            if not isinstance(job, dict):
+                continue
+            job_id = job.get("jobId")
+            if isinstance(job_id, str) and 0 < len(job_id) <= 128:
+                known[job_id] = None
+        while len(known) > _MAX_RELAY_BATCH_JOBS:
+            del known[next(iter(known))]

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/main.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/main.py
@@ -12,7 +12,7 @@ from typing import Any
 from unifi_mcp_relay.client import RelayClient
 from unifi_mcp_relay.config import RelayConfig
 from unifi_mcp_relay.discovery import ServerInfo, discover_all
-from unifi_mcp_relay.forwarder import ToolForwarder
+from unifi_mcp_relay.forwarder import RelayBatchJobs, ToolForwarder
 from unifi_mcp_relay.policy import filter_relay_tools, relay_call_rejection
 from unifi_mcp_relay.protocol import ToolInfo
 
@@ -35,6 +35,9 @@ class RelaySidecar:
         self._config = config
         self._client = RelayClient(config)
         self._forwarder: ToolForwarder | None = None
+        # Shared by replacement forwarders, including completions of in-flight
+        # calls on the old one. Never shared across separate relay instances.
+        self._batch_jobs: RelayBatchJobs = {}
         self._catalog: list[ToolInfo] = []
         self._advertised_catalog: tuple[ToolInfo, ...] = ()
         self._refresh_task: asyncio.Task | None = None
@@ -62,7 +65,7 @@ class RelaySidecar:
         if not catalog:
             raise DiscoveryNotReadyError("configured local MCP servers returned an empty tool catalog")
 
-        forwarder = ToolForwarder(servers)
+        forwarder = ToolForwarder(servers, batch_jobs=self._batch_jobs)
         await forwarder.open()
 
         # Close old forwarder only after the replacement is ready, so a

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/main.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/main.py
@@ -13,6 +13,7 @@ from unifi_mcp_relay.client import RelayClient
 from unifi_mcp_relay.config import RelayConfig
 from unifi_mcp_relay.discovery import ServerInfo, discover_all
 from unifi_mcp_relay.forwarder import ToolForwarder
+from unifi_mcp_relay.policy import filter_relay_tools, relay_call_rejection
 from unifi_mcp_relay.protocol import ToolInfo
 
 logger = logging.getLogger("unifi-mcp-relay")
@@ -57,7 +58,7 @@ class RelaySidecar:
 
         catalog: list[ToolInfo] = []
         for info in servers:
-            catalog.extend(info.tools)
+            catalog.extend(filter_relay_tools(info.tools))
         if not catalog:
             raise DiscoveryNotReadyError("configured local MCP servers returned an empty tool catalog")
 
@@ -117,6 +118,10 @@ class RelaySidecar:
         """
         if self._forwarder is None:
             return None, "Forwarder not initialized"
+
+        rejection = relay_call_rejection(tool_name, arguments)
+        if rejection is not None:
+            return None, rejection
 
         outcome = await self._forwarder.forward_with_error(tool_name, arguments)
         if isinstance(outcome, str):

--- a/packages/unifi-mcp-relay/src/unifi_mcp_relay/policy.py
+++ b/packages/unifi-mcp-relay/src/unifi_mcp_relay/policy.py
@@ -1,0 +1,84 @@
+"""Relay-specific exclusions for support data that must stay direct-to-server."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, TypeVar
+
+from unifi_mcp_shared.meta_tools import is_meta_tool
+
+RELAY_EXCLUDED_TOOL_SUFFIXES: tuple[str, ...] = ("_get_support_bundle",)
+RELAY_EXCLUDED_ERROR = "Support bundle tools are unavailable through the relay; call the direct product MCP server."
+RELAY_NESTED_META_ERROR = "Relay execute and batch wrappers may target domain tools only."
+
+_MAX_WRAPPER_DEPTH = 8
+
+_Tool = TypeVar("_Tool")
+
+
+def is_relay_excluded_tool(name: object) -> bool:
+    """Return whether an exact tool name belongs to a relay-excluded family."""
+    return isinstance(name, str) and name.endswith(RELAY_EXCLUDED_TOOL_SUFFIXES)
+
+
+def filter_relay_tools(tools: Iterable[_Tool]) -> list[_Tool]:
+    """Remove excluded tool objects or mappings from an advertised catalog."""
+    return [tool for tool in tools if not is_relay_excluded_tool(_tool_name(tool))]
+
+
+def filter_tool_index_result(result: Any) -> Any:
+    """Filter an indirect tool-index response without mutating the source value."""
+    if not isinstance(result, Mapping) or not isinstance(result.get("tools"), list):
+        return result
+    filtered = filter_relay_tools(result["tools"])
+    return {**result, "tools": filtered, "count": len(filtered)}
+
+
+def relay_call_rejection(tool_name: object, arguments: object) -> str | None:
+    """Reject excluded tools and meta-tool composition through execute/batch."""
+    return _relay_call_rejection(tool_name, arguments, depth=0, nested=False)
+
+
+def _relay_call_rejection(tool_name: object, arguments: object, *, depth: int, nested: bool) -> str | None:
+    if is_relay_excluded_tool(tool_name):
+        return RELAY_EXCLUDED_ERROR
+    if not isinstance(tool_name, str) or not isinstance(arguments, Mapping):
+        return None
+
+    # Meta-tools remain directly callable through the relay, but allowing one
+    # execution wrapper to target another makes the effective operation opaque
+    # to relay policy and response filtering. Keep wrappers domain-only.
+    if nested and is_meta_tool(tool_name):
+        return RELAY_NESTED_META_ERROR
+    if depth >= _MAX_WRAPPER_DEPTH and tool_name.endswith(("_execute", "_batch")):
+        return RELAY_NESTED_META_ERROR
+
+    if tool_name.endswith("_execute"):
+        inner_arguments = arguments.get("arguments", {})
+        if not isinstance(inner_arguments, Mapping):
+            inner_arguments = {}
+        return _relay_call_rejection(arguments.get("tool"), inner_arguments, depth=depth + 1, nested=True)
+    if tool_name.endswith("_batch"):
+        operations = arguments.get("operations")
+        if isinstance(operations, list):
+            for operation in operations:
+                if not isinstance(operation, Mapping):
+                    continue
+                inner_arguments = operation.get("arguments", {})
+                if not isinstance(inner_arguments, Mapping):
+                    inner_arguments = {}
+                rejection = _relay_call_rejection(
+                    operation.get("tool"),
+                    inner_arguments,
+                    depth=depth + 1,
+                    nested=True,
+                )
+                if rejection is not None:
+                    return rejection
+    return None
+
+
+def _tool_name(tool: Any) -> object:
+    if isinstance(tool, Mapping):
+        return tool.get("name")
+    return getattr(tool, "name", None)

--- a/packages/unifi-mcp-relay/tests/test_discovery.py
+++ b/packages/unifi-mcp-relay/tests/test_discovery.py
@@ -7,7 +7,13 @@ from importlib.metadata import version
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unifi_mcp_relay.discovery import LEGACY_MCP_PROTOCOL_REVISION, McpHttpClient, _relay_client_info
+from unifi_mcp_relay.discovery import (
+    LEGACY_MCP_PROTOCOL_REVISION,
+    McpHttpClient,
+    _build_tools_from_index,
+    _build_tools_from_list,
+    _relay_client_info,
+)
 from unifi_mcp_shared.protocol import DEFAULT_MCP_PROTOCOL_REVISION
 
 
@@ -73,6 +79,28 @@ def test_relay_client_info_matches_current_initialize_metadata():
     assert base64.b64decode(info["icons"][0]["src"].removeprefix("data:image/png;base64,")).startswith(
         b"\x89PNG\r\n\x1a\n"
     )
+
+
+def test_discovery_filters_support_tools_from_index_and_eager_list():
+    index = _build_tools_from_index(
+        {
+            "tools": [
+                {"name": "unifi_tool_index", "schema": {"input": {}}},
+                {"name": "unifi_get_support_bundle", "schema": {"input": {}}},
+            ]
+        },
+        "unifi-network-mcp",
+    )
+    listed = _build_tools_from_list(
+        [
+            {"name": "protect_get_support_bundle", "inputSchema": {}},
+            {"name": "protect_tool_index", "inputSchema": {}},
+        ],
+        "unifi-protect-mcp",
+    )
+
+    assert [tool.name for tool in index] == ["unifi_tool_index"]
+    assert [tool.name for tool in listed] == ["protect_tool_index"]
 
 
 @pytest.mark.asyncio

--- a/packages/unifi-mcp-relay/tests/test_forwarder.py
+++ b/packages/unifi-mcp-relay/tests/test_forwarder.py
@@ -44,6 +44,117 @@ def test_forwarder_builds_routing_table(server_infos):
     assert fwd.get_server_url("nonexistent_tool") is None
 
 
+def test_forwarder_omits_support_tools_even_if_discovery_supplies_them(server_infos):
+    server_infos[0].tools.extend(
+        [
+            ToolInfo(
+                name="unifi_get_support_bundle",
+                description="Support",
+                server_origin="unifi-network-mcp",
+            ),
+            ToolInfo(name="unifi_tool_index", description="Index", server_origin="unifi-network-mcp"),
+        ]
+    )
+
+    fwd = ToolForwarder(server_infos)
+
+    assert fwd.get_server_url("unifi_get_support_bundle") is None
+    assert fwd.get_server_url("unifi_tool_index") == "http://localhost:3000"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("unifi_get_support_bundle", {"probe": "summary"}),
+        ("unifi_execute", {"tool": "unifi_get_support_bundle", "arguments": {}}),
+        (
+            "unifi_batch",
+            {"operations": [{"tool": "unifi_list_devices"}, {"tool": "unifi_get_support_bundle"}]},
+        ),
+    ],
+)
+async def test_forwarder_rejects_direct_and_indirect_support_calls(server_infos, tool_name, arguments):
+    server_infos[0].tools.extend(
+        [
+            ToolInfo(name="unifi_get_support_bundle", description="Support", server_origin="unifi-network-mcp"),
+            ToolInfo(name="unifi_execute", description="Execute", server_origin="unifi-network-mcp"),
+            ToolInfo(name="unifi_batch", description="Batch", server_origin="unifi-network-mcp"),
+        ]
+    )
+    fwd = ToolForwarder(server_infos)
+
+    with patch.object(fwd, "_call", new_callable=AsyncMock) as mock_call:
+        assert await fwd.forward(tool_name, arguments) is None
+        error = await fwd.forward_with_error(tool_name, arguments)
+
+    assert "unavailable through the relay" in error
+    mock_call.assert_not_awaited()
+
+
+async def test_forwarder_filters_support_tools_from_tool_index_results(server_infos):
+    server_infos[0].tools.append(
+        ToolInfo(name="unifi_tool_index", description="Index", server_origin="unifi-network-mcp")
+    )
+    fwd = ToolForwarder(server_infos)
+    with patch.object(fwd, "_parse_tool_result") as parse:
+        parse.return_value = {
+            "tools": [
+                {"name": "unifi_get_support_bundle"},
+                {"name": "unifi_list_devices"},
+            ],
+            "count": 2,
+        }
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value={})
+        fwd._clients["http://localhost:3000"] = mock_client
+
+        result = await fwd._call("http://localhost:3000", "unifi_tool_index", {})
+
+    assert result == {"tools": [{"name": "unifi_list_devices"}], "count": 1}
+
+
+async def test_forwarder_rejects_indirect_tool_index_without_calling_server(server_infos):
+    server_infos[0].tools.append(
+        ToolInfo(name="unifi_execute", description="Execute", server_origin="unifi-network-mcp")
+    )
+    fwd = ToolForwarder(server_infos)
+
+    with patch.object(fwd, "_call", new_callable=AsyncMock) as mock_call:
+        error = await fwd.forward_with_error(
+            "unifi_execute",
+            {"tool": "unifi_tool_index", "arguments": {"include_schemas": True}},
+        )
+
+    assert "domain tools only" in error
+    mock_call.assert_not_awaited()
+
+
+async def test_batch_status_accepts_only_jobs_started_through_this_forwarder(server_infos):
+    server_infos[0].tools.extend(
+        [
+            ToolInfo(name="unifi_batch", description="Batch", server_origin="unifi-network-mcp"),
+            ToolInfo(name="unifi_batch_status", description="Status", server_origin="unifi-network-mcp"),
+        ]
+    )
+    fwd = ToolForwarder(server_infos)
+
+    with patch.object(fwd, "_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {"jobs": [{"jobId": "relay-job", "tool": "unifi_list_devices"}]}
+        await fwd.forward_with_error(
+            "unifi_batch",
+            {"operations": [{"tool": "unifi_list_devices", "arguments": {}}]},
+        )
+
+        mock_call.reset_mock()
+        mock_call.return_value = {"status": "done", "result": {"success": True}}
+        accepted = await fwd.forward_with_error("unifi_batch_status", {"jobId": "relay-job"})
+        rejected = await fwd.forward_with_error("unifi_batch_status", {"jobId": "direct-or-stale-job"})
+
+    assert accepted == {"status": "done", "result": {"success": True}}
+    assert "only for jobs started through this relay connection" in rejected
+    mock_call.assert_awaited_once_with("http://localhost:3000", "unifi_batch_status", {"jobId": "relay-job"})
+
+
 def test_forwarder_creates_one_client_per_server(server_infos):
     fwd = ToolForwarder(server_infos)
     # Two servers -> two clients

--- a/packages/unifi-mcp-relay/tests/test_main.py
+++ b/packages/unifi-mcp-relay/tests/test_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -43,6 +44,68 @@ async def test_sidecar_discovers_and_builds_catalog(config):
             assert len(catalog) == 1
             assert catalog[0].name == "unifi_list_devices"
             mock_fwd_instance.open.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replacement_url", ["http://localhost:3000", "http://localhost:3001"])
+@pytest.mark.parametrize("in_flight", [False, True])
+async def test_batch_provenance_survives_refresh_only_for_same_backend(config, replacement_url, in_flight):
+    from unifi_mcp_relay.discovery import ServerInfo
+    from unifi_mcp_relay.protocol import ToolInfo
+
+    tools = [ToolInfo(name=name, description=name) for name in ("unifi_batch", "unifi_batch_status")]
+    original = ServerInfo(name="network", url=config.servers[0], tools=tools)
+    replacement = ServerInfo(name="network", url=replacement_url, tools=tools)
+    sidecar = RelaySidecar(config)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def batch_call(*args):
+        started.set()
+        await finish.wait()
+        return {"jobs": [{"jobId": "relay-created-job"}]}
+
+    with (
+        patch("unifi_mcp_relay.main.discover_all", AsyncMock(side_effect=[[original], [replacement], [replacement]])),
+        patch("unifi_mcp_relay.forwarder.ToolForwarder.open", AsyncMock()),
+        patch("unifi_mcp_relay.forwarder.ToolForwarder.close", AsyncMock()),
+    ):
+        await sidecar._discover_catalog()
+        old_forwarder = sidecar._forwarder
+        old_forwarder._call = AsyncMock(side_effect=batch_call)
+        pending = asyncio.create_task(sidecar._handle_tool_call("unifi_batch", {"operations": []}))
+        await started.wait()
+        if not in_flight:
+            finish.set()
+            await pending
+        await sidecar._discover_catalog()
+        assert sidecar._forwarder is not old_forwarder
+        finish.set()
+        await pending
+
+        status_call = AsyncMock(return_value={"status": "running"})
+        sidecar._forwarder._call = status_call
+        result, error = await sidecar._handle_tool_call("unifi_batch_status", {"jobId": "relay-created-job"})
+        if replacement_url == original.url:
+            assert result == {"status": "running"}
+            assert error is None
+            status_call.assert_awaited_once()
+        else:
+            assert result is None
+            assert "only for jobs started" in error
+            status_call.assert_not_awaited()
+
+        status_call.reset_mock()
+        _, error = await sidecar._handle_tool_call("unifi_batch_status", {"jobId": "foreign-job"})
+        assert "only for jobs started" in error
+        status_call.assert_not_awaited()
+
+        fresh_sidecar = RelaySidecar(config)
+        await fresh_sidecar._discover_catalog()
+        fresh_sidecar._forwarder._call = status_call
+        _, error = await fresh_sidecar._handle_tool_call("unifi_batch_status", {"jobId": "relay-created-job"})
+        assert "only for jobs started" in error
+        status_call.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/packages/unifi-mcp-relay/tests/test_main.py
+++ b/packages/unifi-mcp-relay/tests/test_main.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from unifi_mcp_relay.config import RelayConfig
 from unifi_mcp_relay.main import DiscoveryNotReadyError, RelaySidecar, _catalog_snapshot
+from unifi_mcp_relay.policy import RELAY_EXCLUDED_ERROR
 
 
 @pytest.fixture
@@ -42,6 +43,30 @@ async def test_sidecar_discovers_and_builds_catalog(config):
             assert len(catalog) == 1
             assert catalog[0].name == "unifi_list_devices"
             mock_fwd_instance.open.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sidecar_never_advertises_support_tools_from_stale_discovery(config):
+    sidecar = RelaySidecar(config)
+    from unifi_mcp_relay.discovery import ServerInfo
+    from unifi_mcp_relay.protocol import ToolInfo
+
+    mock_info = ServerInfo(
+        name="unifi-network-mcp",
+        url="http://localhost:3000",
+        tools=[
+            ToolInfo(name="unifi_get_support_bundle", description="Support", server_origin="unifi-network-mcp"),
+            ToolInfo(name="unifi_tool_index", description="Index", server_origin="unifi-network-mcp"),
+        ],
+    )
+    with (
+        patch("unifi_mcp_relay.main.discover_all", new_callable=AsyncMock, return_value=[mock_info]),
+        patch("unifi_mcp_relay.main.ToolForwarder") as forwarder_class,
+    ):
+        forwarder_class.return_value = AsyncMock()
+        catalog = await sidecar._discover_catalog()
+
+    assert [tool.name for tool in catalog] == ["unifi_tool_index"]
 
 
 @pytest.mark.asyncio
@@ -130,6 +155,26 @@ async def test_sidecar_tool_call_handler_returns_error_string(config):
     result, error = await sidecar._handle_tool_call("unifi_list_devices", {})
     assert result is None
     assert error == "Connection refused"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("unifi_get_support_bundle", {}),
+        ("unifi_execute", {"tool": "unifi_get_support_bundle"}),
+        ("unifi_batch", {"operations": [{"tool": "unifi_get_support_bundle"}]}),
+    ],
+)
+async def test_sidecar_rejects_support_calls_before_forwarder(config, tool_name, arguments):
+    sidecar = RelaySidecar(config)
+    sidecar._forwarder = AsyncMock()
+
+    result, error = await sidecar._handle_tool_call(tool_name, arguments)
+
+    assert result is None
+    assert error == RELAY_EXCLUDED_ERROR
+    sidecar._forwarder.forward_with_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/packages/unifi-mcp-relay/tests/test_policy.py
+++ b/packages/unifi-mcp-relay/tests/test_policy.py
@@ -1,0 +1,111 @@
+"""Tests for the relay-only support-bundle exclusion contract."""
+
+from types import SimpleNamespace
+
+from unifi_mcp_relay.policy import (
+    RELAY_EXCLUDED_ERROR,
+    RELAY_EXCLUDED_TOOL_SUFFIXES,
+    RELAY_NESTED_META_ERROR,
+    filter_relay_tools,
+    filter_tool_index_result,
+    is_relay_excluded_tool,
+    relay_call_rejection,
+)
+
+
+def test_exclusion_contract_is_narrow_and_prefix_independent():
+    assert RELAY_EXCLUDED_TOOL_SUFFIXES == ("_get_support_bundle",)
+    assert is_relay_excluded_tool("unifi_get_support_bundle")
+    assert is_relay_excluded_tool("protect_get_support_bundle")
+    assert is_relay_excluded_tool("access_get_support_bundle")
+    assert not is_relay_excluded_tool("unifi_tool_index")
+    assert not is_relay_excluded_tool("unifi_get_system_info")
+
+
+def test_catalog_and_tool_index_filters_remove_only_support_tools():
+    catalog = [
+        SimpleNamespace(name="unifi_tool_index"),
+        SimpleNamespace(name="unifi_get_support_bundle"),
+        SimpleNamespace(name="unifi_list_devices"),
+    ]
+    assert [tool.name for tool in filter_relay_tools(catalog)] == ["unifi_tool_index", "unifi_list_devices"]
+
+    result = filter_tool_index_result(
+        {
+            "tools": [
+                {"name": "protect_tool_index"},
+                {"name": "protect_get_support_bundle"},
+                {"name": "protect_list_cameras"},
+            ],
+            "count": 3,
+            "categories": ["devices"],
+        }
+    )
+    assert result == {
+        "tools": [{"name": "protect_tool_index"}, {"name": "protect_list_cameras"}],
+        "count": 2,
+        "categories": ["devices"],
+    }
+
+
+def test_direct_execute_and_every_batch_item_are_rejected():
+    assert relay_call_rejection("access_get_support_bundle", {}) == RELAY_EXCLUDED_ERROR
+    assert (
+        relay_call_rejection(
+            "unifi_execute",
+            {"tool": "unifi_get_support_bundle", "arguments": {"probe": "summary"}},
+        )
+        == RELAY_EXCLUDED_ERROR
+    )
+    assert (
+        relay_call_rejection(
+            "protect_batch",
+            {
+                "operations": [
+                    {"tool": "protect_list_cameras", "arguments": {}},
+                    {"tool": "protect_get_support_bundle", "arguments": {}},
+                ]
+            },
+        )
+        == RELAY_EXCLUDED_ERROR
+    )
+    assert relay_call_rejection("unifi_tool_index", {"include_schemas": True}) is None
+    assert relay_call_rejection("unifi_batch", {"operations": [{"tool": "unifi_list_devices"}]}) is None
+
+
+def test_nested_meta_tool_composition_is_rejected_while_direct_meta_calls_remain_available():
+    nested_calls = [
+        (
+            "unifi_execute",
+            {
+                "tool": "unifi_execute",
+                "arguments": {"tool": "unifi_get_support_bundle", "arguments": {"probe": "summary"}},
+            },
+        ),
+        (
+            "unifi_execute",
+            {
+                "tool": "unifi_batch",
+                "arguments": {"operations": [{"tool": "unifi_get_support_bundle", "arguments": {}}]},
+            },
+        ),
+        (
+            "unifi_batch",
+            {
+                "operations": [
+                    {
+                        "tool": "unifi_execute",
+                        "arguments": {"tool": "unifi_get_support_bundle", "arguments": {}},
+                    }
+                ]
+            },
+        ),
+        ("unifi_execute", {"tool": "unifi_tool_index", "arguments": {"include_schemas": True}}),
+        ("unifi_batch", {"operations": [{"tool": "unifi_batch_status", "arguments": {"jobId": "job"}}]}),
+    ]
+
+    for tool_name, arguments in nested_calls:
+        assert relay_call_rejection(tool_name, arguments) == RELAY_NESTED_META_ERROR
+
+    assert relay_call_rejection("unifi_tool_index", {}) is None
+    assert relay_call_rejection("unifi_batch_status", {"jobId": "job"}) is None

--- a/packages/unifi-mcp-shared/pyproject.toml
+++ b/packages/unifi-mcp-shared/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "Shared MCP server patterns: permissions, confirmation, lazy loading, config"
 requires-python = ">=3.13"
 dependencies = [
-    "unifi-core>=0.4.22,<0.5",
+    "unifi-core>=0.4.41,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/__init__.py
@@ -22,6 +22,12 @@ from unifi_mcp_shared.lazy_tools import (
 from unifi_mcp_shared.manifest_helpers import get_tool_annotations
 from unifi_mcp_shared.meta_tools import register_load_tools, register_meta_tools
 from unifi_mcp_shared.server import UniFiMCPServer
+from unifi_mcp_shared.support_bundle import (
+    LiveProbeGate,
+    SupportBundleAdapter,
+    SupportBundleEvidence,
+    SupportBundleService,
+)
 from unifi_mcp_shared.tasks import (
     DEFAULT_TASK_POLL_INTERVAL_MS,
     DEFAULT_TASK_TTL_MS,
@@ -42,6 +48,10 @@ __all__ = [
     "MCP_RELATED_TASK_META",
     "PolicyGateChecker",
     "ResourceValidator",
+    "SupportBundleAdapter",
+    "SupportBundleEvidence",
+    "SupportBundleService",
+    "LiveProbeGate",
     "UniFiMCPServer",
     "DEFAULT_TASK_POLL_INTERVAL_MS",
     "DEFAULT_TASK_TTL_MS",

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/manifest_generator.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/manifest_generator.py
@@ -29,6 +29,12 @@ class _ManifestLazyLoader:
         return False
 
 
+async def _manifest_support_bundle_handler(*, probe: str = "summary", resource: str | None = None) -> dict[str, Any]:
+    """Non-executing build-time handler used only to expose the tool schema."""
+    del probe, resource
+    return {"success": False, "error": "Support bundle collection is unavailable during manifest generation."}
+
+
 def _build_module_map(
     *,
     project_root: Path,
@@ -95,6 +101,7 @@ def _generate_manifest(
         start_async_tool=jobs_mod.start_async_tool,
         get_job_status=jobs_mod.get_job_status,
         register_tool=tool_index_mod.register_tool,
+        support_bundle_handler=_manifest_support_bundle_handler,
         prefix=meta_prefix,
         server_label=server_label,
     )

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Callable, List, Literal
 
 from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
+from pydantic import SkipValidation
 
 from unifi_mcp_shared.response_serialization import normalize_call_tool_result
 from unifi_mcp_shared.tool_index import normalize_tool_annotations
@@ -140,9 +141,11 @@ def register_meta_tools(
         annotations=read_annotations,
     )
     async def _support_bundle_wrapper(
-        probe: Literal["summary", "connectivity", "resource_shape"] = "summary",
-        resource: str | None = None,
+        probe: SkipValidation[Literal["summary", "connectivity", "resource_shape"]] = "summary",
+        resource: SkipValidation[str | None] = None,
     ) -> dict:
+        # Preserve the advertised schema, but validate only inside the service's
+        # privacy boundary: Pydantic errors otherwise echo rejected input values.
         try:
             correlation_id = uuid.uuid4().hex
             started = time.monotonic()
@@ -156,7 +159,9 @@ def register_meta_tools(
             correlation_id = uuid.uuid4().hex
             outcome = "failed"
             duration_bucket = "unknown"
-        safe_probe = probe if probe in {"summary", "connectivity", "resource_shape"} else "invalid"
+        safe_probe = (
+            probe if isinstance(probe, str) and probe in {"summary", "connectivity", "resource_shape"} else "invalid"
+        )
         logger.info(
             "Support bundle audit correlation_id=%s probe=%s outcome=%s duration=%s",
             correlation_id,

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -14,7 +14,9 @@ servers are loaded simultaneously:
 """
 
 import logging
-from typing import TYPE_CHECKING, Callable, List
+import time
+import uuid
+from typing import TYPE_CHECKING, Callable, List, Literal
 
 from mcp.server.mcpserver import Context
 from mcp.types import ToolAnnotations
@@ -33,6 +35,7 @@ META_TOOL_SUFFIXES: tuple[str, ...] = (
     "_batch",
     "_batch_status",
     "_load_tools",
+    "_get_support_bundle",
 )
 
 
@@ -49,6 +52,16 @@ _DEFAULT_DOMAIN_HINTS = {
 }
 
 
+def _duration_bucket(duration_ms: float) -> str:
+    if duration_ms < 100:
+        return "under_100ms"
+    if duration_ms < 1_000:
+        return "100ms_1s"
+    if duration_ms < 5_000:
+        return "1s_5s"
+    return "over_5s"
+
+
 def register_meta_tools(
     server,
     tool_decorator: Callable,
@@ -56,6 +69,7 @@ def register_meta_tools(
     start_async_tool: Callable,
     get_job_status: Callable,
     register_tool: Callable,
+    support_bundle_handler: Callable,
     prefix: str = "unifi",
     server_label: str = "UniFi Network",
     domain_hint: str | None = None,
@@ -67,6 +81,7 @@ def register_meta_tools(
     - {prefix}_execute: Execute a single tool (returns result directly)
     - {prefix}_batch: Execute multiple tools in parallel (returns job IDs)
     - {prefix}_batch_status: Check batch job progress
+    - {prefix}_get_support_bundle: Generate privacy-bounded support evidence
 
     Args:
         server: FastMCP server instance (for call_tool access)
@@ -75,6 +90,7 @@ def register_meta_tools(
         start_async_tool: Function to start async jobs
         get_job_status: Function to get job status
         register_tool: Function to register in tool index
+        support_bundle_handler: Runtime support-bundle service callback.
         prefix: Tool name prefix (e.g. "unifi", "protect", "access").
         server_label: Human-readable server name for descriptions
                       (e.g. "UniFi Network", "UniFi Protect").
@@ -85,12 +101,14 @@ def register_meta_tools(
     exec_name = f"{prefix}_execute"
     batch_name = f"{prefix}_batch"
     status_name = f"{prefix}_batch_status"
+    support_name = f"{prefix}_get_support_bundle"
 
     hint = domain_hint or _DEFAULT_DOMAIN_HINTS.get(prefix, "controller management")
     idx_title = f"{server_label} Tool Index"
     exec_title = f"{server_label} Execute Tool"
     batch_title = f"{server_label} Batch Execute"
     status_title = f"{server_label} Batch Status"
+    support_title = f"{server_label} Support Bundle"
     read_annotations = ToolAnnotations(
         readOnlyHint=True,
         destructiveHint=False,
@@ -102,6 +120,80 @@ def register_meta_tools(
         destructiveHint=False,
         idempotentHint=False,
         openWorldHint=False,
+    )
+
+    # =========================================================================
+    # SUPPORT: {prefix}_get_support_bundle
+    # This uses the original server decorator and a dedicated safe audit line;
+    # it must never pass through ordinary diagnostic argument/result logging.
+    # =========================================================================
+    @tool_decorator(
+        name=support_name,
+        title=support_title,
+        description=(
+            f"Generate a sanitized, reviewable {server_label} support bundle. "
+            "The default summary is local/cache-only. Live connectivity or resource-shape probes "
+            "are bounded and may be unavailable for this product. The result excludes raw logs, "
+            "credentials, controller payload values, and arbitrary exception text. Review the "
+            "bundle before sharing it publicly."
+        ),
+        annotations=read_annotations,
+    )
+    async def _support_bundle_wrapper(
+        probe: Literal["summary", "connectivity", "resource_shape"] = "summary",
+        resource: str | None = None,
+    ) -> dict:
+        try:
+            correlation_id = uuid.uuid4().hex
+            started = time.monotonic()
+            result = await support_bundle_handler(probe=probe, resource=resource)
+            if not isinstance(result, dict):
+                result = {"success": False, "error": "Failed to generate support bundle."}
+            outcome = "success" if result.get("success") is True else "failed"
+            duration_bucket = _duration_bucket((time.monotonic() - started) * 1000)
+        except Exception:
+            result = {"success": False, "error": "Failed to generate support bundle."}
+            correlation_id = uuid.uuid4().hex
+            outcome = "failed"
+            duration_bucket = "unknown"
+        safe_probe = probe if probe in {"summary", "connectivity", "resource_shape"} else "invalid"
+        logger.info(
+            "Support bundle audit correlation_id=%s probe=%s outcome=%s duration=%s",
+            correlation_id,
+            safe_probe,
+            outcome,
+            duration_bucket,
+        )
+        return result
+
+    register_tool(
+        name=support_name,
+        title=support_title,
+        description=(
+            f"Generate sanitized {server_label} support evidence for user review. "
+            "Summary is local/cache-only; live probes are bounded and explicitly allowlisted."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "probe": {
+                    "type": "string",
+                    "enum": ["summary", "connectivity", "resource_shape"],
+                    "default": "summary",
+                },
+                "resource": {"type": ["string", "null"], "default": None},
+            },
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "success": {"type": "boolean"},
+                "data": {"type": "object"},
+                "error": {"type": "string"},
+            },
+            "required": ["success"],
+        },
+        annotations=normalize_tool_annotations(read_annotations),
     )
 
     # =========================================================================
@@ -446,7 +538,14 @@ def register_meta_tools(
         annotations=normalize_tool_annotations(read_annotations),
     )
 
-    logger.info("Registered meta-tools: %s, %s, %s, %s", idx_name, exec_name, batch_name, status_name)
+    logger.info(
+        "Registered meta-tools: %s, %s, %s, %s, %s",
+        idx_name,
+        exec_name,
+        batch_name,
+        status_name,
+        support_name,
+    )
 
 
 def register_load_tools(

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/support_bundle.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/support_bundle.py
@@ -1,0 +1,369 @@
+"""Shared assembly and live-probe controls for sanitized support bundles."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import json
+import platform
+import sys
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, Protocol, cast
+
+from unifi_core.support_bundle import (
+    ConnectionSection,
+    ControllerSection,
+    DependencyPackage,
+    DependencySection,
+    ProbeSection,
+    Product,
+    RuntimeSection,
+    SanitizationSection,
+    ServerFeatureFlag,
+    ServerSection,
+    SupportBundle,
+    bounded_support_bundle,
+    support_bundle_size,
+)
+
+ProbeName = Literal["summary", "connectivity", "resource_shape"]
+
+LIVE_PROBE_COOLDOWN_SECONDS = 30.0
+_MANIFEST_GENERATOR = "scripts/generate_tool_manifest.py"
+_CONTENT_MODES = {
+    "adaptive": "dual",
+    "compact": "json",
+    "compat": "text",
+    "dual": "dual",
+    "json": "json",
+    "text": "text",
+}
+_SERVER_PACKAGES = {
+    Product.NETWORK: "unifi-network-mcp",
+    Product.PROTECT: "unifi-protect-mcp",
+    Product.ACCESS: "unifi-access-mcp",
+}
+_SERVER_TOOLS = {
+    Product.NETWORK: "unifi_get_support_bundle",
+    Product.PROTECT: "protect_get_support_bundle",
+    Product.ACCESS: "access_get_support_bundle",
+}
+_DEPENDENCIES = {
+    Product.NETWORK: (
+        DependencyPackage.AIOUNIFI,
+        DependencyPackage.MCP,
+        DependencyPackage.PYDANTIC,
+        DependencyPackage.UNIFI_CORE,
+        DependencyPackage.UNIFI_MCP_SHARED,
+        DependencyPackage.UNIFI_NETWORK_MCP,
+    ),
+    Product.PROTECT: (
+        DependencyPackage.MCP,
+        DependencyPackage.PYDANTIC,
+        DependencyPackage.UNIFI_CORE,
+        DependencyPackage.UNIFI_MCP_SHARED,
+        DependencyPackage.UNIFI_PROTECT_MCP,
+        DependencyPackage.UIPROTECT,
+    ),
+    Product.ACCESS: (
+        DependencyPackage.MCP,
+        DependencyPackage.PYDANTIC,
+        DependencyPackage.PY_UNIFI_ACCESS,
+        DependencyPackage.UNIFI_ACCESS_MCP,
+        DependencyPackage.UNIFI_CORE,
+        DependencyPackage.UNIFI_MCP_SHARED,
+    ),
+}
+_RESOURCE_EXPOSURES = {
+    (Product.PROTECT, "sensors"): ("protect_list_sensors", "devices"),
+}
+
+
+@dataclass(frozen=True)
+class SupportBundleEvidence:
+    """Core-typed evidence returned by a product adapter."""
+
+    controller: ControllerSection
+    connection: ConnectionSection
+    probe: ProbeSection
+    sanitization: SanitizationSection
+
+
+class SupportBundleAdapter(Protocol):
+    """Product seam for local summaries and explicitly bounded live probes."""
+
+    product: Product
+
+    async def collect(self, probe: ProbeName, resource: str | None) -> SupportBundleEvidence: ...
+
+
+class _LiveProbeBusy(Exception):
+    pass
+
+
+class _LiveProbeCooldown(Exception):
+    pass
+
+
+@dataclass
+class LiveProbeGate:
+    """One process-wide live-probe slot with per-probe/resource cooldowns."""
+
+    cooldown_seconds: float = LIVE_PROBE_COOLDOWN_SECONDS
+    monotonic: Callable[[], float] = time.monotonic
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _last_started: dict[tuple[Product, ProbeName, str | None], float] = field(default_factory=dict, init=False)
+
+    async def run(
+        self,
+        key: tuple[Product, ProbeName, str | None],
+        operation: Callable[[], Awaitable[SupportBundleEvidence]],
+    ) -> SupportBundleEvidence:
+        if self._lock.locked():
+            raise _LiveProbeBusy
+        async with self._lock:
+            now = self.monotonic()
+            previous = self._last_started.get(key)
+            if previous is not None and now - previous < self.cooldown_seconds:
+                raise _LiveProbeCooldown
+            self._last_started[key] = now
+            return await operation()
+
+
+_PROCESS_LIVE_PROBE_GATE = LiveProbeGate()
+
+
+def configured_filter(value: Any) -> tuple[str, ...] | None:
+    """Reduce a configured comma-list/list to exact names without logging values."""
+    if value in (None, "", "null"):
+        return None
+    if isinstance(value, str):
+        return tuple(item.strip() for item in value.split(",") if item.strip())
+    if isinstance(value, (list, tuple)) and all(isinstance(item, str) for item in value):
+        return tuple(item for item in value if item)
+    return ()
+
+
+def configured_transports(server_config: Any) -> tuple[str, ...]:
+    """Return only configured transport enums, never bind addresses or ports."""
+    transports = ["stdio"]
+    http = server_config.get("http", {})
+    enabled = http.get("enabled", True)
+    if enabled is True or (isinstance(enabled, str) and enabled.lower() in {"true", "1", "yes", "on"}):
+        transports.append(http.get("transport", "streamable-http"))
+    return tuple(transports)
+
+
+def fixed_manifest_reader(path: Path) -> Callable[[], Mapping[str, Any]]:
+    """Build a reader for one package-owned manifest path."""
+
+    def read() -> Mapping[str, Any]:
+        value = json.loads(path.read_text())
+        return value if isinstance(value, Mapping) else {}
+
+    return read
+
+
+class SupportBundleService:
+    """Assemble, validate, and bound one product's support bundle."""
+
+    def __init__(
+        self,
+        *,
+        adapter: SupportBundleAdapter,
+        registration_mode: Literal["meta_only", "lazy", "eager"],
+        content_mode: str,
+        transports: tuple[str, ...],
+        diagnostics_enabled: bool,
+        response_redaction_enabled: bool,
+        manifest_reader: Callable[[], Mapping[str, Any]],
+        enabled_categories: tuple[str, ...] | None = None,
+        enabled_tools: tuple[str, ...] | None = None,
+        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+        version_resolver: Callable[[str], str] = importlib.metadata.version,
+        python_version_resolver: Callable[[], str] = platform.python_version,
+        os_family_resolver: Callable[[], str] = lambda: sys.platform,
+        architecture_resolver: Callable[[], str] = platform.machine,
+        live_probe_gate: LiveProbeGate = _PROCESS_LIVE_PROBE_GATE,
+    ) -> None:
+        self._adapter = adapter
+        self._registration_mode = registration_mode
+        self._content_mode = content_mode
+        self._transports = transports
+        self._diagnostics_enabled = diagnostics_enabled
+        self._response_redaction_enabled = response_redaction_enabled
+        self._manifest_reader = manifest_reader
+        self._enabled_categories = frozenset(enabled_categories) if enabled_categories is not None else None
+        self._enabled_tools = frozenset(enabled_tools) if enabled_tools is not None else None
+        self._clock = clock
+        self._version_resolver = version_resolver
+        self._python_version_resolver = python_version_resolver
+        self._os_family_resolver = os_family_resolver
+        self._architecture_resolver = architecture_resolver
+        self._live_probe_gate = live_probe_gate
+
+    async def generate(self, probe: ProbeName = "summary", resource: str | None = None) -> dict[str, Any]:
+        """Return the standard tool response without exposing rejected values."""
+        try:
+            validation_error = self._validate_request(probe, resource)
+        except Exception:
+            return {"success": False, "error": "Failed to generate support bundle."}
+        if validation_error is not None:
+            return {"success": False, "error": validation_error}
+
+        typed_probe = cast(ProbeName, probe)
+        if typed_probe == "resource_shape" and not self._live_surface_enabled(resource):
+            return {
+                "success": False,
+                "error": "Failed to generate support bundle: the backing read surface is disabled by configuration.",
+            }
+
+        try:
+            if typed_probe == "summary":
+                evidence = await self._adapter.collect(typed_probe, None)
+            else:
+                key = (self._adapter.product, typed_probe, resource)
+                evidence = await self._live_probe_gate.run(
+                    key,
+                    lambda: self._adapter.collect(typed_probe, resource),
+                )
+            bundle = bounded_support_bundle(self._assemble(evidence))
+            support_bundle_size(bundle)
+        except _LiveProbeBusy:
+            return {"success": False, "error": "Failed to generate support bundle: another live probe is in progress."}
+        except _LiveProbeCooldown:
+            return {"success": False, "error": "Failed to generate support bundle: this live probe is in cooldown."}
+        except Exception:
+            # Privacy boundary: never stringify or log validation, adapter, or
+            # serialization exceptions because they may retain rejected input.
+            return {"success": False, "error": "Failed to generate support bundle."}
+        return {"success": True, "data": bundle.model_dump(mode="json")}
+
+    def _validate_request(self, probe: object, resource: object) -> str | None:
+        if probe not in {"summary", "connectivity", "resource_shape"}:
+            return "Failed to generate support bundle: unsupported probe."
+        if probe in {"summary", "connectivity"} and resource is not None:
+            return "Failed to generate support bundle: resource is only valid for resource_shape."
+        if probe == "resource_shape":
+            if resource is None:
+                return "Failed to generate support bundle: resource_shape requires a resource."
+            if (self._adapter.product, resource) not in _RESOURCE_EXPOSURES:
+                return "Failed to generate support bundle: unsupported resource for this product."
+        return None
+
+    def _live_surface_enabled(self, resource: str | None) -> bool:
+        exposure = _RESOURCE_EXPOSURES[(self._adapter.product, resource)]
+        tool_name, category = exposure
+        if self._enabled_tools is not None and tool_name not in self._enabled_tools:
+            return False
+        if self._enabled_categories is not None and category not in self._enabled_categories:
+            return False
+        return True
+
+    def _assemble(self, evidence: SupportBundleEvidence) -> SupportBundle:
+        product = self._adapter.product
+        package = _SERVER_PACKAGES[product]
+        feature_flags = (
+            ServerFeatureFlag.DIAGNOSTICS_ENABLED
+            if self._diagnostics_enabled
+            else ServerFeatureFlag.DIAGNOSTICS_DISABLED,
+            ServerFeatureFlag.RESPONSE_REDACTION_ENABLED
+            if self._response_redaction_enabled
+            else ServerFeatureFlag.RESPONSE_REDACTION_DISABLED,
+        )
+        try:
+            manifest_count = self._manifest_reader().get("count")
+        except Exception:
+            manifest_count = 0
+        if not isinstance(manifest_count, int) or isinstance(manifest_count, bool) or not 0 <= manifest_count <= 10_000:
+            manifest_count = 0
+
+        dependencies = tuple(
+            self._dependency(dependency) for dependency in sorted(_DEPENDENCIES[product], key=lambda item: item.value)
+        )
+        generated_at = self._clock().astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+        return SupportBundle(
+            generated_at=generated_at,
+            product=product,
+            server=ServerSection(
+                package=package,
+                version=self._server_version(package),
+                tool=_SERVER_TOOLS[product],
+                feature_flags=feature_flags,
+            ),
+            runtime=RuntimeSection(
+                python_version=self._python_version_resolver(),
+                os_family=_normalize_os_family(self._os_family_resolver()),
+                architecture=_normalize_architecture(self._architecture_resolver()),
+                transports=_normalize_transports(self._transports),
+                registration_mode=self._registration_mode,
+                content_mode=_normalize_content_mode(self._content_mode),
+                manifest_tool_count=manifest_count,
+                manifest_generator=_MANIFEST_GENERATOR,
+            ),
+            dependencies=dependencies,
+            controller=evidence.controller,
+            connection=evidence.connection,
+            probe=evidence.probe,
+            sanitization=evidence.sanitization,
+        )
+
+    def _resolve_version(self, package: str) -> str:
+        try:
+            return self._version_resolver(package)
+        except Exception:
+            return "not_installed"
+
+    def _dependency(self, package: DependencyPackage) -> DependencySection:
+        try:
+            return DependencySection(package=package, version=self._resolve_version(package.value))
+        except Exception:
+            return DependencySection(package=package, version="not_installed")
+
+    def _server_version(self, package: str) -> str:
+        version = self._resolve_version(package)
+        try:
+            ServerSection(
+                package=_SERVER_PACKAGES[self._adapter.product],
+                version=version,
+                tool=_SERVER_TOOLS[self._adapter.product],
+            )
+        except Exception:
+            return "0.0.0"
+        return version
+
+
+def _normalize_os_family(value: str) -> Literal["linux", "macos", "windows", "other"]:
+    normalized = value.lower()
+    if normalized.startswith("linux"):
+        return "linux"
+    if normalized.startswith(("darwin", "macos")):
+        return "macos"
+    if normalized.startswith(("win", "cygwin", "msys")):
+        return "windows"
+    return "other"
+
+
+def _normalize_architecture(value: str) -> Literal["x86_64", "amd64", "arm64", "aarch64", "i386", "i686", "other"]:
+    normalized = value.lower()
+    allowed = {"x86_64", "amd64", "arm64", "aarch64", "i386", "i686"}
+    return cast(Any, normalized if normalized in allowed else "other")
+
+
+def _normalize_transports(values: tuple[str, ...]) -> tuple[Literal["stdio", "streamable_http", "sse"], ...]:
+    normalized = tuple("streamable_http" if value == "streamable-http" else value for value in values)
+    allowed = {"stdio", "streamable_http", "sse"}
+    if any(value not in allowed for value in normalized):
+        raise ValueError("unsupported configured transport")
+    return cast(Any, normalized)
+
+
+def _normalize_content_mode(value: str) -> Literal["json", "text", "dual"]:
+    try:
+        return cast(Any, _CONTENT_MODES[value])
+    except KeyError as exc:
+        raise ValueError("unsupported content mode") from exc

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/support_bundle.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/support_bundle.py
@@ -244,14 +244,14 @@ class SupportBundleService:
         return {"success": True, "data": bundle.model_dump(mode="json")}
 
     def _validate_request(self, probe: object, resource: object) -> str | None:
-        if probe not in {"summary", "connectivity", "resource_shape"}:
+        if not isinstance(probe, str) or probe not in {"summary", "connectivity", "resource_shape"}:
             return "Failed to generate support bundle: unsupported probe."
         if probe in {"summary", "connectivity"} and resource is not None:
             return "Failed to generate support bundle: resource is only valid for resource_shape."
         if probe == "resource_shape":
             if resource is None:
                 return "Failed to generate support bundle: resource_shape requires a resource."
-            if (self._adapter.product, resource) not in _RESOURCE_EXPOSURES:
+            if not isinstance(resource, str) or (self._adapter.product, resource) not in _RESOURCE_EXPOSURES:
                 return "Failed to generate support bundle: unsupported resource for this product."
         return None
 

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_loader.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_loader.py
@@ -14,6 +14,8 @@ import pkgutil
 from types import ModuleType
 from typing import List, Optional, Set
 
+from unifi_mcp_shared.meta_tools import is_meta_tool
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,8 +38,9 @@ def auto_load_tools(
         enabled_tools: If set, load all modules but remove tools not in this list
                       (requires *server* parameter).
         server: FastMCP server instance (required if *enabled_tools* is set).
-        meta_tools: Set of meta-tool names to always keep when filtering by
-                    *enabled_tools*. Defaults to the standard five lazy-loading meta-tools.
+        meta_tools: Additional exact tool names to keep when filtering by
+                    *enabled_tools*. Prefix-specific shared meta-tools are detected
+                    automatically with :func:`is_meta_tool`.
     """
     try:
         tools_pkg: ModuleType = importlib.import_module(base_package)
@@ -81,16 +84,7 @@ def auto_load_tools(
     # If enabled_tools is specified, remove any tools not in the list
     if enabled_tools and server:
         enabled_set = set(enabled_tools)
-        # Always keep meta-tools
-        if meta_tools is None:
-            meta_tools = {
-                "unifi_tool_index",
-                "unifi_execute",
-                "unifi_batch",
-                "unifi_batch_status",
-                "unifi_load_tools",
-            }
-        enabled_set.update(meta_tools)
+        enabled_set.update(meta_tools or set())
 
         try:
 
@@ -98,7 +92,7 @@ def auto_load_tools(
                 tools = await server.list_tools()
                 removed = []
                 for tool in tools:
-                    if tool.name not in enabled_set:
+                    if tool.name not in enabled_set and not is_meta_tool(tool.name):
                         try:
                             server.remove_tool(tool.name)
                             removed.append(tool.name)

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_registration.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_registration.py
@@ -36,6 +36,7 @@ async def register_tools_for_mode(
     base_package: str,
     config: Any,
     logger: logging.Logger,
+    support_bundle_handler: Callable,
     prefix: str = "",
     server_label: str = "",
     register_meta_tools: Callable | None = None,
@@ -57,6 +58,7 @@ async def register_tools_for_mode(
         base_package: Dotted package path for tool modules (e.g. ``"unifi_network_mcp.tools"``).
         config: Server config object (used for ``enabled_categories``/``enabled_tools``).
         logger: Logger instance.
+        support_bundle_handler: Required runtime support-bundle service callback.
         prefix: Tool name prefix (e.g. ``"protect"``). Empty string for Network (uses ``"unifi"``).
         server_label: Human-readable server name (e.g. ``"UniFi Protect"``).
         register_meta_tools: Shared meta-tools registration function.
@@ -79,6 +81,7 @@ async def register_tools_for_mode(
         start_async_tool=start_async_tool,
         get_job_status=get_job_status,
         register_tool=register_tool,
+        support_bundle_handler=support_bundle_handler,
     )
     if prefix:
         meta_kwargs["prefix"] = prefix
@@ -92,7 +95,8 @@ async def register_tools_for_mode(
     if mode == "meta_only":
         logger.info("Tool registration mode: meta_only")
         logger.info(
-            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status",
+            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status, %s_get_support_bundle",
+            tool_prefix,
             tool_prefix,
             tool_prefix,
             tool_prefix,
@@ -107,7 +111,8 @@ async def register_tools_for_mode(
     elif mode == "lazy":
         logger.info("Tool registration mode: lazy")
         logger.info(
-            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status, %s_load_tools",
+            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status, %s_load_tools, %s_get_support_bundle",
+            tool_prefix,
             tool_prefix,
             tool_prefix,
             tool_prefix,

--- a/packages/unifi-mcp-shared/tests/test_meta_tools.py
+++ b/packages/unifi-mcp-shared/tests/test_meta_tools.py
@@ -18,7 +18,7 @@ from mcp.types import (
 )
 from pydantic import BaseModel
 from unifi_core.jobs import JobStore
-from unifi_mcp_shared.meta_tools import register_load_tools, register_meta_tools
+from unifi_mcp_shared.meta_tools import is_meta_tool, register_load_tools, register_meta_tools
 from unifi_mcp_shared.tool_index import TOOL_REGISTRY, get_tool_index, register_tool
 
 
@@ -55,6 +55,7 @@ def _register_test_meta_tools(*, server, prefix, start_async_tool=None, get_job_
         start_async_tool=start_async_tool or AsyncMock(),
         get_job_status=get_job_status or AsyncMock(),
         register_tool=Mock(),
+        support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
         prefix=prefix,
     )
     return registered
@@ -69,6 +70,7 @@ def test_tool_index_schema_describes_ranked_token_search():
         start_async_tool=AsyncMock(),
         get_job_status=AsyncMock(),
         register_tool=register_tool,
+        support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
         prefix="unifi",
     )
 
@@ -92,6 +94,7 @@ def test_execute_tool_index_schema_accepts_null_arguments():
         start_async_tool=AsyncMock(),
         get_job_status=AsyncMock(),
         register_tool=register_tool,
+        support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
         prefix="unifi",
     )
 
@@ -109,6 +112,7 @@ def test_batch_schema_explains_tool_discovery_by_registration_mode():
         start_async_tool=AsyncMock(),
         get_job_status=AsyncMock(),
         register_tool=register_tool,
+        support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
         prefix="unifi",
     )
 
@@ -132,6 +136,7 @@ def test_meta_tool_index_objects_contain_declared_annotations():
             start_async_tool=AsyncMock(),
             get_job_status=AsyncMock(),
             register_tool=register_tool,
+            support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
             prefix="unifi",
         )
         register_load_tools(
@@ -152,16 +157,82 @@ def test_meta_tool_index_objects_contain_declared_annotations():
             "unifi_batch": False,
             "unifi_batch_status": True,
             "unifi_load_tools": False,
+            "unifi_get_support_bundle": True,
         }
         for name, read_only in expected.items():
             assert tools[name]["annotations"] == {
                 "readOnlyHint": read_only,
                 "destructiveHint": False,
-                "idempotentHint": name in {"unifi_tool_index", "unifi_batch_status", "unifi_load_tools"},
+                "idempotentHint": name
+                in {"unifi_tool_index", "unifi_batch_status", "unifi_load_tools", "unifi_get_support_bundle"},
                 "openWorldHint": False,
             }
     finally:
         TOOL_REGISTRY.clear()
+
+
+@pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
+async def test_support_bundle_schema_annotations_and_behavior(prefix):
+    handler = AsyncMock(return_value={"success": True, "data": {"schema_version": 1}})
+    registered, tool_decorator = _capture_tools()
+    register_tool_mock = Mock()
+    register_meta_tools(
+        server=SimpleNamespace(),
+        tool_decorator=tool_decorator,
+        tool_index_handler=AsyncMock(return_value={}),
+        start_async_tool=AsyncMock(),
+        get_job_status=AsyncMock(),
+        register_tool=register_tool_mock,
+        support_bundle_handler=handler,
+        prefix=prefix,
+    )
+
+    name = f"{prefix}_get_support_bundle"
+    tool = registered[name]
+    assert tool["annotations"].read_only_hint is True
+    assert tool["annotations"].destructive_hint is False
+    assert tool["annotations"].idempotent_hint is True
+    assert tool["annotations"].open_world_hint is False
+    assert is_meta_tool(name) is True
+
+    result = await tool["handler"]("summary", None)
+    assert result == {"success": True, "data": {"schema_version": 1}}
+    handler.assert_awaited_once_with(probe="summary", resource=None)
+
+    registered_meta = next(call for call in register_tool_mock.call_args_list if call.kwargs["name"] == name)
+    assert registered_meta.kwargs["input_schema"]["properties"]["probe"]["enum"] == [
+        "summary",
+        "connectivity",
+        "resource_shape",
+    ]
+    assert registered_meta.kwargs["annotations"] == {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    }
+
+
+async def test_support_bundle_wrapper_never_logs_raw_failures_or_payloads(caplog):
+    canary = "token-DO-NOT-LOG"
+    handler = AsyncMock(side_effect=RuntimeError(canary))
+    registered, tool_decorator = _capture_tools()
+    register_meta_tools(
+        server=SimpleNamespace(),
+        tool_decorator=tool_decorator,
+        tool_index_handler=AsyncMock(return_value={}),
+        start_async_tool=AsyncMock(),
+        get_job_status=AsyncMock(),
+        register_tool=Mock(),
+        support_bundle_handler=handler,
+        prefix="unifi",
+    )
+
+    result = await registered["unifi_get_support_bundle"]["handler"]("summary", None)
+
+    assert result == {"success": False, "error": "Failed to generate support bundle."}
+    assert canary not in caplog.text
+    assert "traceback" not in caplog.text.lower()
 
 
 @pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
@@ -288,6 +359,7 @@ async def test_fastmcp_execute_and_batch_expose_domain_payload(prefix):
         start_async_tool=start_async_tool,
         get_job_status=store.status,
         register_tool=Mock(),
+        support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
         prefix=prefix,
     )
 
@@ -330,6 +402,7 @@ async def test_fastmcp_execute_accepts_null_arguments(prefix):
         start_async_tool=AsyncMock(),
         get_job_status=AsyncMock(),
         register_tool=Mock(),
+        support_bundle_handler=AsyncMock(return_value={"success": True, "data": {}}),
         prefix=prefix,
     )
 

--- a/packages/unifi-mcp-shared/tests/test_support_bundle.py
+++ b/packages/unifi-mcp-shared/tests/test_support_bundle.py
@@ -1,0 +1,307 @@
+"""Tests for shared support-bundle assembly and live-probe controls."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from unifi_core.support_bundle import (
+    AccessCapabilities,
+    ConnectionSection,
+    ControllerSection,
+    EvidenceStatus,
+    NetworkCapabilities,
+    Product,
+    ProtectCapabilities,
+    ResourceShapeProbe,
+    SanitizationSection,
+    SummaryProbe,
+    connection_attempt_succeeded,
+)
+from unifi_mcp_shared.support_bundle import (
+    LiveProbeGate,
+    SupportBundleEvidence,
+    SupportBundleService,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _evidence(product: Product, *, probe: str = "summary") -> SupportBundleEvidence:
+    capabilities = {
+        Product.NETWORK: NetworkCapabilities(
+            session_available=True,
+            integration_api_key_configured=False,
+            controller_type="proxy",
+            reconnect_circuit="closed",
+        ),
+        Product.PROTECT: ProtectCapabilities(
+            session_available=True,
+            bootstrap_available=True,
+            public_api_key_configured=False,
+            websocket_state="connected",
+        ),
+        Product.ACCESS: AccessCapabilities(
+            developer_api_available=True,
+            proxy_session_available=False,
+            api_token_configured=True,
+        ),
+    }[product]
+    probe_section = (
+        SummaryProbe(status=EvidenceStatus.AVAILABLE)
+        if probe == "summary"
+        else ResourceShapeProbe(status=EvidenceStatus.UNSUPPORTED, resource="sensors")
+    )
+    return SupportBundleEvidence(
+        controller=ControllerSection(
+            status=EvidenceStatus.AVAILABLE,
+            application_version="10.1.2",
+            api_surface="controller_v2",
+            capability_flags=("cached_state",),
+        ),
+        connection=ConnectionSection(
+            initialized=True,
+            connected=True,
+            tls_verification_enabled=True,
+            last_attempt=connection_attempt_succeeded(),
+            capabilities=capabilities,
+        ),
+        probe=probe_section,
+        sanitization=SanitizationSection(
+            values_suppressed=True,
+            dynamic_keys_suppressed=True,
+            errors_normalized=True,
+            variants_truncated=False,
+            nodes_truncated=False,
+            bytes_truncated=False,
+        ),
+    )
+
+
+class _Adapter:
+    def __init__(self, product: Product) -> None:
+        self.product = product
+        self.collect = AsyncMock(side_effect=self._collect)
+
+    async def _collect(self, probe: str, resource: str | None) -> SupportBundleEvidence:
+        del resource
+        return _evidence(self.product, probe=probe)
+
+
+def _service(product: Product, **overrides) -> tuple[SupportBundleService, _Adapter]:
+    adapter = _Adapter(product)
+    versions = {
+        "aiounifi": "95",
+        "mcp": "2.1.1",
+        "pydantic": "2.12.5",
+        "py-unifi-access": "3.3.0",
+        "unifi-access-mcp": "0.14.0",
+        "unifi-core": "0.4.39",
+        "unifi-mcp-shared": "0.6.12",
+        "unifi-network-mcp": "1.4.2",
+        "unifi-protect-mcp": "0.12.0",
+        "uiprotect": "15.14.2",
+    }
+    kwargs = {
+        "adapter": adapter,
+        "registration_mode": "lazy",
+        "content_mode": "adaptive",
+        "transports": ("stdio", "streamable-http"),
+        "diagnostics_enabled": False,
+        "response_redaction_enabled": True,
+        "manifest_reader": lambda: {"count": 75, "host": "never-read.example.invalid"},
+        "clock": lambda: datetime(2026, 9, 4, 12, 0, tzinfo=UTC),
+        "version_resolver": versions.__getitem__,
+        "python_version_resolver": lambda: "3.13.7",
+        "os_family_resolver": lambda: "darwin",
+        "architecture_resolver": lambda: "arm64",
+        "live_probe_gate": LiveProbeGate(),
+    }
+    kwargs.update(overrides)
+    return SupportBundleService(**kwargs), adapter
+
+
+@pytest.mark.parametrize(
+    ("product", "package", "tool"),
+    [
+        (Product.NETWORK, "unifi-network-mcp", "unifi_get_support_bundle"),
+        (Product.PROTECT, "unifi-protect-mcp", "protect_get_support_bundle"),
+        (Product.ACCESS, "unifi-access-mcp", "access_get_support_bundle"),
+    ],
+)
+async def test_summary_assembles_deterministic_safe_runtime_and_manifest_facts(product, package, tool):
+    service, adapter = _service(product)
+
+    first = await service.generate()
+    second = await service.generate()
+
+    assert first == second
+    assert first["success"] is True
+    data = first["data"]
+    assert data["generated_at"] == "2026-09-04T12:00:00Z"
+    assert data["server"]["package"] == package
+    assert data["server"]["tool"] == tool
+    assert data["runtime"] == {
+        "python_version": "3.13.7",
+        "os_family": "macos",
+        "architecture": "arm64",
+        "transports": ["stdio", "streamable_http"],
+        "registration_mode": "lazy",
+        "content_mode": "dual",
+        "manifest_tool_count": 75,
+        "manifest_generator": "scripts/generate_tool_manifest.py",
+    }
+    assert "never-read.example.invalid" not in json.dumps(first)
+    assert adapter.collect.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("probe", "resource"),
+    [
+        ("unknown", None),
+        ("summary", "sensors"),
+        ("connectivity", "sensors"),
+        ("resource_shape", None),
+        ("resource_shape", "doors"),
+    ],
+)
+async def test_invalid_arguments_never_call_adapter(probe, resource):
+    service, adapter = _service(Product.PROTECT)
+
+    result = await service.generate(probe=probe, resource=resource)
+
+    assert result["success"] is False
+    assert result["error"].startswith("Failed to generate support bundle:")
+    adapter.collect.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("categories", "tools"),
+    [((), None), (None, ()), (("system",), None), (None, ("protect_list_cameras",))],
+)
+async def test_resource_probe_respects_backing_category_and_tool_exposure(categories, tools):
+    service, adapter = _service(
+        Product.PROTECT,
+        enabled_categories=categories,
+        enabled_tools=tools,
+    )
+
+    result = await service.generate(probe="resource_shape", resource="sensors")
+
+    assert result == {
+        "success": False,
+        "error": "Failed to generate support bundle: the backing read surface is disabled by configuration.",
+    }
+    adapter.collect.assert_not_awaited()
+
+
+async def test_enabled_resource_probe_returns_adapter_unsupported_evidence():
+    service, adapter = _service(
+        Product.PROTECT,
+        enabled_categories=("devices",),
+        enabled_tools=("protect_list_sensors",),
+    )
+
+    result = await service.generate(probe="resource_shape", resource="sensors")
+
+    assert result["success"] is True
+    assert result["data"]["probe"] == {
+        "probe": "resource_shape",
+        "status": "unsupported",
+        "resource": "sensors",
+        "shape": None,
+    }
+    adapter.collect.assert_awaited_once()
+
+
+async def test_live_probes_are_single_flight_and_have_per_key_cooldown():
+    monotonic_value = 100.0
+    gate = LiveProbeGate(monotonic=lambda: monotonic_value)
+    service, adapter = _service(Product.PROTECT, live_probe_gate=gate)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_collect(probe: str, resource: str | None) -> SupportBundleEvidence:
+        entered.set()
+        await release.wait()
+        return _evidence(Product.PROTECT, probe=probe)
+
+    adapter.collect.side_effect = slow_collect
+    first = asyncio.create_task(service.generate(probe="resource_shape", resource="sensors"))
+    await entered.wait()
+    busy = await service.generate(probe="resource_shape", resource="sensors")
+    release.set()
+    assert (await first)["success"] is True
+    assert busy["error"] == "Failed to generate support bundle: another live probe is in progress."
+
+    cooldown = await service.generate(probe="resource_shape", resource="sensors")
+    assert cooldown["error"] == "Failed to generate support bundle: this live probe is in cooldown."
+
+
+async def test_adapter_and_validation_failures_return_fixed_errors_without_values(caplog):
+    canary = "token-DO-NOT-LOG"
+    service, adapter = _service(Product.NETWORK)
+    adapter.collect.side_effect = ValueError(canary)
+
+    result = await service.generate()
+
+    assert result == {"success": False, "error": "Failed to generate support bundle."}
+    assert canary not in caplog.text
+
+
+async def test_partial_controller_failure_still_returns_summary():
+    service, adapter = _service(Product.NETWORK)
+    partial = _evidence(Product.NETWORK)
+    adapter.collect.side_effect = None
+    adapter.collect.return_value = SupportBundleEvidence(
+        controller=partial.controller.model_copy(update={"status": EvidenceStatus.NOT_CONNECTED}),
+        connection=partial.connection.model_copy(update={"initialized": False, "connected": False}),
+        probe=SummaryProbe(status=EvidenceStatus.UNAVAILABLE),
+        sanitization=partial.sanitization,
+    )
+
+    result = await service.generate()
+
+    assert result["success"] is True
+    assert result["data"]["controller"]["status"] == "not_connected"
+    assert result["data"]["probe"]["status"] == "unavailable"
+
+
+async def test_manifest_reader_and_version_failures_are_reduced_to_safe_fallbacks():
+    def fail_manifest():
+        raise RuntimeError("/private/path/controller.example.invalid")
+
+    def fail_version(_package: str):
+        raise RuntimeError("secret-index-url")
+
+    service, _ = _service(Product.ACCESS, manifest_reader=fail_manifest, version_resolver=fail_version)
+
+    result = await service.generate()
+
+    assert result["success"] is True
+    assert result["data"]["runtime"]["manifest_tool_count"] == 0
+    assert result["data"]["server"]["version"] == "0.0.0"
+    assert {item["version"] for item in result["data"]["dependencies"]} == {"not_installed"}
+    assert "private" not in json.dumps(result)
+    assert "secret-index" not in json.dumps(result)
+
+
+def test_product_manifests_have_identical_support_input_output_and_annotations():
+    entries = []
+    for product, prefix in (("network", "unifi"), ("protect", "protect"), ("access", "access")):
+        path = REPO_ROOT / "apps" / product / "src" / f"unifi_{product}_mcp" / "tools_manifest.json"
+        manifest = json.loads(path.read_text())
+        entries.append(next(tool for tool in manifest["tools"] if tool["name"] == f"{prefix}_get_support_bundle"))
+
+    assert all(entry["schema"] == entries[0]["schema"] for entry in entries)
+    assert all(entry["annotations"] == entries[0]["annotations"] for entry in entries)
+    assert entries[0]["annotations"] == {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    }

--- a/packages/unifi-mcp-shared/tests/test_support_bundle.py
+++ b/packages/unifi-mcp-shared/tests/test_support_bundle.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from unifi_core.support_bundle import (
@@ -22,6 +22,8 @@ from unifi_core.support_bundle import (
     SummaryProbe,
     connection_attempt_succeeded,
 )
+from unifi_mcp_shared.meta_tools import register_meta_tools
+from unifi_mcp_shared.strict_dispatch import StrictKwargFastMCP
 from unifi_mcp_shared.support_bundle import (
     LiveProbeGate,
     SupportBundleEvidence,
@@ -29,6 +31,53 @@ from unifi_mcp_shared.support_bundle import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    "product,prefix", [(Product.NETWORK, "unifi"), (Product.PROTECT, "protect"), (Product.ACCESS, "access")]
+)
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"probe": "private-canary-token"},
+        {"probe": ["private-canary-token"]},
+        {"probe": {"secret": "private-canary-token"}},
+        {"probe": None},
+        {"probe": 42},
+        {"probe": "resource_shape", "resource": {"secret": "private-canary-token"}},
+        {"probe": "resource_shape", "resource": ["private-canary-token"]},
+        {"resource": ["private-canary-token"]},
+    ],
+)
+async def test_mcp_support_validation_never_echoes_rejected_input(product, prefix, arguments, caplog):
+    service, adapter = _service(product)
+    server = StrictKwargFastMCP("support-validation-test")
+    register_meta_tools(
+        server=server,
+        tool_decorator=server.tool,
+        tool_index_handler=AsyncMock(return_value={}),
+        start_async_tool=AsyncMock(),
+        get_job_status=AsyncMock(),
+        register_tool=Mock(),
+        support_bundle_handler=service.generate,
+        prefix=prefix,
+    )
+    with caplog.at_level("INFO"):
+        result = await server.call_tool(f"{prefix}_get_support_bundle", arguments)
+
+    payload = json.loads(result.content[0].text)
+    assert payload["success"] is False
+    assert payload["error"].startswith("Failed to generate support bundle")
+    assert "private-canary-token" not in result.model_dump_json()
+    assert "private-canary-token" not in caplog.text
+    assert "traceback" not in caplog.text.lower()
+    audits = [record.message for record in caplog.records if "Support bundle audit" in record.message]
+    assert len(audits) == 1
+    assert "outcome=failed" in audits[0]
+    adapter.collect.assert_not_awaited()
+
+    tool = next(tool for tool in await server.list_tools() if tool.name == f"{prefix}_get_support_bundle")
+    assert tool.input_schema["properties"]["probe"]["enum"] == ["summary", "connectivity", "resource_shape"]
 
 
 def _evidence(product: Product, *, probe: str = "summary") -> SupportBundleEvidence:

--- a/packages/unifi-mcp-shared/tests/test_tool_loader.py
+++ b/packages/unifi-mcp-shared/tests/test_tool_loader.py
@@ -1,0 +1,49 @@
+"""Tests for prefix-independent eager tool filtering."""
+
+import asyncio
+import importlib
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from unifi_mcp_shared.tool_loader import auto_load_tools
+
+tool_loader_module = importlib.import_module("unifi_mcp_shared.tool_loader")
+
+
+@pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
+async def test_enabled_tools_preserves_every_prefix_specific_meta_tool(monkeypatch, prefix):
+    package = ModuleType("example_tools")
+    package.__path__ = []
+    names = [
+        f"{prefix}_tool_index",
+        f"{prefix}_execute",
+        f"{prefix}_batch",
+        f"{prefix}_batch_status",
+        f"{prefix}_load_tools",
+        f"{prefix}_get_support_bundle",
+        f"{prefix}_list_devices",
+        f"{prefix}_delete_device",
+    ]
+    server = SimpleNamespace(
+        list_tools=AsyncMock(return_value=[SimpleNamespace(name=name) for name in names]),
+        remove_tool=Mock(),
+    )
+    monkeypatch.setattr(tool_loader_module.importlib, "import_module", lambda _name: package)
+    monkeypatch.setattr(tool_loader_module.pkgutil, "walk_packages", lambda *_args: [])
+
+    auto_load_tools(
+        base_package="example_tools",
+        enabled_tools=[f"{prefix}_list_devices"],
+        server=server,
+    )
+    await _drain_filter_task(server)
+
+    server.remove_tool.assert_called_once_with(f"{prefix}_delete_device")
+
+
+async def _drain_filter_task(server) -> None:
+    for _ in range(10):
+        if server.list_tools.await_count:
+            return
+        await asyncio.sleep(0)

--- a/packages/unifi-mcp-shared/tests/test_tool_registration.py
+++ b/packages/unifi-mcp-shared/tests/test_tool_registration.py
@@ -25,6 +25,7 @@ def _deps():
         "start_async_tool": Mock(),
         "get_job_status": Mock(),
         "register_tool": Mock(),
+        "support_bundle_handler": AsyncMock(return_value={"success": True, "data": {}}),
         "tool_module_map": {"unifi_list_clients": "unifi_network_mcp.tools.clients"},
         "setup_lazy_loading": Mock(return_value="lazy-loader"),
         "register_meta_tools": Mock(),
@@ -51,6 +52,7 @@ class TestRegisterToolsForMode:
         )
 
         deps["register_meta_tools"].assert_called_once()
+        assert deps["register_meta_tools"].call_args.kwargs["support_bundle_handler"] is deps["support_bundle_handler"]
         deps["setup_lazy_loading"].assert_called_once_with(server, deps["original_tool_decorator"])
         deps["register_load_tools"].assert_called_once()
         assert deps["register_load_tools"].call_args.kwargs["lazy_loader"] == "lazy-loader"
@@ -72,6 +74,7 @@ class TestRegisterToolsForMode:
         )
 
         deps["register_meta_tools"].assert_called_once()
+        assert deps["register_meta_tools"].call_args.kwargs["support_bundle_handler"] is deps["support_bundle_handler"]
         deps["setup_lazy_loading"].assert_called_once_with(server, deps["original_tool_decorator"])
         deps["register_load_tools"].assert_not_called()
         deps["auto_load_tools"].assert_not_called()
@@ -92,6 +95,7 @@ class TestRegisterToolsForMode:
         )
 
         deps["register_meta_tools"].assert_called_once()
+        assert deps["register_meta_tools"].call_args.kwargs["support_bundle_handler"] is deps["support_bundle_handler"]
         deps["setup_lazy_loading"].assert_not_called()
         deps["register_load_tools"].assert_not_called()
         deps["auto_load_tools"].assert_called_once_with(

--- a/plugins/unifi-access/skills/unifi-access/SKILL.md
+++ b/plugins/unifi-access/skills/unifi-access/SKILL.md
@@ -5,7 +5,7 @@ description: How to manage UniFi Access door control — locks, credentials, vis
 
 # UniFi Access MCP Server
 
-You have access to a UniFi Access MCP server that lets you query and manage a UniFi Access controller. It provides 36 tools covering doors, locks, credentials, visitors, access policies, events, devices, and system health.
+You have access to a UniFi Access MCP server that lets you query and manage a UniFi Access controller. It provides 37 tools covering doors, locks, credentials, visitors, access policies, events, devices, and system health.
 
 ## Tool Discovery
 
@@ -83,4 +83,4 @@ Access readers are network clients — if a reader appears offline, the Network 
 
 ## Tool Reference
 
-For the complete list of all 36 tools organized by category with descriptions, tips, and common scenarios, read `references/access-tools.md`.
+For the complete list of all 37 tools organized by category with descriptions, tips, and common scenarios, read `references/access-tools.md`.

--- a/plugins/unifi-access/skills/unifi-access/references/access-tools.md
+++ b/plugins/unifi-access/skills/unifi-access/references/access-tools.md
@@ -1,4 +1,4 @@
-# Access Server Tool Reference (36 tools)
+# Access Server Tool Reference (37 tools)
 
 Complete reference for `access_*` tools. All read tools are always available. All mutations are **disabled by default** — the user must explicitly enable them because Access controls physical door locks and building entry.
 

--- a/plugins/unifi-network/skills/unifi-network/SKILL.md
+++ b/plugins/unifi-network/skills/unifi-network/SKILL.md
@@ -5,7 +5,7 @@ description: How to manage UniFi network infrastructure — devices, clients, fi
 
 # UniFi Network MCP Server
 
-You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 189 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
+You have access to a UniFi Network MCP server that lets you query and manage a UniFi Network Controller. It provides 193 tools covering devices, clients, firewall, VPN, routing, WLANs, Traffic Flows, statistics, and more.
 
 ## Tool Discovery
 
@@ -89,4 +89,4 @@ Cameras and access readers appear as network clients — use `unifi_lookup_by_ip
 
 ## Tool Reference
 
-For the complete list of all 189 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.
+For the complete list of all 193 tools organized by category with descriptions, tips, and common scenarios, read `references/network-tools.md`.

--- a/plugins/unifi-network/skills/unifi-network/references/network-tools.md
+++ b/plugins/unifi-network/skills/unifi-network/references/network-tools.md
@@ -1,4 +1,4 @@
-# Network Server Tool Reference (192 tools)
+# Network Server Tool Reference (193 tools)
 
 Complete reference for `unifi_*` tools. All read tools are always available. Mutating tools require permissions (see main skill for details).
 

--- a/plugins/unifi-protect/skills/unifi-protect/SKILL.md
+++ b/plugins/unifi-protect/skills/unifi-protect/SKILL.md
@@ -5,7 +5,7 @@ description: How to manage UniFi Protect cameras and NVR — view cameras, smart
 
 # UniFi Protect MCP Server
 
-You have access to a UniFi Protect MCP server that lets you query and manage a UniFi Protect NVR. It provides 61 tools covering cameras, smart detections, Find Anything detection search, recordings, snapshots, lights, sensors, chimes, Known Faces, license plates, and the Alarm Manager (arm/disarm).
+You have access to a UniFi Protect MCP server that lets you query and manage a UniFi Protect NVR. It provides 62 tools covering cameras, smart detections, Find Anything detection search, recordings, snapshots, lights, sensors, chimes, Known Faces, license plates, and the Alarm Manager (arm/disarm).
 
 ## Tool Discovery
 
@@ -88,4 +88,4 @@ Cameras are network clients — if a camera appears offline, the Network server 
 
 ## Tool Reference
 
-For the complete list of all 61 tools organized by category with descriptions, tips, and common scenarios, read `references/protect-tools.md`.
+For the complete list of all 62 tools organized by category with descriptions, tips, and common scenarios, read `references/protect-tools.md`.

--- a/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
+++ b/plugins/unifi-protect/skills/unifi-protect/references/protect-tools.md
@@ -1,4 +1,4 @@
-# Protect Server Tool Reference (61 tools)
+# Protect Server Tool Reference (62 tools)
 
 Complete reference for `protect_*` tools. All read tools are always available. All mutations are **disabled by default** — the user must explicitly enable them because Protect controls physical security hardware.
 

--- a/scripts/generate_api_action_catalog.py
+++ b/scripts/generate_api_action_catalog.py
@@ -32,6 +32,7 @@ META_TOOL_SUFFIXES: tuple[str, ...] = (
     "_batch",
     "_batch_status",
     "_load_tools",
+    "_get_support_bundle",
 )
 
 

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -503,6 +503,7 @@ class LiveSmokeRunner:
             "base_package": self.config["base_package"],
             "config": runtime_mod.config,
             "logger": bootstrap_mod.logger,
+            "support_bundle_handler": runtime_mod.support_bundle_service.generate,
         }
         if self.config.get("prefix"):
             kwargs["prefix"] = self.config["prefix"]

--- a/tests/test_generate_api_action_catalog.py
+++ b/tests/test_generate_api_action_catalog.py
@@ -176,6 +176,18 @@ def test_generator_meta_tool_suffixes_match_shared_contract() -> None:
     )
 
     assert tuple(ast.literal_eval(assignment.value)) == generator.META_TOOL_SUFFIXES
+    assert "_get_support_bundle" in generator.META_TOOL_SUFFIXES
+
+
+def test_generated_api_catalog_excludes_support_bundle_meta_tools() -> None:
+    catalog = json.loads((REPO_ROOT / "apps/api/src/unifi_api/action_catalog.json").read_text())
+    names = {tool["name"] for tool in catalog["actions"]}
+
+    assert not names & {
+        "unifi_get_support_bundle",
+        "protect_get_support_bundle",
+        "access_get_support_bundle",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add one privacy-bounded support-bundle meta-tool to Network, Protect, and Access in all registration modes
- assemble deterministic local/cache-only summary evidence through a shared collector and product-specific capability adapters
- keep support bundles out of API actions and every relay catalog/forwarding path, including nested meta wrappers and stale/direct batch jobs
- regenerate all product manifests, tool references, public tool counts, and catalog contracts

## Type of change

- [ ] `fix:` bug fix
- [x] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [x] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [x] Network MCP server
- [x] Protect MCP server
- [x] Access MCP server
- [x] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [ ] API server
- [x] Shared packages
- [x] Plugin packaging
- [x] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- `make pre-commit`
- `make relay-test` (139 passed)
- real FastMCP call seam exercised for all three product-prefixed support tools
- independent privacy review of the exact branch diff; initial relay-composition findings were remediated and the re-review returned no findings

## Notes for reviewers

This is PR 2 in GitHub stack #626 and is based on #623, which supplies the Core support-bundle contract and privacy kernel.

`summary` is intentionally local/cache-only. Connectivity remains explicitly unsupported until the next stack layer proves no-retry/no-reconnect behavior per product. Protect sensor shape also remains explicitly unsupported because Gate 0 found no faithful UP-AirQuality field path in the installed `uiprotect` model or available live hardware.

The relay exclusion is intentionally separate from the shared meta-tool classification: ordinary meta-tools remain directly forwardable, while execute/batch wrappers may target domain tools only and batch status is limited to jobs originated by the current relay instance.
