### PR TITLE
fix(network): validate destination/source port shape in firewall policies

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     # require Core 0.4.39. UTC device timestamps in action read views require
     # Core 0.4.43.
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
+    # Shared firewall create-port validation requires Core 0.4.45.
     "unifi-core[network,protect,access]>=0.4.45,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # require Core 0.4.39. UTC device timestamps in action read views require
     # Core 0.4.43.
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
-    "unifi-core[network,protect,access]>=0.4.44,<0.5",
+    "unifi-core[network,protect,access]>=0.4.45,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -2526,7 +2526,7 @@
       "input_schema": {
         "properties": {
           "policy_data": {
-            "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
+            "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For port targeting: port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' array). Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
             "type": "object"
           }
         },

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -672,9 +672,9 @@ def _translate_list_clients(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict
 
 
 # ---------------------------------------------------------------------------
-# Network — update_firewall_policy
+# Network — firewall policy create/update validation
 # ---------------------------------------------------------------------------
-# Tool exposes ``update_data``; manager method takes ``updates``.
+# Create validates port targeting; update also renames ``update_data`` to ``updates``.
 
 
 def _translate_create_firewall_policy(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
@@ -1596,7 +1596,7 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslatorSpec] = {
     "unifi_forget_client": _spec(_rename_mac_address_to_client_mac, "client_mac"),
     # Network — list clients: Core selects online or all/historical clients.
     "unifi_list_clients": _spec(_translate_list_clients, "include_offline"),
-    # Network — firewall: kwarg rename
+    # Network — firewall: shared validation and update kwarg rename
     "unifi_create_firewall_policy": _spec(_translate_create_firewall_policy, "policy_data"),
     "unifi_update_firewall_policy": _spec(_translate_update_firewall_policy, "policy_id", "updates"),
     # Network — port forward toggle/delete: kwarg rename (port_forward_id → rule_id)

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -677,6 +677,15 @@ def _translate_list_clients(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict
 # Tool exposes ``update_data``; manager method takes ``updates``.
 
 
+def _translate_create_firewall_policy(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Apply shared port validation before the API preview/execute split."""
+    from unifi_core.network.models.firewall import validate_policy_port_targeting
+
+    policy_data = args["policy_data"]
+    validate_policy_port_targeting(policy_data)
+    return (), {"policy_data": policy_data}
+
+
 def _translate_update_firewall_policy(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
     """Validate and normalize a V2 firewall-policy partial update."""
     from unifi_core.network.models.firewall import normalize_policy_update
@@ -1588,6 +1597,7 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslatorSpec] = {
     # Network — list clients: Core selects online or all/historical clients.
     "unifi_list_clients": _spec(_translate_list_clients, "include_offline"),
     # Network — firewall: kwarg rename
+    "unifi_create_firewall_policy": _spec(_translate_create_firewall_policy, "policy_data"),
     "unifi_update_firewall_policy": _spec(_translate_update_firewall_policy, "policy_id", "updates"),
     # Network — port forward toggle/delete: kwarg rename (port_forward_id → rule_id)
     "unifi_toggle_port_forward": _spec(_rename_port_forward_id_to_rule_id, "rule_id"),

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -23,6 +23,71 @@ from unifi_core.redaction import REDACTED
 PRODUCTION_REGISTRY = ManifestRegistry.load()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirm", [False, True])
+@pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        {"ports": ["445"]},
+        {"port_matching_type": "SPECIFIC"},
+        {"port_matching_type": "SPECIFIC", "port": ["445"]},
+        {"port_matching_type": "SPECIFIC", "port": 445},
+        {"port_matching_type": "SPECIFIC", "port": ""},
+        {"port_matching_type": "SPECIFIC", "port": " "},
+    ],
+)
+async def test_create_firewall_policy_rejects_invalid_ports_before_preview_or_manager(confirm, direction, endpoint):
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock()
+    data = {"name": "Invalid ports", "action": "ALLOW", direction: endpoint}
+    with pytest.raises(ValueError, match=rf"{direction}\.port"):
+        await dispatch_action(
+            registry=PRODUCTION_REGISTRY,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_create_firewall_policy",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"policy_data": data},
+            confirm=confirm,
+        )
+    factory.get_domain_manager.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirm", [False, True])
+@pytest.mark.parametrize("direction", ["source", "destination"])
+async def test_create_firewall_policy_valid_port_preserves_payload(confirm, direction):
+    import copy
+
+    manager = MagicMock()
+    manager.create_firewall_policy = AsyncMock(return_value={"_id": "new-policy"})
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    data = {"name": "Valid port", "action": "ALLOW", direction: {"port_matching_type": "SPECIFIC", "port": "445"}}
+    before = copy.deepcopy(data)
+    result = await dispatch_action(
+        registry=PRODUCTION_REGISTRY,
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_create_firewall_policy",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"policy_data": data},
+        confirm=confirm,
+    )
+    assert data == before
+    if confirm:
+        manager.create_firewall_policy.assert_awaited_once_with(policy_data=before)
+        assert result == {"_id": "new-policy"}
+    else:
+        assert isinstance(result, MutationPreview)
+        factory.get_domain_manager.assert_not_awaited()
+
+
 def _registry_with(tool: ToolEntry) -> ManifestRegistry:
     if tool.read_only_hint is None and PRODUCTION_REGISTRY.has(tool.name):
         production_entry = PRODUCTION_REGISTRY.resolve(tool.name)

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # Core 0.4.37; explicit zero event limits require Core 0.4.39. UTC device
     # timestamps and expanded site settings require Core 0.4.43.
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
-    "unifi-core[network]>=0.4.44,<0.5",
+    "unifi-core[network]>=0.4.45,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     # Core 0.4.37; explicit zero event limits require Core 0.4.39. UTC device
     # timestamps and expanded site settings require Core 0.4.43.
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
+    # Shared firewall create-port validation requires Core 0.4.45.
     "unifi-core[network]>=0.4.45,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -303,7 +303,8 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
                 "%s.ports is not a valid field; the controller expects %s.port as a single "
                 "string (e.g. '445'), not a plural 'ports' array." % (direction, direction)
             )
-        if ep.get("port_matching_type") == "SPECIFIC" and not ep.get("port"):
+        port = ep.get("port")
+        if ep.get("port_matching_type") == "SPECIFIC" and not (isinstance(port, str) and port):
             return "%s.port is required when port_matching_type is 'SPECIFIC'." % direction
     return None
 

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -298,6 +298,13 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
                 return "%s.ips array is required when matching_target is 'IP'." % direction
         if target == "NETWORK" and not ep.get("network_ids"):
             return "%s.network_ids array is required when matching_target is 'NETWORK'." % direction
+        if "ports" in ep:
+            return (
+                "%s.ports is not a valid field; the controller expects %s.port as a single "
+                "string (e.g. '445'), not a plural 'ports' array." % (direction, direction)
+            )
+        if ep.get("port_matching_type") == "SPECIFIC" and not ep.get("port"):
+            return "%s.port is required when port_matching_type is 'SPECIFIC'." % direction
     return None
 
 
@@ -310,8 +317,10 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
         "targeting: matching_target='IP', matching_target_type='SPECIFIC', "
         "ips=[...]. For network targeting: matching_target='NETWORK', "
         "matching_target_type='OBJECT', network_ids=[...]. For any in zone: "
-        "matching_target='ANY'. Use unifi_list_firewall_zones to discover "
-        "zone_ids; unifi_list_networks for network_ids."
+        "matching_target='ANY'. For port targeting (same source/destination dict): "
+        "port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' "
+        "array). Use unifi_list_firewall_zones to discover zone_ids; "
+        "unifi_list_networks for network_ids."
     ),
     permission_category="firewall_policies",
     permission_action="create",
@@ -327,9 +336,11 @@ async def create_firewall_policy(
                 "destination (same structure). For IP targeting: matching_target='IP', "
                 "matching_target_type='SPECIFIC', ips=[...]. For network targeting: "
                 "matching_target='NETWORK', matching_target_type='OBJECT', "
-                "network_ids=[...]. For any in zone: matching_target='ANY'. Optional: "
-                "enabled, description, protocol, connection_state_type, connection_states, "
-                "ip_version, schedule, logging."
+                "network_ids=[...]. For any in zone: matching_target='ANY'. For port "
+                "targeting: port_matching_type='SPECIFIC', port='445' (a single "
+                "string, not a 'ports' array). Optional: enabled, description, "
+                "protocol, connection_state_type, connection_states, ip_version, "
+                "schedule, logging."
             )
         ),
     ],

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -18,6 +18,7 @@ from unifi_core.network.models.firewall import (
     legacy_policy_error,
     normalize_policy_enums,
     normalize_policy_update,
+    validate_policy_port_targeting,
 )
 from unifi_core.network.read_views import LEGACY_ENGINE_HINT, shape_firewall_policy_list
 from unifi_core.redaction import redact_sensitive_fields
@@ -298,14 +299,10 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
                 return "%s.ips array is required when matching_target is 'IP'." % direction
         if target == "NETWORK" and not ep.get("network_ids"):
             return "%s.network_ids array is required when matching_target is 'NETWORK'." % direction
-        if "ports" in ep:
-            return (
-                "%s.ports is not a valid field; the controller expects %s.port as a single "
-                "string (e.g. '445'), not a plural 'ports' array." % (direction, direction)
-            )
-        port = ep.get("port")
-        if ep.get("port_matching_type") == "SPECIFIC" and not (isinstance(port, str) and port):
-            return "%s.port is required when port_matching_type is 'SPECIFIC'." % direction
+    try:
+        validate_policy_port_targeting(validated_data)
+    except ValueError as exc:
+        return str(exc)
     return None
 
 

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1787,7 +1787,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a V2 zone-based firewall policy with schema validation. Required: name, action (ALLOW/BLOCK/REJECT), source (zone_id + matching_target), destination (same structure). For specific IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. Use unifi_list_firewall_zones to discover zone_ids; unifi_list_networks for network_ids.",
+      "description": "Create a V2 zone-based firewall policy with schema validation. Required: name, action (ALLOW/BLOCK/REJECT), source (zone_id + matching_target), destination (same structure). For specific IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For port targeting (same source/destination dict): port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' array). Use unifi_list_firewall_zones to discover zone_ids; unifi_list_networks for network_ids.",
       "name": "unifi_create_firewall_policy",
       "permission_action": "create",
       "permission_category": "firewall_policies",
@@ -1799,7 +1799,7 @@
               "type": "boolean"
             },
             "policy_data": {
-              "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
+              "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For port targeting: port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' array). Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
               "type": "object"
             }
           },

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -64,6 +64,21 @@ def firewall_manager(mock_connection):
     return FirewallManager(mock_connection)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize(
+    "endpoint",
+    [{"ports": ["445"]}, {"port_matching_type": "SPECIFIC"}, {"port_matching_type": "SPECIFIC", "port": 445}],
+)
+async def test_create_policy_rejects_invalid_ports_before_connection(
+    firewall_manager, mock_connection, direction, endpoint
+):
+    with pytest.raises(ValueError, match=rf"{direction}\.port"):
+        await firewall_manager.create_firewall_policy({direction: endpoint})
+    mock_connection.ensure_connected.assert_not_awaited()
+    mock_connection.request.assert_not_awaited()
+
+
 class TestUpdateTrafficRouteMutationSafety:
     """Ensure update_traffic_route does not mutate the cached TrafficRoute.raw."""
 

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -496,6 +496,35 @@ class TestCreateFirewallPolicyV2Validation:
 
 
 class TestCreateZoneTargetingValidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("confirm", [False, True])
+    @pytest.mark.parametrize("direction", ["source", "destination"])
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            {"ports": ["445"]},
+            {"port_matching_type": "SPECIFIC"},
+            {"port_matching_type": "SPECIFIC", "port": 445},
+            {"port_matching_type": "SPECIFIC", "port": " "},
+        ],
+    )
+    async def test_invalid_ports_never_reach_manager(self, confirm, direction, endpoint):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        data = {
+            "name": "Invalid port",
+            "action": "ALLOW",
+            "source": {"zone_id": "source", "matching_target": "ANY"},
+            "destination": {"zone_id": "destination", "matching_target": "ANY"},
+        }
+        data[direction].update(endpoint)
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as manager:
+            manager.create_firewall_policy = AsyncMock()
+            result = await create_firewall_policy(policy_data=data, confirm=confirm)
+        assert result["success"] is False
+        assert direction + ".port" in result["error"]
+        manager.create_firewall_policy.assert_not_awaited()
+
     """Test matching_target_type validation for zone-based policies."""
 
     @pytest.mark.asyncio
@@ -653,7 +682,7 @@ class TestCreateZoneTargetingValidation:
     async def test_ports_array_is_rejected_not_silently_accepted(self):
         """A 'ports' array (the plural, undocumented guess) must be rejected at
         preview/create time instead of being echoed back and only failing on the
-        live controller write with MissingFirewallDestinationPort (#608)."""
+        live controller write with MissingFirewallDestinationPort."""
         zone_data = {
             "name": "Bad port shape",
             "action": "ALLOW",
@@ -687,7 +716,7 @@ class TestCreateZoneTargetingValidation:
     async def test_non_string_port_for_specific_port_matching_type_fails(self):
         """A truthy but non-string port ([\"445\"] or the int 445) must fail the
         same as a missing one, since the controller only accepts a single string
-        (#608 review: a truthiness check alone lets these through)."""
+        (a truthiness check alone lets these through)."""
         for bad_port in (["445"], 445):
             zone_data = {
                 "name": "Malformed port",

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -496,6 +496,8 @@ class TestCreateFirewallPolicyV2Validation:
 
 
 class TestCreateZoneTargetingValidation:
+    """Test matching_target_type and port validation for zone-based policies."""
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("confirm", [False, True])
     @pytest.mark.parametrize("direction", ["source", "destination"])
@@ -524,8 +526,6 @@ class TestCreateZoneTargetingValidation:
         assert result["success"] is False
         assert direction + ".port" in result["error"]
         manager.create_firewall_policy.assert_not_awaited()
-
-    """Test matching_target_type validation for zone-based policies."""
 
     @pytest.mark.asyncio
     async def test_missing_matching_target_type_for_ip(self):

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -684,6 +684,35 @@ class TestCreateZoneTargetingValidation:
         assert "port" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_non_string_port_for_specific_port_matching_type_fails(self):
+        """A truthy but non-string port ([\"445\"] or the int 445) must fail the
+        same as a missing one, since the controller only accepts a single string
+        (#608 review: a truthiness check alone lets these through)."""
+        for bad_port in (["445"], 445):
+            zone_data = {
+                "name": "Malformed port",
+                "action": "ALLOW",
+                "protocol": "tcp",
+                "source": {"zone_id": "untrusted", "matching_target": "ANY"},
+                "destination": {
+                    "zone_id": "internal",
+                    "matching_target": "IP",
+                    "matching_target_type": "SPECIFIC",
+                    "ips": ["10.0.15.10"],
+                    "port_matching_type": "SPECIFIC",
+                    "port": bad_port,
+                },
+            }
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+            assert result["success"] is False
+            assert "port" in result["error"]
+            assert "SPECIFIC" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_missing_port_for_specific_port_matching_type_fails(self):
         """port_matching_type='SPECIFIC' without a port string should fail validation."""
         zone_data = {

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -649,6 +649,104 @@ class TestCreateZoneTargetingValidation:
         assert result["success"] is False
         assert "ip_group_id" in result["error"]
 
+    @pytest.mark.asyncio
+    async def test_ports_array_is_rejected_not_silently_accepted(self):
+        """A 'ports' array (the plural, undocumented guess) must be rejected at
+        preview/create time instead of being echoed back and only failing on the
+        live controller write with MissingFirewallDestinationPort (#608)."""
+        zone_data = {
+            "name": "Bad port shape",
+            "action": "ALLOW",
+            "protocol": "tcp",
+            "source": {
+                "zone_id": "untrusted",
+                "matching_target": "IP",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["10.0.28.10"],
+                "port_matching_type": "ANY",
+            },
+            "destination": {
+                "zone_id": "internal",
+                "matching_target": "IP",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["10.0.15.10"],
+                "port_matching_type": "SPECIFIC",
+                "ports": ["445"],
+            },
+        }
+
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is False
+        assert "ports" in result["error"]
+        assert "port" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_port_for_specific_port_matching_type_fails(self):
+        """port_matching_type='SPECIFIC' without a port string should fail validation."""
+        zone_data = {
+            "name": "Missing port",
+            "action": "ALLOW",
+            "protocol": "tcp",
+            "source": {"zone_id": "untrusted", "matching_target": "ANY"},
+            "destination": {
+                "zone_id": "internal",
+                "matching_target": "IP",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["10.0.15.10"],
+                "port_matching_type": "SPECIFIC",
+                # missing port
+            },
+        }
+
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is False
+        assert "port" in result["error"]
+        assert "SPECIFIC" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_specific_port_matching_type_with_port_string_passes_validation(self):
+        """The documented shape (singular 'port' string) must pass validation and
+        reach the manager, matching the controller's actual accepted shape."""
+        zone_data = {
+            "name": "Allow SMB to host",
+            "action": "ALLOW",
+            "protocol": "tcp",
+            "source": {
+                "zone_id": "untrusted",
+                "matching_target": "IP",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["10.0.28.10"],
+                "port_matching_type": "ANY",
+            },
+            "destination": {
+                "zone_id": "internal",
+                "matching_target": "IP",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["10.0.15.10"],
+                "port_matching_type": "SPECIFIC",
+                "port": "445",
+            },
+        }
+        created_raw = {**zone_data, "_id": "new_port_001"}
+        mock_created = MagicMock()
+        mock_created.raw = created_raw
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_policy = AsyncMock(return_value=mock_created)
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=zone_data, confirm=True)
+
+        assert result["success"] is True
+        assert result["policy_id"] == "new_port_001"
+
 
 # ---------------------------------------------------------------------------
 # Legacy V1 field migration errors (#210)


### PR DESCRIPTION
Firewall policy creation now rejects plural `ports` and requires a non-empty string for `port_matching_type='SPECIFIC'` before preview or controller execution. Both source and destination are covered. The MCP wrapper and API argument translator use the shared Core validator, so API callers receive the same fail-fast behavior.

The Core prerequisite landed in #662 and is published as `unifi-core==0.4.45`. This PR raises Network/API dependency floors accordingly and documents the accepted port shape in generated tool descriptions.

Fixes #608.

Validation on final head `7b61c380c00669d7d25e1712d8c3307e7a5dc75b`:

- All 14 fresh CI checks pass, including published-package pin alignment.
- Rebased Network firewall tests: 147 passed. API dispatcher tests: 327 passed. Generated artifacts match.
- Full `make pre-commit` passed before the rebase; the rebase only removed the separately merged Core prerequisite.
- Maintainer reference-hardware testing rejected 48 malformed-port cases across MCP/API, source/destination, and preview/execute. Two disabled-policy create/update/readback/delete cycles verified port preservation and left zero orphaned policies.
- Network safe smoke: 160 successful checks, no failures, three disposable resources cleaned and gateway settings restored. Published Core 0.4.45 also passed independent Network/Protect/Access installed-wheel smoke and a targeted disabled-policy lifecycle.
- Copilot's validation and comment-drift feedback is addressed. Its request for live-controller verification is covered above.

<details>
<summary>Targeted maintainer hardware probe output</summary>

```text
mcp: malformed ports rejected in preview and execution
api: malformed ports rejected in preview and execution
mcp: disabled policy created, ports preserved after update, and deleted
api: disabled policy created, ports preserved after update, and deleted
{"invalid_cases_rejected": 48, "cycles": ["mcp: create/update/readback passed", "api: create/update/readback passed"], "orphans": 0}
```

The valid test policies were disabled, used explicit string ports and `create_allow_respond=false`, and were deleted after readback verification.

</details>
