### PR TITLE
feat(network): validate port and client targeting on firewall policies

### DIFF
--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -2526,7 +2526,7 @@
       "input_schema": {
         "properties": {
           "policy_data": {
-            "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For port targeting: port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' array). Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
+            "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For clients: matching_target='CLIENT', client_macs=[...]. Ports on either side: port_matching_type='SPECIFIC' + port='53,853' (a single string, not a 'ports' array) or 'OBJECT' + port_group_id. Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
             "type": "object"
           }
         },
@@ -6265,7 +6265,7 @@
             "type": "string"
           },
           "update_data": {
-            "description": "Dictionary of V2 zone-based fields to update: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, logging, connection_state_type, connection_states, schedule. index is not accepted here; use unifi_reorder_firewall_policies to change order.",
+            "description": "Dictionary of V2 zone-based fields to update: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, logging, connection_state_type, connection_states, schedule. Partial source/destination dicts are merged with the current policy; port_matching_type='SPECIFIC' needs port, 'OBJECT' needs port_group_id, and switching to another port_matching_type (or a side off CLIENT) retires the stored port/port_group_id/client_macs automatically. index is not accepted here; use unifi_reorder_firewall_policies to change order.",
             "type": "object"
           }
         },

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -678,11 +678,24 @@ def _translate_list_clients(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict
 
 
 def _translate_create_firewall_policy(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    """Apply shared port validation before the API preview/execute split."""
-    from unifi_core.network.models.firewall import validate_policy_port_targeting
+    """Apply shared port and selector validation before the API preview/execute split.
 
-    policy_data = args["policy_data"]
+    Both checks also run in ``FirewallManager.create_firewall_policy``; running them
+    here as well is what gives the API preview the same verdict as its execute, since
+    neither needs stored controller state.
+    """
+    from unifi_core.network.models.firewall import (
+        normalize_policy_endpoint_enums,
+        validate_policy_port_targeting,
+        validate_policy_selectors,
+        validate_zone_targeting,
+    )
+
+    policy_data = normalize_policy_endpoint_enums(args["policy_data"])
+    if zone_error := validate_zone_targeting(policy_data):
+        raise ValueError(zone_error)
     validate_policy_port_targeting(policy_data)
+    validate_policy_selectors(policy_data)
     return (), {"policy_data": policy_data}
 
 

--- a/apps/api/tests/test_actions_dispatcher.py
+++ b/apps/api/tests/test_actions_dispatcher.py
@@ -59,6 +59,105 @@ async def test_create_firewall_policy_rejects_invalid_ports_before_preview_or_ma
 @pytest.mark.asyncio
 @pytest.mark.parametrize("confirm", [False, True])
 @pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ({"matching_target": "CLIENT"}, "client_macs"),
+        ({"matching_target": "CLIENT", "client_macs": ["nope"]}, "client_macs"),
+        ({"port_matching_type": "OBJECT"}, "port_group_id"),
+        ({"port_matching_type": "ANY", "port": "53"}, "port_matching_type"),
+        ({"matching_target": "ANY", "client_macs": ["aa:bb:cc:dd:ee:ff"]}, "matching_target"),
+    ],
+)
+async def test_create_firewall_policy_rejects_inactive_selectors_before_preview_or_manager(
+    confirm, direction, endpoint, expected
+):
+    """The Core create path rejects these at execution; the API preview must refuse them too,
+    since no stored state is needed to judge them."""
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock()
+    data = {"name": "Inactive selector", "action": "ALLOW", direction: endpoint}
+    with pytest.raises(ValueError, match=expected):
+        await dispatch_action(
+            registry=PRODUCTION_REGISTRY,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_create_firewall_policy",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"policy_data": data},
+            confirm=confirm,
+        )
+    factory.get_domain_manager.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirm", [False, True])
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ({"matching_target": "any", "port_matching_type": "specific"}, "port"),
+        ({"matching_target": "any", "port_matching_type": "object"}, "port_group_id"),
+        ({"matching_target": "client", "client_macs": []}, "client_macs"),
+    ],
+)
+async def test_create_firewall_policy_validates_lower_case_endpoint_enums(confirm, endpoint, expected):
+    """The MCP tool upper-cases endpoint enums before validating. Until the API create
+    translator did the same, a lower-case enum turned every one of these checks into a
+    no-op on this surface only."""
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock()
+    data = {"name": "Lower case", "action": "ALLOW", "source": {"zone_id": "z1", **endpoint}}
+    with pytest.raises(ValueError, match=expected):
+        await dispatch_action(
+            registry=PRODUCTION_REGISTRY,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_create_firewall_policy",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"policy_data": data},
+            confirm=confirm,
+        )
+    factory.get_domain_manager.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirm", [False, True])
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ({"matching_target": "IP"}, "matching_target_type is required"),
+        ({"matching_target": "NETWORK", "matching_target_type": "OBJECT"}, "network_ids array is required"),
+        ({"matching_target": "IP", "matching_target_type": "OBJECT"}, "ip_group_id is required"),
+    ],
+)
+async def test_create_firewall_policy_rejects_an_incomplete_target(confirm, endpoint, expected):
+    """The completeness rules used to live in the MCP tool, so this surface accepted a
+    target with nothing to match — a BLOCK policy that stops blocking."""
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock()
+    data = {"name": "Incomplete", "action": "ALLOW", "source": {"zone_id": "z1", **endpoint}}
+    with pytest.raises(ValueError, match=expected):
+        await dispatch_action(
+            registry=PRODUCTION_REGISTRY,
+            factory=factory,
+            session=MagicMock(),
+            tool_name="unifi_create_firewall_policy",
+            controller_id="cid",
+            controller_products=["network"],
+            site="default",
+            args={"policy_data": data},
+            confirm=confirm,
+        )
+    factory.get_domain_manager.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirm", [False, True])
+@pytest.mark.parametrize("direction", ["source", "destination"])
 async def test_create_firewall_policy_valid_port_preserves_payload(confirm, direction):
     import copy
 
@@ -2491,6 +2590,129 @@ async def test_dispatch_update_firewall_policy_rejects_index_before_preview_and_
     factory.get_domain_manager.assert_not_called()
     domain_manager.get_firewall_policies.assert_not_awaited()
     domain_manager.update_firewall_policy.assert_not_awaited()
+
+
+def _live_firewall_manager(stored: dict) -> tuple[object, list]:
+    """A real FirewallManager over a fake connection; returns it and the mutation log."""
+    from unifi_core.network.managers.firewall_manager import FirewallManager
+
+    sent: list = []
+
+    async def request(api_request, *args, **kwargs):
+        if api_request.method == "get":
+            return [stored]
+        sent.append((api_request.method, api_request.data))
+        return {}
+
+    conn = MagicMock()
+    conn.site = "default"
+    conn.ensure_connected = AsyncMock(return_value=True)
+    conn.request = AsyncMock(side_effect=request)
+    conn.get_cached = MagicMock(return_value=None)
+    conn._update_cache = MagicMock()
+    conn._invalidate_cache = MagicMock()
+    return FirewallManager(conn), sent
+
+
+def _stored_policy(destination: dict) -> dict:
+    return {
+        "_id": "pol_zone_001",
+        "name": "disposable",
+        "enabled": False,
+        "action": "BLOCK",
+        "predefined": False,
+        "source": {"zone_id": "z1", "matching_target": "ANY"},
+        "destination": {"zone_id": "z1", "matching_target": "ANY", **destination},
+    }
+
+
+async def _dispatch_update_firewall_policy(manager, update_data: dict, *, confirm: bool):
+    entry = ToolEntry(
+        name="unifi_update_firewall_policy",
+        product="network",
+        category="firewall_policies",
+        manager="",
+        method="",
+    )
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    factory.get_connection_manager = AsyncMock(return_value=MagicMock(site="default", set_site=AsyncMock()))
+    result = await dispatch_action(
+        registry=_registry_with(entry),
+        factory=factory,
+        session=MagicMock(),
+        tool_name="unifi_update_firewall_policy",
+        controller_id="cid",
+        controller_products=["network"],
+        site="default",
+        args={"policy_id": "pol_zone_001", "update_data": update_data},
+        confirm=confirm,
+        dispatch_table={
+            "unifi_update_firewall_policy": DispatchEntry(
+                manager_attr="firewall_manager", method="update_firewall_policy"
+            ),
+        },
+    )
+    return result, factory
+
+
+@pytest.mark.asyncio
+async def test_dispatch_update_firewall_policy_rejects_selector_only_update_on_inactive_enum() -> None:
+    """API confirmed execution: port on a stored port_matching_type ANY is rejected by the
+    real manager before any PUT (the MCP wrapper already rejected this; the API did not)."""
+    manager, sent = _live_firewall_manager(_stored_policy({"port_matching_type": "ANY"}))
+
+    with pytest.raises(ValueError, match="port_matching_type"):
+        await _dispatch_update_firewall_policy(manager, {"destination": {"port": "53"}}, confirm=True)
+
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_update_firewall_policy_activation_change_retires_stored_port() -> None:
+    """API confirmed execution: SPECIFIC/53 → ANY must not carry the stale port to the controller."""
+    stored = _stored_policy({"port_matching_type": "SPECIFIC", "port": "53"})
+    manager, sent = _live_firewall_manager(stored)
+
+    result, _ = await _dispatch_update_firewall_policy(
+        manager, {"destination": {"port_matching_type": "ANY"}}, confirm=True
+    )
+
+    assert result is True
+    assert [method for method, _ in sent] == ["put"]
+    body = sent[0][1]
+    assert body["destination"]["port_matching_type"] == "ANY"
+    assert "port" not in body["destination"]
+    assert body["source"] == stored["source"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_update_firewall_policy_preview_defers_the_stored_state_verdict() -> None:
+    """Documented bound, pinned so it cannot change unnoticed: dispatch_action builds the
+    API preview before any manager is resolved, so checks that need the stored policy run
+    at execution only. The MCP wrapper reads the policy itself and rejects at preview."""
+    manager, sent = _live_firewall_manager(_stored_policy({"port_matching_type": "ANY"}))
+
+    result, factory = await _dispatch_update_firewall_policy(manager, {"destination": {"port": "53"}}, confirm=False)
+
+    assert isinstance(result, MutationPreview)
+    factory.get_domain_manager.assert_not_awaited()
+    assert sent == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirm", [False, True])
+async def test_dispatch_update_firewall_policy_rejects_contradictory_selector_before_manager(confirm: bool) -> None:
+    """A selector paired with a non-activating enum in the same update is rejected statelessly,
+    so the API preview refuses it too, before any manager is resolved."""
+    manager, sent = _live_firewall_manager(_stored_policy({"port_matching_type": "ANY"}))
+
+    with pytest.raises(ValueError, match="port_matching_type"):
+        await _dispatch_update_firewall_policy(
+            manager, {"destination": {"port_matching_type": "ANY", "port": "53"}}, confirm=confirm
+        )
+
+    assert sent == []
 
 
 # ---------------------------------------------------------------------------

--- a/apps/network/src/unifi_network_mcp/tools/firewall.py
+++ b/apps/network/src/unifi_network_mcp/tools/firewall.py
@@ -18,7 +18,10 @@ from unifi_core.network.models.firewall import (
     legacy_policy_error,
     normalize_policy_enums,
     normalize_policy_update,
+    prepare_policy_update,
     validate_policy_port_targeting,
+    validate_policy_selectors,
+    validate_zone_targeting,
 )
 from unifi_core.network.read_views import LEGACY_ENGINE_HINT, shape_firewall_policy_list
 from unifi_core.redaction import redact_sensitive_fields
@@ -32,12 +35,13 @@ logger = logging.getLogger(__name__)
     description=(
         "List firewall policies configured on the Unifi Network controller. "
         "Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, "
-        "IPs, network IDs).\n\n"
+        "IPs, network IDs, client MACs, IP/port groups, port matching).\n\n"
         "Filters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, "
         "limit (default 50), include_predefined. By default (summary=true) returns a curated "
-        "entry per policy (id, name, enabled, action, rule_index, description + source/destination "
-        "targeting). Set summary=false for the full fw_from_controller().model_dump() shape "
-        "including protocol, schedule, logging, ip_version, index, etc."
+        "entry per policy (id, name, enabled, action, rule_index, description, protocol + "
+        "source/destination targeting incl. port_matching_type/port/port_group_id when set). "
+        "Set summary=false for the full fw_from_controller().model_dump() shape including "
+        "schedule, logging, ip_version, connection_state_type, index, etc."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -272,38 +276,32 @@ async def toggle_firewall_policy(
 
 
 def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
-    """Validate matching_target_type requirements for zone-based policies.
+    """Every targeting rule, as one message or None, for the create preview.
 
-    Returns an error message string if validation fails, or None if valid.
+    A delegate: the rules themselves live in ``unifi_core`` so the API dispatcher and
+    the update path apply the same ones. Kept under this name because the create tool
+    reads better for it.
     """
-    for direction in ("source", "destination"):
-        ep = validated_data.get(direction, {})
-        if not isinstance(ep, dict):
-            continue
-        target = ep.get("matching_target")
-        if target in ("IP", "NETWORK") and not ep.get("matching_target_type"):
-            expected = "'SPECIFIC' or 'OBJECT'" if target == "IP" else "'OBJECT'"
-            return "%s.matching_target_type is required when matching_target is '%s'. Use %s." % (
-                direction,
-                target,
-                expected,
-            )
-        if target == "IP":
-            target_type = ep.get("matching_target_type")
-            if target_type == "OBJECT" and not ep.get("ip_group_id"):
-                return (
-                    "%s.ip_group_id is required when matching_target is 'IP' with matching_target_type 'OBJECT'."
-                    % direction
-                )
-            if target_type != "OBJECT" and not ep.get("ips"):
-                return "%s.ips array is required when matching_target is 'IP'." % direction
-        if target == "NETWORK" and not ep.get("network_ids"):
-            return "%s.network_ids array is required when matching_target is 'NETWORK'." % direction
+    if error := validate_zone_targeting(validated_data):
+        return error
     try:
         validate_policy_port_targeting(validated_data)
+        validate_policy_selectors(validated_data)
     except ValueError as exc:
         return str(exc)
     return None
+
+
+def _selector_applied(key: str, expected: Any, actual: Dict[str, Any]) -> bool:
+    """Whether the controller's re-read shows an updated endpoint key as applied.
+
+    ``prepare_policy_update`` marks a retired selector with ``None`` and the manager
+    removes the key from the PUT body, so the controller may answer with the key gone
+    or with its own empty default. Both mean retired; only a surviving value does not.
+    """
+    if expected is None:
+        return not actual.get(key)
+    return actual.get(key) == expected
 
 
 @server.tool(
@@ -315,10 +313,13 @@ def _validate_zone_targeting(validated_data: Dict[str, Any]) -> str | None:
         "targeting: matching_target='IP', matching_target_type='SPECIFIC', "
         "ips=[...]. For network targeting: matching_target='NETWORK', "
         "matching_target_type='OBJECT', network_ids=[...]. For any in zone: "
-        "matching_target='ANY'. For port targeting (same source/destination dict): "
-        "port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' "
-        "array). Use unifi_list_firewall_zones to discover zone_ids; "
-        "unifi_list_networks for network_ids."
+        "matching_target='ANY'. For client targeting: matching_target='CLIENT', "
+        "client_macs=[...]. For port targeting (same source/destination dict): "
+        "port_matching_type='SPECIFIC', port='53,853' (a single string, not a 'ports' "
+        "array) or port_matching_type='OBJECT', port_group_id=<port group>; set protocol "
+        "to tcp, udp or tcp_udp. Use unifi_list_firewall_zones to discover zone_ids; "
+        "unifi_list_networks for network_ids; unifi_list_firewall_groups for "
+        "ip_group_id/port_group_id."
     ),
     permission_category="firewall_policies",
     permission_action="create",
@@ -334,9 +335,10 @@ async def create_firewall_policy(
                 "destination (same structure). For IP targeting: matching_target='IP', "
                 "matching_target_type='SPECIFIC', ips=[...]. For network targeting: "
                 "matching_target='NETWORK', matching_target_type='OBJECT', "
-                "network_ids=[...]. For any in zone: matching_target='ANY'. For port "
-                "targeting: port_matching_type='SPECIFIC', port='445' (a single "
-                "string, not a 'ports' array). Optional: enabled, description, "
+                "network_ids=[...]. For any in zone: matching_target='ANY'. For clients: "
+                "matching_target='CLIENT', client_macs=[...]. Ports on either side: "
+                "port_matching_type='SPECIFIC' + port='53,853' (a single string, not a "
+                "'ports' array) or 'OBJECT' + port_group_id. Optional: enabled, description, "
                 "protocol, connection_state_type, connection_states, ip_version, "
                 "schedule, logging."
             )
@@ -484,7 +486,12 @@ async def create_firewall_policy(
         "Update specific fields of an existing V2 zone-based firewall policy by ID. "
         "Accepts: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, "
         "protocol, ip_version, logging, connection_state_type, connection_states, "
-        "schedule. To change policy order use unifi_reorder_firewall_policies; index is rejected here."
+        "schedule. source/destination are deep-merged with the current policy and accept "
+        "the same targeting and port fields as create (matching_target, port_matching_type, "
+        "port, port_group_id, client_macs); the merged result is checked for port shape and "
+        "selector activation, while the zone/IP/NETWORK completeness rules are checked on "
+        "create only. To change policy order use unifi_reorder_firewall_policies; index is "
+        "rejected here."
     ),
     permission_category="firewall_policies",
     permission_action="update",
@@ -504,6 +511,10 @@ async def update_firewall_policy(
                 "Dictionary of V2 zone-based fields to update: name, action "
                 "(ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, "
                 "logging, connection_state_type, connection_states, schedule. "
+                "Partial source/destination dicts are merged with the current policy; "
+                "port_matching_type='SPECIFIC' needs port, 'OBJECT' needs port_group_id, and "
+                "switching to another port_matching_type (or a side off CLIENT) retires the "
+                "stored port/port_group_id/client_macs automatically. "
                 "index is not accepted here; use unifi_reorder_firewall_policies to change order."
             )
         ),
@@ -538,6 +549,14 @@ async def update_firewall_policy(
             }
         current = current_policy_obj.raw
 
+        # Retire deactivated selectors and validate each updated side as merged. The
+        # manager runs the same step before its PUT; it is repeated here so the preview
+        # shows the retired selectors and fails the same way.
+        try:
+            validated_data = prepare_policy_update(current, validated_data)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
+
         if not confirm:
             return redact_sensitive_fields(
                 update_preview(
@@ -565,31 +584,20 @@ async def update_firewall_policy(
             # For nested dicts (source, destination, schedule), check that each
             # requested key-value is present in the response (subset check),
             # since deep_merge preserves unmentioned sibling keys.
+            # The log names the field, never the value: an update payload can carry a
+            # MAC address, and a MAC never goes to a log.
             mismatched = []
             for field, expected in validated_data.items():
                 actual = updated_details.get(field)
                 if isinstance(expected, dict) and isinstance(actual, dict):
                     for k, v in expected.items():
-                        if actual.get(k) != v:
+                        if not _selector_applied(k, v, actual):
                             mismatched.append(field)
-                            logger.warning(
-                                "Firewall policy %s field '%s.%s' not applied: expected %s, got %s",
-                                policy_id,
-                                field,
-                                k,
-                                v,
-                                actual.get(k),
-                            )
+                            logger.warning("Firewall policy %s field '%s.%s' not applied", policy_id, field, k)
                             break
                 elif actual != expected:
                     mismatched.append(field)
-                    logger.warning(
-                        "Firewall policy %s field '%s' not applied: expected %s, got %s",
-                        policy_id,
-                        field,
-                        expected,
-                        actual,
-                    )
+                    logger.warning("Firewall policy %s field '%s' not applied", policy_id, field)
             if mismatched:
                 return redact_sensitive_fields(
                     {

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -1788,7 +1788,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Create a V2 zone-based firewall policy with schema validation. Required: name, action (ALLOW/BLOCK/REJECT), source (zone_id + matching_target), destination (same structure). For specific IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For port targeting (same source/destination dict): port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' array). Use unifi_list_firewall_zones to discover zone_ids; unifi_list_networks for network_ids.",
+      "description": "Create a V2 zone-based firewall policy with schema validation. Required: name, action (ALLOW/BLOCK/REJECT), source (zone_id + matching_target), destination (same structure). For specific IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For client targeting: matching_target='CLIENT', client_macs=[...]. For port targeting (same source/destination dict): port_matching_type='SPECIFIC', port='53,853' (a single string, not a 'ports' array) or port_matching_type='OBJECT', port_group_id=<port group>; set protocol to tcp, udp or tcp_udp. Use unifi_list_firewall_zones to discover zone_ids; unifi_list_networks for network_ids; unifi_list_firewall_groups for ip_group_id/port_group_id.",
       "name": "unifi_create_firewall_policy",
       "permission_action": "create",
       "permission_category": "firewall_policies",
@@ -1800,7 +1800,7 @@
               "type": "boolean"
             },
             "policy_data": {
-              "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For port targeting: port_matching_type='SPECIFIC', port='445' (a single string, not a 'ports' array). Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
+              "description": "V2 zone-based firewall policy dict. Required: name, action (ALLOW/BLOCK/REJECT), source (object with zone_id, matching_target), destination (same structure). For IP targeting: matching_target='IP', matching_target_type='SPECIFIC', ips=[...]. For network targeting: matching_target='NETWORK', matching_target_type='OBJECT', network_ids=[...]. For any in zone: matching_target='ANY'. For clients: matching_target='CLIENT', client_macs=[...]. Ports on either side: port_matching_type='SPECIFIC' + port='53,853' (a single string, not a 'ports' array) or 'OBJECT' + port_group_id. Optional: enabled, description, protocol, connection_state_type, connection_states, ip_version, schedule, logging.",
               "type": "object"
             }
           },
@@ -11960,7 +11960,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "List firewall policies configured on the Unifi Network controller. Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, IPs, network IDs).\n\nFilters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, limit (default 50), include_predefined. By default (summary=true) returns a curated entry per policy (id, name, enabled, action, rule_index, description + source/destination targeting). Set summary=false for the full fw_from_controller().model_dump() shape including protocol, schedule, logging, ip_version, index, etc.",
+      "description": "List firewall policies configured on the Unifi Network controller. Returns V2 zone-based targeting (zone_id, matching_target, matching_target_type, IPs, network IDs, client MACs, IP/port groups, port matching).\n\nFilters: search (name substring), action (ALLOW/BLOCK/REJECT), enabled_only, limit (default 50), include_predefined. By default (summary=true) returns a curated entry per policy (id, name, enabled, action, rule_index, description, protocol + source/destination targeting incl. port_matching_type/port/port_group_id when set). Set summary=false for the full fw_from_controller().model_dump() shape including schedule, logging, ip_version, connection_state_type, index, etc.",
       "name": "unifi_list_firewall_policies",
       "schema": {
         "input": {
@@ -17237,7 +17237,7 @@
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Update specific fields of an existing V2 zone-based firewall policy by ID. Accepts: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, logging, connection_state_type, connection_states, schedule. To change policy order use unifi_reorder_firewall_policies; index is rejected here.",
+      "description": "Update specific fields of an existing V2 zone-based firewall policy by ID. Accepts: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, logging, connection_state_type, connection_states, schedule. source/destination are deep-merged with the current policy and accept the same targeting and port fields as create (matching_target, port_matching_type, port, port_group_id, client_macs); the merged result is checked for port shape and selector activation, while the zone/IP/NETWORK completeness rules are checked on create only. To change policy order use unifi_reorder_firewall_policies; index is rejected here.",
       "name": "unifi_update_firewall_policy",
       "permission_action": "update",
       "permission_category": "firewall_policies",
@@ -17253,7 +17253,7 @@
               "type": "string"
             },
             "update_data": {
-              "description": "Dictionary of V2 zone-based fields to update: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, logging, connection_state_type, connection_states, schedule. index is not accepted here; use unifi_reorder_firewall_policies to change order.",
+              "description": "Dictionary of V2 zone-based fields to update: name, action (ALLOW/BLOCK/REJECT), enabled, source, destination, protocol, ip_version, logging, connection_state_type, connection_states, schedule. Partial source/destination dicts are merged with the current policy; port_matching_type='SPECIFIC' needs port, 'OBJECT' needs port_group_id, and switching to another port_matching_type (or a side off CLIENT) retires the stored port/port_group_id/client_macs automatically. index is not accepted here; use unifi_reorder_firewall_policies to change order.",
               "type": "object"
             }
           },

--- a/apps/network/tests/unit/test_firewall_manager.py
+++ b/apps/network/tests/unit/test_firewall_manager.py
@@ -6,6 +6,7 @@ endpoint with deep_merge.
 """
 
 import copy
+import logging
 import os
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -212,6 +213,24 @@ class TestUpdateFirewallPolicyEndpoint:
         # Sibling keys preserved by deep_merge
         assert payload["source"]["matching_target"] == "NETWORK"
         assert payload["source"]["network_ids"] == ["net001"]
+
+    @pytest.mark.asyncio
+    async def test_none_inside_an_endpoint_removes_the_key_from_the_payload(self, firewall_manager, mock_connection):
+        """A retired selector (value None) must not be sent as null; the controller stores selectors only
+        under their activating enum, so the key is dropped from the merged endpoint."""
+        raw = copy.deepcopy(SAMPLE_POLICY_RAW)
+        raw["destination"].update({"port_matching_type": "SPECIFIC", "port": "53"})
+        policy = _make_firewall_policy(raw)
+
+        with patch.object(firewall_manager, "get_firewall_policies", new_callable=AsyncMock, return_value=[policy]):
+            await firewall_manager.update_firewall_policy(
+                "pol001", {"destination": {"port_matching_type": "ANY", "port": None}}
+            )
+
+        payload = mock_connection.request.call_args[0][0].data
+        assert payload["destination"]["port_matching_type"] == "ANY"
+        assert "port" not in payload["destination"]
+        assert payload["destination"]["zone_id"] == "zone-external"
 
     @pytest.mark.asyncio
     async def test_does_not_mutate_cached_policy(self, firewall_manager, mock_connection):
@@ -1297,3 +1316,218 @@ class TestFirewallZoneCrud:
 
         assert zone["_id"] == "znew"
         sleep.assert_awaited_once()
+
+
+class TestUpdateFirewallPolicySelectorPath:
+    """Selector retirement and merged-state validation live in the manager, so every
+    caller (MCP wrapper, API dispatcher, direct Core use) gets the same behaviour."""
+
+    @staticmethod
+    def _stored(destination: dict) -> dict:
+        return {
+            "_id": "pol_zone_001",
+            "name": "disposable",
+            "enabled": False,
+            "action": "BLOCK",
+            "predefined": False,
+            "source": {"zone_id": "z1", "matching_target": "ANY"},
+            "destination": {"zone_id": "z1", "matching_target": "ANY", **destination},
+        }
+
+    @staticmethod
+    def _wire(mock_connection, stored: dict) -> list:
+        sent: list = []
+
+        async def request(api_request, *args, **kwargs):
+            if api_request.method == "get":
+                return [stored]
+            sent.append((api_request.method, api_request.data))
+            return {}
+
+        mock_connection.request = AsyncMock(side_effect=request)
+        return sent
+
+    @pytest.mark.asyncio
+    async def test_activation_change_retires_the_stored_port_in_the_put_body(self, firewall_manager, mock_connection):
+        stored = self._stored({"port_matching_type": "SPECIFIC", "port": "53"})
+        sent = self._wire(mock_connection, stored)
+
+        assert await firewall_manager.update_firewall_policy(
+            "pol_zone_001", {"destination": {"port_matching_type": "ANY"}}
+        )
+
+        assert [method for method, _ in sent] == ["put"]
+        body = sent[0][1]
+        assert body["destination"]["port_matching_type"] == "ANY"
+        assert "port" not in body["destination"]
+        assert body["source"] == stored["source"]
+        assert body["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_targeting_error_never_reaches_the_log(self, firewall_manager, mock_connection, caplog):
+        """The error goes back to the caller and, on the API, into a durable audit row.
+        It names the offending position, never the address (AGENTS.md privacy rule)."""
+        stored = self._stored({})
+        stored["source"] = {"zone_id": "z1", "matching_target": "CLIENT", "client_macs": ["aa:bb:cc:dd:ee:ff"]}
+        sent = self._wire(mock_connection, stored)
+
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(ValueError) as excinfo:
+                await firewall_manager.update_firewall_policy(
+                    "pol_zone_001", {"source": {"client_macs": ["11:22:33:44:55:66", "not-a-mac"]}}
+                )
+
+        assert sent == []
+        for mac in ("11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"):
+            assert mac not in caplog.text
+            assert mac not in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_update_is_not_an_operator_facing_error(self, firewall_manager, mock_connection, caplog):
+        """A mistyped selector is caller input, not a controller failure. create_firewall_policy
+        validates outside its try and logs nothing; the update path must match."""
+        stored = self._stored({"port_matching_type": "OBJECT", "port_group_id": "g1"})
+        self._wire(mock_connection, stored)
+
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(ValueError):
+                await firewall_manager.update_firewall_policy(
+                    "pol_zone_001", {"destination": {"port_matching_type": "SPECIFIC"}}
+                )
+
+        assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+        assert not any(r.exc_info for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_caller_supplied_null_outside_the_selectors_still_reaches_the_controller(
+        self, firewall_manager, mock_connection
+    ):
+        """Retirement removes the three selector keys and nothing else. Dropping any other
+        null would turn a request the controller rejects into silent data loss."""
+        stored = self._stored({"port_matching_type": "SPECIFIC", "port": "53"})
+        sent = self._wire(mock_connection, stored)
+
+        assert await firewall_manager.update_firewall_policy(
+            "pol_zone_001", {"destination": {"port_matching_type": "ANY", "zone_id": None}}
+        )
+
+        body = sent[0][1]
+        assert "port" not in body["destination"]
+        assert body["destination"]["zone_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_an_untouched_side_is_not_stripped(self, firewall_manager, mock_connection):
+        stored = self._stored({})
+        stored["source"] = {"zone_id": "z1", "matching_target": "ANY", "client_macs": None}
+        sent = self._wire(mock_connection, stored)
+
+        assert await firewall_manager.update_firewall_policy("pol_zone_001", {"enabled": True})
+
+        assert sent[0][1]["source"] == stored["source"]
+
+    @pytest.mark.asyncio
+    async def test_create_does_not_log_client_macs(self, firewall_manager, mock_connection, caplog):
+        mock_connection.request = AsyncMock(return_value={"_id": "new-policy"})
+
+        with caplog.at_level(logging.DEBUG):
+            await firewall_manager.create_firewall_policy(
+                {
+                    "name": "Admin workstations",
+                    "action": "ALLOW",
+                    "source": {"zone_id": "z1", "matching_target": "CLIENT", "client_macs": ["AA:BB:CC:DD:EE:FF"]},
+                    "destination": {"zone_id": "z2", "matching_target": "ANY"},
+                }
+            )
+
+        assert "aa:bb:cc:dd:ee:ff" not in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_create_sends_client_macs_in_the_canonical_colon_form(self, firewall_manager, mock_connection):
+        """Validation accepts dashed and bare-hex spellings; the controller reports colons."""
+        mock_connection.request = AsyncMock(return_value={"_id": "new-policy"})
+
+        await firewall_manager.create_firewall_policy(
+            {
+                "name": "Admin workstations",
+                "action": "ALLOW",
+                "source": {
+                    "zone_id": "z1",
+                    "matching_target": "CLIENT",
+                    "client_macs": ["AA-BB-CC-DD-EE-FF", "AABBCCDDEEFF"],
+                },
+            }
+        )
+
+        sent = mock_connection.request.call_args[0][0].data
+        assert sent["source"]["client_macs"] == ["aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:ff"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("endpoint", "expected"),
+        [
+            ({"matching_target": "any", "port_matching_type": "object"}, "port_group_id"),
+            # Only this one depends on the normalization: the selector table compares
+            # case-insensitively, validate_policy_port_targeting compares exactly.
+            ({"matching_target": "any", "port_matching_type": "specific"}, "destination.port"),
+            ({"matching_target": "client", "client_macs": []}, "client_macs"),
+        ],
+    )
+    async def test_create_validates_a_lower_case_endpoint_enum(
+        self, firewall_manager, mock_connection, endpoint, expected
+    ):
+        """The MCP tool normalizes before validating; every other caller of this manager
+        did not, and a lower-case enum used to skip the checks entirely."""
+        mock_connection.request = AsyncMock(return_value={"_id": "new-policy"})
+
+        with pytest.raises(ValueError, match=expected):
+            await firewall_manager.create_firewall_policy(
+                {"name": "x", "action": "ALLOW", "destination": {"zone_id": "z2", **endpoint}}
+            )
+
+        mock_connection.request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_create_response_is_not_quoted_back(self, firewall_manager, mock_connection, caplog):
+        """A V2 create response echoes the policy document, client_macs included; it
+        reaches the tool's error field and the API audit row."""
+        mock_connection.request = AsyncMock(
+            return_value={"meta": {"rc": "error"}, "data": [{"client_macs": ["aa:bb:cc:dd:ee:ff"]}]}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(RuntimeError) as excinfo:
+                await firewall_manager.create_firewall_policy(
+                    {
+                        "name": "Admin only",
+                        "action": "ALLOW",
+                        "source": {"zone_id": "z1", "matching_target": "CLIENT", "client_macs": ["aa:bb:cc:dd:ee:ff"]},
+                    }
+                )
+
+        assert "aa:bb:cc:dd:ee:ff" not in str(excinfo.value)
+        assert "aa:bb:cc:dd:ee:ff" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_stored_controller_null_survives_an_unrelated_update(self, firewall_manager, mock_connection):
+        """The PUT is a full document: only the keys this update retired are removed."""
+        stored = self._stored({"port_matching_type": "ANY", "port": None, "ips": None})
+        sent = self._wire(mock_connection, stored)
+
+        assert await firewall_manager.update_firewall_policy("pol_zone_001", {"destination": {"zone_id": "z9"}})
+
+        body = sent[0][1]["destination"]
+        assert body["zone_id"] == "z9"
+        assert body["port"] is None
+        assert body["ips"] is None
+
+    @pytest.mark.asyncio
+    async def test_selector_only_update_on_inactive_enum_is_rejected_before_any_put(
+        self, firewall_manager, mock_connection
+    ):
+        stored = self._stored({"port_matching_type": "ANY"})
+        sent = self._wire(mock_connection, stored)
+
+        with pytest.raises(ValueError, match="port_matching_type"):
+            await firewall_manager.update_firewall_policy("pol_zone_001", {"destination": {"port": "53"}})
+
+        assert sent == []

--- a/apps/network/tests/unit/test_firewall_tools.py
+++ b/apps/network/tests/unit/test_firewall_tools.py
@@ -1,6 +1,8 @@
 """Tests for firewall tool enhancements: zone-based targeting, auto-detection, and delete tool."""
 
 import copy
+import json
+import logging
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -227,7 +229,8 @@ class TestListFirewallPolicies:
     @pytest.mark.asyncio
     async def test_summary_false_returns_full_model_dump(self):
         """summary=False returns the legacy fw_from_controller().model_dump() shape —
-        protocol/ip_version/logging/index present, not narrowed to the curated 6 keys."""
+        ip_version/logging/index present, not narrowed to the curated summary keys
+        (protocol is part of the summary as well)."""
         mock_policy = _make_policy(SAMPLE_ZONE_POLICY_RAW)
         mock_conn = MagicMock()
         mock_conn.site = "default"
@@ -243,7 +246,7 @@ class TestListFirewallPolicies:
 
         # curated path: narrowed 6-key entry + targeting; protocol/logging absent
         cp = curated["policies"][0]
-        assert "protocol" not in cp and "logging" not in cp and "ip_version" not in cp
+        assert "logging" not in cp and "ip_version" not in cp
         # raw path: full model dump fields present
         rp = raw["policies"][0]
         assert rp.get("protocol") == "all"
@@ -809,6 +812,522 @@ class TestCreateZoneTargetingValidation:
 # ---------------------------------------------------------------------------
 # Legacy V1 field migration errors
 # ---------------------------------------------------------------------------
+
+
+class TestCreatePortAndClientTargetingValidation:
+    """CLIENT targeting and the port OBJECT mode, plus the rule that a selector only
+    travels with the enum that activates it. The SPECIFIC port *shape* is Core's
+    validate_policy_port_targeting and is already covered by its own tests."""
+
+    @staticmethod
+    def _policy(**destination):
+        return {
+            "name": "Port matched policy",
+            "action": "BLOCK",
+            "protocol": "tcp_udp",
+            "source": {"zone_id": "internal", "matching_target": "ANY"},
+            "destination": {"zone_id": "external", "matching_target": "ANY", **destination},
+        }
+
+    @pytest.mark.asyncio
+    async def test_specific_port_matching_without_port_fails(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=self._policy(port_matching_type="SPECIFIC"), confirm=True)
+
+        assert result["success"] is False
+        assert "destination.port" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_object_port_matching_without_port_group_id_fails(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=self._policy(port_matching_type="OBJECT"), confirm=True)
+
+        assert result["success"] is False
+        assert "port_group_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_port_without_specific_port_matching_fails(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(
+            policy_data=self._policy(port_matching_type="ANY", port="53"), confirm=True
+        )
+
+        assert result["success"] is False
+        assert "port_matching_type" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_preview_rejects_an_inactive_selector_before_the_manager_is_reached(self):
+        """confirm=False never touches the manager, so the tool layer must run the same
+        selector check the Core create path runs."""
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.create_firewall_policy = AsyncMock(return_value=None)
+
+            from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+            result = await create_firewall_policy(policy_data=self._policy(port_matching_type="OBJECT"), confirm=False)
+
+        assert result["success"] is False
+        assert "port_group_id" in result["error"]
+        mock_fm.create_firewall_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_specific_port_preview_echoes_port_and_upper_cases_enum(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(
+            policy_data=self._policy(port_matching_type="specific", port="53,853"), confirm=False
+        )
+
+        assert result["success"] is True
+        dumped = json.dumps(result)
+        assert "53,853" in dumped
+        assert '"SPECIFIC"' in dumped
+        assert '"specific"' not in dumped
+
+    @pytest.mark.asyncio
+    async def test_unknown_matching_target_and_port_type_pass_through(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(
+            policy_data=self._policy(matching_target="APP", app_ids=["app-1"], port_matching_type="FUTURE"),
+            confirm=False,
+        )
+
+        assert result["success"] is True
+        assert "APP" in json.dumps(result)
+
+    @pytest.mark.asyncio
+    async def test_client_target_without_client_macs_fails(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        policy = self._policy()
+        policy["source"] = {"zone_id": "internal", "matching_target": "CLIENT"}
+        result = await create_firewall_policy(policy_data=policy, confirm=True)
+
+        assert result["success"] is False
+        assert "source.client_macs" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_client_target_with_macs_passes(self):
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        policy = self._policy()
+        policy["source"] = {"zone_id": "internal", "matching_target": "CLIENT", "client_macs": ["aa:bb:cc:dd:ee:ff"]}
+        result = await create_firewall_policy(policy_data=policy, confirm=False)
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_lowercase_enum_still_fails_validation_on_create(self):
+        """Normalization must run before validation, or a lower-case enum would skip the port check."""
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=self._policy(port_matching_type="specific"), confirm=True)
+
+        assert result["success"] is False
+        assert "destination.port" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_zone_targeting_rules_still_apply(self):
+        """The IP/NETWORK requirements stay where main put them; adding selector checks
+        must not displace them."""
+        from unifi_network_mcp.tools.firewall import create_firewall_policy
+
+        result = await create_firewall_policy(policy_data=self._policy(matching_target="IP"), confirm=True)
+
+        assert result["success"] is False
+        assert "matching_target_type" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_upper_cases_port_matching_type(self):
+        mock_policy = _make_policy(SAMPLE_ZONE_POLICY_RAW)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "specific", "port": "53"}},
+                confirm=False,
+            )
+
+        assert result["success"] is True
+        dumped = json.dumps(result)
+        assert '"specific"' not in dumped
+        assert '"port_matching_type": "SPECIFIC"' in dumped
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("update", "expected"),
+        [
+            ({"matching_target": "IP"}, "matching_target_type is required"),
+            ({"matching_target": "NETWORK", "matching_target_type": "OBJECT"}, "network_ids array is required"),
+        ],
+    )
+    async def test_update_rejects_a_target_with_nothing_to_match(self, update, expected):
+        """A BLOCK policy whose source targets IP with no ips matches nothing. The
+        completeness rules used to be checked on create only."""
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["source"] = {"zone_id": "z1", "matching_target": "ANY"}
+        mock_policy = _make_policy(raw)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001", update_data={"source": update}, confirm=True
+            )
+
+        assert result["success"] is False
+        assert expected in result["error"]
+        mock_fm.update_firewall_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_validates_against_merged_document(self):
+        """A partial update that switches to OBJECT without a port_group_id is rejected."""
+        mock_policy = _make_policy(SAMPLE_ZONE_POLICY_RAW)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "OBJECT"}},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "port_group_id" in result["error"]
+        mock_fm.update_firewall_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_port_without_specific_matching_is_rejected(self):
+        """A port sent to a policy whose stored port_matching_type is ANY would be ignored by the controller."""
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["destination"]["port_matching_type"] = "ANY"
+        mock_policy = _make_policy(raw)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port": "53,853"}},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "port_matching_type" in result["error"]
+        mock_fm.update_firewall_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_non_dict_endpoint(self):
+        mock_policy = _make_policy(SAMPLE_ZONE_POLICY_RAW)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(policy_id="pol_zone_001", update_data={"source": "ANY"}, confirm=True)
+
+        assert result["success"] is False
+        assert "source" in result["error"]
+        mock_fm.update_firewall_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lowercase_enum_still_fails_validation_on_update(self):
+        mock_policy = _make_policy(SAMPLE_ZONE_POLICY_RAW)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "specific"}},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "port" in result["error"]
+        mock_fm.update_firewall_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_does_not_revalidate_untouched_side(self):
+        """An invalid stored source must not block an update that only touches destination."""
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["source"] = {"zone_id": "x", "matching_target": "CLIENT"}
+        mock_policy = _make_policy(raw)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "SPECIFIC", "port": "53"}},
+                confirm=False,
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_does_not_reject_preexisting_targeting_gaps(self):
+        """A controller-stored CLIENT match with an empty MAC list must still accept a port change."""
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["destination"] = {
+            "zone_id": "z2",
+            "matching_target": "CLIENT",
+            "client_macs": [],
+            "port_matching_type": "ANY",
+        }
+        mock_policy = _make_policy(raw)
+        updated = copy.deepcopy(raw)
+        updated["destination"].update({"port_matching_type": "SPECIFIC", "port": "53"})
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[mock_policy], [_make_policy(updated)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "SPECIFIC", "port": "53"}},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        mock_fm.update_firewall_policy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_with_missing_stored_endpoint_validates_the_update_alone(self):
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["destination"] = None
+        mock_policy = _make_policy(raw)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={
+                    "destination": {
+                        "zone_id": "z2",
+                        "matching_target": "ANY",
+                        "port_matching_type": "SPECIFIC",
+                        "port": "53",
+                    }
+                },
+                confirm=False,
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_switching_port_matching_to_any_retires_the_stored_port(self):
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["destination"].update({"port_matching_type": "SPECIFIC", "port": "53"})
+        mock_policy = _make_policy(raw)
+        updated = copy.deepcopy(raw)
+        updated["destination"]["port_matching_type"] = "ANY"
+        del updated["destination"]["port"]
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[mock_policy], [_make_policy(updated)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "ANY"}},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+        sent = mock_fm.update_firewall_policy.call_args[0][1]
+        assert sent["destination"] == {"port_matching_type": "ANY", "port": None}
+
+    @pytest.mark.asyncio
+    async def test_update_merged_document_keeps_existing_port(self):
+        """Changing only the port on an existing SPECIFIC match is still valid after the merge."""
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["destination"].update({"port_matching_type": "SPECIFIC", "port": "53"})
+        mock_policy = _make_policy(raw)
+        updated = copy.deepcopy(raw)
+        updated["destination"]["port"] = "53,853"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[mock_policy], [_make_policy(updated)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port": "53,853"}},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+
+
+class TestUpdatePreviewAndVerification:
+    """confirm=False must reach the same verdict as confirm=True, and the post-PUT
+    re-read must not read a completed retirement as an unapplied change."""
+
+    @staticmethod
+    def _stored(**destination):
+        raw = copy.deepcopy(SAMPLE_ZONE_POLICY_RAW)
+        raw["destination"] = {"zone_id": "z2", "matching_target": "ANY", **destination}
+        return raw
+
+    @pytest.mark.asyncio
+    async def test_preview_rejects_a_selector_the_stored_enum_does_not_activate(self):
+        mock_policy = _make_policy(self._stored(port_matching_type="ANY"))
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001", update_data={"destination": {"port": "53"}}, confirm=False
+            )
+
+        assert result["success"] is False
+        assert "port_matching_type" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_preview_shows_the_retirement_the_confirmed_call_will_perform(self):
+        mock_policy = _make_policy(self._stored(port_matching_type="SPECIFIC", port="53"))
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(return_value=[mock_policy])
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "ANY"}},
+                confirm=False,
+            )
+
+        assert result["success"] is True
+        assert '"port": null' in json.dumps(result)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("echoed", [{}, {"port": ""}, {"port": None}])
+    async def test_a_retired_selector_the_controller_answers_as_empty_is_applied(self, echoed):
+        """The controller may drop the key or answer with its own empty default; both
+        mean retired, and reporting either as 'not applied' fails a write that landed."""
+        raw = self._stored(port_matching_type="SPECIFIC", port="53")
+        after = copy.deepcopy(raw)
+        after["destination"] = {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "ANY", **echoed}
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[_make_policy(raw)], [_make_policy(after)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "ANY"}},
+                confirm=True,
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_selector_the_controller_kept_is_still_reported_as_not_applied(self):
+        raw = self._stored(port_matching_type="SPECIFIC", port="53")
+        after = copy.deepcopy(raw)
+        after["destination"]["port_matching_type"] = "ANY"
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[_make_policy(raw)], [_make_policy(after)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            result = await update_firewall_policy(
+                policy_id="pol_zone_001",
+                update_data={"destination": {"port_matching_type": "ANY"}},
+                confirm=True,
+            )
+
+        assert result["success"] is False
+        assert "did not apply changes to: destination" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_a_non_dict_reread_is_reported_without_logging_the_update(self, caplog):
+        """When the controller answers with a non-dict endpoint the comparison falls to the
+        scalar branch, where the whole submitted endpoint used to go to the log."""
+        raw = self._stored(matching_target="CLIENT", client_macs=["aa:bb:cc:dd:ee:ff"])
+        after = copy.deepcopy(raw)
+        after["destination"] = None
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[_make_policy(raw)], [_make_policy(after)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            with caplog.at_level(logging.DEBUG):
+                result = await update_firewall_policy(
+                    policy_id="pol_zone_001",
+                    update_data={"destination": {"client_macs": ["11:22:33:44:55:66"]}},
+                    confirm=True,
+                )
+
+        assert result["success"] is False
+        assert "11:22:33:44:55:66" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_client_macs_mismatch_is_reported_without_logging_a_mac(self, caplog):
+        """AGENTS.md: a Network tool logs operation context, never a MAC address."""
+        raw = self._stored(matching_target="CLIENT", client_macs=["aa:bb:cc:dd:ee:ff"])
+        after = copy.deepcopy(raw)
+
+        with patch("unifi_network_mcp.tools.firewall.firewall_manager") as mock_fm:
+            mock_fm.get_firewall_policies = AsyncMock(side_effect=[[_make_policy(raw)], [_make_policy(after)]])
+            mock_fm.update_firewall_policy = AsyncMock(return_value=True)
+
+            from unifi_network_mcp.tools.firewall import update_firewall_policy
+
+            with caplog.at_level(logging.DEBUG):
+                result = await update_firewall_policy(
+                    policy_id="pol_zone_001",
+                    update_data={"destination": {"client_macs": ["11:22:33:44:55:66"]}},
+                    confirm=True,
+                )
+
+        assert result["success"] is False
+        assert "11:22:33:44:55:66" not in caplog.text
+        assert "aa:bb:cc:dd:ee:ff" not in caplog.text
 
 
 class TestLegacyFieldMigration:

--- a/packages/unifi-core/src/unifi_core/mac.py
+++ b/packages/unifi-core/src/unifi_core/mac.py
@@ -36,6 +36,7 @@ __all__ = [
     "normalize_mac_list",
     "canonical_mac",
     "mask_macs",
+    "mask_exception_macs",
 ]
 
 # Six hex pairs separated by ':' or '-', or twelve bare hex digits.
@@ -159,3 +160,47 @@ def normalize_mac_list(values: Any) -> Any:
     if not isinstance(values, list):
         return values
     return [normalize_mac(v) or v for v in values]
+
+
+def _mask_macs_in(value: Any) -> Any:
+    """``mask_macs`` over a decoded controller payload of any shape."""
+    if isinstance(value, str):
+        return mask_macs(value)
+    if isinstance(value, dict):
+        return {k: _mask_macs_in(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        rebuilt = [_mask_macs_in(v) for v in value]
+        return type(value)(rebuilt) if isinstance(value, tuple) else rebuilt
+    return value
+
+
+def mask_exception_macs(error: BaseException) -> BaseException:
+    """Replace every MAC-shaped token inside ``error`` in place, and return it.
+
+    A controller rejection quotes the record it refused, and aiounifi raises with
+    the decoded response as ``args[0]``. A firewall policy that targets clients,
+    an ACL rule, a block or a rename all carry MAC addresses in that record, so
+    the exception reaches the manager log, any caller that formats ``str(e)`` and
+    the API audit row carrying them. Credential scrubbing does not cover a MAC,
+    which is not a secret-keyed value.
+
+    Mutates in place (keeping the exception type and identity) and follows the
+    ``__cause__``/``__context__`` chain, the same way ``sanitize_exception`` does.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        current.args = tuple(_mask_macs_in(arg) for arg in current.args)
+        for attr in ("message", "msg", "reason", "detail"):
+            value = getattr(current, attr, None)
+            if isinstance(value, str):
+                try:
+                    setattr(current, attr, mask_macs(value))
+                except (AttributeError, TypeError):
+                    pass  # read-only property; args above already carries the masked text
+        notes = getattr(current, "__notes__", None)
+        if isinstance(notes, list):
+            current.__notes__ = [_mask_macs_in(note) for note in notes]
+        current = current.__cause__ if current.__cause__ is not None else current.__context__
+    return error

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -23,7 +23,7 @@ from aiounifi.errors import (
 from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.configuration import Configuration
 
-from unifi_core.mac import mask_macs
+from unifi_core.mac import mask_exception_macs, mask_macs
 from unifi_core.redaction import collect_secret_values, sanitize_exception, scrub_secret_values
 from unifi_core.support_bundle import (
     ConnectivityProbe,
@@ -381,12 +381,18 @@ class ConnectionManager:
         key in the request payload, following the exception's cause chain, and
         marks them the way this manager's own credential masking does.
 
-        Returns the secret set so the log sink can scrub the text it is about
+        MAC addresses are masked as well. Returns the secret set so the log sink
+        can scrub the text it is about
         to write: an exception whose ``__str__`` ignores ``args`` (pydantic's
         ValidationError) passes through the rewrite untouched.
         """
         secrets = self._secret_rules(api_request)
         sanitize_exception(error, secrets, marker=_CREDENTIAL_MASK)
+        # A MAC is not a secret-keyed value, so credential scrubbing leaves it in
+        # place, and the record a controller quotes back carries one for every
+        # client-targeting policy, ACL rule, block and rename. The log sink already
+        # masks the text it writes; this brings the re-raised exception in line.
+        mask_exception_macs(error)
         return secrets
 
     def _secret_rules(self, api_request: Any = None) -> dict[str, bool]:

--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -15,7 +15,15 @@ from unifi_core.auth import UniFiAuth
 from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
 from unifi_core.merge import deep_merge
 from unifi_core.network.managers.connection_manager import ConnectionManager
-from unifi_core.network.models.firewall import _normalize_endpoint_macs, validate_policy_port_targeting
+from unifi_core.network.models.firewall import (
+    RETIRABLE_SELECTORS,
+    _normalize_endpoint_macs,
+    normalize_policy_endpoint_enums,
+    prepare_policy_update,
+    validate_policy_port_targeting,
+    validate_policy_selectors,
+    validate_zone_targeting,
+)
 
 logger = logging.getLogger("unifi-network-mcp")
 
@@ -390,8 +398,24 @@ class FirewallManager:
                 logger.error("Could not get raw data for policy %s. Update aborted.", policy_id)
                 return False
 
+            # Shared MCP/API step: retire the selectors an activation change deactivates and
+            # validate each updated side as merged. Raises ValueError before any PUT.
+            updates = prepare_policy_update(policy_to_update.raw, updates)
+
             # Deep merge preserves nested sub-objects (source, destination, schedule, etc.)
             merged_data = deep_merge(policy_to_update.raw, updates)
+            # A retired selector is carried as None and must be REMOVED from the PUT body,
+            # not sent as null. Only the keys THIS update retired: any other None is the
+            # caller's own (the controller rejects it loudly rather than dropping a field)
+            # or the controller's own, and the PUT is a full document.
+            for side in ("source", "destination"):
+                update_side = updates.get(side)
+                endpoint = merged_data.get(side)
+                if not isinstance(update_side, dict) or not isinstance(endpoint, dict):
+                    continue
+                retired = {k for k, v in update_side.items() if v is None and k in RETIRABLE_SELECTORS}
+                if retired:
+                    merged_data[side] = {k: v for k, v in endpoint.items() if k not in retired}
 
             logger.info("Updating firewall policy %s via single-policy endpoint", policy_id)
 
@@ -407,6 +431,12 @@ class FirewallManager:
 
             logger.info("Successfully submitted update for firewall policy %s.", policy_id)
             return True
+        except ValueError:
+            # Caller input, not a controller failure: it is returned to the caller,
+            # and an operator-facing ERROR with a traceback for a mistyped selector
+            # is noise. create_firewall_policy validates outside its try for the
+            # same reason. The message carries no caller values.
+            raise
         except Exception as e:
             logger.error("Error updating firewall policy %s: %s", policy_id, e, exc_info=True)
             raise
@@ -984,7 +1014,14 @@ class FirewallManager:
         Returns:
             The created FirewallPolicy object, or None if creation failed.
         """
+        # Upper-case the endpoint enums BEFORE validating: both checks compare against
+        # the controller's upper-case spelling, and the MCP tool is the only caller that
+        # normalized first, so a lower-case enum used to skip them on every other path.
+        policy_data = normalize_policy_endpoint_enums(policy_data)
+        if zone_error := validate_zone_targeting(policy_data):
+            raise ValueError(zone_error)
         validate_policy_port_targeting(policy_data)
+        validate_policy_selectors(policy_data)
         if not await self._connection.ensure_connected():
             raise ConnectionError("Not connected to controller")
 
@@ -998,7 +1035,9 @@ class FirewallManager:
         try:
             policy_name = policy_data.get("name", "Unnamed Policy")
             logger.info("Attempting to create firewall policy '%s' via V2 endpoint.", policy_name)
-            logger.debug("Firewall policy create payload: %s", json.dumps(policy_data, indent=2))
+            # No payload dump: a CLIENT endpoint carries client_macs, and MAC addresses
+            # are one of the values this project never writes to a log.
+            logger.debug("Firewall policy create payload fields: %s", sorted(policy_data))
 
             api_request = ApiRequestV2(method="post", path="/firewall-policies", data=policy_data)
 
@@ -1020,11 +1059,13 @@ class FirewallManager:
                 return FirewallPolicy(created_policy_data)
             else:
                 logger.error(
-                    "Failed to create firewall policy '%s'. Unexpected V2 response format: %s", policy_name, response
+                    "Failed to create firewall policy '%s'. Unexpected V2 response type: %s",
+                    policy_name,
+                    type(response).__name__,
                 )
                 raise RuntimeError(
-                    "Unexpected response from controller (no _id in response). Raw: %s"
-                    % json.dumps(response, default=str)
+                    "Unexpected response from controller creating firewall policy '%s' (no _id in the response)."
+                    % policy_name
                 )
 
         except Exception as e:

--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -707,7 +707,10 @@ def _selector_activator_errors(
             )
     if _activator_matches(ep.get("port_matching_type"), "ANY") and ep.get("match_opposite_ports"):
         leftover.append(
-            ("match_opposite_ports", "%s.match_opposite_ports must be false when port_matching_type is 'ANY'." % direction)
+            (
+                "match_opposite_ports",
+                "%s.match_opposite_ports must be false when port_matching_type is 'ANY'." % direction,
+            )
         )
     # What the chosen enum is missing comes first. Told "port_matching_type must be
     # 'SPECIFIC'" when they asked for OBJECT, a caller undoes the change they meant.

--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -564,6 +564,7 @@ _SELECTOR_OWNER_KEYS: Dict[str, frozenset[str]] = {
     "client_macs": frozenset({"client_macs", "matching_target"}),
     "port": frozenset({"port", "ports", "port_matching_type"}),
     "port_group_id": frozenset({"port_group_id", "port_matching_type"}),
+    "match_opposite_ports": frozenset({"match_opposite_ports", "port_matching_type"}),
 }
 
 # The enum values this project has observed. A value outside its set is a controller
@@ -704,6 +705,10 @@ def _selector_activator_errors(
                     % (direction, selector, direction, activator_key, shown, direction, activator_key, activator_value),
                 )
             )
+    if _activator_matches(ep.get("port_matching_type"), "ANY") and ep.get("match_opposite_ports"):
+        leftover.append(
+            ("match_opposite_ports", "%s.match_opposite_ports must be false when port_matching_type is 'ANY'." % direction)
+        )
     # What the chosen enum is missing comes first. Told "port_matching_type must be
     # 'SPECIFIC'" when they asked for OBJECT, a caller undoes the change they meant.
     return activated + leftover
@@ -748,6 +753,12 @@ def retire_stale_selectors(stored: Any, update: Any) -> Any:
     if not isinstance(stored, dict) or not isinstance(update, dict):
         return update
     retired = dict(update)
+    if (
+        _activator_matches(update.get("port_matching_type"), "ANY")
+        and "match_opposite_ports" not in update
+        and stored.get("match_opposite_ports")
+    ):
+        retired["match_opposite_ports"] = False
     for selector, activator_key, activator_value in SELECTOR_ACTIVATORS:
         if activator_key not in update or selector in update:
             continue

--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -32,7 +32,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from unifi_core.mac import normalize_mac_list
+from unifi_core.mac import canonical_mac, looks_like_mac, normalize_mac
+from unifi_core.merge import deep_merge
 
 # ---------------------------------------------------------------------------
 # FirewallRule pydantic model
@@ -537,6 +538,301 @@ def validate_policy_port_targeting(fields: Dict[str, Any]) -> None:
             raise ValueError("%s.port must be a non-empty string when port_matching_type is 'SPECIFIC'." % direction)
 
 
+# ---------------------------------------------------------------------------
+# Selector activation
+# ---------------------------------------------------------------------------
+# The controller stores a targeting selector only under the enum value that
+# activates it; under any other value it accepts the field and silently ignores
+# it. (selector key, activating enum key, activating value).
+
+SELECTOR_ACTIVATORS: tuple[tuple[str, str, str], ...] = (
+    ("client_macs", "matching_target", "CLIENT"),
+    ("port", "port_matching_type", "SPECIFIC"),
+    ("port_group_id", "port_matching_type", "OBJECT"),
+)
+
+# The only endpoint keys retire_stale_selectors may set to None, and therefore the
+# only keys a None inside an endpoint is allowed to remove. Any other None is the
+# caller's own and must reach the controller, which rejects it loudly.
+RETIRABLE_SELECTORS: frozenset[str] = frozenset(selector for selector, _, _ in SELECTOR_ACTIVATORS)
+
+# The endpoint keys that make a caller responsible for a selector's error. An error
+# the stored policy already had is not an update's fault, unless the update wrote one
+# of these keys - then the result is the caller's whatever it was before.
+_SELECTOR_OWNER_KEYS: Dict[str, frozenset[str]] = {
+    "matching_target": frozenset({"matching_target", "matching_target_type", "ips", "ip_group_id", "network_ids"}),
+    "client_macs": frozenset({"client_macs", "matching_target"}),
+    "port": frozenset({"port", "ports", "port_matching_type"}),
+    "port_group_id": frozenset({"port_group_id", "port_matching_type"}),
+}
+
+# The enum values this project has observed. A value outside its set is a controller
+# target this project has not seen (App, Web, Region, ...): validation passes it
+# through, and the list view keeps showing whatever the controller stored beside it
+# rather than hiding a selector it may well be enforcing.
+_KNOWN_ACTIVATOR_VALUES: Dict[str, frozenset[str]] = {
+    "matching_target": frozenset({"ANY", "IP", "NETWORK", "CLIENT"}),
+    "port_matching_type": frozenset({"ANY", "SPECIFIC", "OBJECT"}),
+}
+
+
+def activator_is_known(activator_key: str, value: Any) -> bool:
+    """Whether an endpoint's enum value is one this project recognises."""
+    return isinstance(value, str) and value.strip().upper() in _KNOWN_ACTIVATOR_VALUES.get(activator_key, frozenset())
+
+
+def _activator_matches(value: Any, activator_value: str) -> bool:
+    """Whether an endpoint's enum value activates its selector.
+
+    Case- and space-insensitive: the MCP tool normalizes endpoint enums before
+    validating, the API create translator does not, and a check that only knew
+    the upper-case spelling gave the two surfaces opposite verdicts on the same
+    policy.
+    """
+    return isinstance(value, str) and value.strip().upper() == activator_value
+
+
+def _client_macs_error(direction: str, value: Any) -> str | None:
+    """Reject a client_macs value, naming the position rather than the address.
+
+    The message reaches tool logs and the API audit row, and a MAC address is
+    one of the values this project never writes to either.
+    """
+    if not isinstance(value, list) or not value:
+        return "%s.client_macs must be a non-empty array of MAC addresses when matching_target is 'CLIENT'." % direction
+    for index, mac in enumerate(value):
+        if not looks_like_mac(mac):
+            return "%s.client_macs[%d] is not a MAC address; expected the AA:BB:CC:DD:EE:FF form." % (direction, index)
+    return None
+
+
+def _port_group_error(direction: str, value: Any) -> str | None:
+    if not value:
+        return "%s.port_group_id is required when port_matching_type is 'OBJECT'." % direction
+    return None
+
+
+# ``port`` under SPECIFIC is deliberately absent: its shape is
+# :func:`validate_policy_port_targeting`'s contract, and this table only decides
+# which selector belongs under which enum.
+_SELECTOR_VALIDATORS = {
+    "client_macs": _client_macs_error,
+    "port_group_id": _port_group_error,
+}
+
+
+def zone_target_error(direction: str, ep: Any) -> str | None:
+    """The completeness rule for one endpoint's ``matching_target``.
+
+    IP and NETWORK each need a ``matching_target_type`` and the selector that goes
+    with it; the controller stores an incomplete one and matches nothing, so a BLOCK
+    policy silently stops blocking. Unknown targets pass through, like everywhere
+    else in this module. A non-dict endpoint is :func:`validate_policy_selectors`'
+    to report, so it is ignored here rather than reported twice.
+    """
+    if not isinstance(ep, dict):
+        return None
+    target = ep.get("matching_target")
+    if target in ("IP", "NETWORK") and not ep.get("matching_target_type"):
+        expected = "'SPECIFIC' or 'OBJECT'" if target == "IP" else "'OBJECT'"
+        return "%s.matching_target_type is required when matching_target is '%s'. Use %s." % (
+            direction,
+            target,
+            expected,
+        )
+    if target == "IP":
+        target_type = ep.get("matching_target_type")
+        if target_type == "OBJECT" and not ep.get("ip_group_id"):
+            return "%s.ip_group_id is required when matching_target is 'IP' with matching_target_type 'OBJECT'." % (
+                direction
+            )
+        if target_type != "OBJECT" and not ep.get("ips"):
+            return "%s.ips array is required when matching_target is 'IP'." % direction
+    if target == "NETWORK" and not ep.get("network_ids"):
+        return "%s.network_ids array is required when matching_target is 'NETWORK'." % direction
+    return None
+
+
+def validate_zone_targeting(fields: Dict[str, Any]) -> str | None:
+    """The first ``matching_target`` completeness error across both endpoints.
+
+    Lived in the Network tool, where only ``unifi_create_firewall_policy`` called it,
+    so an update and an API create could both write a target with nothing to match.
+    Same messages and same order; the tool keeps its own name as a delegate.
+    """
+    for direction in ("source", "destination"):
+        if error := zone_target_error(direction, fields.get(direction)):
+            return error
+    return None
+
+
+def _selector_activator_errors(
+    direction: str, ep: Dict[str, Any], *, require_both_present: bool = False
+) -> List[tuple[str, str]]:
+    """``(selector key, message)`` for every selector-vs-activating-enum problem.
+
+    With ``require_both_present`` the check is limited to pairs the dict itself
+    carries, which is what a partial update can be judged on without the stored
+    policy.
+    """
+    activated: List[tuple[str, str]] = []
+    leftover: List[tuple[str, str]] = []
+    for selector, activator_key, activator_value in SELECTOR_ACTIVATORS:
+        if require_both_present and (activator_key not in ep or selector not in ep):
+            continue
+        value = ep.get(selector)
+        if _activator_matches(ep.get(activator_key), activator_value):
+            validator = _SELECTOR_VALIDATORS.get(selector)
+            error = validator(direction, value) if validator else None
+            if error:
+                activated.append((selector, error))
+        elif value:
+            # Directional on purpose. "port_matching_type must be 'OBJECT'" told a caller
+            # who had just chosen SPECIFIC to undo that choice, when the thing to remove
+            # was the port_group_id left behind. The enum's value is quoted only when it
+            # is one this project knows, so no caller string reaches a log or audit row.
+            current = ep.get(activator_key)
+            shown = (
+                "'%s'" % str(current).strip().upper()
+                if activator_is_known(activator_key, current)
+                else ("unset" if current is None else "an unrecognised value")
+            )
+            leftover.append(
+                (
+                    selector,
+                    "%s.%s is ignored while %s.%s is %s. Remove it, or set %s.%s to '%s'."
+                    % (direction, selector, direction, activator_key, shown, direction, activator_key, activator_value),
+                )
+            )
+    # What the chosen enum is missing comes first. Told "port_matching_type must be
+    # 'SPECIFIC'" when they asked for OBJECT, a caller undoes the change they meant.
+    return activated + leftover
+
+
+def _endpoint_selector_errors(direction: str, ep: Any) -> List[tuple[str, str]]:
+    """Selector problems on one source/destination value, in check order."""
+    if ep is None:
+        return []
+    if not isinstance(ep, dict):
+        return [("", "%s must be an object with zone_id and matching_target." % direction)]
+    return _selector_activator_errors(direction, ep)
+
+
+def validate_policy_selectors(fields: Dict[str, Any]) -> None:
+    """Reject targeting selectors the controller would store and then ignore.
+
+    Complements :func:`validate_policy_port_targeting` (the SPECIFIC ``port``
+    shape) and the Network tool's zone/IP/NETWORK requirements: this function
+    owns CLIENT targeting, the ``OBJECT`` port-group mode, and the rule that a
+    selector only travels with the enum value that activates it. Unknown
+    ``matching_target`` / ``port_matching_type`` values pass through so newer
+    controller targets (App, Web, Region, ...) keep working.
+    """
+    for direction in ("source", "destination"):
+        errors = _endpoint_selector_errors(direction, fields.get(direction))
+        if errors:
+            raise ValueError(errors[0][1])
+
+
+def retire_stale_selectors(stored: Any, update: Any) -> Any:
+    """Mark selectors a partial endpoint update deactivates for removal.
+
+    A partial update that moves ``port_matching_type`` or ``matching_target``
+    away from the value that activates a stored selector (``port``,
+    ``port_group_id``, ``client_macs``) would otherwise deep-merge into a
+    document carrying a selector the controller ignores. The returned copy of
+    ``update`` sets each such selector to ``None``; the manager drops ``None``
+    keys inside an endpoint before the PUT. Selectors the update sets itself
+    are left alone.
+    """
+    if not isinstance(stored, dict) or not isinstance(update, dict):
+        return update
+    retired = dict(update)
+    for selector, activator_key, activator_value in SELECTOR_ACTIVATORS:
+        if activator_key not in update or selector in update:
+            continue
+        if not _activator_matches(update[activator_key], activator_value) and stored.get(selector) is not None:
+            retired[selector] = None
+    return retired
+
+
+def _merged_endpoint_errors(direction: str, ep: Any) -> List[tuple[str, str]]:
+    """``(selector key, message)`` for every targeting error this layer can see."""
+    errors = _endpoint_selector_errors(direction, ep)
+    if isinstance(ep, dict):
+        if zone_error := zone_target_error(direction, ep):
+            errors.append(("matching_target", zone_error))
+        try:
+            validate_policy_port_targeting({direction: ep})
+        except ValueError as exc:
+            errors.append(("port", str(exc)))
+    return errors
+
+
+def policy_update_targeting_error(current: Dict[str, Any], updates: Dict[str, Any]) -> str | None:
+    """Return the first targeting error a partial update would introduce.
+
+    The manager deep-merges ``source``/``destination`` with the stored policy,
+    so each updated side is validated as merged. Sides the update does not
+    touch are left alone, and errors the stored side already has (state this
+    project did not author) are not held against an update that leaves them
+    in place.
+    """
+    for side in ("source", "destination"):
+        if side not in updates:
+            continue
+        stored = current.get(side)
+        stored = stored if isinstance(stored, dict) else {}
+        update = updates[side]
+        merged = deep_merge(stored, update) if isinstance(update, dict) else update
+        touched = set(update) if isinstance(update, dict) else set()
+        preexisting = {key for key, _ in _merged_endpoint_errors(side, stored)}
+        for key, message in _merged_endpoint_errors(side, merged):
+            # Suppression is per selector, not per message: two updates to the same
+            # bad selector produce the same words, and comparing the words would let
+            # a caller write a new invalid value into an already-invalid selector.
+            if key in preexisting and not (touched & _SELECTOR_OWNER_KEYS.get(key, frozenset({key}))):
+                continue
+            return message
+    return None
+
+
+def _selector_contradiction_error(direction: str, ep: Any) -> str | None:
+    """Reject a selector paired with a non-activating enum inside one update dict.
+
+    This needs no stored state, so it runs at the normalization boundary and
+    protects previews on surfaces that cannot read the controller first.
+    """
+    if not isinstance(ep, dict):
+        return None
+    errors = _selector_activator_errors(direction, ep, require_both_present=True)
+    return errors[0][1] if errors else None
+
+
+def prepare_policy_update(current: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Finish a normalized partial update against the stored policy document.
+
+    This is the shared MCP/API step that needs controller state: it retires the
+    selectors an activation change deactivates (:func:`retire_stale_selectors`)
+    and validates each updated side as the controller will store it
+    (:func:`policy_update_targeting_error`). Raises ``ValueError`` on the first
+    targeting error; the manager calls it before building the PUT body and the
+    MCP wrapper calls it for the preview.
+    """
+    # Upper-case the endpoint enums first: activation is compared case-insensitively
+    # but validate_policy_port_targeting compares against the controller's spelling,
+    # so a lower-case "specific" would look active to one check and inert to the other
+    # and write a SPECIFIC endpoint with no port. create_firewall_policy normalizes for
+    # the same reason.
+    prepared = normalize_policy_endpoint_enums(updates)
+    for side in ("source", "destination"):
+        if side in prepared:
+            prepared[side] = retire_stale_selectors(current.get(side), prepared[side])
+    if error := policy_update_targeting_error(current, prepared):
+        raise ValueError(error)
+    return prepared
+
+
 def legacy_policy_error(fields: Dict[str, Any]) -> str | None:
     """Return the actionable V1-to-V2 migration error when legacy input is detected."""
     if _LEGACY_V1_FIREWALL_FIELDS & set(fields):
@@ -547,6 +843,34 @@ def legacy_policy_error(fields: Dict[str, Any]) -> str | None:
     return None
 
 
+_ENDPOINT_ENUM_KEYS = ("matching_target", "matching_target_type", "port_matching_type")
+
+
+def _normalize_endpoint_enums(endpoint: Any) -> Any:
+    """Upper-case the enum-valued keys inside a source/destination endpoint dict."""
+    if not isinstance(endpoint, dict):
+        return endpoint
+    return {
+        k: (v.strip().upper() if k in _ENDPOINT_ENUM_KEYS and isinstance(v, str) else v) for k, v in endpoint.items()
+    }
+
+
+def normalize_policy_endpoint_enums(fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Upper-case the source/destination enum values and nothing else.
+
+    The narrow half of :func:`normalize_policy_enums`, for the create paths that
+    must not also validate and rewrite the top-level fields. The controller stores
+    these enums upper-case; a validator comparing against the upper-case spelling
+    on one surface and not the other is how two surfaces reach opposite verdicts
+    on the same policy.
+    """
+    normalized = dict(fields)
+    for side in ("source", "destination"):
+        if side in normalized:
+            normalized[side] = _normalize_endpoint_enums(normalized[side])
+    return normalized
+
+
 def normalize_policy_enums(fields: Dict[str, Any]) -> Dict[str, Any]:
     """Upper-case the controller's V2 firewall enum values."""
     normalized = dict(fields)
@@ -554,7 +878,9 @@ def normalize_policy_enums(fields: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(action, str):
         upper_action = action.upper()
         if upper_action not in {"ALLOW", "BLOCK", "REJECT"}:
-            raise ValueError(f"Invalid action '{action}'.")
+            # No echo of the submitted value: this message reaches the API audit row,
+            # which scrubs secret-keyed values only.
+            raise ValueError("Invalid action; must be one of ALLOW, BLOCK, REJECT.")
         normalized["action"] = upper_action
     for key in ("ip_version", "connection_state_type"):
         if isinstance(normalized.get(key), str):
@@ -562,7 +888,7 @@ def normalize_policy_enums(fields: Dict[str, Any]) -> Dict[str, Any]:
     states = normalized.get("connection_states")
     if isinstance(states, list):
         normalized["connection_states"] = [state.upper() if isinstance(state, str) else state for state in states]
-    return normalized
+    return normalize_policy_endpoint_enums(normalized)
 
 
 def _normalize_endpoint_macs(endpoint: Any) -> Any:
@@ -575,7 +901,13 @@ def _normalize_endpoint_macs(endpoint: Any) -> Any:
     """
     if not isinstance(endpoint, dict) or "client_macs" not in endpoint:
         return endpoint
-    return {**endpoint, "client_macs": normalize_mac_list(endpoint["client_macs"])}
+    macs = endpoint["client_macs"]
+    if not isinstance(macs, list):
+        return endpoint
+    # The controller reports colon-separated pairs and validation accepts the dashed
+    # and bare-hex spellings too, so send the canonical form rather than whichever
+    # one the caller happened to type.
+    return {**endpoint, "client_macs": [canonical_mac(mac) or normalize_mac(mac) or mac for mac in macs]}
 
 
 def normalize_policy_update(fields: Dict[str, Any]) -> Dict[str, Any]:
@@ -583,8 +915,10 @@ def normalize_policy_update(fields: Dict[str, Any]) -> Dict[str, Any]:
 
     This is the shared mutation boundary for MCP and API callers. It rejects
     ``index`` (ordering is a separate tool family), rejects retired V1 fields,
-    normalizes the controller's upper-case enums, and drops unknown/read-only
-    fields through :func:`to_controller_update`.
+    normalizes the controller's upper-case enums, drops unknown/read-only
+    fields through :func:`to_controller_update`, and rejects a selector paired
+    with a non-activating enum in the same update. Checks that need the stored
+    policy run in :func:`prepare_policy_update`.
     """
     if "index" in fields:
         # The V2 policy endpoint accepts index and silently ignores it, so the
@@ -600,6 +934,8 @@ def normalize_policy_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     payload = to_controller_update(normalized)
     for side in ("source", "destination"):
         if side in payload:
+            if error := _selector_contradiction_error(side, payload[side]):
+                raise ValueError(error)
             payload[side] = _normalize_endpoint_macs(payload[side])
     if not payload:
         raise ValueError("Update data is effectively empty or invalid.")

--- a/packages/unifi-core/src/unifi_core/network/read_views.py
+++ b/packages/unifi-core/src/unifi_core/network/read_views.py
@@ -876,6 +876,9 @@ def shape_firewall_policy_list(
                 # and a port selector only under the port_matching_type that activates it.
                 for key in _FIREWALL_TARGETING_KEYS:
                     activator = _SELECTOR_ACTIVATION.get(key)
+                    if key == "match_opposite_ports" and _activator_matches(port_matching_type, "OBJECT"):
+                        # Inversion also applies to a stored port-group match.
+                        activator = None
                     if activator and not _selector_is_active(endpoint, activator):
                         continue
                     if endpoint.get(key):

--- a/packages/unifi-core/src/unifi_core/network/read_views.py
+++ b/packages/unifi-core/src/unifi_core/network/read_views.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from unifi_core.network.models.clients import _is_online, client_from_controller
 from unifi_core.network.models.devices import normalize_radio_channel
+from unifi_core.network.models.firewall import SELECTOR_ACTIVATORS, _activator_matches, activator_is_known
 from unifi_core.network.models.firewall import from_controller as firewall_policy_from_controller
 from unifi_core.network.models.networks import from_controller as network_from_controller
 
@@ -783,6 +784,49 @@ def shape_wlan_list(
     }
 
 
+# selector -> (activating enum key, value); a selector under any other value is not shown.
+# The write side validates and retires the three in SELECTOR_ACTIVATORS. The IP and
+# NETWORK selectors below follow the same contract on the controller but are not yet
+# validated or retired, so a stale one is routinely present — and showing `ips` beside
+# `matching_target: ANY` reports a zone-wide rule as if it were address-scoped, which
+# is the reading this summary must never produce.
+_SELECTOR_ACTIVATION = {
+    **{selector: (key, value) for selector, key, value in SELECTOR_ACTIVATORS},
+    "ips": ("matching_target", "IP"),
+    "ip_group_id": ("matching_target", "IP"),
+    "match_opposite_ips": ("matching_target", "IP"),
+    "network_ids": ("matching_target", "NETWORK"),
+    "match_opposite_networks": ("matching_target", "NETWORK"),
+    "match_opposite_ports": ("port_matching_type", "SPECIFIC"),
+}
+
+
+def _selector_is_active(endpoint: dict[str, Any], activator: tuple[str, str]) -> bool:
+    """Whether a stored selector is one the controller acts on, for display purposes."""
+    key, activating = activator
+    value = endpoint.get(key)
+    if value is not None and not activator_is_known(key, value):
+        # A target this project has not seen (App, Web, Region, ...). The controller
+        # may well be enforcing the selector, and reporting a narrow rule as broad is
+        # the worse error on the surface the firewall auditor reads.
+        return True
+    return _activator_matches(value, activating)
+
+
+_FIREWALL_TARGETING_KEYS = (
+    "matching_target_type",
+    "ips",
+    "ip_group_id",
+    "network_ids",
+    "client_macs",
+    "port",
+    "port_group_id",
+    "match_opposite_ips",
+    "match_opposite_networks",
+    "match_opposite_ports",
+)
+
+
 def shape_firewall_policy_list(
     policies: list[Any],
     *,
@@ -819,11 +863,21 @@ def shape_firewall_policy_list(
             "rule_index": shaped.index,
             "description": policy.get("description", policy.get("desc", "")),
         }
+        if shaped.protocol:
+            entry["protocol"] = shaped.protocol
         for direction in ("source", "destination"):
             endpoint = getattr(shaped, direction)
             if endpoint and isinstance(endpoint, dict):
                 targeting = {"zone_id": endpoint.get("zone_id"), "matching_target": endpoint.get("matching_target")}
-                for key in ("matching_target_type", "ips", "network_ids", "client_macs"):
+                port_matching_type = endpoint.get("port_matching_type")
+                if port_matching_type and port_matching_type != "ANY":
+                    targeting["port_matching_type"] = port_matching_type
+                # Selectors and inversion flags, in display order; only set (truthy) values are shown,
+                # and a port selector only under the port_matching_type that activates it.
+                for key in _FIREWALL_TARGETING_KEYS:
+                    activator = _SELECTOR_ACTIVATION.get(key)
+                    if activator and not _selector_is_active(endpoint, activator):
+                        continue
                     if endpoint.get(key):
                         targeting[key] = endpoint[key]
                 entry[direction] = targeting

--- a/packages/unifi-core/tests/network/managers/test_firewall_port_validation.py
+++ b/packages/unifi-core/tests/network/managers/test_firewall_port_validation.py
@@ -1,4 +1,7 @@
-"""Port validation at the Core firewall create boundary."""
+"""Port and selector validation at the Core firewall create boundary.
+
+This is the one create path both the MCP tool and the API dispatcher execute
+through, so a check that only lives in a tool wrapper is not enough."""
 
 import copy
 from unittest.mock import AsyncMock, MagicMock
@@ -54,3 +57,51 @@ async def test_valid_ports_reach_controller_without_mutating_input():
     assert created.raw["source"]["port"] == "445"
     assert created.raw["destination"]["port"] == "8443"
     assert data == before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ({"matching_target": "CLIENT"}, "client_macs"),
+        ({"matching_target": "CLIENT", "client_macs": []}, "client_macs"),
+        ({"matching_target": "CLIENT", "client_macs": ["nope"]}, "client_macs"),
+        ({"port_matching_type": "OBJECT"}, "port_group_id"),
+        ({"port_matching_type": "ANY", "port": "53"}, "port_matching_type"),
+        ({"matching_target": "ANY", "client_macs": ["aa:bb:cc:dd:ee:ff"]}, "matching_target"),
+        ({"port_group_id": "g1"}, "port_matching_type"),
+    ],
+)
+async def test_inactive_selectors_fail_before_controller_connection(direction, endpoint, expected):
+    """The controller accepts a selector under the wrong enum and silently ignores it."""
+    connection = MagicMock()
+    connection.ensure_connected = AsyncMock()
+    connection.request = AsyncMock()
+    manager = FirewallManager(connection)
+
+    with pytest.raises(ValueError, match=expected):
+        await manager.create_firewall_policy({direction: endpoint})
+
+    connection.ensure_connected.assert_not_awaited()
+    connection.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_activated_selectors_reach_the_controller():
+    data = {
+        "name": "Client and port group",
+        "action": "BLOCK",
+        "enabled": False,
+        "source": {"matching_target": "CLIENT", "client_macs": ["AA:BB:CC:DD:EE:FF"]},
+        "destination": {"port_matching_type": "OBJECT", "port_group_id": "grp-1"},
+    }
+    connection = MagicMock()
+    connection.ensure_connected = AsyncMock(return_value=True)
+    connection.request = AsyncMock(return_value={"_id": "created-policy", **data})
+
+    await FirewallManager(connection).create_firewall_policy(data)
+
+    sent = connection.request.call_args.args[0].data
+    assert sent["source"]["client_macs"] == ["aa:bb:cc:dd:ee:ff"]
+    assert sent["destination"]["port_group_id"] == "grp-1"

--- a/packages/unifi-core/tests/network/managers/test_mac_error_masking.py
+++ b/packages/unifi-core/tests/network/managers/test_mac_error_masking.py
@@ -1,0 +1,125 @@
+"""A MAC address must not survive into a log line or a re-raised controller error.
+
+Credential scrubbing does not cover a MAC: it is not a secret-keyed value, so
+``collect_secret_values`` never sees it and the API audit sink stores whatever the
+controller quoted back. Client targeting on firewall policies, ACL rules, blocks
+and renames all put MACs in the record a rejection echoes.
+"""
+
+import json
+import logging
+
+import pytest
+from aiounifi.errors import ResponseError
+from aiounifi.models.api import ApiRequestV2
+from unifi_core.mac import mask_exception_macs
+from unifi_core.network.managers.connection_manager import ConnectionManager
+
+MAC = "aa:bb:cc:dd:ee:ff"
+DASHED = "AA-BB-CC-DD-EE-FF"
+
+
+class _Session:
+    closed = False
+
+    async def close(self):
+        return None
+
+
+class _Config:
+    def __init__(self):
+        self.session = _Session()
+
+
+class _Connectivity:
+    def __init__(self):
+        self.can_retry_login = True
+        self.config = _Config()
+        self.is_unifi_os = True
+
+
+class _Controller:
+    def __init__(self, raiser):
+        self.connectivity = _Connectivity()
+        self._raiser = raiser
+
+    async def login(self):
+        self.connectivity.can_retry_login = False
+
+    async def request(self, api_request):
+        raise self._raiser()
+
+
+def _manager(controller):
+    manager = ConnectionManager("192.168.1.1", "admin", "pw")
+    manager.controller = controller
+    manager._aiohttp_session = controller.connectivity.config.session
+    manager._initialized = True
+    manager._auth_generation = 1
+    return manager
+
+
+def _rejected_policy_write():
+    body = {
+        "meta": {"rc": "error", "msg": "api.err.InvalidPayload"},
+        "data": [{"name": "Admin only", "source": {"matching_target": "CLIENT", "client_macs": [MAC]}}],
+    }
+    return ResponseError(json.dumps(body))
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_client_targeted_write_keeps_the_mac_out_of_the_log_and_the_error(caplog):
+    manager = _manager(_Controller(_rejected_policy_write))
+    request = ApiRequestV2(
+        method="post",
+        path="/firewall-policies",
+        data={"name": "Admin only", "source": {"matching_target": "CLIENT", "client_macs": [MAC]}},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(Exception) as excinfo:
+            await manager.request(request)
+
+    assert MAC not in caplog.text
+    assert MAC not in str(excinfo.value)
+    assert "[redacted]" in str(excinfo.value)
+
+
+class TestMaskExceptionMacs:
+    def test_masks_a_mac_inside_a_decoded_response_dict(self):
+        error = ValueError({"data": [{"client_macs": [MAC, DASHED]}]})
+
+        mask_exception_macs(error)
+
+        assert MAC not in str(error)
+        assert DASHED.lower() not in str(error).lower()
+
+    def test_follows_the_cause_chain(self):
+        inner = ValueError(f"rejected {MAC}")
+        outer = RuntimeError("wrapped")
+        outer.__cause__ = inner
+
+        mask_exception_macs(outer)
+
+        assert MAC not in str(inner)
+
+    def test_a_cycle_in_the_chain_terminates(self):
+        a = ValueError(f"a {MAC}")
+        b = ValueError("b")
+        a.__cause__ = b
+        b.__cause__ = a
+
+        mask_exception_macs(a)
+
+        assert MAC not in str(a)
+
+    def test_leaves_an_identifier_that_is_not_a_mac_alone(self):
+        error = ValueError("policy 68a1f0c2d4e5b6a7c8d9e0f1 rejected")
+
+        mask_exception_macs(error)
+
+        assert "68a1f0c2d4e5b6a7c8d9e0f1" in str(error)
+
+    def test_returns_the_same_exception_object(self):
+        error = ValueError(MAC)
+        assert mask_exception_macs(error) is error

--- a/packages/unifi-core/tests/network/models/test_firewall.py
+++ b/packages/unifi-core/tests/network/models/test_firewall.py
@@ -18,16 +18,23 @@ from unifi_core.network.models.firewall import (
     FirewallRule,
     FirewallZone,
     LegacyFirewallRule,
+    activator_is_known,
     firewall_group_from_controller,
     firewall_zone_from_controller,
     from_controller,
     legacy_firewall_rule_from_controller,
+    normalize_policy_enums,
     normalize_policy_update,
+    policy_update_targeting_error,
+    prepare_policy_update,
+    retire_stale_selectors,
     to_controller_update,
     to_group_create,
     to_zone_create,
     to_zone_update,
     validate_policy_port_targeting,
+    validate_policy_selectors,
+    validate_zone_targeting,
 )
 
 
@@ -223,14 +230,515 @@ class TestNormalizePolicyUpdate:
             ({"ruleset": "WAN_IN"}, "Legacy V1 firewall fields"),
             ({"action": "accept"}, "Legacy V1 firewall fields"),
             ({"action": "invalid"}, "Invalid action"),
+            ({"action": "SENTINEL-caller-value"}, "must be one of ALLOW, BLOCK, REJECT"),
             ({"id": "read-only"}, "effectively empty"),
             ({"index": 2000, "enabled": True}, "unifi_reorder_firewall_policies"),
             ({"index": 2000}, "unifi_reorder_firewall_policies"),
+            ({"destination": {"port_matching_type": "ANY", "port": "53"}}, "port_matching_type"),
+            ({"source": {"matching_target": "ANY", "client_macs": ["aa:bb:cc:dd:ee:ff"]}}, "matching_target"),
         ],
     )
     def test_rejects_legacy_invalid_or_empty_updates(self, fields: dict, message: str) -> None:
         with pytest.raises(ValueError, match=message):
             normalize_policy_update(fields)
+
+    def test_the_action_rejection_does_not_echo_the_submitted_value(self) -> None:
+        """It reaches the API audit row, which scrubs secret-keyed values only."""
+        with pytest.raises(ValueError) as excinfo:
+            normalize_policy_update({"action": "SENTINEL-caller-value"})
+
+        assert "SENTINEL-caller-value" not in str(excinfo.value)
+
+
+class TestNormalizePolicyEnumsEndpoints:
+    def test_upper_cases_endpoint_enums_on_both_sides(self) -> None:
+        result = normalize_policy_enums(
+            {
+                "source": {"zone_id": "z1", "matching_target": "client", "client_macs": ["aa:bb"]},
+                "destination": {
+                    "zone_id": "z2",
+                    "matching_target": "ip",
+                    "matching_target_type": "specific",
+                    "ips": ["10.0.0.1"],
+                    "port_matching_type": "specific",
+                    "port": "53",
+                },
+            }
+        )
+
+        assert result["source"]["matching_target"] == "CLIENT"
+        assert result["destination"]["matching_target"] == "IP"
+        assert result["destination"]["matching_target_type"] == "SPECIFIC"
+        assert result["destination"]["port_matching_type"] == "SPECIFIC"
+        assert result["destination"]["port"] == "53"
+
+    def test_strips_and_upper_cases_padded_enum_values(self) -> None:
+        result = normalize_policy_enums(
+            {"destination": {"port_matching_type": " specific ", "matching_target": "any "}}
+        )
+
+        assert result["destination"] == {"port_matching_type": "SPECIFIC", "matching_target": "ANY"}
+
+    def test_leaves_non_string_and_non_dict_endpoints_alone(self) -> None:
+        result = normalize_policy_enums(
+            {"source": {"zone_id": "z1", "matching_target": None}, "destination": "not-a-dict"}
+        )
+
+        assert result["source"] == {"zone_id": "z1", "matching_target": None}
+        assert result["destination"] == "not-a-dict"
+
+    def test_an_activation_only_update_passes_the_stateless_boundary(self) -> None:
+        """Switching to OBJECT without naming port_group_id may be perfectly valid against
+        a policy that already stores one; only prepare_policy_update can tell."""
+        assert normalize_policy_update({"destination": {"port_matching_type": "OBJECT"}}) == {
+            "destination": {"port_matching_type": "OBJECT"}
+        }
+        assert normalize_policy_update({"source": {"matching_target": "CLIENT"}}) == {
+            "source": {"matching_target": "CLIENT"}
+        }
+
+    def test_normalize_policy_update_inherits_endpoint_enums(self) -> None:
+        result = normalize_policy_update({"destination": {"port_matching_type": "object", "port_group_id": "g1"}})
+
+        assert result == {"destination": {"port_matching_type": "OBJECT", "port_group_id": "g1"}}
+
+
+class TestValidatePolicySelectors:
+    """The selector half of V2 targeting: CLIENT, port OBJECT, and the rule that a
+    selector is only accepted under the enum value that activates it. Port *shape*
+    under SPECIFIC stays with validate_policy_port_targeting; zone/IP/NETWORK
+    requirements stay with the Network tool's _validate_zone_targeting."""
+
+    @staticmethod
+    def _policy(**destination):
+        return {
+            "source": {"zone_id": "z1", "matching_target": "ANY"},
+            "destination": {"zone_id": "z2", "matching_target": "ANY", **destination},
+        }
+
+    def _error(self, **destination) -> str:
+        with pytest.raises(ValueError) as excinfo:
+            validate_policy_selectors(self._policy(**destination))
+        return str(excinfo.value)
+
+    def test_client_target_requires_client_macs(self) -> None:
+        assert "client_macs" in self._error(matching_target="CLIENT")
+        assert "client_macs" in self._error(matching_target="CLIENT", client_macs=[])
+        validate_policy_selectors(self._policy(matching_target="CLIENT", client_macs=["aa:bb:cc:dd:ee:ff"]))
+
+    def test_object_port_matching_requires_port_group_id(self) -> None:
+        assert "port_group_id" in self._error(port_matching_type="OBJECT")
+        validate_policy_selectors(self._policy(port_matching_type="OBJECT", port_group_id="g1"))
+
+    @pytest.mark.parametrize(
+        ("extra", "expected"),
+        [
+            ({"port": "53"}, "port_matching_type"),
+            ({"port_matching_type": "ANY", "port": "53"}, "port_matching_type"),
+            ({"port_group_id": "g1"}, "port_matching_type"),
+            ({"port_matching_type": "SPECIFIC", "port": "53", "port_group_id": "g1"}, "port_matching_type"),
+            ({"client_macs": ["aa:bb:cc:dd:ee:ff"]}, "matching_target"),
+        ],
+    )
+    def test_selector_without_its_activating_enum_is_rejected(self, extra: dict, expected: str) -> None:
+        """A selector the controller would accept and silently ignore must not pass validation."""
+        assert expected in self._error(**extra)
+
+    @pytest.mark.parametrize("macs", ["aa:bb:cc:dd:ee:ff", ["zz"], [" "], [None]])
+    def test_client_macs_must_be_a_list_of_valid_macs(self, macs) -> None:
+        assert "client_macs" in self._error(matching_target="CLIENT", client_macs=macs)
+
+    def test_client_macs_accepts_mixed_case_and_dashes(self) -> None:
+        validate_policy_selectors(self._policy(matching_target="CLIENT", client_macs=["AA-BB-CC-DD-EE-FF"]))
+
+    def test_unknown_targets_and_port_types_pass_through(self) -> None:
+        validate_policy_selectors(self._policy(matching_target="APP", app_ids=["x"]))
+        validate_policy_selectors(self._policy(port_matching_type="SOMETHING_NEW"))
+
+    def test_any_and_absent_endpoints_need_nothing(self) -> None:
+        validate_policy_selectors(self._policy(port_matching_type="ANY"))
+        validate_policy_selectors({"source": None, "destination": None})
+
+    def test_port_shape_and_zone_requirements_are_not_this_function(self) -> None:
+        """Boundary pin: the SPECIFIC port string is validate_policy_port_targeting's and
+        the IP/NETWORK requirements are validate_zone_targeting's."""
+        validate_policy_selectors(self._policy(port_matching_type="SPECIFIC", port="not-a-port"))
+        validate_policy_selectors(self._policy(matching_target="IP"))
+
+    def test_non_dict_endpoint_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="source"):
+            validate_policy_selectors({"source": "ANY", "destination": None})
+
+    @pytest.mark.parametrize(
+        ("macs", "forbidden"),
+        [
+            (["aa:bb:cc:dd:ee:ff", "nope"], "aa:bb:cc:dd:ee:ff"),
+            (["nope"], "nope"),
+            ("aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:ff"),
+            ([], "["),
+            # A real address in a spelling looks_like_mac rejects: the element that fails
+            # IS the MAC, so only a message that quotes nothing keeps it out.
+            (["aabb.ccdd.eeff"], "aabb.ccdd.eeff"),
+            (["11:22:33:44:55:66:77"], "11:22:33:44:55:66"),
+        ],
+    )
+    def test_the_message_never_quotes_a_mac_address(self, macs, forbidden: str) -> None:
+        """It reaches tool logs and the API audit row, where a MAC must never land."""
+        error = self._error(matching_target="CLIENT", client_macs=macs)
+        assert forbidden not in error
+        assert "client_macs" in error
+
+    def test_the_chosen_enums_own_gap_is_reported_before_a_leftover_selector(self) -> None:
+        """Reporting the leftover first tells a caller to undo the mode they just asked for."""
+        error = self._error(port_matching_type="OBJECT", port="53")
+        assert "port_group_id" in error
+
+    def test_a_leftover_selector_is_named_as_the_thing_to_remove(self) -> None:
+        """The chosen mode is valid and complete; it is the stale selector that must go."""
+        error = self._error(port_matching_type="SPECIFIC", port="53", port_group_id="g1")
+        assert error.startswith("destination.port_group_id is ignored while")
+        assert "Remove it, or set destination.port_matching_type to 'OBJECT'." in error
+
+    def test_an_unrecognised_enum_value_is_not_echoed_into_the_message(self) -> None:
+        error = self._error(port_matching_type="SENTINEL-caller-value", port="53")
+        assert "SENTINEL-caller-value" not in error
+        assert "an unrecognised value" in error
+
+    def test_an_absent_activator_is_named_as_unset(self) -> None:
+        assert "is unset" in self._error(port="53")
+
+    def test_a_read_modify_write_that_echoes_a_stale_selector_is_rejected(self) -> None:
+        """Deliberate, and asymmetric with the partial form: the echoed document itself
+        contains the contradiction, and the stateless boundary is the only check the API
+        preview gets. Sending the same intent as a partial dict is accepted."""
+        stale = {"zone_id": "z", "matching_target": "ANY", "port_matching_type": "ANY", "port": "53"}
+        with pytest.raises(ValueError, match="port_matching_type"):
+            normalize_policy_update({"source": stale})
+        assert normalize_policy_update({"source": {"zone_id": "z9"}}) == {"source": {"zone_id": "z9"}}
+
+    @pytest.mark.parametrize("value", ["object", " Object ", "OBJECT"])
+    def test_activation_is_case_insensitive(self, value: str) -> None:
+        """Callers reach this through several normalization histories; a case-sensitive
+        check gave two surfaces opposite verdicts on the same policy."""
+        assert "port_group_id" in self._error(port_matching_type=value)
+
+    def test_a_lower_case_client_target_is_not_read_as_a_leftover_selector(self) -> None:
+        validate_policy_selectors(self._policy(matching_target="client", client_macs=["aa:bb:cc:dd:ee:ff"]))
+
+    @pytest.mark.parametrize(
+        ("key", "value", "known"),
+        [
+            ("matching_target", "CLIENT", True),
+            ("matching_target", "client", True),
+            ("matching_target", "APP", False),
+            ("port_matching_type", "OBJECT", True),
+            ("port_matching_type", "PORT_GROUP", False),
+            ("port_matching_type", None, False),
+            ("something_else", "ANY", False),
+        ],
+    )
+    def test_activator_is_known_marks_the_values_this_project_has_seen(self, key, value, known) -> None:
+        assert activator_is_known(key, value) is known
+
+
+class TestValidateZoneTargeting:
+    """The matching_target completeness rules, moved from the Network tool so the
+    update path and the API create path get them too. Same messages, same order."""
+
+    @staticmethod
+    def _policy(**source):
+        return {
+            "source": {"zone_id": "z1", **source},
+            "destination": {"zone_id": "z2", "matching_target": "ANY"},
+        }
+
+    @pytest.mark.parametrize(
+        ("endpoint", "expected"),
+        [
+            ({"matching_target": "IP"}, "source.matching_target_type is required"),
+            ({"matching_target": "NETWORK"}, "source.matching_target_type is required"),
+            ({"matching_target": "IP", "matching_target_type": "OBJECT"}, "source.ip_group_id is required"),
+            ({"matching_target": "IP", "matching_target_type": "SPECIFIC"}, "source.ips array is required"),
+            ({"matching_target": "NETWORK", "matching_target_type": "OBJECT"}, "source.network_ids array is required"),
+        ],
+    )
+    def test_an_incomplete_target_is_rejected(self, endpoint: dict, expected: str) -> None:
+        assert expected in validate_zone_targeting(self._policy(**endpoint))
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            {"matching_target": "ANY"},
+            {"matching_target": "IP", "matching_target_type": "SPECIFIC", "ips": ["10.0.0.1"]},
+            {"matching_target": "IP", "matching_target_type": "OBJECT", "ip_group_id": "g1"},
+            {"matching_target": "NETWORK", "matching_target_type": "OBJECT", "network_ids": ["n1"]},
+            {"matching_target": "CLIENT", "client_macs": ["aa:bb:cc:dd:ee:ff"]},
+            {"matching_target": "APP", "app_ids": ["x"]},
+        ],
+    )
+    def test_a_complete_or_unknown_target_passes(self, endpoint: dict) -> None:
+        assert validate_zone_targeting(self._policy(**endpoint)) is None
+
+    def test_a_non_dict_endpoint_is_left_to_the_selector_check(self) -> None:
+        assert validate_zone_targeting({"source": "ANY", "destination": None}) is None
+
+
+class TestPolicyUpdateTargetingError:
+    _stored = {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "ANY"}
+
+    def test_partial_update_is_validated_as_merged(self) -> None:
+        current = {"destination": dict(self._stored)}
+        assert policy_update_targeting_error(current, {"destination": {"port_matching_type": "OBJECT"}}) is not None
+        assert (
+            policy_update_targeting_error(current, {"destination": {"port_matching_type": "SPECIFIC", "port": "53"}})
+            is None
+        )
+
+    def test_merged_port_shape_is_validated(self) -> None:
+        """Blanking the port of a stored SPECIFIC match is only invalid after the merge:
+        the update dict alone carries no port_matching_type to judge it against."""
+        current = {
+            "destination": {
+                "zone_id": "z2",
+                "matching_target": "ANY",
+                "port_matching_type": "SPECIFIC",
+                "port": "53",
+            }
+        }
+        error = policy_update_targeting_error(current, {"destination": {"port": "   "}})
+        assert error is not None and "destination.port" in error
+
+    def test_untouched_side_is_not_revalidated(self) -> None:
+        current = {"source": {"zone_id": "x", "matching_target": "CLIENT"}, "destination": dict(self._stored)}
+        assert (
+            policy_update_targeting_error(current, {"destination": {"port_matching_type": "SPECIFIC", "port": "53"}})
+            is None
+        )
+
+    def test_preexisting_error_on_the_updated_side_is_not_held_against_the_update(self) -> None:
+        current = {"destination": {"zone_id": "z2", "matching_target": "CLIENT", "client_macs": []}}
+        assert (
+            policy_update_targeting_error(current, {"destination": {"port_matching_type": "SPECIFIC", "port": "53"}})
+            is None
+        )
+
+    def test_new_error_is_reported_even_when_a_different_one_preexists(self) -> None:
+        current = {"destination": {"zone_id": "z2", "matching_target": "CLIENT", "client_macs": []}}
+        error = policy_update_targeting_error(current, {"destination": {"port": "53"}})
+        assert error is not None and "port_matching_type" in error
+
+    @pytest.mark.parametrize(
+        ("stored", "update", "expected"),
+        [
+            (
+                {"matching_target": "CLIENT", "client_macs": []},
+                {"client_macs": ["zz"]},
+                "client_macs[0]",
+            ),
+            # Two writes to the same bad selector produce the same words, so suppressing
+            # by message text would let the second one through.
+            (
+                {"matching_target": "ANY", "port_matching_type": "ANY", "port": "445"},
+                {"port": "80"},
+                "port_matching_type",
+            ),
+            (
+                {"matching_target": "ANY", "port_matching_type": "SPECIFIC", "port_group_id": "g_old"},
+                {"port_group_id": "g_new"},
+                "port_matching_type",
+            ),
+            (
+                {"matching_target": "ANY", "port_matching_type": "ANY", "port": "445"},
+                {"port_matching_type": "OBJECT"},
+                "port_group_id",
+            ),
+            # The matching_target family, which used to be checked on create only.
+            ({"matching_target": "ANY"}, {"matching_target": "IP"}, "matching_target_type is required"),
+            (
+                {"matching_target": "ANY"},
+                {"matching_target": "NETWORK", "matching_target_type": "OBJECT"},
+                "network_ids array is required",
+            ),
+            (
+                {"matching_target": "IP", "matching_target_type": "SPECIFIC", "ips": ["10.0.0.1"]},
+                {"matching_target_type": "OBJECT"},
+                "ip_group_id is required",
+            ),
+            # Stored side ALREADY broken, and the update touches a member of the same
+            # family without fixing it: the caller now owns the result. Excusing this
+            # because the error was there before lets an update leave a policy matching
+            # nothing while reporting success.
+            (
+                {"matching_target": "IP", "matching_target_type": "SPECIFIC"},
+                {"matching_target_type": "OBJECT"},
+                "ip_group_id is required",
+            ),
+            (
+                {"matching_target": "IP", "matching_target_type": "SPECIFIC"},
+                {"ips": []},
+                "ips array is required",
+            ),
+            (
+                {"matching_target": "NETWORK", "matching_target_type": "OBJECT"},
+                {"network_ids": []},
+                "network_ids array is required",
+            ),
+        ],
+    )
+    def test_writing_to_an_already_invalid_selector_is_reported(self, stored, update, expected) -> None:
+        """A pre-existing error excuses an update that leaves the selector alone, not one
+        that writes to it."""
+        current = {"source": {"zone_id": "z", **stored}}
+        error = policy_update_targeting_error(current, {"source": update})
+        assert error is not None and expected in error
+
+    @pytest.mark.parametrize(
+        ("stored", "update", "expected"),
+        [
+            # Activating an already-junk stored selector: the update names no selector key,
+            # only the enum that switches it on, and the caller now owns the result.
+            ({"matching_target": "ANY", "client_macs": ["nope"]}, {"matching_target": "CLIENT"}, "client_macs[0]"),
+            (
+                {"matching_target": "ANY", "port_matching_type": "ANY", "port": "  "},
+                {"port_matching_type": "SPECIFIC"},
+                "source.port",
+            ),
+            (
+                {"matching_target": "ANY", "port_matching_type": "ANY", "port_group_id": ""},
+                {"port_matching_type": "OBJECT"},
+                "port_group_id",
+            ),
+            # The plural alias is the same field to validate_policy_port_targeting.
+            (
+                {"matching_target": "ANY", "port_matching_type": "ANY"},
+                {"ports": ["445"]},
+                "ports is not a valid field",
+            ),
+        ],
+    )
+    def test_activating_an_already_invalid_selector_is_reported(self, stored, update, expected) -> None:
+        current = {"source": {"zone_id": "z", **stored}}
+        error = policy_update_targeting_error(current, {"source": update})
+        assert error is not None and expected in error
+
+    def test_a_selector_the_update_never_touches_stays_excused(self) -> None:
+        current = {"source": {"zone_id": "z", "matching_target": "ANY", "port_matching_type": "ANY", "port": "445"}}
+        assert policy_update_targeting_error(current, {"source": {"zone_id": "z2"}}) is None
+
+    def test_a_zone_gap_the_controller_already_had_is_not_held_against_an_unrelated_update(self) -> None:
+        """State this project did not author: an IP side with no ips, already stored,
+        must not block a rename or a port change."""
+        current = {"source": {"zone_id": "z", "matching_target": "IP", "matching_target_type": "SPECIFIC"}}
+        assert policy_update_targeting_error(current, {"source": {"zone_id": "z2"}}) is None
+
+    def test_a_completed_target_clears_the_error_it_had(self) -> None:
+        current = {"source": {"zone_id": "z", "matching_target": "IP", "matching_target_type": "SPECIFIC"}}
+        assert policy_update_targeting_error(current, {"source": {"ips": ["10.0.0.1"]}}) is None
+
+    def test_missing_or_non_dict_stored_side_validates_the_update_alone(self) -> None:
+        assert (
+            policy_update_targeting_error(
+                {"destination": None}, {"destination": {"zone_id": "z", "matching_target": "ANY"}}
+            )
+            is None
+        )
+        assert "object" in policy_update_targeting_error({"source": "junk"}, {"source": "ANY"})
+
+
+class TestPreparePolicyUpdate:
+    """The one update path both MCP and API run composes retirement with merged-state
+    validation; each half is covered by its own class."""
+
+    _stored = {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "SPECIFIC", "port": "53"}
+
+    def test_selector_only_update_on_inactive_stored_enum_is_rejected(self) -> None:
+        current = {"destination": {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "ANY"}}
+        with pytest.raises(ValueError, match="port_matching_type"):
+            prepare_policy_update(current, {"destination": {"port": "53"}})
+
+    def test_activation_change_retires_the_stored_selector(self) -> None:
+        current = {"destination": dict(self._stored)}
+        assert prepare_policy_update(current, {"destination": {"port_matching_type": "ANY"}}) == {
+            "destination": {"port_matching_type": "ANY", "port": None}
+        }
+
+    @pytest.mark.parametrize("value", ["SPECIFIC", "specific", " Specific "])
+    def test_a_lower_case_activation_does_not_slip_past_the_port_shape_check(self, value: str) -> None:
+        """Activation is compared case-insensitively and the port shape check is not, so
+        an un-normalized update could look active to one and inert to the other."""
+        current = {"destination": {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "ANY"}}
+        with pytest.raises(ValueError, match="destination.port"):
+            prepare_policy_update(current, {"destination": {"port_matching_type": value}})
+
+    def test_endpoint_enums_are_upper_cased_in_the_prepared_update(self) -> None:
+        current = {"destination": {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "ANY"}}
+        prepared = prepare_policy_update(current, {"destination": {"port_matching_type": "specific", "port": "53"}})
+        assert prepared["destination"]["port_matching_type"] == "SPECIFIC"
+
+    def test_non_endpoint_updates_pass_through_untouched(self) -> None:
+        current = {"destination": dict(self._stored)}
+        assert prepare_policy_update(current, {"enabled": False}) == {"enabled": False}
+
+    def test_the_caller_dict_is_not_mutated(self) -> None:
+        current = {"destination": dict(self._stored)}
+        updates = {"destination": {"port_matching_type": "ANY"}}
+        prepare_policy_update(current, updates)
+        assert updates == {"destination": {"port_matching_type": "ANY"}}
+
+
+class TestRetireStaleSelectors:
+    def test_switching_port_matching_to_any_retires_the_stored_port(self) -> None:
+        stored = {"zone_id": "z", "matching_target": "ANY", "port_matching_type": "SPECIFIC", "port": "53"}
+        assert retire_stale_selectors(stored, {"port_matching_type": "ANY"}) == {
+            "port_matching_type": "ANY",
+            "port": None,
+        }
+
+    def test_switching_between_specific_and_object_retires_the_other_selector(self) -> None:
+        specific = {"port_matching_type": "SPECIFIC", "port": "53"}
+        as_object = retire_stale_selectors(specific, {"port_matching_type": "OBJECT", "port_group_id": "g1"})
+        assert as_object == {"port_matching_type": "OBJECT", "port_group_id": "g1", "port": None}
+
+        obj = {"port_matching_type": "OBJECT", "port_group_id": "g1"}
+        as_specific = retire_stale_selectors(obj, {"port_matching_type": "SPECIFIC", "port": "53"})
+        assert as_specific == {"port_matching_type": "SPECIFIC", "port": "53", "port_group_id": None}
+
+    def test_switching_client_target_away_retires_client_macs(self) -> None:
+        stored = {"matching_target": "CLIENT", "client_macs": ["aa:bb:cc:dd:ee:ff"]}
+        assert retire_stale_selectors(stored, {"matching_target": "ANY"}) == {
+            "matching_target": "ANY",
+            "client_macs": None,
+        }
+
+    def test_update_that_does_not_touch_the_activator_is_unchanged(self) -> None:
+        stored = {"port_matching_type": "SPECIFIC", "port": "53"}
+        assert retire_stale_selectors(stored, {"port": "53,853"}) == {"port": "53,853"}
+        assert retire_stale_selectors(stored, {"zone_id": "z2"}) == {"zone_id": "z2"}
+
+    def test_a_stored_empty_selector_is_still_retired(self) -> None:
+        """Truthiness is not the question: an empty stored port under SPECIFIC must be
+        removed from the PUT, not sent back as ''."""
+        stored = {"port_matching_type": "SPECIFIC", "port": ""}
+        assert retire_stale_selectors(stored, {"port_matching_type": "ANY"}) == {
+            "port_matching_type": "ANY",
+            "port": None,
+        }
+
+    def test_update_that_sets_the_selector_itself_is_unchanged(self) -> None:
+        stored = {"port_matching_type": "SPECIFIC", "port": "53"}
+        update = {"port_matching_type": "ANY", "port": ""}
+        assert retire_stale_selectors(stored, update) == update
+
+    def test_non_dict_inputs_pass_through(self) -> None:
+        assert retire_stale_selectors(None, {"port_matching_type": "ANY"}) == {"port_matching_type": "ANY"}
+        assert retire_stale_selectors({"port": "53"}, "ANY") == "ANY"
+
+    def test_retired_update_validates_clean(self) -> None:
+        current = {
+            "destination": {"zone_id": "z", "matching_target": "ANY", "port_matching_type": "SPECIFIC", "port": "53"}
+        }
+        update = {"destination": retire_stale_selectors(current["destination"], {"port_matching_type": "ANY"})}
+        assert policy_update_targeting_error(current, update) is None
 
 
 class TestFirewallGroupFieldSets:

--- a/packages/unifi-core/tests/network/models/test_firewall_port_inversion.py
+++ b/packages/unifi-core/tests/network/models/test_firewall_port_inversion.py
@@ -1,0 +1,26 @@
+"""Controller-supported transitions for inverted port matches."""
+
+import pytest
+
+from unifi_core.network.models.firewall import (
+    normalize_policy_update,
+    prepare_policy_update,
+    validate_policy_selectors,
+)
+
+
+@pytest.mark.parametrize("mode,selector", [("SPECIFIC", {"port": "53"}), ("OBJECT", {"port_group_id": "ports"})])
+def test_disabling_port_matching_clears_inversion_and_retires_selector(mode, selector):
+    current = {
+        "destination": {"port_matching_type": mode, "match_opposite_ports": True, **selector},
+    }
+    update = prepare_policy_update(current, {"destination": {"port_matching_type": "ANY"}})
+    assert update["destination"]["match_opposite_ports"] is False
+    assert update["destination"][next(iter(selector))] is None
+    assert current["destination"]["match_opposite_ports"] is True
+
+
+@pytest.mark.parametrize("validate", [validate_policy_selectors, normalize_policy_update])
+def test_explicit_any_port_inversion_is_rejected(validate):
+    with pytest.raises(ValueError, match="match_opposite_ports must be false"):
+        validate({"destination": {"port_matching_type": "ANY", "match_opposite_ports": True}})

--- a/packages/unifi-core/tests/network/models/test_firewall_port_inversion.py
+++ b/packages/unifi-core/tests/network/models/test_firewall_port_inversion.py
@@ -1,7 +1,6 @@
 """Controller-supported transitions for inverted port matches."""
 
 import pytest
-
 from unifi_core.network.models.firewall import (
     normalize_policy_update,
     prepare_policy_update,

--- a/packages/unifi-core/tests/network/test_read_views.py
+++ b/packages/unifi-core/tests/network/test_read_views.py
@@ -472,6 +472,15 @@ def test_shape_firewall_policy_list_summary_hides_address_selectors_under_anothe
             True,
         ),
         ({"matching_target": "ANY", "port_matching_type": "ANY", "match_opposite_ports": True}, False),
+        (
+            {
+                "matching_target": "ANY",
+                "port_matching_type": "OBJECT",
+                "port_group_id": "ports",
+                "match_opposite_ports": True,
+            },
+            True,
+        ),
     ],
 )
 def test_shape_firewall_policy_list_summary_gates_the_inversion_flags(endpoint: dict, shown: bool) -> None:

--- a/packages/unifi-core/tests/network/test_read_views.py
+++ b/packages/unifi-core/tests/network/test_read_views.py
@@ -210,9 +210,103 @@ def test_shape_firewall_policy_list_applies_filters_and_shapes() -> None:
     full = shape_firewall_policy_list(policies[:1], site="default", summary=False)
 
     assert result["policies"][0]["id"] == "p1"
+    assert "protocol" not in result["policies"][0]
     assert result["returned_count"] == 1
     assert "source" in full["policies"][0]
     assert shape_firewall_policy_list([], site="default")["note"]
+
+
+def test_shape_firewall_policy_list_summary_surfaces_port_matching() -> None:
+    policies = [
+        {
+            "_id": "p-port",
+            "name": "Block external DNS",
+            "enabled": True,
+            "action": "BLOCK",
+            "index": 1,
+            "protocol": "tcp_udp",
+            "source": {
+                "zone_id": "z1",
+                "matching_target": "IP",
+                "matching_target_type": "OBJECT",
+                "ip_group_id": "resolvers",
+                "match_opposite_ips": True,
+                "port_matching_type": "ANY",
+                "match_opposite_ports": False,
+            },
+            "destination": {
+                "zone_id": "z2",
+                "matching_target": "ANY",
+                "port_matching_type": "SPECIFIC",
+                "port": "53,853",
+                "match_opposite_ports": False,
+            },
+        },
+        {
+            "_id": "p-plain",
+            "name": "Allow all",
+            "enabled": True,
+            "action": "ALLOW",
+            "index": 2,
+            "protocol": "all",
+            "source": {"zone_id": "z1", "matching_target": "ANY", "port_matching_type": "ANY"},
+            "destination": {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "ANY"},
+        },
+    ]
+
+    result = shape_firewall_policy_list(policies, site="default", summary=True)
+    port_entry, plain_entry = result["policies"]
+
+    assert port_entry["protocol"] == "tcp_udp"
+    assert port_entry["destination"] == {
+        "zone_id": "z2",
+        "matching_target": "ANY",
+        "port_matching_type": "SPECIFIC",
+        "port": "53,853",
+    }
+    assert port_entry["source"]["ip_group_id"] == "resolvers"
+    assert port_entry["source"]["match_opposite_ips"] is True
+    assert "match_opposite_ports" not in port_entry["source"]
+    assert "port_matching_type" not in port_entry["source"]
+
+    assert plain_entry["protocol"] == "all"
+    assert plain_entry["destination"] == {"zone_id": "z2", "matching_target": "ANY"}
+
+
+def test_shape_firewall_policy_list_summary_hides_selectors_the_controller_ignores() -> None:
+    """A residual port under port_matching_type ANY must not read as a port match."""
+    policies = [
+        {
+            "_id": "p-stale",
+            "name": "Stale",
+            "enabled": True,
+            "action": "ALLOW",
+            "index": 1,
+            "source": {"zone_id": "z1", "matching_target": "ANY", "port_matching_type": "ANY", "port": "53"},
+            "destination": {
+                "zone_id": "z2",
+                "matching_target": "ANY",
+                "port_matching_type": "SPECIFIC",
+                "port_group_id": "g1",
+            },
+        },
+        {
+            "_id": "p-no-enum",
+            "name": "No enum at all",
+            "enabled": True,
+            "action": "ALLOW",
+            "index": 2,
+            "source": {"zone_id": "z1", "matching_target": "ANY", "port": "53"},
+            "destination": {"zone_id": "z2", "matching_target": "ANY"},
+        },
+    ]
+
+    entry, no_enum = shape_firewall_policy_list(policies, site="default", summary=True)["policies"]
+
+    assert entry["source"] == {"zone_id": "z1", "matching_target": "ANY"}
+    assert entry["destination"] == {"zone_id": "z2", "matching_target": "ANY", "port_matching_type": "SPECIFIC"}
+    # Every observed controller emits port_matching_type; a port with no enum at all is treated as inert.
+    assert no_enum["source"] == {"zone_id": "z1", "matching_target": "ANY"}
 
 
 def test_shape_rogue_ap_list_applies_filters_pagination_and_shape() -> None:
@@ -270,3 +364,132 @@ def test_shape_device_list_last_seen_is_utc_aware() -> None:
     shaped = shape_device_list([device], site="default")
 
     assert shaped["devices"][0]["last_seen"] == "2023-11-14T22:13:20+00:00"
+
+
+def test_shape_firewall_policy_list_summary_shows_client_and_inversion_selectors() -> None:
+    policies = [
+        {
+            "_id": "p-client",
+            "name": "Admin workstations",
+            "enabled": True,
+            "action": "ALLOW",
+            "index": 1,
+            "source": {
+                "zone_id": "z1",
+                "matching_target": "CLIENT",
+                "client_macs": ["aa:bb:cc:dd:ee:ff"],
+            },
+            "destination": {"zone_id": "z2", "matching_target": "ANY", "client_macs": ["aa:bb:cc:dd:ee:ff"]},
+        }
+    ]
+
+    entry = shape_firewall_policy_list(policies, site="default", summary=True)["policies"][0]
+
+    assert entry["source"]["client_macs"] == ["aa:bb:cc:dd:ee:ff"]
+    assert "client_macs" not in entry["destination"]
+
+
+def test_shape_firewall_policy_list_summary_keeps_selectors_under_an_unknown_target() -> None:
+    """A target this project has not seen may still be enforcing its selector; hiding it
+    would report a narrow rule as if it matched the whole zone."""
+    policies = [
+        {
+            "_id": "p-future",
+            "name": "Future target",
+            "enabled": True,
+            "action": "BLOCK",
+            "index": 1,
+            "source": {"zone_id": "z1", "matching_target": "CLIENT_GROUP", "client_macs": ["aa:bb:cc:dd:ee:ff"]},
+            "destination": {
+                "zone_id": "z2",
+                "matching_target": "ANY",
+                "port_matching_type": "PORT_GROUP",
+                "port_group_id": "g1",
+            },
+        }
+    ]
+
+    entry = shape_firewall_policy_list(policies, site="default", summary=True)["policies"][0]
+
+    assert entry["source"]["client_macs"] == ["aa:bb:cc:dd:ee:ff"]
+    assert entry["destination"]["port_group_id"] == "g1"
+
+
+def test_summary_suppression_covers_exactly_the_write_side_selectors() -> None:
+    """A canary on the write-side table, not a test of the shaper: read_views imports
+    SELECTOR_ACTIVATORS, so adding a row there changes every list response. Fail here
+    and decide deliberately what the summary should do with the new selector."""
+    from unifi_core.network.models.firewall import SELECTOR_ACTIVATORS
+
+    assert {selector for selector, _, _ in SELECTOR_ACTIVATORS} == {"client_macs", "port", "port_group_id"}
+
+
+def test_shape_firewall_policy_list_summary_hides_address_selectors_under_another_target() -> None:
+    """Showing `ips` beside `matching_target: ANY` reports a zone-wide rule as
+    address-scoped — the reading this summary must never produce."""
+    policies = [
+        {
+            "_id": "p-stale-ips",
+            "name": "Zone wide",
+            "enabled": True,
+            "action": "ALLOW",
+            "index": 1,
+            "source": {
+                "zone_id": "zA",
+                "matching_target": "ANY",
+                "matching_target_type": "SPECIFIC",
+                "ips": ["10.0.0.5"],
+                "ip_group_id": "grp-admins",
+                "network_ids": ["net-mgmt"],
+                "match_opposite_ips": True,
+                "port_matching_type": "ANY",
+                "port": "22",
+            },
+            "destination": {
+                "zone_id": "zB",
+                "matching_target": "NETWORK",
+                "matching_target_type": "OBJECT",
+                "network_ids": ["net-iot"],
+                "ips": ["10.0.0.9"],
+            },
+        }
+    ]
+
+    entry = shape_firewall_policy_list(policies, site="default", summary=True)["policies"][0]
+
+    assert entry["source"] == {"zone_id": "zA", "matching_target": "ANY", "matching_target_type": "SPECIFIC"}
+    assert entry["destination"]["network_ids"] == ["net-iot"]
+    assert "ips" not in entry["destination"]
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "shown"),
+    [
+        ({"matching_target": "NETWORK", "network_ids": ["n1"], "match_opposite_networks": True}, True),
+        ({"matching_target": "ANY", "match_opposite_networks": True}, False),
+        (
+            {"matching_target": "ANY", "port_matching_type": "SPECIFIC", "port": "53", "match_opposite_ports": True},
+            True,
+        ),
+        ({"matching_target": "ANY", "port_matching_type": "ANY", "match_opposite_ports": True}, False),
+    ],
+)
+def test_shape_firewall_policy_list_summary_gates_the_inversion_flags(endpoint: dict, shown: bool) -> None:
+    """An inversion flag reverses a rule's meaning. Showing one on a rule that does not
+    invert, or hiding one that does, is the same error in opposite directions."""
+    flag = "match_opposite_networks" if "match_opposite_networks" in endpoint else "match_opposite_ports"
+    policies = [
+        {
+            "_id": "p1",
+            "name": "Inversion",
+            "enabled": True,
+            "action": "BLOCK",
+            "index": 1,
+            "source": {"zone_id": "z1", "matching_target": "ANY"},
+            "destination": {"zone_id": "z2", **endpoint},
+        }
+    ]
+
+    entry = shape_firewall_policy_list(policies, site="default", summary=True)["policies"][0]
+
+    assert (flag in entry["destination"]) is shown

--- a/plugins/unifi-network/skills/firewall-auditor/references/security-benchmarks.md
+++ b/plugins/unifi-network/skills/firewall-auditor/references/security-benchmarks.md
@@ -154,7 +154,7 @@ unifi_create_firewall_policy:
     network_ids: [<management network ID>]
 ```
 
-**MAC-based admin allow list:** If the admin sources are identified by client MAC rather than IP, V2 firewall policies cannot match by client MAC — use `unifi_create_acl_rule` instead. The example below restricts management-VLAN access to a specific set of admin workstations by MAC:
+**MAC-based admin allow list:** If the admin sources are identified by client MAC rather than IP, a V2 firewall policy can match them directly with `source.matching_target: CLIENT` and `source.client_macs: [...]` (see the firewall-manager schema reference). Use `unifi_create_acl_rule` instead when the enforcement must happen on the switch (L2, without passing through the gateway). The example below restricts management-VLAN access to a specific set of admin workstations by MAC at the switch:
 
 ```yaml
 # Security intent: only the listed admin MACs may originate traffic on the management VLAN.
@@ -267,7 +267,7 @@ unifi_create_firewall_policy:
 
 **Severity:** warning
 
-**How to fix:** This benchmark cannot be fully enforced through the firewall surface alone. V2 zone-based firewall policies do not match on port, so a literal "block UDP/TCP 53 except to approved resolvers" rule isn't expressible at this layer. The benchmark therefore splits into a **partial firewall fix** (what MCP can do today) and a **manual UniFi UI step** (the rest):
+**How to fix:** V2 zone-based policies *can* match on port (`port_matching_type` `SPECIFIC` with a `port` string, or `OBJECT` with a `port_group_id`), so a "block UDP/TCP 53 except to approved resolvers" rule is expressible at this layer on Network 9.0+ with a UniFi gateway. A full DNS-egress recipe built on that is **not yet published here**: it has not been verified against live traffic on an isolated client, so this benchmark still splits into a **partial firewall fix** (below) and a **manual UniFi UI step** (the rest):
 
 **Part 1 — partial firewall fix (programmatic):** Allow client traffic to reach approved resolver IPs externally. This handles the legitimate-DNS path but does not block port-53 traffic to other destinations.
 

--- a/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
+++ b/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
@@ -95,6 +95,8 @@ Set `protocol` to `tcp`, `udp` or `tcp_udp` on a port-matching policy. The contr
 
 `match_opposite_ports: true` inverts the match (every port except the listed ones); `match_opposite_ips: true` does the same for `ips` / `ip_group_id`.
 
+Port inversion also applies to `OBJECT` port-group matches and is included in list summaries. Switching to `port_matching_type: ANY` clears a stored port-inversion flag automatically; explicitly requesting `ANY` together with `match_opposite_ports: true` is rejected because the controller does not support that combination.
+
 Three selectors are only accepted together with the value that activates them: `port` needs `port_matching_type: SPECIFIC`, `port_group_id` needs `OBJECT`, and `client_macs` needs `matching_target: CLIENT`. The controller would accept and silently ignore any other pairing, so the tools reject those three and retire them on update. `ips`, `ip_group_id` and `network_ids` follow the same contract on the controller, but the tools only check that they are present on create — a stale one left under a different `matching_target` is not yet rejected or retired. To turn port matching off on an existing policy, update with `{"destination": {"port_matching_type": "ANY"}}`; the tool retires the stored `port` for you. The same applies when switching between `SPECIFIC` and `OBJECT`, or moving a side off `CLIENT`.
 
 ### Example — any-in-zone to any-in-zone

--- a/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
+++ b/plugins/unifi-network/skills/firewall-manager/references/firewall-schema.md
@@ -42,17 +42,60 @@ Both `source` and `destination` are objects with the same shape. The required fi
 | Field | Type | Required For |
 |-------|------|--------------|
 | `zone_id` | string | always — controller zone ID from `unifi_list_firewall_zones` |
-| `matching_target` | enum | always — `ANY`, `IP`, `NETWORK`, or `OBJECT` |
+| `matching_target` | enum | always — `ANY`, `IP`, `NETWORK`, or `CLIENT` (see below) |
 | `matching_target_type` | enum | required when `matching_target` is `IP` or `NETWORK` — `SPECIFIC` (IPs) or `OBJECT` (group/network IDs) |
-| `ips` | array of strings | required when `matching_target_type="SPECIFIC"` — list of IPs/CIDRs |
+| `ips` | array of strings | required when `matching_target="IP"` and `matching_target_type="SPECIFIC"` — list of IPs/CIDRs |
+| `ip_group_id` | string | required when `matching_target="IP"` and `matching_target_type="OBJECT"` — address group from `unifi_list_firewall_groups` |
 | `network_ids` | array of strings | required when `matching_target="NETWORK"` and `matching_target_type="OBJECT"` |
+| `client_macs` | array of strings | required when `matching_target="CLIENT"` — client MAC addresses |
+| `match_opposite_ips` | boolean | optional — invert the IP match (everything **except** `ips` / `ip_group_id`) |
+| `match_opposite_networks` | boolean | optional — invert the network match |
+| `port_matching_type` | enum | optional — `ANY` (default), `SPECIFIC`, or `OBJECT`; see Port Matching |
+| `port` | string | required when `port_matching_type="SPECIFIC"` — `"53"`, `"53,853"`, `"1000-2000"` |
+| `port_group_id` | string | required when `port_matching_type="OBJECT"` — port group from `unifi_list_firewall_groups` |
+| `match_opposite_ports` | boolean | optional — invert the port match |
 
-### `matching_target` Enum (live-probe-confirmed)
+### `matching_target` Enum
+
+Values observed on Network 10.6 controllers (the tools validate these four and pass any other value through unchanged):
 
 - **`ANY`** — match all traffic in the zone. No additional selectors needed.
-- **`IP`** — match specific IPs/CIDRs. Pair with `matching_target_type: "SPECIFIC"` and `ips: [...]`.
+- **`IP`** — match specific IPs/CIDRs. Pair with `matching_target_type: "SPECIFIC"` and `ips: [...]`, or `matching_target_type: "OBJECT"` and `ip_group_id`.
 - **`NETWORK`** — match by network membership. Pair with `matching_target_type: "OBJECT"` and `network_ids: [...]`.
-- **`OBJECT`** — match an IP-group object. Pair with `matching_target_type: "OBJECT"` and the relevant object ID.
+- **`CLIENT`** — match specific clients by MAC. Pair with `client_macs: [...]`.
+
+The Zone-Based Firewall UI also offers App, Domain ("Web") and Region targets. Their V2 field names are not documented here yet; `unifi_list_firewall_policies` with `summary: false` shows the exact shape of any such policy on your controller, and `unifi_update_firewall_policy` passes those fields through.
+
+### Port Matching
+
+Either side can match on destination or source ports. This is how a policy expresses "DNS", "SSH" or "web" instead of "everything between these zones".
+
+| `port_matching_type` | Pair with | Meaning |
+|---|---|---|
+| `ANY` (default) | nothing | all ports |
+| `SPECIFIC` | `port: "53,853"` | comma-separated ports; `low-high` ranges accepted |
+| `OBJECT` | `port_group_id` | a reusable port group from `unifi_list_firewall_groups` |
+
+Set `protocol` to `tcp`, `udp` or `tcp_udp` on a port-matching policy. The controller also stores ports under `protocol: "all"` and existing user policies use that combination; the auditor treats both as port rules.
+
+```json
+{
+  "name": "Block external DNS",
+  "action": "BLOCK",
+  "protocol": "tcp_udp",
+  "source":      { "zone_id": "<internal_zone_id>", "matching_target": "ANY" },
+  "destination": {
+    "zone_id": "<external_zone_id>",
+    "matching_target": "ANY",
+    "port_matching_type": "SPECIFIC",
+    "port": "53,853"
+  }
+}
+```
+
+`match_opposite_ports: true` inverts the match (every port except the listed ones); `match_opposite_ips: true` does the same for `ips` / `ip_group_id`.
+
+Three selectors are only accepted together with the value that activates them: `port` needs `port_matching_type: SPECIFIC`, `port_group_id` needs `OBJECT`, and `client_macs` needs `matching_target: CLIENT`. The controller would accept and silently ignore any other pairing, so the tools reject those three and retire them on update. `ips`, `ip_group_id` and `network_ids` follow the same contract on the controller, but the tools only check that they are present on create — a stale one left under a different `matching_target` is not yet rejected or retired. To turn port matching off on an existing policy, update with `{"destination": {"port_matching_type": "ANY"}}`; the tool retires the stored `port` for you. The same applies when switching between `SPECIFIC` and `OBJECT`, or moving a side off `CLIENT`.
 
 ### Example — any-in-zone to any-in-zone
 
@@ -105,6 +148,7 @@ Always discover IDs at runtime. Never hardcode.
 | `all` | Match all protocols (default). |
 | `tcp` | TCP only. |
 | `udp` | UDP only. |
+| `tcp_udp` | TCP and UDP (the usual choice for port-matching policies). |
 | `icmp` | ICMP only. |
 
 ---
@@ -239,9 +283,9 @@ accepted by `/proxy/network/integration/v1/sites/.../firewall/policies/ordering`
 
 ---
 
-## MAC-Based Targeting (Important Caveat)
+## Client (MAC) Targeting
 
-The V2 zone-based firewall does **not** accept client MAC addresses as a matching target. Source/destination is always zone- + IP/network/object-based. To enforce per-client (MAC-level) blocking, use `unifi_create_acl_rule` with `source_macs=[...]` instead of the firewall surface.
+`matching_target: "CLIENT"` with `client_macs: [...]` matches specific clients on either side of a policy. MACs are lower-cased before they reach the controller. For switch-level (L2) enforcement that does not pass through the gateway, `unifi_create_acl_rule` with `source_macs=[...]` remains the right tool.
 
 ---
 


### PR DESCRIPTION
Zone-based firewall policies can target clients and specific ports or port groups, but the tools lacked consistent validation and read-back of those selectors. This change validates activating enums and required selectors, canonicalizes client MACs, and includes active targeting fields and inversion flags in policy summaries.

Partial updates share Core preparation across MCP and API execution: merge against stored state, retire obsolete selectors, preserve untouched fields, and reject invalid targeting before PUT. MCP previews use the same preparation. API previews reject contradictions visible in the supplied update; validation requiring stored policy state occurs at execution. Policy ordering remains a separate API family.

Independent live testing found two additional port-inversion defects and this revision fixes both: summaries retain inversion for OBJECT port groups, and switching to ANY automatically clears stored port inversion. Explicit ANY plus inversion is rejected locally, matching the controller's observed rejection.

The unproven DNS deployment recipes are excluded. The remaining docs describe selector syntax and read-back behavior; this PR does not claim proof of end-to-end DNS enforcement. It addresses the firewall selector portion of #216, not the full issue.

Validation:

- Focused Core selector/read-view tests, including inversion transition regressions.
- Independently installed Core and Network wheels exercised a disposable disabled policy and port group against the controller: create and read CLIENT/SPECIFIC selectors, transition to OBJECT with inversion, preserve the untouched source, retire client/port selectors by switching to ANY, and delete both test resources. All mutations followed preview then confirmation. Existing policies matched the initial full read-back after cleanup.
- The original inversion failure was reproduced, corrected, and the same lifecycle passed afterward. This proves storage/transition behavior; it does not test packet enforcement.
- Full `make pre-commit` and all 14 GitHub checks passed on 2f57eef9d2b0be360298b695ed1c206ecd2a1cd7.

Release Core first, then raise Network/API Core floors before app publication. The installed smoke used a locally built Core wheel, not an already published Core version.
