### PR TITLE
fix(network): use the per-MAC client lookup from Core past the /rest/user cap

### DIFF
--- a/apps/api/src/unifi_api/routes/resources/network/clients.py
+++ b/apps/api/src/unifi_api/routes/resources/network/clients.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from unifi_core.exceptions import UniFiNotFoundError
+from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
@@ -109,6 +109,9 @@ async def get_client(
             client = await mgr.get_client_details(mac)
     except UniFiNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
+    except UniFiOperationError as exc:
+        # The per-MAC lookup failed, so existence is undetermined: not a 404.
+        raise HTTPException(status_code=502, detail=str(exc))
     if client is None:
         raise HTTPException(status_code=404, detail="client not found")
 

--- a/apps/api/tests/routes/resources/test_network_resources.py
+++ b/apps/api/tests/routes/resources/test_network_resources.py
@@ -142,6 +142,39 @@ async def test_list_clients_capability_mismatch(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_client_detail_maps_manager_errors(tmp_path, monkeypatch) -> None:
+    """Not-found is 404; an undetermined lookup (the per-MAC endpoint failed)
+    is a 502, never a 404 and never an unhandled 500."""
+    from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
+    from unifi_core.network.managers.client_manager import ClientManager
+
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    _stub_connection(app, cid)
+
+    async def fake_details(self, mac):
+        if mac == "aa:bb:cc:dd:ee:01":
+            raise UniFiNotFoundError("client", mac)
+        raise UniFiOperationError("existence could not be determined")
+
+    monkeypatch.setattr(ClientManager, "get_client_details", fake_details)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        missing = await c.get(
+            f"/v1/sites/default/clients/aa:bb:cc:dd:ee:01?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        undetermined = await c.get(
+            f"/v1/sites/default/clients/aa:bb:cc:dd:ee:02?controller={cid}",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+
+    assert missing.status_code == 404
+    assert undetermined.status_code == 502
+    assert "could not be determined" in undetermined.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_get_client_detail_happy_and_404(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
     app, key, cid = await _bootstrap(tmp_path)

--- a/apps/network/src/unifi_network_mcp/tools/stats.py
+++ b/apps/network/src/unifi_network_mcp/tools/stats.py
@@ -241,7 +241,7 @@ async def get_top_clients(
         for entry in top_client_stats:
             mac = entry.get("mac")
             if mac:
-                details = await client_manager.get_client_details(mac)
+                details = await client_manager.get_client_details(mac, existence_only=True)
                 if details:
                     raw = details.raw if hasattr(details, "raw") else details
                     if not entry.get("name") and not entry.get("hostname"):

--- a/apps/network/tests/unit/test_clients_filtering.py
+++ b/apps/network/tests/unit/test_clients_filtering.py
@@ -251,6 +251,24 @@ async def test_get_client_details_not_found():
 
 
 @pytest.mark.asyncio
+async def test_get_client_details_reports_an_undetermined_lookup_as_an_error():
+    from unifi_core.exceptions import UniFiOperationError
+
+    with patch("unifi_network_mcp.tools.clients.client_manager") as mock_cm:
+        mock_cm.get_client_details = AsyncMock(side_effect=UniFiOperationError("existence could not be determined"))
+        mock_cm._connection = _mock_conn()
+
+        from unifi_network_mcp.tools.clients import get_client_details
+
+        result = await get_client_details("aa:bb:cc:99:99:99")
+
+    assert result == {
+        "success": False,
+        "error": "Failed to get client details for aa:bb:cc:99:99:99: existence could not be determined",
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_client_details_summary_status_offline_without_signal():
     # Offline/historical clients lack `is_online` and active-connection counters;
     # status must be derived as Offline, not defaulted to Online.

--- a/apps/network/tests/unit/test_top_clients_existence_only.py
+++ b/apps/network/tests/unit/test_top_clients_existence_only.py
@@ -1,0 +1,31 @@
+"""``unifi_get_top_clients`` enriches names through ``get_client_details``.
+
+Every entry it enriches costs a client lookup; a client past the /rest/user
+row cap would otherwise cost a per-MAC controller request per entry, and the
+name enrichment only needs to know the client exists (Core ``existence_only``).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_top_clients_enrichment_asks_for_existence_only():
+    with (
+        patch("unifi_network_mcp.tools.stats.stats_manager") as mock_sm,
+        patch("unifi_network_mcp.tools.stats.client_manager") as mock_cm,
+    ):
+        mock_sm._connection = MagicMock(site="default")
+        mock_sm.get_top_clients = AsyncMock(return_value=[{"mac": "aa:bb:cc:dd:ee:ff", "rx_bytes": 1, "tx_bytes": 2}])
+        mock_cm.get_client_details = AsyncMock(
+            return_value=SimpleNamespace(mac="aa:bb:cc:dd:ee:ff", raw={"mac": "aa:bb:cc:dd:ee:ff", "name": "printer"})
+        )
+
+        from unifi_network_mcp.tools.stats import get_top_clients
+
+        result = await get_top_clients(duration="daily", limit=1)
+
+    assert result["success"] is True
+    mock_cm.get_client_details.assert_awaited_once_with("aa:bb:cc:dd:ee:ff", existence_only=True)


### PR DESCRIPTION
## Summary

Closes #632. App half of the fix; the Core half is #659 and this branch is rebased on it (merge #659 first, the diff here then shrinks to the app commit).

`get_client_details` scanned `/stat/sta` and `/rest/user`, and the controller caps `/rest/user` at 3,000 rows, so a client past that window was reported as `client '<mac>' not found` although the controller has its record. #659 makes `ClientManager` consult the authoritative per-MAC `GET /stat/user/<mac>` when the scan misses, and raises `UniFiOperationError` ("existence could not be determined") when that lookup fails for any reason other than the controller's own `api.err.UnknownUser` / a 404 answer.

This PR wires the apps to it:
- `unifi_get_top_clients` enriches names with `existence_only=True`, so an entry past the cap does not cost a per-MAC request.
- The API client route maps `UniFiOperationError` to 502 instead of an unhandled 500, and keeps 404 for a real not-found.
- The MCP tool reports an undetermined lookup as an error rather than a not-found (regression only; the tool's error path already did this).

Dependency floor: `unifi-core[network]>=0.4.44` is committed locally and will be pushed once PyPI serves the Core release that carries `existence_only`, per the review.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server
- [x] API server

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. (No tool signature or description changed; `make check-generated` passes with no diff.)
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. (No user-facing doc describes the lookup path.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

```
uv run --package unifi-core --all-extras pytest packages/unifi-core/tests -n auto   # 1961 passed
uv run --package unifi-network-mcp pytest apps/network/tests/unit -n auto           # 1085 passed
uv run --package unifi-api-server pytest apps/api/tests -n auto                     # 1372 passed
uv run --package unifi-protect-mcp pytest apps/protect/tests -n auto                #  513 passed
uv run ruff format --check . && uv run ruff check . && make check-generated && make docs-test
```

New tests here: `apps/network/tests/unit/test_top_clients_existence_only.py`, `apps/network/tests/unit/test_clients_filtering.py` (undetermined lookup → error), `apps/api/tests/routes/resources/test_network_resources.py` (404 vs 502). The per-MAC behaviour suite and the status-parsing regressions live with Core in #659.

Site evidence on the affected site is in the comment below, tied to the head SHA.

## Notes for reviewers

- Measured on the reporting site: `/rest/user` returns exactly 3,000 rows, `/stat/alluser` 55,990; 55 online clients are absent from `/rest/user`, so the merge path is needed, not only the both-miss path.
- No REST/GraphQL surface exposes `existence_only`; the API always performs the full lookup.

### Deferred items

- `get_client_by_ip` still scans the capped lists; an IP lookup past the cap misses.
- `apps/network/src/unifi_network_mcp/tools/stats.py` (`get_client_stats`, `get_top_clients`) logs the client identifier and exception text at ERROR, a pre-existing exception to the Logging rule; worth its own fix.
- The diagnostics channel (`UNIFI_MCP_DIAGNOSTICS`, opt-in) still records the raw request path and error text, as it does for every endpoint.
