### PR TITLE
feat(network): expose categories and severities on unifi_list_events

### DIFF
--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -4939,6 +4939,10 @@
       "manager_method": "get_events",
       "input_schema": {
         "properties": {
+          "categories": {
+            "description": "Filter by v2 system-log categories (for example ['SECURITY', 'DEVICES']). Ignored on legacy controllers",
+            "type": "array"
+          },
           "event_type": {
             "description": "Filter by an exact event key (for example 'CLIENT_DISCONNECTED_WIRELESS_2'). Use unifi_get_event_types to see recently observed keys",
             "type": "string"
@@ -4946,6 +4950,10 @@
           "limit": {
             "description": "Maximum number of events to return (default 100)",
             "type": "integer"
+          },
+          "severities": {
+            "description": "Filter by v2 system-log severities (for example ['HIGH', 'CRITICAL']). Ignored on legacy controllers",
+            "type": "array"
           },
           "start": {
             "description": "Offset for pagination, skip the first N events (default 0)",

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -4940,7 +4940,7 @@
       "input_schema": {
         "properties": {
           "categories": {
-            "description": "Filter by v2 system-log categories (for example ['SECURITY', 'DEVICES']). Ignored on legacy controllers",
+            "description": "Filter by v2 system-log categories (for example ['SECURITY', 'UNIFI_DEVICES']). Ignored on legacy controllers",
             "type": "array"
           },
           "event_type": {
@@ -4952,7 +4952,7 @@
             "type": "integer"
           },
           "severities": {
-            "description": "Filter by v2 system-log severities (for example ['HIGH', 'CRITICAL']). Ignored on legacy controllers",
+            "description": "Filter by v2 system-log severities (for example ['HIGH', 'VERY_HIGH']). Ignored on legacy controllers",
             "type": "array"
           },
           "start": {

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -5,7 +5,7 @@ This module provides MCP tools to view events and manage alarms on a UniFi Netwo
 """
 
 import logging
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -39,7 +39,9 @@ def _get_event_manager():
         "Returns timestamped event log entries (client connects/disconnects, device "
         "state changes, firmware updates, config changes) sorted newest-first. "
         "Filter by within_hours (default 24), an exact event_type key (use "
-        "unifi_get_event_types for recently observed keys), and paginate with start/limit. "
+        "unifi_get_event_types for recently observed keys), categories (for example "
+        "['SECURITY']) and severities (for example ['HIGH', 'CRITICAL']) on v2 controllers, "
+        "and paginate with start/limit. "
         "For critical alerts specifically, use unifi_list_alarms instead."
     ),
 )
@@ -53,6 +55,18 @@ async def list_events(
             description="Filter by an exact event key (for example 'CLIENT_DISCONNECTED_WIRELESS_2'). Use unifi_get_event_types to see recently observed keys"
         ),
     ] = None,
+    categories: Annotated[
+        Optional[List[str]],
+        Field(
+            description="Filter by v2 system-log categories (for example ['SECURITY', 'DEVICES']). Ignored on legacy controllers"
+        ),
+    ] = None,
+    severities: Annotated[
+        Optional[List[str]],
+        Field(
+            description="Filter by v2 system-log severities (for example ['HIGH', 'CRITICAL']). Ignored on legacy controllers"
+        ),
+    ] = None,
 ) -> Dict[str, Any]:
     """List events with optional filtering."""
     try:
@@ -62,6 +76,8 @@ async def list_events(
             limit=limit,
             start=start,
             event_type=event_type,
+            categories=categories,
+            severities=severities,
         )
 
         shaped = [event_log_from_controller(e).model_dump(exclude_none=True) for e in events]
@@ -74,6 +90,8 @@ async def list_events(
                 "limit": limit,
                 "start": start,
                 "event_type": event_type,
+                "categories": categories,
+                "severities": severities,
             },
             "events": shaped,
         }

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -40,7 +40,7 @@ def _get_event_manager():
         "state changes, firmware updates, config changes) sorted newest-first. "
         "Filter by within_hours (default 24), an exact event_type key (use "
         "unifi_get_event_types for recently observed keys), categories (for example "
-        "['SECURITY']) and severities (for example ['HIGH', 'CRITICAL']) on v2 controllers, "
+        "['SECURITY']) and severities (for example ['HIGH', 'VERY_HIGH']) on v2 controllers, "
         "and paginate with start/limit. "
         "For critical alerts specifically, use unifi_list_alarms instead."
     ),
@@ -58,13 +58,13 @@ async def list_events(
     categories: Annotated[
         Optional[List[str]],
         Field(
-            description="Filter by v2 system-log categories (for example ['SECURITY', 'DEVICES']). Ignored on legacy controllers"
+            description="Filter by v2 system-log categories (for example ['SECURITY', 'UNIFI_DEVICES']). Ignored on legacy controllers"
         ),
     ] = None,
     severities: Annotated[
         Optional[List[str]],
         Field(
-            description="Filter by v2 system-log severities (for example ['HIGH', 'CRITICAL']). Ignored on legacy controllers"
+            description="Filter by v2 system-log severities (for example ['HIGH', 'VERY_HIGH']). Ignored on legacy controllers"
         ),
     ] = None,
 ) -> Dict[str, Any]:

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -11682,11 +11682,15 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), an exact event_type key (use unifi_get_event_types for recently observed keys), and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
+      "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), an exact event_type key (use unifi_get_event_types for recently observed keys), categories (for example ['SECURITY']) and severities (for example ['HIGH', 'CRITICAL']) on v2 controllers, and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
       "name": "unifi_list_events",
       "schema": {
         "input": {
           "properties": {
+            "categories": {
+              "description": "Filter by v2 system-log categories (for example ['SECURITY', 'DEVICES']). Ignored on legacy controllers",
+              "type": "array"
+            },
             "event_type": {
               "description": "Filter by an exact event key (for example 'CLIENT_DISCONNECTED_WIRELESS_2'). Use unifi_get_event_types to see recently observed keys",
               "type": "string"
@@ -11694,6 +11698,10 @@
             "limit": {
               "description": "Maximum number of events to return (default 100)",
               "type": "integer"
+            },
+            "severities": {
+              "description": "Filter by v2 system-log severities (for example ['HIGH', 'CRITICAL']). Ignored on legacy controllers",
+              "type": "array"
             },
             "start": {
               "description": "Offset for pagination, skip the first N events (default 0)",

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -11682,13 +11682,13 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), an exact event_type key (use unifi_get_event_types for recently observed keys), categories (for example ['SECURITY']) and severities (for example ['HIGH', 'CRITICAL']) on v2 controllers, and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
+      "description": "Returns timestamped event log entries (client connects/disconnects, device state changes, firmware updates, config changes) sorted newest-first. Filter by within_hours (default 24), an exact event_type key (use unifi_get_event_types for recently observed keys), categories (for example ['SECURITY']) and severities (for example ['HIGH', 'VERY_HIGH']) on v2 controllers, and paginate with start/limit. For critical alerts specifically, use unifi_list_alarms instead.",
       "name": "unifi_list_events",
       "schema": {
         "input": {
           "properties": {
             "categories": {
-              "description": "Filter by v2 system-log categories (for example ['SECURITY', 'DEVICES']). Ignored on legacy controllers",
+              "description": "Filter by v2 system-log categories (for example ['SECURITY', 'UNIFI_DEVICES']). Ignored on legacy controllers",
               "type": "array"
             },
             "event_type": {
@@ -11700,7 +11700,7 @@
               "type": "integer"
             },
             "severities": {
-              "description": "Filter by v2 system-log severities (for example ['HIGH', 'CRITICAL']). Ignored on legacy controllers",
+              "description": "Filter by v2 system-log severities (for example ['HIGH', 'VERY_HIGH']). Ignored on legacy controllers",
               "type": "array"
             },
             "start": {

--- a/apps/network/tests/unit/test_event_tools.py
+++ b/apps/network/tests/unit/test_event_tools.py
@@ -1,6 +1,7 @@
 """Tests for event/alarm tool confirmation previews."""
 
 import os
+import re
 
 import pytest
 
@@ -182,10 +183,48 @@ async def test_list_events_passes_categories_and_severities_through(monkeypatch)
 
     monkeypatch.setattr(events_module, "_get_event_manager", lambda: _CapturingEventManager([]))
 
-    result = await events_module.list_events(categories=["SECURITY"], severities=["HIGH", "CRITICAL"])
+    result = await events_module.list_events(categories=["SECURITY"], severities=["HIGH", "VERY_HIGH"])
 
     assert result["success"] is True
     assert captured["categories"] == ["SECURITY"]
-    assert captured["severities"] == ["HIGH", "CRITICAL"]
+    assert captured["severities"] == ["HIGH", "VERY_HIGH"]
     assert result["filters"]["categories"] == ["SECURITY"]
-    assert result["filters"]["severities"] == ["HIGH", "CRITICAL"]
+    assert result["filters"]["severities"] == ["HIGH", "VERY_HIGH"]
+
+
+def _bracketed_examples(text: str) -> list[str]:
+    """Return every quoted value inside a bracketed example list in ``text``."""
+    values: list[str] = []
+    for group in re.findall(r"\[([^\]]*)\]", text):
+        values.extend(re.findall(r"'([A-Z_]+)'", group))
+    return values
+
+
+def test_list_events_examples_use_controller_supported_spellings():
+    """Every category/severity example the tool advertises must be a manager-known spelling.
+
+    Maintainer live run on Network 10.6.102: ``categories=["DEVICES"]`` and
+    ``severities=["CRITICAL"]`` both fail on the controller, yet the tool
+    description, the manifest and the API catalog advertised them.
+    """
+    from unifi_core.network.managers import event_manager as manager_module
+    from unifi_network_mcp.tools import events as events_module
+
+    known_categories = {entry["category"] for entry in manager_module.EventManager.get_event_categories(None)}
+    known_severities = set(manager_module._DEFAULT_SEVERITIES)
+
+    tool = events_module.server._tool_manager.get_tool("unifi_list_events")
+    assert tool is not None
+    schema = tool.parameters["properties"]
+
+    advertised_categories = set(_bracketed_examples(schema["categories"]["description"]))
+    advertised_severities = set(_bracketed_examples(schema["severities"]["description"]))
+    advertised_in_description = set(_bracketed_examples(tool.description))
+
+    assert advertised_categories, "category example missing from the parameter description"
+    assert advertised_severities, "severity example missing from the parameter description"
+    assert advertised_in_description <= known_categories | known_severities, (
+        advertised_in_description - known_categories - known_severities
+    )
+    assert advertised_categories <= known_categories, advertised_categories - known_categories
+    assert advertised_severities <= known_severities, advertised_severities - known_severities

--- a/apps/network/tests/unit/test_event_tools.py
+++ b/apps/network/tests/unit/test_event_tools.py
@@ -166,3 +166,26 @@ async def test_get_event_types_returns_standard_error_when_discovery_fails(monke
         "success": False,
         "error": "Failed to get event types: controller event query failed",
     }
+
+
+@pytest.mark.asyncio
+async def test_list_events_passes_categories_and_severities_through(monkeypatch):
+    """The manager already accepts categories/severities; the tool must expose and forward them."""
+    from unifi_network_mcp.tools import events as events_module
+
+    captured: dict = {}
+
+    class _CapturingEventManager(_StubEventManager):
+        async def get_events(self, **kwargs):
+            captured.update(kwargs)
+            return self._records
+
+    monkeypatch.setattr(events_module, "_get_event_manager", lambda: _CapturingEventManager([]))
+
+    result = await events_module.list_events(categories=["SECURITY"], severities=["HIGH", "CRITICAL"])
+
+    assert result["success"] is True
+    assert captured["categories"] == ["SECURITY"]
+    assert captured["severities"] == ["HIGH", "CRITICAL"]
+    assert result["filters"]["categories"] == ["SECURITY"]
+    assert result["filters"]["severities"] == ["HIGH", "CRITICAL"]


### PR DESCRIPTION
## Summary

`EventManager.get_events()` already accepts `categories` and `severities` for the v2 system-log API, but `unifi_list_events` never exposed them, so the single most useful query for firewall work (`categories=["SECURITY"]`) was unreachable through the tool. This adds both as optional list parameters, forwards them to the manager, echoes them in the response's `filters` block, and mentions them in the tool description. Legacy controllers ignore them, exactly as the manager already does. Small enough that I did not open an issue first; happy to if you would rather track it.

## Type of change

- [x] `feat:` new feature

## Scope

- [x] Network MCP server

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. (Tool description + manifest; no separate doc lists the `unifi_list_events` parameters.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

Python side of `make pre-commit` (`ruff format`, `make manifest`, `make server-manifest`, `ruff check`, network suite); the worker npm install was skipped on this host, and no worker code is touched. `server.json` regenerated with no diff.

```
uv run pytest apps/network/tests/unit/test_event_tools.py   # new pass-through test fails before, passes after
uv run pytest apps/network/tests                            -> 1086 passed
uv run ruff format / ruff check apps/network                -> clean
```

## Notes for reviewers

The manifest diff is the two new parameters plus the description sentence. `filters` in the response gains two keys (`null` when unset), which is additive.
