### PR TITLE
fix(security): verify and remediate initial CodeQL alerts

### DIFF
--- a/.github/workflows/check-skill-references.yml
+++ b/.github/workflows/check-skill-references.yml
@@ -1,5 +1,8 @@
 name: "Generated Artifacts: Check Drift"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: "Lint: Ruff"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/test-access.yml
+++ b/.github/workflows/test-access.yml
@@ -1,5 +1,8 @@
 name: "Access: Test"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -1,5 +1,8 @@
 name: "API: Test"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/test-network.yml
+++ b/.github/workflows/test-network.yml
@@ -1,5 +1,8 @@
 name: "Network: Test"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/test-plugin-setup.yml
+++ b/.github/workflows/test-plugin-setup.yml
@@ -1,5 +1,8 @@
 name: "Test: Plugin setup scripts"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/test-protect.yml
+++ b/.github/workflows/test-protect.yml
@@ -1,5 +1,8 @@
 name: "Protect: Test"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/test-relay.yml
+++ b/.github/workflows/test-relay.yml
@@ -1,5 +1,8 @@
 name: "Relay: Test"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/test-worker.yml
+++ b/.github/workflows/test-worker.yml
@@ -1,5 +1,8 @@
 name: "Worker: Test"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 
 ### Logging
 
+- Network client/device managers and tools log operation context and exception class only; never log MAC/IP addresses, names, update payloads, exception messages, or tracebacks. This is a narrow privacy exception to the ordinary tool `exc_info=True` rule because controller exceptions can embed those values.
+
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation
 - Configuration errors SHOULD fail fast at startup with clear guidance

--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -232,7 +232,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
             )
             await session.commit()
             return {"success": False, "error": f"unknown tool: {tool_name}"}
-        except actions_svc.CapabilityMismatch as e:
+        except actions_svc.CapabilityMismatch:
             await write_audit(
                 session,
                 key_id_prefix=key_prefix,
@@ -242,7 +242,10 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 error_kind="capability_mismatch",
             )
             await session.commit()
-            return {"success": False, "error": str(e)}
+            return {
+                "success": False,
+                "error": "Failed to execute action: controller does not support this tool product.",
+            }
         except SerializerContractError as e:
             await write_audit(
                 session,
@@ -259,7 +262,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 detail={
                     "kind": "serializer_contract_error",
                     "tool": tool_name,
-                    "detail": str(e),
+                    "detail": "Failed to serialize action result. Contact the server administrator.",
                 },
             )
         except SerializerRegistryError as e:
@@ -278,7 +281,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 detail={
                     "kind": "serializer_missing",
                     "tool": tool_name,
-                    "detail": str(e),
+                    "detail": "Action serializer is unavailable. Contact the server administrator.",
                 },
             )
         except Exception as e:
@@ -292,4 +295,4 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 detail=str(e),
             )
             await session.commit()
-            return {"success": False, "error": f"{type(e).__name__}: {e}"}
+            return {"success": False, "error": "Failed to execute action. Check the server audit log for details."}

--- a/apps/api/tests/test_action_endpoint.py
+++ b/apps/api/tests/test_action_endpoint.py
@@ -433,7 +433,9 @@ async def test_action_endpoint_rejects_malformed_shared_read_shape(tmp_path, mon
 
     assert response.status_code == 500
     assert response.json()["detail"]["kind"] == "serializer_contract_error"
-    assert "shared read view returned dict" in response.json()["detail"]["detail"]
+    assert response.json()["detail"]["detail"] == (
+        "Failed to serialize action result. Contact the server administrator."
+    )
 
 
 @pytest.mark.asyncio
@@ -779,3 +781,45 @@ async def test_action_endpoint_unknown_controller(tmp_path, monkeypatch) -> None
             json={"site": "default", "controller": fake_cid, "args": {}, "confirm": False},
         )
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", ["unexpected", "capability", "contract", "registry"])
+async def test_action_exception_details_are_not_exposed(tmp_path, monkeypatch, error_type) -> None:
+    """Arbitrary exception messages must not reach action clients, even on opt-out."""
+    from unifi_api.serializers._base import SerializerContractError
+    from unifi_api.serializers._registry import SerializerRegistryError
+    from unifi_api.services import actions as actions_svc
+
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, redact_sensitive_fields=False)
+    private = "Traceback /private/server.py password=do-not-expose"
+    errors = {
+        "unexpected": RuntimeError(private),
+        "capability": actions_svc.CapabilityMismatch(private),
+        "contract": SerializerContractError(private),
+        "registry": SerializerRegistryError(private),
+    }
+    monkeypatch.setattr(actions_svc, "dispatch_action", AsyncMock(side_effect=errors[error_type]))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/actions/unifi_list_clients",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": {}, "confirm": False},
+        )
+    assert response.status_code == (500 if error_type in {"contract", "registry"} else 200)
+    for marker in ("Traceback", "/private/server.py", "do-not-expose", "RuntimeError"):
+        assert marker not in response.text
+    body = response.json()
+    if response.status_code == 500:
+        assert body["detail"]["tool"] == "unifi_list_clients"
+        assert body["detail"]["kind"] in {"serializer_contract_error", "serializer_missing"}
+    else:
+        assert body["success"] is False
+        assert "Failed to execute action" in body["error"]
+    async with app.state.sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+        actions = [row for row in rows if row.target == "unifi_list_clients"]
+        assert len(actions) == 1
+        assert actions[0].outcome == "error"
+        assert actions[0].error_kind

--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -58,7 +58,7 @@ async def lookup_by_ip(
             "error": f"No client found with IP: {ip_address}",
         }
     except Exception as e:
-        logger.error("Error looking up client by IP %s: %s", ip_address, e, exc_info=True)
+        logger.error("Error looking up client by IP [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to look up client by IP {ip_address}: {e}"}
 
 
@@ -112,7 +112,7 @@ async def list_clients(
             fields=fields,
         )
     except Exception as e:
-        logger.error("Error listing clients: %s", e, exc_info=True)
+        logger.error("Error listing clients: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to list clients: {e}"}
 
 
@@ -162,7 +162,7 @@ async def get_client_details(
             summary=summary,
         )
     except Exception as e:
-        logger.error("Error getting client details for %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error getting client details for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to get client details for {mac_address}: {e}"}
 
 
@@ -188,7 +188,7 @@ async def list_blocked_clients() -> Dict[str, Any]:
             "blocked_clients": formatted_clients,
         }
     except Exception as e:
-        logger.error("Error listing blocked clients: %s", e, exc_info=True)
+        logger.error("Error listing blocked clients: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to list blocked clients: {e}"}
 
 
@@ -250,7 +250,7 @@ async def block_client(
             }
         return {"success": False, "error": f"Failed to block client {mac_address}."}
     except Exception as e:
-        logger.error("Error blocking client %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error blocking client [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to block client {mac_address}: {e}"}
 
 
@@ -314,7 +314,7 @@ async def unblock_client(
             }
         return {"success": False, "error": f"Failed to unblock client {mac_address}."}
     except Exception as e:
-        logger.error("Error unblocking client %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error unblocking client [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to unblock client {mac_address}: {e}"}
 
 
@@ -372,7 +372,7 @@ async def rename_client(
             }
         return {"success": False, "error": f"Failed to rename client {mac_address}."}
     except Exception as e:
-        logger.error("Error renaming client %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error renaming client [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to rename client {mac_address}: {e}"}
 
 
@@ -446,7 +446,7 @@ async def force_reconnect_client(
             "error": f"Failed to force reconnect for client {mac_address}.",
         }
     except Exception as e:
-        logger.error("Error forcing reconnect for client %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error forcing reconnect for client [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to force reconnect for client {mac_address}: {e}"}
 
 
@@ -513,7 +513,7 @@ async def forget_client(
             }
         return {"success": False, "error": f"Failed to forget client {mac_address}."}
     except Exception as e:
-        logger.error("Error forgetting client %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error forgetting client [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to forget client {mac_address}: {e}"}
 
 
@@ -608,7 +608,7 @@ async def authorize_guest(
             }
         return {"success": False, "error": f"Failed to authorize guest {mac_address}."}
     except Exception as e:
-        logger.error("Error authorizing guest %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error authorizing guest [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to authorize guest {mac_address}: {e}"}
 
 
@@ -679,7 +679,7 @@ async def unauthorize_guest(
             "error": f"Failed to unauthorize guest {mac_address}.",
         }
     except Exception as e:
-        logger.error("Error unauthorizing guest %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error unauthorizing guest [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to unauthorize guest {mac_address}: {e}"}
 
 
@@ -813,5 +813,5 @@ async def set_client_ip_settings(
             "error": f"Failed to update IP settings for client {mac_address}.",
         }
     except Exception as e:
-        logger.error("Error setting IP settings for %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error setting IP settings for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to set IP settings for client {mac_address}: {e}"}

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -100,7 +100,7 @@ async def list_devices(
             summary=summary,
         )
     except Exception as e:
-        logger.error("Error listing devices: %s", e, exc_info=True)
+        logger.error("Error listing devices: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to list devices: {e}"}
 
 
@@ -156,7 +156,7 @@ async def get_device_details(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error getting device details for %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error getting device details for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to get device details for {mac_address}: {e}"}
 
 
@@ -205,7 +205,7 @@ async def reboot_device(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error rebooting device %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error rebooting device [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to reboot device {mac_address}: {e}"}
 
 
@@ -253,7 +253,7 @@ async def rename_device(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error renaming device %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error renaming device [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to rename device {mac_address}: {e}"}
 
 
@@ -306,7 +306,7 @@ async def adopt_device(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error adopting device %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error adopting device [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to adopt device {mac_address}: {e}"}
 
 
@@ -363,7 +363,7 @@ async def upgrade_device(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error upgrading device %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error upgrading device [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to upgrade device {mac_address}: {e}"}
 
 
@@ -403,7 +403,7 @@ async def get_device_radio(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error getting radio info for %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error getting radio info for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to get radio info for device {mac_address}: {e}"}
 
 
@@ -560,7 +560,7 @@ async def update_device_radio(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error updating radio on %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error updating radio on [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to update radio on device {mac_address}: {e}"}
 
 
@@ -605,7 +605,7 @@ async def locate_device(
             return {"success": True, "message": f"Locate mode {state} on device '{device_mac}'."}
         return {"success": False, "error": f"Failed to set locate mode on '{device_mac}'."}
     except Exception as e:
-        logger.error("Error setting locate mode on %s: %s", device_mac, e, exc_info=True)
+        logger.error("Error setting locate mode on [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to set locate mode on {device_mac}: {e}"}
 
 
@@ -644,7 +644,7 @@ async def force_provision_device(
             return {"success": True, "message": f"Force provision initiated for device '{device_mac}'."}
         return {"success": False, "error": f"Failed to force provision device '{device_mac}'."}
     except Exception as e:
-        logger.error("Error force provisioning %s: %s", device_mac, e, exc_info=True)
+        logger.error("Error force provisioning [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to force provision device {device_mac}: {e}"}
 
 
@@ -683,7 +683,7 @@ async def trigger_speedtest(
             }
         return {"success": False, "error": f"Failed to trigger speedtest on '{gateway_mac}'."}
     except Exception as e:
-        logger.error("Error triggering speedtest on %s: %s", gateway_mac, e, exc_info=True)
+        logger.error("Error triggering speedtest on [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to trigger speedtest on {gateway_mac}: {e}"}
 
 
@@ -705,7 +705,7 @@ async def get_speedtest_status(
             "status": status,
         }
     except Exception as e:
-        logger.error("Error getting speedtest status for %s: %s", gateway_mac, e, exc_info=True)
+        logger.error("Error getting speedtest status for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to get speedtest status for {gateway_mac}: {e}"}
 
 
@@ -762,7 +762,7 @@ async def list_rogue_aps(
             summary=summary,
         )
     except Exception as e:
-        logger.error("Error listing rogue APs: %s", e, exc_info=True)
+        logger.error("Error listing rogue APs: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to list rogue APs: {e}"}
 
 
@@ -817,7 +817,7 @@ async def trigger_rf_scan(
             }
         return {"success": False, "error": f"Failed to trigger RF scan on AP '{ap_mac}'."}
     except Exception as e:
-        logger.error("Error triggering RF scan on %s: %s", ap_mac, e, exc_info=True)
+        logger.error("Error triggering RF scan on [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to trigger RF scan on AP '{ap_mac}': {e}"}
 
 
@@ -850,7 +850,7 @@ async def get_rf_scan_results(
             "scan_results": results,
         }
     except Exception as e:
-        logger.error("Error getting RF scan results for %s: %s", ap_mac, e, exc_info=True)
+        logger.error("Error getting RF scan results for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to get RF scan results for AP '{ap_mac}': {e}"}
 
 
@@ -873,7 +873,7 @@ async def list_available_channels() -> Dict[str, Any]:
             "channels": channels,
         }
     except Exception as e:
-        logger.error("Error listing available channels: %s", e, exc_info=True)
+        logger.error("Error listing available channels: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to list available channels: {e}"}
 
 
@@ -928,7 +928,7 @@ async def set_device_led(
             return {"success": True, "message": f"LED override set to '{led_state}' on device '{device_mac}'."}
         return {"success": False, "error": f"Failed to set LED override on '{device_mac}'."}
     except Exception as e:
-        logger.error("Error setting LED override on %s: %s", device_mac, e, exc_info=True)
+        logger.error("Error setting LED override on [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to set LED override on {device_mac}: {e}"}
 
 
@@ -968,7 +968,7 @@ async def toggle_device(
             return {"success": True, "message": f"Device '{device_mac}' has been {state}."}
         return {"success": False, "error": f"Failed to set disabled state on '{device_mac}'."}
     except Exception as e:
-        logger.error("Error toggling device %s: %s", device_mac, e, exc_info=True)
+        logger.error("Error toggling device [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to toggle device {device_mac}: {e}"}
 
 
@@ -1012,7 +1012,7 @@ async def set_site_leds(
             return {"success": True, "message": f"Site-wide LEDs have been {state}."}
         return {"success": False, "error": "Failed to set site-wide LED state."}
     except Exception as e:
-        logger.error("Error setting site LEDs: %s", e, exc_info=True)
+        logger.error("Error setting site LEDs: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to set site-wide LED state: {e}"}
 
 
@@ -1054,7 +1054,7 @@ async def get_pdu_outlets(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error getting PDU outlets for %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error getting PDU outlets for [redacted]: %s", type(e).__name__)
         return {"success": False, "error": f"Failed to get PDU outlets for {mac_address}: {e}"}
 
 
@@ -1201,7 +1201,7 @@ async def set_outlet_state(
     except UniFiNotFoundError as e:
         return {"success": False, "error": str(e)}
     except Exception as e:
-        logger.error("Error setting outlet state on %s: %s", mac_address, e, exc_info=True)
+        logger.error("Error setting outlet state on [redacted]: %s", type(e).__name__)
         return {
             "success": False,
             "error": f"Failed to set outlet state on PDU {mac_address}: {e}",

--- a/apps/network/tests/unit/test_identifier_logging.py
+++ b/apps/network/tests/unit/test_identifier_logging.py
@@ -1,0 +1,36 @@
+"""Tool error logging must not reintroduce private controller identifiers."""
+
+import importlib
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("domain", ["clients", "devices"])
+async def test_detail_error_logs_do_not_include_private_exception(domain, monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_HOST", "127.0.0.1")
+    monkeypatch.setenv("UNIFI_USERNAME", "test")
+    monkeypatch.setenv("UNIFI_PASSWORD", "test")
+    from unifi_network_mcp import runtime
+
+    singular = "client" if domain == "clients" else "device"
+    private = "aa:bb:cc:11:22:33 private-owner password=do-not-log"
+    manager = MagicMock()
+    method = f"get_{singular}_details"
+    setattr(manager, method, AsyncMock(side_effect=RuntimeError(private)))
+    monkeypatch.setattr(runtime, f"{singular}_manager", manager)
+    module = importlib.import_module(f"unifi_network_mcp.tools.{domain}")
+    monkeypatch.setattr(module, f"{singular}_manager", manager)
+    with caplog.at_level(logging.ERROR, logger=module.__name__):
+        result = await getattr(module, method)("aa:bb:cc:11:22:33")
+    assert result["success"] is False
+    records = [record for record in caplog.records if record.name == module.__name__]
+    assert records
+    for record in records:
+        assert record.exc_info is None
+        for marker in ("aa:bb:cc:11:22:33", "private-owner", "do-not-log"):
+            assert marker not in record.getMessage()
+            assert marker not in repr(record.args)
+    assert "RuntimeError" in caplog.text

--- a/apps/worker/test/cli/wrangler.test.mjs
+++ b/apps/worker/test/cli/wrangler.test.mjs
@@ -43,7 +43,10 @@ new_sqlite_classes = ["RelayObject"]`;
       observability: true,
     });
     assert.ok(result.includes("[[routes]]"));
-    assert.ok(result.includes("mcp.example.com"));
+    assert.deepEqual(
+      result.split("\n").filter((line) => line.startsWith("pattern = ")),
+      ['pattern = "mcp.example.com"'],
+    );
     assert.ok(result.includes("[observability]"));
   });
 

--- a/docs/security/code-scanning-2026-09-04.md
+++ b/docs/security/code-scanning-2026-09-04.md
@@ -1,0 +1,94 @@
+# CodeQL alert verification — 2026-09-04
+
+Baseline: `3632e9d45f57e7c0ae7f46d5be9e5a104e794c5d` (the scanned main commit). All 68 open alerts were inspected by rule and source location.
+
+## Findings and remediation
+
+- **55 private-data logging alerts:** MAC identifiers reach logger arguments in Network client/device managers and tools. Remove them at the logging call; also remove adjacent names, IP-setting payloads, and exception text/tracebacks, which can carry the same values. Retain operation context, safe state fields, and exception class. This is privacy hardening, not evidence that 55 credentials leaked.
+- **10 workflow-permission alerts across nine workflows:** token permissions were implicit. All affected jobs need checkout/read access only; declare workflow-level `contents: read`. The Codecov token is separately provided where needed.
+- **Alert 12:** current `CapabilityMismatch` text is locally constructed from tool product and controller capabilities, not a traceback. This instance is a false positive for stack disclosure. A fixed actionable response defensively removes dependence on exception text.
+- **Alert 13:** the catch-all action handler exposes arbitrary exception class and message to callers. Confirmed information-disclosure path. Replace with a fixed response, and harden neighboring serializer exception details too. Preserve HTTP status, success/error envelope, serializer kind/tool, and administrator-only audit diagnostics.
+- **Alert 11:** substring assertion in a test of generated TOML, not a production URL allowlist or authentication decision. False positive for URL validation. Replace with an exact route-line assertion that also detects duplicate patterns.
+
+## Relationship to existing redaction
+
+The `unifi_core.redaction` vocabulary and response policy apply to secret-bearing structured fields. MAC addresses, names, and other inventory data remain available in controller requests and tool/API results. Do not expand the secret vocabulary to clear a logging alert, and do not make logging safety depend on the response-policy opt-out. The existing ConnectionManager auth-error sanitizer removes configured username/password values; it cannot protect arbitrary device identifiers or arbitrary downstream exceptions. No new sanitizer is introduced here.
+
+## Verification
+
+Regression tests capture actual manager and MCP tool logs with synthetic private identifiers and private exception messages, while asserting real controller inputs remain intact. ASGI tests inject unexpected, capability, contract, and registry exceptions with private text, including with response redaction disabled. API artifacts are regenerated; no schema change is intended. Full workspace verification and PR CodeQL results are recorded in the PR. GitHub main alerts remain open until the fix is merged and main is rescanned; no alerts are dismissed by this change.
+
+## Alert ledger
+
+Locations below refer to the baseline commit. “Remediated” describes the branch change, not GitHub alert closure.
+
+| Alert | Rule | Baseline location | Disposition |
+| --- | --- | --- | --- |
+| [#1](https://github.com/sirkirby/unifi-mcp/security/code-scanning/1) | `actions/missing-workflow-permissions` | `.github/workflows/check-skill-references.yml:12` | Confirmed; remediated |
+| [#2](https://github.com/sirkirby/unifi-mcp/security/code-scanning/2) | `actions/missing-workflow-permissions` | `.github/workflows/lint.yml:12` | Confirmed; remediated |
+| [#3](https://github.com/sirkirby/unifi-mcp/security/code-scanning/3) | `actions/missing-workflow-permissions` | `.github/workflows/test-access.yml:16` | Confirmed; remediated |
+| [#4](https://github.com/sirkirby/unifi-mcp/security/code-scanning/4) | `actions/missing-workflow-permissions` | `.github/workflows/test-network.yml:16` | Confirmed; remediated |
+| [#5](https://github.com/sirkirby/unifi-mcp/security/code-scanning/5) | `actions/missing-workflow-permissions` | `.github/workflows/test-plugin-setup.yml:20` | Confirmed; remediated |
+| [#6](https://github.com/sirkirby/unifi-mcp/security/code-scanning/6) | `actions/missing-workflow-permissions` | `.github/workflows/test-plugin-setup.yml:31` | Confirmed; remediated |
+| [#7](https://github.com/sirkirby/unifi-mcp/security/code-scanning/7) | `actions/missing-workflow-permissions` | `.github/workflows/test-protect.yml:16` | Confirmed; remediated |
+| [#8](https://github.com/sirkirby/unifi-mcp/security/code-scanning/8) | `actions/missing-workflow-permissions` | `.github/workflows/test-api.yml:16` | Confirmed; remediated |
+| [#9](https://github.com/sirkirby/unifi-mcp/security/code-scanning/9) | `actions/missing-workflow-permissions` | `.github/workflows/test-worker.yml:12` | Confirmed; remediated |
+| [#10](https://github.com/sirkirby/unifi-mcp/security/code-scanning/10) | `actions/missing-workflow-permissions` | `.github/workflows/test-relay.yml:16` | Confirmed; remediated |
+| [#11](https://github.com/sirkirby/unifi-mcp/security/code-scanning/11) | `js/incomplete-url-substring-sanitization` | `apps/worker/test/cli/wrangler.test.mjs:46` | False positive; strengthen test assertion |
+| [#12](https://github.com/sirkirby/unifi-mcp/security/code-scanning/12) | `py/stack-trace-exposure` | `apps/api/src/unifi_api/routes/actions.py:245` | False positive at current source; defensively harden response |
+| [#13](https://github.com/sirkirby/unifi-mcp/security/code-scanning/13) | `py/stack-trace-exposure` | `apps/api/src/unifi_api/routes/actions.py:295` | Confirmed; remediated |
+| [#14](https://github.com/sirkirby/unifi-mcp/security/code-scanning/14) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:213` | Confirmed; remediated |
+| [#15](https://github.com/sirkirby/unifi-mcp/security/code-scanning/15) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:217` | Confirmed; remediated |
+| [#16](https://github.com/sirkirby/unifi-mcp/security/code-scanning/16) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:237` | Confirmed; remediated |
+| [#17](https://github.com/sirkirby/unifi-mcp/security/code-scanning/17) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:241` | Confirmed; remediated |
+| [#18](https://github.com/sirkirby/unifi-mcp/security/code-scanning/18) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:254` | Confirmed; remediated |
+| [#19](https://github.com/sirkirby/unifi-mcp/security/code-scanning/19) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:266` | Confirmed; remediated |
+| [#20](https://github.com/sirkirby/unifi-mcp/security/code-scanning/20) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:272` | Confirmed; remediated |
+| [#21](https://github.com/sirkirby/unifi-mcp/security/code-scanning/21) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:276` | Confirmed; remediated |
+| [#22](https://github.com/sirkirby/unifi-mcp/security/code-scanning/22) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:294` | Confirmed; remediated |
+| [#23](https://github.com/sirkirby/unifi-mcp/security/code-scanning/23) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:298` | Confirmed; remediated |
+| [#24](https://github.com/sirkirby/unifi-mcp/security/code-scanning/24) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:316` | Confirmed; remediated |
+| [#25](https://github.com/sirkirby/unifi-mcp/security/code-scanning/25) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:320` | Confirmed; remediated |
+| [#26](https://github.com/sirkirby/unifi-mcp/security/code-scanning/26) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:357` | Confirmed; remediated |
+| [#27](https://github.com/sirkirby/unifi-mcp/security/code-scanning/27) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:361` | Confirmed; remediated |
+| [#28](https://github.com/sirkirby/unifi-mcp/security/code-scanning/28) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:379` | Confirmed; remediated |
+| [#29](https://github.com/sirkirby/unifi-mcp/security/code-scanning/29) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:383` | Confirmed; remediated |
+| [#30](https://github.com/sirkirby/unifi-mcp/security/code-scanning/30) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:443` | Confirmed; remediated |
+| [#31](https://github.com/sirkirby/unifi-mcp/security/code-scanning/31) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:450` | Confirmed; remediated |
+| [#32](https://github.com/sirkirby/unifi-mcp/security/code-scanning/32) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:490` | Confirmed; remediated |
+| [#33](https://github.com/sirkirby/unifi-mcp/security/code-scanning/33) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:499` | Confirmed; remediated |
+| [#34](https://github.com/sirkirby/unifi-mcp/security/code-scanning/34) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/client_manager.py:503` | Confirmed; remediated |
+| [#35](https://github.com/sirkirby/unifi-mcp/security/code-scanning/35) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:165` | Confirmed; remediated |
+| [#36](https://github.com/sirkirby/unifi-mcp/security/code-scanning/36) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:253` | Confirmed; remediated |
+| [#37](https://github.com/sirkirby/unifi-mcp/security/code-scanning/37) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:317` | Confirmed; remediated |
+| [#38](https://github.com/sirkirby/unifi-mcp/security/code-scanning/38) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:375` | Confirmed; remediated |
+| [#39](https://github.com/sirkirby/unifi-mcp/security/code-scanning/39) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:449` | Confirmed; remediated |
+| [#40](https://github.com/sirkirby/unifi-mcp/security/code-scanning/40) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:516` | Confirmed; remediated |
+| [#41](https://github.com/sirkirby/unifi-mcp/security/code-scanning/41) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:611` | Confirmed; remediated |
+| [#42](https://github.com/sirkirby/unifi-mcp/security/code-scanning/42) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:682` | Confirmed; remediated |
+| [#43](https://github.com/sirkirby/unifi-mcp/security/code-scanning/43) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/clients.py:816` | Confirmed; remediated |
+| [#44](https://github.com/sirkirby/unifi-mcp/security/code-scanning/44) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:78` | Confirmed; remediated |
+| [#45](https://github.com/sirkirby/unifi-mcp/security/code-scanning/45) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:82` | Confirmed; remediated |
+| [#46](https://github.com/sirkirby/unifi-mcp/security/code-scanning/46) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:95` | Confirmed; remediated |
+| [#47](https://github.com/sirkirby/unifi-mcp/security/code-scanning/47) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:101` | Confirmed; remediated |
+| [#48](https://github.com/sirkirby/unifi-mcp/security/code-scanning/48) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:105` | Confirmed; remediated |
+| [#49](https://github.com/sirkirby/unifi-mcp/security/code-scanning/49) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:123` | Confirmed; remediated |
+| [#50](https://github.com/sirkirby/unifi-mcp/security/code-scanning/50) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:127` | Confirmed; remediated |
+| [#51](https://github.com/sirkirby/unifi-mcp/security/code-scanning/51) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:145` | Confirmed; remediated |
+| [#52](https://github.com/sirkirby/unifi-mcp/security/code-scanning/52) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:149` | Confirmed; remediated |
+| [#53](https://github.com/sirkirby/unifi-mcp/security/code-scanning/53) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:267` | Confirmed; remediated |
+| [#54](https://github.com/sirkirby/unifi-mcp/security/code-scanning/54) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:280` | Confirmed; remediated |
+| [#55](https://github.com/sirkirby/unifi-mcp/security/code-scanning/55) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:289` | Confirmed; remediated |
+| [#56](https://github.com/sirkirby/unifi-mcp/security/code-scanning/56) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:293` | Confirmed; remediated |
+| [#57](https://github.com/sirkirby/unifi-mcp/security/code-scanning/57) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:610` | Confirmed; remediated |
+| [#58](https://github.com/sirkirby/unifi-mcp/security/code-scanning/58) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:620` | Confirmed; remediated |
+| [#59](https://github.com/sirkirby/unifi-mcp/security/code-scanning/59) | `py/clear-text-logging-sensitive-data` | `packages/unifi-core/src/unifi_core/network/managers/device_manager.py:658` | Confirmed; remediated |
+| [#60](https://github.com/sirkirby/unifi-mcp/security/code-scanning/60) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:159` | Confirmed; remediated |
+| [#61](https://github.com/sirkirby/unifi-mcp/security/code-scanning/61) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:208` | Confirmed; remediated |
+| [#62](https://github.com/sirkirby/unifi-mcp/security/code-scanning/62) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:256` | Confirmed; remediated |
+| [#63](https://github.com/sirkirby/unifi-mcp/security/code-scanning/63) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:309` | Confirmed; remediated |
+| [#64](https://github.com/sirkirby/unifi-mcp/security/code-scanning/64) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:366` | Confirmed; remediated |
+| [#65](https://github.com/sirkirby/unifi-mcp/security/code-scanning/65) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:406` | Confirmed; remediated |
+| [#66](https://github.com/sirkirby/unifi-mcp/security/code-scanning/66) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:563` | Confirmed; remediated |
+| [#67](https://github.com/sirkirby/unifi-mcp/security/code-scanning/67) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:1057` | Confirmed; remediated |
+| [#68](https://github.com/sirkirby/unifi-mcp/security/code-scanning/68) | `py/clear-text-logging-sensitive-data` | `apps/network/src/unifi_network_mcp/tools/devices.py:1204` | Confirmed; remediated |

--- a/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
@@ -59,11 +59,11 @@ class ClientManager:
                         self._connection._update_cache(cache_key, raw_clients)
                         return raw_clients  # type: ignore[return-value]
                 except Exception as fallback_e:
-                    logger.debug("Raw clients fallback failed: %s", fallback_e)
+                    logger.debug("Raw clients fallback failed: %s", type(fallback_e).__name__)
             self._connection._update_cache(cache_key, clients)
             return clients
         except Exception as e:
-            logger.error("Error getting online clients: %s", e)
+            logger.error("Error getting online clients: %s", type(e).__name__)
             raise
 
     async def get_all_clients(self) -> List[Client]:
@@ -91,11 +91,11 @@ class ClientManager:
                         self._connection._update_cache(cache_key, raw_all)
                         return raw_all  # type: ignore[return-value]
                 except Exception as fallback_e:
-                    logger.debug("Raw all-clients fallback failed: %s", fallback_e)
+                    logger.debug("Raw all-clients fallback failed: %s", type(fallback_e).__name__)
             self._connection._update_cache(cache_key, all_clients)
             return all_clients
         except Exception as e:
-            logger.error("Error getting all clients: %s", e)
+            logger.error("Error getting all clients: %s", type(e).__name__)
             raise
 
     @staticmethod
@@ -152,7 +152,7 @@ class ClientManager:
                     break
         except Exception as e:
             active_error = e
-            logger.debug("/stat/sta fetch failed during get_client_details: %s", e)
+            logger.debug("/stat/sta fetch failed during get_client_details: %s", type(e).__name__)
 
         user_record: Optional[Any] = None
         user_error: Optional[Exception] = None
@@ -164,7 +164,7 @@ class ClientManager:
                     break
         except Exception as e:
             user_error = e
-            logger.debug("/rest/user fetch failed during get_client_details: %s", e)
+            logger.debug("/rest/user fetch failed during get_client_details: %s", type(e).__name__)
 
         if active_record is None and user_record is None:
             if active_error is not None and user_error is not None:
@@ -210,11 +210,11 @@ class ClientManager:
             )
             # Call the updated request method
             await self._connection.request(api_request)
-            logger.info("Block command sent for client %s", client_mac)
+            logger.info("Block command sent for client [redacted]")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")  # Invalidate all client caches
             return True
         except Exception as e:
-            logger.error("Error blocking client %s: %s", client_mac, e)
+            logger.error("Error blocking client [redacted]: %s", type(e).__name__)
             raise
 
     async def unblock_client(self, client_mac: str) -> bool:
@@ -234,11 +234,11 @@ class ClientManager:
             )
             # Call the updated request method
             await self._connection.request(api_request)
-            logger.info("Unblock command sent for client %s", client_mac)
+            logger.info("Unblock command sent for client [redacted]")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error unblocking client %s: %s", client_mac, e)
+            logger.error("Error unblocking client [redacted]: %s", type(e).__name__)
             raise
 
     async def rename_client(self, client_mac: str, name: str) -> bool:
@@ -251,7 +251,7 @@ class ClientManager:
         try:
             client = await self.get_client_details(client_mac)  # raises on miss
             if "_id" not in client.raw:
-                logger.error("Cannot rename client %s: missing _id in raw payload.", client_mac)
+                logger.error("Cannot rename client [redacted]: missing _id in raw payload.")
                 return False
             client_id = client.raw["_id"]
 
@@ -262,18 +262,16 @@ class ClientManager:
                 await self._connection.request(api_request)
             except Exception as e:
                 logger.debug(
-                    "REST endpoint failed for rename, falling back to legacy /upd/user/ for %s: %s",
-                    client_mac,
-                    e,
-                    exc_info=True,
+                    "REST endpoint failed for rename, falling back to legacy /upd/user/ for [redacted]: %s",
+                    type(e).__name__,
                 )
                 api_request = ApiRequest(method="put", path=f"/upd/user/{client_id}", data={"name": name})
                 await self._connection.request(api_request)
-            logger.info("Rename command sent for client %s to '%s'", client_mac, name)
+            logger.info("Rename command sent for client [redacted] to '[redacted]'")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error renaming client %s to '%s': %s", client_mac, name, e)
+            logger.error("Error renaming client [redacted] to '[redacted]': %s", type(e).__name__)
             raise
 
     async def force_reconnect_client(self, client_mac: str) -> bool:
@@ -291,11 +289,11 @@ class ClientManager:
                 data={"mac": client_mac, "cmd": "kick-sta"},
             )
             await self._connection.request(api_request)
-            logger.info("Force reconnect (kick) command sent for client %s", client_mac)
+            logger.info("Force reconnect (kick) command sent for client [redacted]")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error forcing reconnect for client %s: %s", client_mac, e)
+            logger.error("Error forcing reconnect for client [redacted]: %s", type(e).__name__)
             raise
 
     async def forget_client(self, client_mac: str) -> bool:
@@ -313,11 +311,11 @@ class ClientManager:
                 data={"macs": [client_mac], "cmd": "forget-sta"},
             )
             await self._connection.request(api_request)
-            logger.info("Forget command sent for client %s", client_mac)
+            logger.info("Forget command sent for client [redacted]")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error forgetting client %s: %s", client_mac, e)
+            logger.error("Error forgetting client [redacted]: %s", type(e).__name__)
             raise
 
     async def get_blocked_clients(self) -> List[Client]:
@@ -354,11 +352,11 @@ class ClientManager:
             api_request = ApiRequest(method="post", path="/cmd/stamgr", data=payload)
             # Call the updated request method
             await self._connection.request(api_request)
-            logger.info("Authorize command sent for guest %s for %s minutes", client_mac, minutes)
+            logger.info("Authorize command sent for guest [redacted] for %s minutes", minutes)
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error authorizing guest %s: %s", client_mac, e)
+            logger.error("Error authorizing guest [redacted]: %s", type(e).__name__)
             raise
 
     async def unauthorize_guest(self, client_mac: str) -> bool:
@@ -376,11 +374,11 @@ class ClientManager:
                 data={"mac": client_mac, "cmd": "unauthorize-guest"},
             )
             await self._connection.request(api_request)
-            logger.info("Unauthorize command sent for guest %s", client_mac)
+            logger.info("Unauthorize command sent for guest [redacted]")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error unauthorizing guest %s: %s", client_mac, e)
+            logger.error("Error unauthorizing guest [redacted]: %s", type(e).__name__)
             raise
 
     async def get_client_by_ip(self, ip_address: str) -> Optional[Client]:
@@ -440,14 +438,14 @@ class ClientManager:
 
             client_raw = client.raw if hasattr(client, "raw") else client
             if "_id" not in client_raw:
-                logger.error("Cannot set IP settings for %s: Missing _id", client_mac)
+                logger.error("Cannot set IP settings for [redacted]: Missing _id")
                 return False
 
             client_id = client_raw["_id"]
 
             # If client is not "noted" (known), mark it first to enable IP config
             if not client_raw.get("noted"):
-                logger.info("Client %s not noted, marking as known first", client_mac)
+                logger.info("Client [redacted] not noted, marking as known first")
                 note_payload = {"noted": True}
                 if not client_raw.get("name") and client_raw.get("hostname"):
                     note_payload["name"] = client_raw["hostname"]
@@ -459,7 +457,7 @@ class ClientManager:
                     )
                     await self._connection.request(note_request)
                 except Exception as note_err:
-                    logger.warning("Could not mark client as noted: %s", note_err)
+                    logger.warning("Could not mark client as noted: %s", type(note_err).__name__)
 
             # Build payload with only explicitly provided fields
             payload: dict = {}
@@ -487,7 +485,7 @@ class ClientManager:
                 payload["local_dns_record"] = local_dns_record
 
             if not payload:
-                logger.warning("No IP settings provided for %s", client_mac)
+                logger.warning("No IP settings provided for [redacted]")
                 return False
 
             api_request = ApiRequest(
@@ -496,9 +494,9 @@ class ClientManager:
                 data=payload,
             )
             await self._connection.request(api_request)
-            logger.info("IP settings updated for client %s: %s", client_mac, payload)
+            logger.info("IP settings updated for client [redacted]: [redacted]")
             self._connection._invalidate_cache(f"{CACHE_PREFIX_CLIENTS}")
             return True
         except Exception as e:
-            logger.error("Error setting IP settings for %s: %s", client_mac, e)
+            logger.error("Error setting IP settings for [redacted]: %s", type(e).__name__)
             raise

--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -44,7 +44,7 @@ class DeviceManager:
             self._connection._update_cache(cache_key, devices)
             return devices
         except Exception as e:
-            logger.error("Error getting devices: %s", e)
+            logger.error("Error getting devices: %s", type(e).__name__)
             raise
 
     async def get_device_details(self, device_mac: str) -> Device:
@@ -75,11 +75,11 @@ class DeviceManager:
                 data={"mac": device_mac, "cmd": "restart"},
             )
             await self._connection.request(api_request)
-            logger.info("Reboot command sent for device %s", device_mac)
+            logger.info("Reboot command sent for device [redacted]")
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error rebooting device %s: %s", device_mac, e)
+            logger.error("Error rebooting device [redacted]: %s", type(e).__name__)
             raise
 
     async def rename_device(self, device_mac: str, name: str) -> bool:
@@ -92,17 +92,17 @@ class DeviceManager:
         try:
             device = await self.get_device_details(device_mac)  # raises on miss
             if "_id" not in device.raw:
-                logger.error("Cannot rename device %s: missing _id in raw payload.", device_mac)
+                logger.error("Cannot rename device [redacted]: missing _id in raw payload.")
                 return False
             device_id = device.raw["_id"]
 
             api_request = ApiRequest(method="put", path=f"/rest/device/{device_id}", data={"name": name})
             await self._connection.request(api_request)
-            logger.info("Rename command sent for device %s to '%s'", device_mac, name)
+            logger.info("Rename command sent for device [redacted] to '[redacted]'")
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error renaming device %s to '%s': %s", device_mac, name, e)
+            logger.error("Error renaming device [redacted] to '[redacted]': %s", type(e).__name__)
             raise
 
     async def adopt_device(self, device_mac: str) -> bool:
@@ -120,11 +120,11 @@ class DeviceManager:
                 data={"mac": device_mac, "cmd": "adopt"},
             )
             await self._connection.request(api_request)
-            logger.info("Adopt command sent for device %s", device_mac)
+            logger.info("Adopt command sent for device [redacted]")
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error adopting device %s: %s", device_mac, e)
+            logger.error("Error adopting device [redacted]: %s", type(e).__name__)
             raise
 
     async def upgrade_device(self, device_mac: str) -> bool:
@@ -142,11 +142,11 @@ class DeviceManager:
                 data={"mac": device_mac, "cmd": "upgrade"},
             )
             await self._connection.request(api_request)
-            logger.info("Upgrade command sent for device %s", device_mac)
+            logger.info("Upgrade command sent for device [redacted]")
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error upgrading device %s: %s", device_mac, e)
+            logger.error("Error upgrading device [redacted]: %s", type(e).__name__)
             raise
 
     async def locate_device(self, device_mac: str, enabled: bool = True) -> bool:
@@ -168,10 +168,10 @@ class DeviceManager:
                 data={"cmd": cmd, "mac": device_mac},
             )
             await self._connection.request(api_request)
-            logger.info("Locate %s for device %s", "enabled" if enabled else "disabled", device_mac)
+            logger.info("Locate %s for device [redacted]", "enabled" if enabled else "disabled")
             return True
         except Exception as e:
-            logger.error("Error setting locate mode on device %s: %s", device_mac, e)
+            logger.error("Error setting locate mode on device [redacted]: %s", type(e).__name__)
             raise
 
     async def force_provision(self, device_mac: str) -> bool:
@@ -191,10 +191,10 @@ class DeviceManager:
                 data={"cmd": "force-provision", "mac": device_mac},
             )
             await self._connection.request(api_request)
-            logger.info("Force provision command sent for device %s", device_mac)
+            logger.info("Force provision command sent for device [redacted]")
             return True
         except Exception as e:
-            logger.error("Error force provisioning device %s: %s", device_mac, e)
+            logger.error("Error force provisioning device [redacted]: %s", type(e).__name__)
             raise
 
     async def get_device_radio(self, device_mac: str) -> Optional[Dict[str, Any]]:
@@ -264,7 +264,7 @@ class DeviceManager:
         try:
             device = await self.get_device_details(device_mac)  # raises on miss
             if "_id" not in device.raw:
-                logger.error("Cannot update radio for %s: missing _id in raw payload.", device_mac)
+                logger.error("Cannot update radio for [redacted]: missing _id in raw payload.")
                 return False
             device_id = device.raw["_id"]
 
@@ -277,7 +277,7 @@ class DeviceManager:
                     break
 
             if not matched:
-                logger.error("Radio '%s' not found on device %s.", radio_id, device_mac)
+                logger.error("Radio '%s' not found on device [redacted].", radio_id)
                 return False
 
             api_request = ApiRequest(
@@ -286,11 +286,11 @@ class DeviceManager:
                 data={"radio_table": radio_table},
             )
             await self._connection.request(api_request)
-            logger.info("Radio '%s' updated on device %s: %s", radio_id, device_mac, list(updates.keys()))
+            logger.info("Radio '%s' updated on device [redacted]: %s", radio_id, list(updates.keys()))
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error updating radio '%s' on device %s: %s", radio_id, device_mac, e)
+            logger.error("Error updating radio '%s' on device [redacted]: %s", radio_id, type(e).__name__)
             raise
 
     async def trigger_speedtest(self, gateway_mac: str) -> bool:
@@ -310,10 +310,10 @@ class DeviceManager:
                 data={"mac": gateway_mac, "cmd": "speedtest"},
             )
             await self._connection.request(api_request)
-            logger.info("Speedtest triggered on gateway %s", gateway_mac)
+            logger.info("Speedtest triggered on gateway [redacted]")
             return True
         except Exception as e:
-            logger.error("Error triggering speedtest on %s: %s", gateway_mac, e)
+            logger.error("Error triggering speedtest on [redacted]: %s", type(e).__name__)
             raise
 
     async def get_speedtest_status(self, gateway_mac: str) -> Dict[str, Any]:
@@ -335,7 +335,7 @@ class DeviceManager:
             response = await self._connection.request(api_request)
             return response if isinstance(response, dict) else {}
         except Exception as e:
-            logger.error("Error getting speedtest status for %s: %s", gateway_mac, e)
+            logger.error("Error getting speedtest status for [redacted]: %s", type(e).__name__)
             raise
 
     async def list_rogue_aps(self, within_hours: int = 24) -> List[Dict[str, Any]]:
@@ -363,7 +363,7 @@ class DeviceManager:
             self._connection._update_cache(cache_key, result, timeout=300)
             return result
         except Exception as e:
-            logger.error("Error listing rogue APs: %s", e)
+            logger.error("Error listing rogue APs: %s", type(e).__name__)
             raise
 
     async def trigger_rf_scan(self, ap_mac: str) -> bool:
@@ -383,10 +383,10 @@ class DeviceManager:
                 data={"cmd": "spectrum-scan", "mac": ap_mac},
             )
             await self._connection.request(api_request)
-            logger.info("RF scan triggered on AP %s", ap_mac)
+            logger.info("RF scan triggered on AP [redacted]")
             return True
         except Exception as e:
-            logger.error("Error triggering RF scan on %s: %s", ap_mac, e)
+            logger.error("Error triggering RF scan on [redacted]: %s", type(e).__name__)
             raise
 
     async def get_rf_scan_results(self, ap_mac: str) -> List[Dict[str, Any]]:
@@ -414,7 +414,7 @@ class DeviceManager:
             self._connection._update_cache(cache_key, result, timeout=60)
             return result
         except Exception as e:
-            logger.error("Error getting RF scan results for %s: %s", ap_mac, e)
+            logger.error("Error getting RF scan results for [redacted]: %s", type(e).__name__)
             raise
 
     async def list_available_channels(self) -> List[Dict[str, Any]]:
@@ -438,7 +438,7 @@ class DeviceManager:
             self._connection._update_cache(cache_key, result, timeout=3600)
             return result
         except Exception as e:
-            logger.error("Error listing available channels: %s", e)
+            logger.error("Error listing available channels: %s", type(e).__name__)
             raise
 
     async def set_device_led_override(self, device_mac: str, led_override: str) -> bool:
@@ -455,7 +455,7 @@ class DeviceManager:
         try:
             device = await self.get_device_details(device_mac)
             if not device or "_id" not in device.raw:
-                logger.error("Cannot set LED override for %s: Not found or missing ID.", device_mac)
+                logger.error("Cannot set LED override for [redacted]: Not found or missing ID.")
                 return False
             device_id = device.raw["_id"]
 
@@ -465,11 +465,11 @@ class DeviceManager:
                 data={"led_override": led_override},
             )
             await self._connection.request(api_request)
-            logger.info("LED override set to '%s' for device %s", led_override, device_mac)
+            logger.info("LED override set to '%s' for device [redacted]", led_override)
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error setting LED override on device %s: %s", device_mac, e)
+            logger.error("Error setting LED override on device [redacted]: %s", type(e).__name__)
             raise
 
     async def set_device_disabled(self, device_mac: str, disabled: bool) -> bool:
@@ -486,7 +486,7 @@ class DeviceManager:
         try:
             device = await self.get_device_details(device_mac)
             if not device or "_id" not in device.raw:
-                logger.error("Cannot set disabled state for %s: Not found or missing ID.", device_mac)
+                logger.error("Cannot set disabled state for [redacted]: Not found or missing ID.")
                 return False
             device_id = device.raw["_id"]
 
@@ -496,11 +496,11 @@ class DeviceManager:
                 data={"disabled": disabled},
             )
             await self._connection.request(api_request)
-            logger.info("Device %s %s", device_mac, "disabled" if disabled else "enabled")
+            logger.info("Device [redacted] %s", "disabled" if disabled else "enabled")
             self._connection._invalidate_cache(CACHE_PREFIX_DEVICES)
             return True
         except Exception as e:
-            logger.error("Error setting disabled state on device %s: %s", device_mac, e)
+            logger.error("Error setting disabled state on device [redacted]: %s", type(e).__name__)
             raise
 
     @staticmethod
@@ -607,7 +607,7 @@ class DeviceManager:
         if not self._is_pdu(device.raw):
             return None
         if "_id" not in device.raw:
-            logger.error("Cannot set outlet state on %s: missing _id in raw payload.", device_mac)
+            logger.error("Cannot set outlet state on [redacted]: missing _id in raw payload.")
             return None
         device_id = device.raw["_id"]
 
@@ -617,7 +617,7 @@ class DeviceManager:
             None,
         )
         if sensed is None:
-            logger.error("Outlet index %s not found on PDU %s.", outlet_index, device_mac)
+            logger.error("Outlet index %s not found on PDU [redacted].", outlet_index)
             return None
         if sensed.get("has_relay") is False:
             raise ValueError(
@@ -653,9 +653,8 @@ class DeviceManager:
         )
         await self._connection.request(api_request)
         logger.info(
-            "Outlet %s on PDU %s set to relay_state=%s cycle_enabled=%s (preserved %d sibling overrides)",
+            "Outlet %s on PDU [redacted] set to relay_state=%s cycle_enabled=%s (preserved %d sibling overrides)",
             outlet_index,
-            device_mac,
             relay_state,
             target.get("cycle_enabled"),
             max(len(overrides) - 1, 0),
@@ -688,5 +687,5 @@ class DeviceManager:
             logger.info("Site LEDs %s", "enabled" if enabled else "disabled")
             return True
         except Exception as e:
-            logger.error("Error setting site LED state: %s", e)
+            logger.error("Error setting site LED state: %s", type(e).__name__)
             raise

--- a/packages/unifi-core/tests/network/test_identifier_logging.py
+++ b/packages/unifi-core/tests/network/test_identifier_logging.py
@@ -1,0 +1,43 @@
+"""Identifier-bearing controller operations must keep private data out of logs."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.network.managers.client_manager import ClientManager
+from unifi_core.network.managers.device_manager import DeviceManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "manager_type,method,lookup",
+    [
+        (ClientManager, "rename_client", "get_client_details"),
+        (DeviceManager, "rename_device", "get_device_details"),
+    ],
+)
+@pytest.mark.parametrize("fails", [False, True])
+async def test_rename_logs_exclude_identifiers_and_exception_text(caplog, manager_type, method, lookup, fails):
+    mac = "aa:bb:cc:11:22:33"
+    name = "private-owner-device"
+    private = f"{mac} {name} 192.0.2.41 password=private-password"
+    connection = MagicMock()
+    connection.request = AsyncMock(side_effect=RuntimeError(private) if fails else None)
+    manager = manager_type(connection)
+    setattr(manager, lookup, AsyncMock(return_value=SimpleNamespace(raw={"_id": "device-id"})))
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        if fails:
+            with pytest.raises(RuntimeError):
+                await getattr(manager, method)(mac, name)
+        else:
+            assert await getattr(manager, method)(mac, name) is True
+    assert caplog.records
+    for value in (mac, name, "192.0.2.41", "private-password"):
+        assert value not in caplog.text
+        assert all(value not in repr(record.args) for record in caplog.records)
+    assert all(record.exc_info is None for record in caplog.records)
+    if fails:
+        assert "RuntimeError" in caplog.text
+    # Privacy applies only to logging; the controller must still receive real values.
+    assert connection.request.call_args.args[0].data == {"name": name}


### PR DESCRIPTION
## Problem and change

The initial CodeQL scan reports 68 open alerts on main: 55 private-identifier logging findings, 10 implicit workflow-permission findings, two exception-response findings, and one test assertion flagged as URL validation.

Remove MAC addresses and adjacent private names/payloads from Network client/device logs, and log exception class without exception text or tracebacks at those boundaries. This preserves the existing secret-field response policy: inventory identifiers remain available in tool/API results and controller requests. Return safe action error messages while preserving response status/envelopes and administrator audit diagnostics. Declare `contents: read` in the nine affected workflows.

Two findings are false positives at their current sources: the capability mismatch message is locally constructed, and the URL substring check is a test of generated TOML. Harden the former defensively and strengthen the latter to an exact route assertion. The [verification report](docs/security/code-scanning-2026-09-04.md) records all 68 alert dispositions. No alerts were dismissed.

## Validation

- Four manager log-capture regression cases and two MCP tool log-capture cases pass, including exceptions containing private values.
- All 26 action endpoint tests pass, including four adversarial exception classes with response redaction disabled.
- API SDL, OpenAPI, and both reference docs regenerated with no artifact changes.
- Full `make pre-commit` passed: format, generation, lint, all Python/app suites, protocol smoke, worker tests, artifact drift, and worker typecheck.
- All 20 GitHub checks passed on `2d0f1631db192305575ec1c5b3f05f5cd09a1493`. CodeQL Actions, JavaScript/TypeScript, and Python analyses each report zero results; the PR check states “No new alerts in code changed by this pull request.” This is distinct from closure of the baseline main alerts, which requires merge and rescan.

The deliberate diagnostic tradeoff is less detail in these logs and public error responses. Operation context and exception class remain in logs; detailed action failures remain in administrator-only audit records. Main alerts can only close after merge and rescan.
