### PR TITLE
fix(network): populate current values in the auto-backup update preview

### DIFF
--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -91,6 +91,8 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     # Gateway/SNMP settings updates pre-fetch current state for previews.
     "unifi_update_gateway_settings": ("gateway_settings_manager", "update_gateway_settings"),
     "unifi_update_snmp_settings": ("system_manager", "update_settings"),
+    # Auto-backup update pre-fetches get_autobackup_settings for the preview.
+    "unifi_update_autobackup_settings": ("system_manager", "update_autobackup_settings"),
     # Firewall: tool layer pre-fetches list to find policy by id.
     "unifi_toggle_firewall_policy": ("firewall_manager", "toggle_firewall_policy"),
     "unifi_get_firewall_policy_details": ("firewall_manager", "get_firewall_policy_by_id"),

--- a/apps/network/src/unifi_network_mcp/tools/system.py
+++ b/apps/network/src/unifi_network_mcp/tools/system.py
@@ -359,11 +359,16 @@ async def update_autobackup_settings(
         return {"success": False, "error": "No valid fields to update after validation."}
 
     if not confirm:
+        try:
+            current = await system_manager.get_autobackup_settings()
+        except Exception as e:
+            logger.error("Error preparing auto-backup settings preview: %s", e, exc_info=True)
+            return {"success": False, "error": f"Failed to prepare auto-backup settings preview: {e}"}
         return update_preview(
             resource_type="autobackup_settings",
             resource_id="super_mgmt",
             resource_name="Auto-Backup Settings",
-            current_state={},
+            current_state=current,
             updates=validated_data,
         )
 

--- a/apps/network/tests/unit/test_backup_tools.py
+++ b/apps/network/tests/unit/test_backup_tools.py
@@ -202,6 +202,41 @@ class TestBackupTools:
         assert api_req.data["cmd"] == "list-backups"
 
 
+class TestAutoBackupTools:
+    """Tests for the auto-backup update preview."""
+
+    @pytest.mark.asyncio
+    async def test_update_autobackup_settings_preview_shows_current_values(self, monkeypatch):
+        """The preview must diff against the live settings, not against an empty dict."""
+        from unifi_network_mcp.tools import system
+
+        mock_mgr = MagicMock()
+        mock_mgr._connection.site = "default"
+        mock_mgr.get_autobackup_settings = AsyncMock(
+            return_value={
+                "autobackup_enabled": True,
+                "autobackup_cron_expr": "0 2 * * *",
+                "autobackup_days": 30,
+                "autobackup_max_files": 10,
+                "autobackup_timezone": "America/Denver",
+                "autobackup_cloud_enabled": False,
+            }
+        )
+        monkeypatch.setattr(system, "system_manager", mock_mgr)
+
+        result = await system.update_autobackup_settings(
+            update_data={"autobackup_max_files": 5, "autobackup_cron_expr": "30 0 * * 0"},
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert result["requires_confirmation"] is True
+        assert result["preview"]["current"]["autobackup_max_files"] == 10
+        assert result["preview"]["current"]["autobackup_cron_expr"] == "0 2 * * *"
+        assert result["preview"]["proposed"]["autobackup_max_files"] == 5
+        assert result["preview"]["proposed"]["autobackup_cron_expr"] == "30 0 * * 0"
+
+
 class TestSnmpTools:
     """Tests for SNMP tool response redaction."""
 


### PR DESCRIPTION
## Summary

`unifi_update_autobackup_settings` built its preview with `current_state={}`, so every field came back `current: null` even when the controller had a value. The preview confirmed which fields were addressed and nothing else: it could not diff, and an operator reading it could not see they were about to replace a working schedule. `unifi_update_snmp_settings` in the same module already reads the live record before previewing; this does the same via `system_manager.get_autobackup_settings()`, and returns the standard `{success: false, error}` shape if that read fails instead of previewing against nothing.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. (Regenerated; no diff, the signature is unchanged.)
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-visible changes. (No doc describes the preview's `current` block.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

Python side of `make pre-commit` (`ruff format`, `make manifest`, `make server-manifest`, `ruff check`, network suite); the worker npm install was skipped on this host, and no worker code is touched.

```
uv run pytest apps/network/tests/unit/test_backup_tools.py   # new preview test fails before (current is None), passes after
uv run pytest apps/network/tests                             -> 1086 passed
uv run ruff format / ruff check apps/network                 -> clean
```

## Notes for reviewers

The preview now makes one extra read (`rest/setting` → `super_mgmt`) before returning, same cost as the SNMP preview. Client-side range checks for bounded fields (`autobackup_max_files` has a controller ceiling the preview still cannot see) are a separate change I have not made here.
