### PR TITLE
fix(shared): preserve legacy registration compatibility

### DIFF
--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/meta_tools.py
@@ -70,10 +70,11 @@ def register_meta_tools(
     start_async_tool: Callable,
     get_job_status: Callable,
     register_tool: Callable,
-    support_bundle_handler: Callable,
     prefix: str = "unifi",
     server_label: str = "UniFi Network",
     domain_hint: str | None = None,
+    *,
+    support_bundle_handler: Callable | None = None,
 ) -> None:
     """Register meta-tools with the MCP server.
 
@@ -91,7 +92,8 @@ def register_meta_tools(
         start_async_tool: Function to start async jobs
         get_job_status: Function to get job status
         register_tool: Function to register in tool index
-        support_bundle_handler: Runtime support-bundle service callback.
+        support_bundle_handler: Optional runtime callback. Omit for legacy apps
+            that do not expose support bundles.
         prefix: Tool name prefix (e.g. "unifi", "protect", "access").
         server_label: Human-readable server name for descriptions
                       (e.g. "UniFi Network", "UniFi Protect").
@@ -128,78 +130,82 @@ def register_meta_tools(
     # This uses the original server decorator and a dedicated safe audit line;
     # it must never pass through ordinary diagnostic argument/result logging.
     # =========================================================================
-    @tool_decorator(
-        name=support_name,
-        title=support_title,
-        description=(
-            f"Generate a sanitized, reviewable {server_label} support bundle. "
-            "The default summary is local/cache-only. Live connectivity or resource-shape probes "
-            "are bounded and may be unavailable for this product. The result excludes raw logs, "
-            "credentials, controller payload values, and arbitrary exception text. Review the "
-            "bundle before sharing it publicly."
-        ),
-        annotations=read_annotations,
-    )
-    async def _support_bundle_wrapper(
-        probe: SkipValidation[Literal["summary", "connectivity", "resource_shape"]] = "summary",
-        resource: SkipValidation[str | None] = None,
-    ) -> dict:
-        # Preserve the advertised schema, but validate only inside the service's
-        # privacy boundary: Pydantic errors otherwise echo rejected input values.
-        try:
-            correlation_id = uuid.uuid4().hex
-            started = time.monotonic()
-            result = await support_bundle_handler(probe=probe, resource=resource)
-            if not isinstance(result, dict):
-                result = {"success": False, "error": "Failed to generate support bundle."}
-            outcome = "success" if result.get("success") is True else "failed"
-            duration_bucket = _duration_bucket((time.monotonic() - started) * 1000)
-        except Exception:
-            result = {"success": False, "error": "Failed to generate support bundle."}
-            correlation_id = uuid.uuid4().hex
-            outcome = "failed"
-            duration_bucket = "unknown"
-        safe_probe = (
-            probe if isinstance(probe, str) and probe in {"summary", "connectivity", "resource_shape"} else "invalid"
-        )
-        logger.info(
-            "Support bundle audit correlation_id=%s probe=%s outcome=%s duration=%s",
-            correlation_id,
-            safe_probe,
-            outcome,
-            duration_bucket,
-        )
-        return result
+    if support_bundle_handler is not None:
 
-    register_tool(
-        name=support_name,
-        title=support_title,
-        description=(
-            f"Generate sanitized {server_label} support evidence for user review. "
-            "Summary is local/cache-only; live probes are bounded and explicitly allowlisted."
-        ),
-        input_schema={
-            "type": "object",
-            "properties": {
-                "probe": {
-                    "type": "string",
-                    "enum": ["summary", "connectivity", "resource_shape"],
-                    "default": "summary",
+        @tool_decorator(
+            name=support_name,
+            title=support_title,
+            description=(
+                f"Generate a sanitized, reviewable {server_label} support bundle. "
+                "The default summary is local/cache-only. Live connectivity or resource-shape probes "
+                "are bounded and may be unavailable for this product. The result excludes raw logs, "
+                "credentials, controller payload values, and arbitrary exception text. Review the "
+                "bundle before sharing it publicly."
+            ),
+            annotations=read_annotations,
+        )
+        async def _support_bundle_wrapper(
+            probe: SkipValidation[Literal["summary", "connectivity", "resource_shape"]] = "summary",
+            resource: SkipValidation[str | None] = None,
+        ) -> dict:
+            # Preserve the advertised schema, but validate only inside the service's
+            # privacy boundary: Pydantic errors otherwise echo rejected input values.
+            try:
+                correlation_id = uuid.uuid4().hex
+                started = time.monotonic()
+                result = await support_bundle_handler(probe=probe, resource=resource)
+                if not isinstance(result, dict):
+                    result = {"success": False, "error": "Failed to generate support bundle."}
+                outcome = "success" if result.get("success") is True else "failed"
+                duration_bucket = _duration_bucket((time.monotonic() - started) * 1000)
+            except Exception:
+                result = {"success": False, "error": "Failed to generate support bundle."}
+                correlation_id = uuid.uuid4().hex
+                outcome = "failed"
+                duration_bucket = "unknown"
+            safe_probe = (
+                probe
+                if isinstance(probe, str) and probe in {"summary", "connectivity", "resource_shape"}
+                else "invalid"
+            )
+            logger.info(
+                "Support bundle audit correlation_id=%s probe=%s outcome=%s duration=%s",
+                correlation_id,
+                safe_probe,
+                outcome,
+                duration_bucket,
+            )
+            return result
+
+        register_tool(
+            name=support_name,
+            title=support_title,
+            description=(
+                f"Generate sanitized {server_label} support evidence for user review. "
+                "Summary is local/cache-only; live probes are bounded and explicitly allowlisted."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "probe": {
+                        "type": "string",
+                        "enum": ["summary", "connectivity", "resource_shape"],
+                        "default": "summary",
+                    },
+                    "resource": {"type": ["string", "null"], "default": None},
                 },
-                "resource": {"type": ["string", "null"], "default": None},
             },
-        },
-        output_schema={
-            "type": "object",
-            "properties": {
-                "success": {"type": "boolean"},
-                "data": {"type": "object"},
-                "error": {"type": "string"},
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "success": {"type": "boolean"},
+                    "data": {"type": "object"},
+                    "error": {"type": "string"},
+                },
+                "required": ["success"],
             },
-            "required": ["success"],
-        },
-        annotations=normalize_tool_annotations(read_annotations),
-    )
+            annotations=normalize_tool_annotations(read_annotations),
+        )
 
     # =========================================================================
     # DISCOVERY: {prefix}_tool_index
@@ -543,14 +549,10 @@ def register_meta_tools(
         annotations=normalize_tool_annotations(read_annotations),
     )
 
-    logger.info(
-        "Registered meta-tools: %s, %s, %s, %s, %s",
-        idx_name,
-        exec_name,
-        batch_name,
-        status_name,
-        support_name,
-    )
+    names = [idx_name, exec_name, batch_name, status_name]
+    if support_bundle_handler is not None:
+        names.append(support_name)
+    logger.info("Registered meta-tools: %s", ", ".join(names))
 
 
 def register_load_tools(

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_registration.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_registration.py
@@ -36,7 +36,7 @@ async def register_tools_for_mode(
     base_package: str,
     config: Any,
     logger: logging.Logger,
-    support_bundle_handler: Callable,
+    support_bundle_handler: Callable | None = None,
     prefix: str = "",
     server_label: str = "",
     register_meta_tools: Callable | None = None,
@@ -58,7 +58,7 @@ async def register_tools_for_mode(
         base_package: Dotted package path for tool modules (e.g. ``"unifi_network_mcp.tools"``).
         config: Server config object (used for ``enabled_categories``/``enabled_tools``).
         logger: Logger instance.
-        support_bundle_handler: Required runtime support-bundle service callback.
+        support_bundle_handler: Optional runtime callback; legacy callers can omit it.
         prefix: Tool name prefix (e.g. ``"protect"``). Empty string for Network (uses ``"unifi"``).
         server_label: Human-readable server name (e.g. ``"UniFi Protect"``).
         register_meta_tools: Shared meta-tools registration function.
@@ -81,8 +81,9 @@ async def register_tools_for_mode(
         start_async_tool=start_async_tool,
         get_job_status=get_job_status,
         register_tool=register_tool,
-        support_bundle_handler=support_bundle_handler,
     )
+    if support_bundle_handler is not None:
+        meta_kwargs["support_bundle_handler"] = support_bundle_handler
     if prefix:
         meta_kwargs["prefix"] = prefix
         meta_kwargs["server_label"] = server_label
@@ -91,16 +92,17 @@ async def register_tools_for_mode(
     register_meta_tools(**meta_kwargs)
 
     tool_prefix = prefix or "unifi"
+    support_hint = f", {tool_prefix}_get_support_bundle" if support_bundle_handler is not None else ""
 
     if mode == "meta_only":
         logger.info("Tool registration mode: meta_only")
         logger.info(
-            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status, %s_get_support_bundle",
+            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status%s",
             tool_prefix,
             tool_prefix,
             tool_prefix,
             tool_prefix,
-            tool_prefix,
+            support_hint,
         )
         logger.info("   Use %s_execute to run domain tools by name", tool_prefix)
         logger.info("   To load all tools directly: set UNIFI_TOOL_REGISTRATION_MODE=eager")
@@ -111,13 +113,13 @@ async def register_tools_for_mode(
     elif mode == "lazy":
         logger.info("Tool registration mode: lazy")
         logger.info(
-            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status, %s_load_tools, %s_get_support_bundle",
+            "   Meta-tools: %s_tool_index, %s_execute, %s_batch, %s_batch_status, %s_load_tools%s",
             tool_prefix,
             tool_prefix,
             tool_prefix,
             tool_prefix,
             tool_prefix,
-            tool_prefix,
+            support_hint,
         )
         logger.info("   Use %s_execute to run any tool - works with all clients", tool_prefix)
 

--- a/packages/unifi-mcp-shared/tests/test_meta_tools.py
+++ b/packages/unifi-mcp-shared/tests/test_meta_tools.py
@@ -172,6 +172,28 @@ def test_meta_tool_index_objects_contain_declared_annotations():
 
 
 @pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
+async def test_legacy_positional_meta_registration_does_not_advertise_support(prefix, caplog):
+    server = FastMCP("legacy-app")
+    registered = Mock()
+    with caplog.at_level("INFO"):
+        register_meta_tools(
+            server,
+            server.tool,
+            AsyncMock(),
+            AsyncMock(),
+            AsyncMock(),
+            registered,
+            prefix,
+            "Legacy app",
+            "legacy domain",
+        )
+    names = {tool.name for tool in await server.list_tools()}
+    assert names == {f"{prefix}_{suffix}" for suffix in ("tool_index", "execute", "batch", "batch_status")}
+    assert {call.kwargs["name"] for call in registered.call_args_list} == names
+    assert "get_support_bundle" not in caplog.text
+
+
+@pytest.mark.parametrize("prefix", ["unifi", "protect", "access"])
 async def test_support_bundle_schema_annotations_and_behavior(prefix):
     handler = AsyncMock(return_value={"success": True, "data": {"schema_version": 1}})
     registered, tool_decorator = _capture_tools()

--- a/packages/unifi-mcp-shared/tests/test_tool_registration.py
+++ b/packages/unifi-mcp-shared/tests/test_tool_registration.py
@@ -37,6 +37,22 @@ def _deps():
 class TestRegisterToolsForMode:
     """Tests for the tool visibility surfaces in each registration mode."""
 
+    @pytest.mark.parametrize("mode", ["lazy", "meta_only", "eager"])
+    async def test_legacy_apps_can_omit_support_handler(self, mode, caplog):
+        deps = _deps()
+        deps.pop("support_bundle_handler")
+        with caplog.at_level("INFO"):
+            await register_tools_for_mode(
+                mode=mode,
+                server=_server(),
+                base_package="unifi_network_mcp.tools",
+                config=_config(),
+                logger=logging.getLogger("test"),
+                **deps,
+            )
+        assert "support_bundle_handler" not in deps["register_meta_tools"].call_args.kwargs
+        assert "get_support_bundle" not in caplog.text
+
     @pytest.mark.asyncio
     async def test_lazy_mode_registers_meta_tools_load_tools_and_lazy_loader(self):
         server = _server()


### PR DESCRIPTION
## Summary

Follow up #625 before publishing Shared: preserve registration compatibility with already-published Network, Protect, and Access packages. Those wheels do not pass the new support-bundle callback, so making it required would break startup when they resolve the next Shared 0.6.x release.

- Make the callback optional and keyword-only in direct meta-tool registration, retaining the legacy positional prefix/label/domain arguments.
- Register and advertise the support tool only when the application supplies its handler. Current workspace apps still supply it in all registration modes.
- Do not pass the new keyword to legacy injected registrars when no handler is supplied.
- Add six regression cases covering the three product prefixes and three registration modes.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes (no new user-facing behavior; restores compatibility).
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- Six new regression cases failed before the fix and pass afterward.
- Shared suite: 427 passed.
- Ruff format/lint and `git diff --check`: passed.
- `make manifest`: passed; generated artifacts unchanged.
- Clean isolated install: published Network 0.29.8, Protect 0.7.14, and Access 0.5.14 with the candidate Shared wheel passed actual startup registration in lazy, eager, and meta_only modes (9/9). Connection initialization and transport startup were stubbed, with socket connections forbidden; no live-controller verification is claimed by this check.
- Full `make pre-commit`: passed, including Core 1,848, Shared 427, root 382, Relay 143, Network 1,085, Protect 512, Access 221, API 1,370 tests, plus worker checks.
- `uv run scripts/check_pin_alignment.py`: passed; wheel security floors, runtime pins, downstream upgrades/installs/imports, and published Core-floor call sites all validated.

## Notes for reviewers

This is a pre-publication compatibility bridge, not a release. Shared publication is held until this lands. The support handler's safe validation and auditing behavior is unchanged; most of the meta-tools diff is indentation beneath the handler-presence guard. No new Core dependency is introduced.
