### PR TITLE
fix(network): start the event websocket listener and report its state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,13 @@ UNIFI_MCP_LOG_LEVEL=INFO
 # ACCESS_EVENT_BUFFER_TTL=300
 # ACCESS_WEBSOCKET_ENABLED=true
 
+# ---------------------------------------------------------------------------
+# Network event streaming (feeds unifi_recent_events)
+# ---------------------------------------------------------------------------
+# UNIFI_NETWORK_EVENT_BUFFER_SIZE=100
+# UNIFI_NETWORK_EVENT_BUFFER_TTL=300
+# UNIFI_NETWORK_WEBSOCKET_ENABLED=true
+
 # ── Cloud relay (optional) ───────────────────────
 # UNIFI_RELAY_URL=https://your-worker.workers.dev
 # UNIFI_RELAY_TOKEN=your-relay-token

--- a/apps/access/src/unifi_access_mcp/main.py
+++ b/apps/access/src/unifi_access_mcp/main.py
@@ -58,72 +58,75 @@ async def main_async():
     check_unknown_policy_env_vars("access", logger, policy_gates(), ACCESS_CATEGORY_MAP)
     assert_credentials_configured(config, plugin_name="unifi-access", env_prefix="ACCESS", logger=logger)
 
-    # Initialize the global Access connection
-    logger.info("Initializing global Access connection from main_async...")
-    if not await connection_manager.initialize():
-        logger.error("Failed to connect to UniFi Access. Tool functionality may be impaired.")
-    else:
-        logger.info("Global Access connection initialized successfully from main_async.")
-
-        # Start the websocket event listener if enabled and connection succeeded
-        ws_enabled_raw = config.access.events.get("websocket_enabled", True) if hasattr(config, "access") else True
-        ws_enabled = parse_config_bool(ws_enabled_raw)
-        if ws_enabled:
-            try:
-                event_manager.set_server(server)
-                # start_listening needs an API client: the Access websocket is
-                # key-authenticated, and a proxy-only session cannot open it.
-                # It logs that condition itself and returns without raising, so
-                # a proxy-only deployment keeps working with REST queries and
-                # an empty recent-events buffer.
-                await event_manager.start_listening()
-            except Exception as ws_exc:
-                logger.error(
-                    "Failed to start event websocket listener: %s. "
-                    "Real-time events will be unavailable; REST queries still work.",
-                    ws_exc,
-                    exc_info=True,
-                )
-        else:
-            logger.info("Access event websocket disabled via config.")
-
-    # ---- Register MCP resources ----
     try:
-        import unifi_access_mcp.resources.events  # noqa: F401
+        # Initialize the global Access connection
+        logger.info("Initializing global Access connection from main_async...")
+        if not await connection_manager.initialize():
+            logger.error("Failed to connect to UniFi Access. Tool functionality may be impaired.")
+        else:
+            logger.info("Global Access connection initialized successfully from main_async.")
 
-        logger.info("MCP resources registered (events).")
-    except Exception as res_exc:
-        logger.error("Failed to register MCP resources: %s", res_exc, exc_info=True)
+            # Start the websocket event listener if enabled and connection succeeded
+            ws_enabled_raw = config.access.events.get("websocket_enabled", True) if hasattr(config, "access") else True
+            ws_enabled = parse_config_bool(ws_enabled_raw)
+            if ws_enabled:
+                try:
+                    event_manager.set_server(server)
+                    # start_listening needs an API client: the Access websocket is
+                    # key-authenticated, and a proxy-only session cannot open it.
+                    # It logs that condition itself and returns without raising, so
+                    # a proxy-only deployment keeps working with REST queries and
+                    # an empty recent-events buffer.
+                    await event_manager.start_listening()
+                except Exception as ws_exc:
+                    logger.error(
+                        "Failed to start event websocket listener: %s. "
+                        "Real-time events will be unavailable; REST queries still work.",
+                        ws_exc,
+                        exc_info=True,
+                    )
+            else:
+                logger.info("Access event websocket disabled via config.")
 
-    # ---- Register tools ----
-    await register_tools_for_mode(
-        mode=UNIFI_TOOL_REGISTRATION_MODE,
-        server=server,
-        original_tool_decorator=_original_tool_decorator,
-        tool_index_handler=tool_index_handler,
-        start_async_tool=start_async_tool,
-        get_job_status=get_job_status,
-        register_tool=register_tool,
-        tool_module_map=TOOL_MODULE_MAP,
-        setup_lazy_loading=setup_lazy_loading,
-        base_package="unifi_access_mcp.tools",
-        config=config,
-        logger=logger,
-        support_bundle_handler=support_bundle_service.generate,
-        prefix="access",
-        server_label="UniFi Access",
-    )
+        # ---- Register MCP resources ----
+        try:
+            import unifi_access_mcp.resources.events  # noqa: F401
 
-    # ---- Start transports ----
-    http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3002, logger=logger)
-    await run_transports(
-        server=server,
-        http_enabled=http_enabled,
-        host=host,
-        port=port,
-        http_transport=http_transport,
-        logger=logger,
-    )
+            logger.info("MCP resources registered (events).")
+        except Exception as res_exc:
+            logger.error("Failed to register MCP resources: %s", res_exc, exc_info=True)
+
+        # ---- Register tools ----
+        await register_tools_for_mode(
+            mode=UNIFI_TOOL_REGISTRATION_MODE,
+            server=server,
+            original_tool_decorator=_original_tool_decorator,
+            tool_index_handler=tool_index_handler,
+            start_async_tool=start_async_tool,
+            get_job_status=get_job_status,
+            register_tool=register_tool,
+            tool_module_map=TOOL_MODULE_MAP,
+            setup_lazy_loading=setup_lazy_loading,
+            base_package="unifi_access_mcp.tools",
+            config=config,
+            logger=logger,
+            support_bundle_handler=support_bundle_service.generate,
+            prefix="access",
+            server_label="UniFi Access",
+        )
+
+        # ---- Start transports ----
+        http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3002, logger=logger)
+        await run_transports(
+            server=server,
+            http_enabled=http_enabled,
+            host=host,
+            port=port,
+            http_transport=http_transport,
+            logger=logger,
+        )
+    finally:
+        await connection_manager.close()
 
 
 def main():

--- a/apps/access/tests/unit/test_server_cleanup.py
+++ b/apps/access/tests/unit/test_server_cleanup.py
@@ -1,0 +1,33 @@
+"""Server teardown releases the controller after normal and failed startup."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [None, "initialize", "registration", "transport"])
+async def test_server_always_closes_its_connection(monkeypatch, failure):
+    from unifi_access_mcp import main
+
+    initialize = AsyncMock(return_value=False)
+    registration = AsyncMock()
+    transport = AsyncMock()
+    close = AsyncMock()
+    stages = {"initialize": initialize, "registration": registration, "transport": transport}
+    if failure:
+        stages[failure].side_effect = RuntimeError("startup failure")
+    monkeypatch.setattr(main.connection_manager, "initialize", initialize)
+    monkeypatch.setattr(main.connection_manager, "close", close)
+    monkeypatch.setattr("unifi_mcp_shared.bootstrap.assert_credentials_configured", lambda *a, **kw: None)
+    monkeypatch.setattr("unifi_mcp_shared.tool_registration.register_tools_for_mode", registration)
+    monkeypatch.setattr("unifi_mcp_shared.transport.run_transports", transport)
+    monkeypatch.setattr(
+        "unifi_mcp_shared.transport.resolve_http_config", lambda *a, **kw: (False, "http", "127.0.0.1", 3000)
+    )
+    if failure:
+        with pytest.raises(RuntimeError, match="startup failure"):
+            await main.main_async()
+    else:
+        await main.main_async()
+    close.assert_awaited_once()

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -279,38 +279,14 @@ def create_app(config: ApiConfig) -> FastAPI:
             for product in [p for p in controller.product_kinds.split(",") if p]:
                 try:
                     async with sm() as session:
-                        mgr = await app.state.manager_factory.get_domain_manager(
+                        await app.state.manager_factory.get_domain_manager(
                             session,
                             controller.id,
                             product,
                             "event_manager",
                         )
-                    if hasattr(mgr, "start_listening"):
-                        # Background-launch: some product listeners block until
-                        # the socket closes, and the subscription is best-effort
-                        # warm-up for SSE consumers; failing it must not delay
-                        # HTTP readiness. A returning start_listening only means
-                        # the listener was started, not that it attached.
-                        async def _bg_start(c_id: str, p: str, m=mgr) -> None:
-                            try:
-                                await m.start_listening()
-                                _streams_log.info(
-                                    "[streams] start_listening started for %s/%s",
-                                    c_id,
-                                    p,
-                                )
-                            except Exception:
-                                _streams_log.warning(
-                                    "[streams] start_listening failed for %s/%s",
-                                    c_id,
-                                    p,
-                                    exc_info=True,
-                                )
-
-                        asyncio.create_task(
-                            _bg_start(controller.id, product),
-                            name=f"start_listening:{controller.id}/{product}",
-                        )
+                    # The factory owns listener startup and shutdown, including
+                    # managers created later after credential rotation.
                 except Exception:
                     _streams_log.warning(
                         "[streams] start_listening setup failed for %s/%s",
@@ -460,8 +436,10 @@ def create_app(config: ApiConfig) -> FastAPI:
 
     cipher = ColumnCipher(derive_key(db_key))
     app.state.cipher = cipher
-    app.state.manager_factory = ManagerFactory(app.state.sessionmaker, cipher)
     app.state.subscriber_pool = SubscriberPool()
+    app.state.manager_factory = ManagerFactory(
+        app.state.sessionmaker, cipher, on_manager_discard=app.state.subscriber_pool.disconnect_manager
+    )
     app.state.argon_cache = ArgonVerifyCache()
     app.state.capability_cache = CapabilityCache()
     app.state.settings_service = SettingsService(app.state.sessionmaker)

--- a/apps/api/src/unifi_api/server.py
+++ b/apps/api/src/unifi_api/server.py
@@ -286,16 +286,16 @@ def create_app(config: ApiConfig) -> FastAPI:
                             "event_manager",
                         )
                     if hasattr(mgr, "start_listening"):
-                        # Background-launch: aiounifi's start_websocket awaits
-                        # its own message loop, so awaiting here blocks the
-                        # whole lifespan. The WS subscription is best-effort
-                        # warm-up for SSE consumers; failing it must not
-                        # delay HTTP readiness.
+                        # Background-launch: some product listeners block until
+                        # the socket closes, and the subscription is best-effort
+                        # warm-up for SSE consumers; failing it must not delay
+                        # HTTP readiness. A returning start_listening only means
+                        # the listener was started, not that it attached.
                         async def _bg_start(c_id: str, p: str, m=mgr) -> None:
                             try:
                                 await m.start_listening()
                                 _streams_log.info(
-                                    "[streams] start_listening ok for %s/%s",
+                                    "[streams] start_listening started for %s/%s",
                                     c_id,
                                     p,
                                 )

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -20,6 +20,7 @@ their cache identity remains controller + product.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import time
@@ -204,6 +205,25 @@ class ManagerFactory:
         if product == "network":
             return site or "default"
         return None
+
+    @staticmethod
+    async def _stop_domain_managers(managers: list[Any]) -> None:
+        """Stop any dropped domain manager that owns a background task.
+
+        The Network EventManager runs a reconnecting websocket task; left
+        running after its connection manager is discarded it would keep
+        logging in with the old credentials.
+        """
+        for manager in managers:
+            stop = getattr(manager, "stop_listening", None)
+            if stop is None:
+                continue
+            try:
+                result = stop()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                logger.warning("Failed to stop %s listener: %s", type(manager).__name__, exc)
 
     @staticmethod
     async def _close_connection_manager(cm: Any) -> None:
@@ -507,9 +527,9 @@ class ManagerFactory:
             # them synchronously with the pops (same invariant as
             # invalidate_controller). Survivors rebuild from cached healthy
             # connections on next use.
-            for k in [k for k in self._domain_cache if k[0] == controller_id]:
-                self._domain_cache.pop(k, None)
+            dropped = [self._domain_cache.pop(k) for k in [k for k in self._domain_cache if k[0] == controller_id]]
             removed = [self._connection_cache.pop(k) for k in healable]
+            await self._stop_domain_managers(dropped)
             logger.info(
                 "Probe succeeded; dropping %d auth-blocked cached connection(s) for controller %s",
                 len(removed),
@@ -529,11 +549,11 @@ class ManagerFactory:
             # state: a domain-cache miss followed by a connection-cache hit on
             # an entry still awaiting close would rebuild a domain manager
             # around a disposed session and its pre-rotation credentials.
-            for k in [k for k in self._domain_cache if k[0] == controller_id]:
-                self._domain_cache.pop(k, None)
+            dropped = [self._domain_cache.pop(k) for k in [k for k in self._domain_cache if k[0] == controller_id]]
             removed = [
                 self._connection_cache.pop(k) for k in [k for k in self._connection_cache if k[0] == controller_id]
             ]
+            await self._stop_domain_managers(dropped)
             for cm in removed:
                 try:
                     await self._close_connection_manager(cm)

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -210,6 +210,12 @@ class ManagerFactory:
             return site or "default"
         return None
 
+    @staticmethod
+    def _connection_key_for(domain_key: tuple[str, str, str, str | None]) -> tuple[str, str, str | None]:
+        """The connection-cache key the domain manager at ``domain_key`` was built on."""
+        controller_id, product, _attr_name, site_scope = domain_key
+        return (controller_id, product, site_scope)
+
     async def _stop_domain_managers(self, managers: list[Any]) -> None:
         """Stop any dropped domain manager that owns a background task.
 
@@ -546,11 +552,15 @@ class ManagerFactory:
             ]
             if not healable:
                 return
-            # Domain managers may be bound to the blocked connections; sweep
-            # them synchronously with the pops (same invariant as
-            # invalidate_controller). Survivors rebuild from cached healthy
-            # connections on next use.
-            dropped = [self._domain_cache.pop(k) for k in [k for k in self._domain_cache if k[0] == controller_id]]
+            # A controller id covers every product and site on one console, so
+            # sweeping by it alone would stop a healthy Protect listener to heal a
+            # blocked Network one. Sweep synchronously with the pops, same
+            # invariant as invalidate_controller.
+            healed = set(healable)
+            dropped = [
+                self._domain_cache.pop(k)
+                for k in [k for k in self._domain_cache if self._connection_key_for(k) in healed]
+            ]
             removed = [self._connection_cache.pop(k) for k in healable]
             await self._stop_domain_managers(dropped)
             logger.info(

--- a/apps/api/src/unifi_api/services/managers.py
+++ b/apps/api/src/unifi_api/services/managers.py
@@ -185,6 +185,8 @@ class ManagerFactory:
         self,
         sessionmaker: async_sessionmaker[AsyncSession],
         cipher: ColumnCipher,
+        *,
+        on_manager_discard: Callable[[Any], None] | None = None,
     ) -> None:
         self._sm = sessionmaker
         self._cipher = cipher
@@ -192,6 +194,8 @@ class ManagerFactory:
         self._domain_cache: dict[tuple[str, str, str, str | None], Any] = {}
         self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._builder_cache: dict[str, dict[str, Callable[[Any], Any]]] = {}
+        self._listener_tasks: dict[int, asyncio.Task[None]] = {}
+        self._on_manager_discard = on_manager_discard
 
     @staticmethod
     def _site_scope(product: str, site: str | None) -> str | None:
@@ -206,8 +210,7 @@ class ManagerFactory:
             return site or "default"
         return None
 
-    @staticmethod
-    async def _stop_domain_managers(managers: list[Any]) -> None:
+    async def _stop_domain_managers(self, managers: list[Any]) -> None:
         """Stop any dropped domain manager that owns a background task.
 
         The Network EventManager runs a reconnecting websocket task; left
@@ -215,6 +218,12 @@ class ManagerFactory:
         logging in with the old credentials.
         """
         for manager in managers:
+            if self._on_manager_discard is not None:
+                self._on_manager_discard(manager)
+            task = self._listener_tasks.pop(id(manager), None)
+            if task is not None and not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
             stop = getattr(manager, "stop_listening", None)
             if stop is None:
                 continue
@@ -223,7 +232,13 @@ class ManagerFactory:
                 if inspect.isawaitable(result):
                     await result
             except Exception as exc:
-                logger.warning("Failed to stop %s listener: %s", type(manager).__name__, exc)
+                logger.warning("Failed to stop %s listener: %s", type(manager).__name__, type(exc).__name__)
+
+    async def _start_listener(self, manager: Any) -> None:
+        try:
+            await manager.start_listening()
+        except Exception as exc:
+            logger.warning("Failed to start event listener: %s", type(exc).__name__)
 
     @staticmethod
     async def _close_connection_manager(cm: Any) -> None:
@@ -398,9 +413,8 @@ class ManagerFactory:
         site scope. Does NOT take the per-controller lock here —
         get_connection_manager already serializes the slow path
         (initialize()), and the rest of this function is a synchronous builder
-        call where a brief race on first-use produces last-writer-wins on the
-        cache, which is harmless because builders are pure and share the
-        cached connection manager for the same site.
+        call. Recheck the domain cache after awaiting the connection so concurrent
+        first-use callers share one manager and one listener startup task.
 
         Acquiring the lock here would deadlock — it's non-reentrant and
         get_connection_manager acquires the same lock.
@@ -420,8 +434,17 @@ class ManagerFactory:
             product,
             site=site_scope,
         )
+        # Another waiter may have populated the domain cache while connection
+        # initialization yielded. Reuse it before creating a background owner.
+        cached = self._domain_cache.get(key)
+        if cached is not None:
+            return cached
         instance = builder(cm)
         self._domain_cache[key] = instance
+        if attr_name == "event_manager" and callable(getattr(instance, "start_listening", None)):
+            self._listener_tasks[id(instance)] = asyncio.create_task(
+                self._start_listener(instance), name="api-event-listener"
+            )
         return instance
 
     async def probe_controller(self, controller_id: str) -> dict:

--- a/apps/api/src/unifi_api/services/stream_generator.py
+++ b/apps/api/src/unifi_api/services/stream_generator.py
@@ -72,6 +72,8 @@ async def sse_event_stream(
         while True:
             try:
                 evt = await asyncio.wait_for(sub.queue.get(), timeout=keepalive_interval)
+                if evt is None:
+                    return
                 yield format_sse_frame(
                     event=evt,
                     product=product,

--- a/apps/api/src/unifi_api/services/streams.py
+++ b/apps/api/src/unifi_api/services/streams.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import weakref
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -18,7 +19,7 @@ logger = logging.getLogger("unifi-api.streams")
 
 @dataclass
 class StreamSubscriber:
-    queue: asyncio.Queue[dict] = field(default_factory=lambda: asyncio.Queue(maxsize=256))
+    queue: asyncio.Queue[dict | None] = field(default_factory=lambda: asyncio.Queue(maxsize=256))
     filter_fn: Callable[[dict], bool] | None = None
 
 
@@ -28,16 +29,45 @@ class SubscriberPool:
     def __init__(self, queue_maxsize: int = 256) -> None:
         self._pools: dict[tuple[str, str], list[StreamSubscriber]] = {}
         self._unsubs: dict[tuple[str, str], Callable[[], None]] = {}
+        self._managers: dict[tuple[str, str], Any] = {}
+        self._discarded: weakref.WeakSet[Any] = weakref.WeakSet()
         self._queue_maxsize = queue_maxsize
 
     async def attach(self, controller_id: str, product: str, manager: Any) -> StreamSubscriber:
         key = (controller_id, product)
         sub = StreamSubscriber(queue=asyncio.Queue(maxsize=self._queue_maxsize))
+        if manager in self._discarded:
+            sub.queue.put_nowait(None)
+            return sub
+        previous = self._managers.get(key)
+        if previous is not None and previous is not manager:
+            self.disconnect_manager(previous)
         self._pools.setdefault(key, []).append(sub)
         if key not in self._unsubs:
-            self._unsubs[key] = manager.add_subscriber(lambda evt, k=key: self._broadcast(k, evt))
-            logger.debug(f"[streams] attached manager callback for {key}")
+            self._unsubs[key] = manager.add_subscriber(
+                lambda evt, k=key, m=manager: self._broadcast(k, evt) if self._managers.get(k) is m else None
+            )
+            self._managers[key] = manager
+            logger.debug("[streams] attached manager callback for %s", key)
         return sub
+
+    def disconnect_manager(self, manager: Any) -> None:
+        """End streams tied to a discarded manager so clients can reconnect."""
+        self._discarded.add(manager)
+        for key in [key for key, value in self._managers.items() if value is manager]:
+            self._managers.pop(key)
+            unsub = self._unsubs.pop(key, None)
+            if unsub is not None:
+                try:
+                    unsub()
+                except Exception as exc:
+                    logger.debug("[streams] unsubscribe failed: %s", type(exc).__name__)
+            for sub in self._pools.pop(key, []):
+                # Discard buffered data from the old credential generation and
+                # make room for the termination signal even for a slow client.
+                while not sub.queue.empty():
+                    sub.queue.get_nowait()
+                sub.queue.put_nowait(None)
 
     async def detach(self, controller_id: str, product: str, sub: StreamSubscriber) -> None:
         key = (controller_id, product)
@@ -51,9 +81,10 @@ class SubscriberPool:
                 try:
                     unsub()
                 except Exception:
-                    logger.debug(f"[streams] error unsubscribing {key}", exc_info=True)
+                    logger.debug("[streams] error unsubscribing %s", key)
             self._pools.pop(key, None)
-            logger.debug(f"[streams] detached last subscriber for {key}")
+            self._managers.pop(key, None)
+            logger.debug("[streams] detached last subscriber for %s", key)
 
     def _broadcast(self, key: tuple[str, str], event: dict) -> None:
         for sub in list(self._pools.get(key, [])):
@@ -62,4 +93,4 @@ class SubscriberPool:
             try:
                 sub.queue.put_nowait(event)
             except asyncio.QueueFull:
-                logger.warning(f"[streams] queue full for subscriber on {key}; dropping event")
+                logger.warning("[streams] queue full for subscriber on %s; dropping event", key)

--- a/apps/api/tests/test_lifespan_streams.py
+++ b/apps/api/tests/test_lifespan_streams.py
@@ -25,7 +25,7 @@ def test_create_app_initializes_subscriber_pool(tmp_path, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_lifespan_eager_starts_listening_per_controller(tmp_path, monkeypatch) -> None:
-    """Lifespan iterates registered controllers and calls start_listening."""
+    """Lifespan warms event managers; the factory owns listener startup."""
     monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
 
     import uuid
@@ -56,17 +56,12 @@ async def test_lifespan_eager_starts_listening_per_controller(tmp_path, monkeypa
         )
         await session.commit()
 
-    # Stub manager_factory.get_domain_manager to return managers with mock start_listening
+    # Record warm-up requests without starting a second, unowned listener.
     started: list[tuple[str, str]] = []
 
     async def fake_get_domain_manager(session, ctrl_id, product, attr):
-        m = MagicMock()
-
-        async def _start():
-            started.append((ctrl_id, product))
-
-        m.start_listening = _start
-        return m
+        started.append((ctrl_id, product))
+        return MagicMock()
 
     app.state.manager_factory.get_domain_manager = AsyncMock(side_effect=fake_get_domain_manager)
 

--- a/apps/api/tests/test_managers_factory.py
+++ b/apps/api/tests/test_managers_factory.py
@@ -509,3 +509,59 @@ async def test_invalidate_closes_every_site_connection(tmp_path: Path, monkeypat
     assert len(instances) == 2
     assert [cm.close_calls for cm in instances] == [1, 1]
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_stops_listening_event_managers(tmp_path: Path, monkeypatch) -> None:
+    """The Network EventManager owns a background websocket task; dropping it
+    from the cache must stop the task, or it keeps reconnecting with the
+    discarded credentials."""
+    _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    factory = ManagerFactory(sm, cipher)
+    async with sm() as session:
+        mgr = await factory.get_domain_manager(session, cid, "network", "event_manager")
+    stop = AsyncMock()
+    monkeypatch.setattr(mgr, "stop_listening", stop)
+
+    await factory.invalidate_controller(cid)
+
+    stop.assert_awaited_once()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_probe_heal_stops_listening_event_managers(tmp_path: Path, monkeypatch) -> None:
+    _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    factory = ManagerFactory(sm, cipher)
+    async with sm() as session:
+        cached = await factory.get_connection_manager(session, cid, "network")
+        mgr = await factory.get_domain_manager(session, cid, "network", "event_manager")
+    cached.reconnect_blocked = True
+    stop = AsyncMock()
+    monkeypatch.setattr(mgr, "stop_listening", stop)
+
+    result = await factory.probe_controller(cid)
+
+    assert result["ok"] is True
+    stop.assert_awaited_once()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_still_closes_the_connection_when_a_listener_fails_to_stop(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    factory = ManagerFactory(sm, cipher)
+    async with sm() as session:
+        cm = await factory.get_connection_manager(session, cid, "network")
+        mgr = await factory.get_domain_manager(session, cid, "network", "event_manager")
+    monkeypatch.setattr(mgr, "stop_listening", AsyncMock(side_effect=RuntimeError("stuck")))
+
+    await factory.invalidate_controller(cid)
+
+    assert cm.close_calls == 1
+    await engine.dispose()

--- a/apps/api/tests/test_managers_factory.py
+++ b/apps/api/tests/test_managers_factory.py
@@ -39,6 +39,51 @@ class _FakeCM:
         self.close_calls += 1
 
 
+@pytest.mark.asyncio
+async def test_event_listener_is_owned_across_rotation(tmp_path, monkeypatch):
+    from unifi_api.services.streams import SubscriberPool
+
+    _patch_network_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path)
+    pool = SubscriberPool()
+    factory = ManagerFactory(sm, cipher, on_manager_discard=pool.disconnect_manager)
+
+    class Listener:
+        def __init__(self, cm):
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+            self.stop_listening = AsyncMock()
+
+        async def start_listening(self):
+            self.started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                self.cancelled.set()
+
+        def add_subscriber(self, callback):
+            self.callback = callback
+            return lambda: None
+
+    factory._builder_cache["network"] = {"event_manager": Listener}
+    try:
+        async with sm() as session:
+            old = await factory.get_domain_manager(session, cid, "network", "event_manager")
+            await asyncio.wait_for(old.started.wait(), 1)
+            sub = await pool.attach(cid, "network", old)
+            assert await factory.get_domain_manager(session, cid, "network", "event_manager") is old
+            await factory.invalidate_controller(cid)
+            assert old.cancelled.is_set()
+            old.stop_listening.assert_awaited_once()
+            assert sub.queue.get_nowait() is None
+            replacement = await factory.get_domain_manager(session, cid, "network", "event_manager")
+            assert replacement is not old
+            await asyncio.wait_for(replacement.started.wait(), 1)
+    finally:
+        await factory.invalidate_controller(cid)
+        await engine.dispose()
+
+
 def _patch_network_cm(monkeypatch) -> list[_FakeCM]:
     """Replace the network ConnectionManager with a fake; return the
     instance list so callers can assert against constructions."""

--- a/apps/api/tests/test_managers_factory.py
+++ b/apps/api/tests/test_managers_factory.py
@@ -84,8 +84,8 @@ async def test_event_listener_is_owned_across_rotation(tmp_path, monkeypatch):
         await engine.dispose()
 
 
-def _patch_network_cm(monkeypatch) -> list[_FakeCM]:
-    """Replace the network ConnectionManager with a fake; return the
+def _patch_cm(monkeypatch, module, attr: str) -> list[_FakeCM]:
+    """Replace a product's ConnectionManager with a fake; return the
     instance list so callers can assert against constructions."""
     instances: list[_FakeCM] = []
 
@@ -94,10 +94,20 @@ def _patch_network_cm(monkeypatch) -> list[_FakeCM]:
         instances.append(cm)
         return cm
 
+    monkeypatch.setattr(module, attr, _factory)
+    return instances
+
+
+def _patch_network_cm(monkeypatch) -> list[_FakeCM]:
     from unifi_core.network.managers import connection_manager as cm_module
 
-    monkeypatch.setattr(cm_module, "ConnectionManager", _factory)
-    return instances
+    return _patch_cm(monkeypatch, cm_module, "ConnectionManager")
+
+
+def _patch_protect_cm(monkeypatch) -> list[_FakeCM]:
+    from unifi_core.protect.managers import connection_manager as cm_module
+
+    return _patch_cm(monkeypatch, cm_module, "ProtectConnectionManager")
 
 
 async def _seed(tmp_path: Path, products: list[str] = ["network"]):
@@ -609,4 +619,86 @@ async def test_invalidate_still_closes_the_connection_when_a_listener_fails_to_s
     await factory.invalidate_controller(cid)
 
     assert cm.close_calls == 1
+    await engine.dispose()
+
+
+class _SiblingListener:
+    """Domain manager that owns a subscription, for sibling-eviction tests."""
+
+    def __init__(self, cm):
+        self.stop_listening = AsyncMock()
+        self.unsubscribed = False
+        self._callbacks: list = []
+
+    def add_subscriber(self, callback):
+        self._callbacks.append(callback)
+
+        def _unsub() -> None:
+            self.unsubscribed = True
+            self._callbacks.remove(callback)
+
+        return _unsub
+
+    def emit(self, event: dict) -> None:
+        for callback in list(self._callbacks):
+            callback(event)
+
+
+async def _seed_console(tmp_path: Path, monkeypatch, **factory_kwargs):
+    """A two-product console with a cached connection and listener for each."""
+    _patch_network_cm(monkeypatch)
+    _patch_protect_cm(monkeypatch)
+    engine, sm, cipher, cid = await _seed(tmp_path, products=["network", "protect"])
+    factory = ManagerFactory(sm, cipher, **factory_kwargs)
+    factory._builder_cache["network"] = {"event_manager": _SiblingListener}
+    factory._builder_cache["protect"] = {"event_manager": _SiblingListener}
+    async with sm() as session:
+        net_cm = await factory.get_connection_manager(session, cid, "network")
+        await factory.get_connection_manager(session, cid, "protect")
+        net_mgr = await factory.get_domain_manager(session, cid, "network", "event_manager")
+        protect_mgr = await factory.get_domain_manager(session, cid, "protect", "event_manager")
+    return engine, sm, cid, factory, net_cm, net_mgr, protect_mgr
+
+
+@pytest.mark.asyncio
+async def test_probe_heal_leaves_a_healthy_products_manager_cached(tmp_path: Path, monkeypatch) -> None:
+    """Healing a blocked Network connection must not evict Protect on the same console."""
+    engine, sm, cid, factory, net_cm, net_mgr, protect_mgr = await _seed_console(tmp_path, monkeypatch)
+    net_cm.reconnect_blocked = True
+
+    assert (await factory.probe_controller(cid))["ok"] is True
+
+    net_mgr.stop_listening.assert_awaited_once()
+    protect_mgr.stop_listening.assert_not_awaited()
+    # Still the cached instance: not merely left running, but never rebuilt.
+    async with sm() as session:
+        assert await factory.get_domain_manager(session, cid, "protect", "event_manager") is protect_mgr
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_probe_heal_keeps_a_healthy_sibling_stream_delivering(tmp_path: Path, monkeypatch) -> None:
+    """A live Protect stream must survive the healing of a blocked Network connection."""
+    from unifi_api.services.streams import SubscriberPool
+
+    pool = SubscriberPool()
+    engine, _sm, cid, factory, net_cm, net_mgr, protect_mgr = await _seed_console(
+        tmp_path, monkeypatch, on_manager_discard=pool.disconnect_manager
+    )
+
+    sub = await pool.attach(cid, "protect", protect_mgr)
+    protect_mgr.emit({"id": "before"})
+    assert sub.queue.get_nowait() == {"id": "before"}
+
+    net_cm.reconnect_blocked = True
+    assert (await factory.probe_controller(cid))["ok"] is True
+
+    # The healed Network listener is stopped; the untouched Protect one still
+    # carries its subscription and its stream was never terminated.
+    net_mgr.stop_listening.assert_awaited_once()
+    assert protect_mgr.unsubscribed is False
+    protect_mgr.emit({"id": "after"})
+    assert sub.queue.get_nowait() == {"id": "after"}
+
     await engine.dispose()

--- a/apps/api/tests/test_streams_pool.py
+++ b/apps/api/tests/test_streams_pool.py
@@ -66,3 +66,26 @@ async def test_queue_full_drops_event_for_slow_subscriber() -> None:
     captured_cb["cb"]({"id": "e3"})  # this one drops
     items = [sub.queue.get_nowait() for _ in range(sub.queue.qsize())]
     assert [i["id"] for i in items] == ["e1", "e2"]
+
+
+@pytest.mark.asyncio
+async def test_rotation_ends_old_stream_and_new_stream_receives_live_events() -> None:
+    pool = SubscriberPool(queue_maxsize=1)
+    old, new = MagicMock(), MagicMock()
+    previous = await pool.attach("ctrl1", "network", old)
+    previous.queue.put_nowait({"id": "old"})
+    pool.disconnect_manager(old)
+    assert previous.queue.get_nowait() is None
+    old.add_subscriber.return_value.assert_called_once()
+
+    current = await pool.attach("ctrl1", "network", new)
+    # The old generator's finally must not unregister the replacement.
+    await pool.detach("ctrl1", "network", previous)
+    new.add_subscriber.call_args.args[0]({"id": "new"})
+    assert current.queue.get_nowait() == {"id": "new"}
+    new.add_subscriber.return_value.assert_not_called()
+    old.add_subscriber.call_args.args[0]({"id": "stale"})
+    assert current.queue.empty()
+    late = await pool.attach("ctrl1", "network", old)
+    assert late.queue.get_nowait() is None
+    new.add_subscriber.return_value.assert_not_called()

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -85,6 +85,9 @@ UNIFI_NETWORK_PASSWORD=your-password # Admin password
 # UNIFI_NETWORK_PORT=443             # Controller HTTPS port
 # UNIFI_NETWORK_SITE=default         # UniFi site name
 # UNIFI_NETWORK_VERIFY_SSL=false     # SSL certificate verification
+# UNIFI_NETWORK_WEBSOCKET_ENABLED=true   # Real-time event listener feeding unifi_recent_events
+# UNIFI_NETWORK_EVENT_BUFFER_SIZE=100    # Ring buffer capacity for buffered events
+# UNIFI_NETWORK_EVENT_BUFFER_TTL=300     # Seconds a buffered event stays readable
 ```
 
 **Fallback:** Existing `UNIFI_*` variables (e.g., `UNIFI_HOST`) continue to work. The server checks for `UNIFI_NETWORK_*` first and falls back to `UNIFI_*` if the server-specific variable is not set. For single-controller setups, the shared variables are all you need.

--- a/apps/network/docs/configuration.md
+++ b/apps/network/docs/configuration.md
@@ -19,6 +19,9 @@ The Network server supports server-specific environment variables with the `UNIF
 | `UNIFI_NETWORK_PORT` | `UNIFI_PORT` | No | `443` | Controller HTTPS port |
 | `UNIFI_NETWORK_SITE` | `UNIFI_SITE` | No | `default` | UniFi site name |
 | `UNIFI_NETWORK_VERIFY_SSL` | `UNIFI_VERIFY_SSL` | No | `false` | SSL certificate verification |
+| `UNIFI_NETWORK_WEBSOCKET_ENABLED` | -- | No | `true` | Start the real-time event listener that feeds `unifi_recent_events` |
+| `UNIFI_NETWORK_EVENT_BUFFER_SIZE` | -- | No | `100` | Max events held in the websocket ring buffer |
+| `UNIFI_NETWORK_EVENT_BUFFER_TTL` | -- | No | `300` | Seconds before buffered events expire (lazy eviction) |
 
 **Resolution order:** `UNIFI_NETWORK_*` > `UNIFI_*` > YAML config > hardcoded default.
 

--- a/apps/network/docs/tools.md
+++ b/apps/network/docs/tools.md
@@ -193,13 +193,15 @@ Gateway-wide security / NAT / connection-tracking settings (the controller's `us
 - `unifi_unauthorize_guest` — Revoke guest authorization
 - `unifi_set_client_ip_settings` — Set fixed IP / local DNS record
 
-## Events & Alarms (5 tools)
+## Events & Alarms (7 tools)
 
 - `unifi_list_events` — List timestamped event log entries
 - `unifi_list_alarms` — List active alarms
 - `unifi_archive_alarm` — Archive a specific alarm
 - `unifi_archive_all_alarms` — Archive all active alarms
 - `unifi_get_event_types` — Get exact event keys observed in the 1,000 most recent events within the last 7 days
+- `unifi_recent_events` — Events from the in-memory websocket buffer, with listener state (`listening`, `attached`, `buffer_capacity`)
+- `unifi_subscribe_events` — Handle for the live event resource plus listener state
 
 ## Routing (5 tools)
 

--- a/apps/network/src/unifi_network_mcp/config/config.yaml
+++ b/apps/network/src/unifi_network_mcp/config/config.yaml
@@ -65,6 +65,12 @@ server:
     log_tool_result: ${oc.env:UNIFI_MCP_DIAG_LOG_TOOL_RESULT,true}
     max_payload_chars: ${oc.env:UNIFI_MCP_DIAG_MAX_PAYLOAD,2000}
 
+network:
+  events:
+    buffer_size: ${oc.env:UNIFI_NETWORK_EVENT_BUFFER_SIZE,100}
+    buffer_ttl_seconds: ${oc.env:UNIFI_NETWORK_EVENT_BUFFER_TTL,300}
+    websocket_enabled: ${oc.env:UNIFI_NETWORK_WEBSOCKET_ENABLED,true}
+
 policy:
   response:
     redact_sensitive_fields: ${oc.env:UNIFI_NETWORK_REDACT_SENSITIVE_FIELDS,true}

--- a/apps/network/src/unifi_network_mcp/main.py
+++ b/apps/network/src/unifi_network_mcp/main.py
@@ -19,6 +19,7 @@ from unifi_network_mcp.jobs import get_job_status, start_async_tool
 from unifi_network_mcp.runtime import (
     config,
     connection_manager,
+    event_manager,
     server,
     support_bundle_service,
 )
@@ -46,6 +47,7 @@ logger.info("Using global Manager instances.")
 
 async def main_async():
     """Main asynchronous function to setup and run the server."""
+    from unifi_core.config_helpers import parse_config_bool
     from unifi_core.policy_gate import check_deprecated_env_vars, check_unknown_policy_env_vars
     from unifi_mcp_shared.bootstrap import assert_credentials_configured
     from unifi_mcp_shared.server_lifecycle import apply_log_level, install_asyncio_exception_handler
@@ -64,6 +66,21 @@ async def main_async():
         logger.error("Failed to connect to Unifi Controller from main_async. Tool functionality may be impaired.")
     else:
         logger.info("Global Unifi connection initialized successfully from main_async.")
+
+        # Start the websocket event listener if enabled and the connection succeeded.
+        # It feeds unifi_recent_events; without it that buffer can never fill.
+        ws_enabled_raw = config.network.events.get("websocket_enabled", True) if hasattr(config, "network") else True
+        if parse_config_bool(ws_enabled_raw, default=True):
+            try:
+                await event_manager.start_listening()
+            except Exception as ws_exc:
+                logger.error(
+                    "Failed to start event websocket listener: %s. "
+                    "Real-time events will be unavailable; unifi_list_events still works.",
+                    type(ws_exc).__name__,
+                )
+        else:
+            logger.info("Network event websocket disabled via config.")
 
     # ---- Register tools ----
     await register_tools_for_mode(
@@ -84,14 +101,18 @@ async def main_async():
 
     # ---- Start transports ----
     http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3000, logger=logger)
-    await run_transports(
-        server=server,
-        http_enabled=http_enabled,
-        host=host,
-        port=port,
-        http_transport=http_transport,
-        logger=logger,
-    )
+    try:
+        await run_transports(
+            server=server,
+            http_enabled=http_enabled,
+            host=host,
+            port=port,
+            http_transport=http_transport,
+            logger=logger,
+        )
+    finally:
+        # The listener owns a background task; it must not outlive the server.
+        await event_manager.stop_listening()
 
 
 def main():

--- a/apps/network/src/unifi_network_mcp/main.py
+++ b/apps/network/src/unifi_network_mcp/main.py
@@ -60,48 +60,50 @@ async def main_async():
     check_unknown_policy_env_vars("network", logger, policy_gates(), NETWORK_CATEGORY_MAP)
     assert_credentials_configured(config, plugin_name="unifi-network", env_prefix="NETWORK", logger=logger)
 
-    # Initialize the global Unifi connection
-    logger.info("Initializing global Unifi connection from main_async...")
-    if not await connection_manager.initialize():
-        logger.error("Failed to connect to Unifi Controller from main_async. Tool functionality may be impaired.")
-    else:
-        logger.info("Global Unifi connection initialized successfully from main_async.")
-
-        # Start the websocket event listener if enabled and the connection succeeded.
-        # It feeds unifi_recent_events; without it that buffer can never fill.
-        ws_enabled_raw = config.network.events.get("websocket_enabled", True) if hasattr(config, "network") else True
-        if parse_config_bool(ws_enabled_raw, default=True):
-            try:
-                await event_manager.start_listening()
-            except Exception as ws_exc:
-                logger.error(
-                    "Failed to start event websocket listener: %s. "
-                    "Real-time events will be unavailable; unifi_list_events still works.",
-                    type(ws_exc).__name__,
-                )
-        else:
-            logger.info("Network event websocket disabled via config.")
-
-    # ---- Register tools ----
-    await register_tools_for_mode(
-        mode=UNIFI_TOOL_REGISTRATION_MODE,
-        server=server,
-        original_tool_decorator=_original_tool_decorator,
-        tool_index_handler=tool_index_handler,
-        start_async_tool=start_async_tool,
-        get_job_status=get_job_status,
-        register_tool=register_tool,
-        tool_module_map=TOOL_MODULE_MAP,
-        setup_lazy_loading=setup_lazy_loading,
-        base_package="unifi_network_mcp.tools",
-        config=config,
-        logger=logger,
-        support_bundle_handler=support_bundle_service.generate,
-    )
-
-    # ---- Start transports ----
-    http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3000, logger=logger)
     try:
+        # Initialize the global Unifi connection
+        logger.info("Initializing global Unifi connection from main_async...")
+        if not await connection_manager.initialize():
+            logger.error("Failed to connect to Unifi Controller from main_async. Tool functionality may be impaired.")
+        else:
+            logger.info("Global Unifi connection initialized successfully from main_async.")
+
+            # Start the websocket event listener if enabled and the connection succeeded.
+            # It feeds unifi_recent_events; without it that buffer can never fill.
+            ws_enabled_raw = (
+                config.network.events.get("websocket_enabled", True) if hasattr(config, "network") else True
+            )
+            if parse_config_bool(ws_enabled_raw, default=True):
+                try:
+                    await event_manager.start_listening()
+                except Exception as ws_exc:
+                    logger.error(
+                        "Failed to start event websocket listener: %s. "
+                        "Real-time events will be unavailable; unifi_list_events still works.",
+                        type(ws_exc).__name__,
+                    )
+            else:
+                logger.info("Network event websocket disabled via config.")
+
+        # ---- Register tools ----
+        await register_tools_for_mode(
+            mode=UNIFI_TOOL_REGISTRATION_MODE,
+            server=server,
+            original_tool_decorator=_original_tool_decorator,
+            tool_index_handler=tool_index_handler,
+            start_async_tool=start_async_tool,
+            get_job_status=get_job_status,
+            register_tool=register_tool,
+            tool_module_map=TOOL_MODULE_MAP,
+            setup_lazy_loading=setup_lazy_loading,
+            base_package="unifi_network_mcp.tools",
+            config=config,
+            logger=logger,
+            support_bundle_handler=support_bundle_service.generate,
+        )
+
+        # ---- Start transports ----
+        http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3000, logger=logger)
         await run_transports(
             server=server,
             http_enabled=http_enabled,
@@ -111,8 +113,10 @@ async def main_async():
             logger=logger,
         )
     finally:
-        # The listener owns a background task; it must not outlive the server.
-        await event_manager.stop_listening()
+        try:
+            await event_manager.stop_listening()
+        finally:
+            await connection_manager.cleanup()
 
 
 def main():

--- a/apps/network/src/unifi_network_mcp/runtime.py
+++ b/apps/network/src/unifi_network_mcp/runtime.py
@@ -264,7 +264,13 @@ def get_gateway_settings_manager() -> GatewaySettingsManager:
 
 @lru_cache
 def get_event_manager() -> EventManager:
-    return EventManager(get_connection_manager())
+    cfg = get_config()
+    events_cfg: dict = {}
+    try:
+        events_cfg = dict(cfg.network.events) if hasattr(cfg, "network") and hasattr(cfg.network, "events") else {}
+    except Exception as exc:
+        logger.warning("Ignoring unreadable network.events config (%s); using defaults", type(exc).__name__)
+    return EventManager(get_connection_manager(), config=events_cfg)
 
 
 @lru_cache

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -17,19 +17,39 @@ from unifi_network_mcp.runtime import server
 
 logger = logging.getLogger(__name__)
 
-# Lazy import to avoid circular dependencies
-_event_manager = None
+_NOT_RUNNING_HINT = (
+    "The websocket listener is not running, so this buffer cannot fill. Check "
+    "UNIFI_NETWORK_WEBSOCKET_ENABLED (default true) and the server startup log; use "
+    "unifi_list_events for historical events."
+)
+_NOT_ATTACHED_HINT = (
+    "The websocket listener is running but has not attached to the controller ({error}), so this "
+    "buffer cannot fill; it keeps retrying. Check the server log; use unifi_list_events for "
+    "historical events."
+)
 
 
 def _get_event_manager():
-    """Lazy-load the event manager to avoid circular imports."""
-    global _event_manager
-    if _event_manager is None:
-        from unifi_core.network.managers.event_manager import EventManager
-        from unifi_network_mcp.runtime import get_connection_manager
+    """The runtime's EventManager singleton (the one main_async starts); resolved
+    lazily so importing this module does not import the runtime's managers."""
+    from unifi_network_mcp.runtime import get_event_manager
 
-        _event_manager = EventManager(get_connection_manager())
-    return _event_manager
+    return get_event_manager()
+
+
+def _listener_state(mgr) -> Dict[str, Any]:
+    state: Dict[str, Any] = {
+        "listening": bool(mgr.is_listening),
+        "attached": bool(mgr.attached),
+        "last_error": mgr.last_error,
+        "buffer_size": mgr.buffer_size,
+        "buffer_capacity": mgr.buffer_capacity,
+    }
+    if not state["listening"]:
+        state["hint"] = _NOT_RUNNING_HINT
+    elif not state["attached"]:
+        state["hint"] = _NOT_ATTACHED_HINT.format(error=mgr.last_error or "unknown")
+    return state
 
 
 @server.tool(
@@ -148,7 +168,11 @@ async def list_alarms(
         "(no API call) and returns events received via the real-time websocket "
         "stream. Supports filtering by exact event_type key, client/device mac, "
         "and limit. Use this for real-time monitoring; use unifi_list_events "
-        "for historical queries."
+        "for historical queries. The response reports whether the listener is "
+        "running (listening) and attached to the controller (attached, with "
+        "last_error when not), the buffer occupancy (buffer_size) and its "
+        "capacity (buffer_capacity); an empty buffer with attached=false is "
+        "not 'no events'."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -177,7 +201,7 @@ async def unifi_recent_events(
     mgr = _get_event_manager()
     events = mgr.get_recent_from_buffer(event_type=event_type, mac=mac, limit=limit)
     shaped = [event_log_from_controller(e).model_dump(exclude_none=True) for e in events]
-    return {"events": shaped, "count": len(shaped), "buffer_size": mgr.buffer_size}
+    return {"success": True, "events": shaped, "count": len(shaped), **_listener_state(mgr)}
 
 
 @server.tool(
@@ -185,7 +209,10 @@ async def unifi_recent_events(
     description=(
         "Returns a handle describing how to subscribe to live network events. "
         "Provides the MCP resource URI for the event stream and pointers to the "
-        "buffered-event tool. Use this to set up continuous event monitoring."
+        "buffered-event tool, plus whether the websocket listener is running "
+        "(listening) and attached (attached, last_error) and the buffer "
+        "occupancy and capacity. Use this to set up "
+        "continuous event monitoring."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -194,9 +221,10 @@ async def unifi_subscribe_events() -> Dict[str, Any]:
     logger.info("unifi_subscribe_events called")
     mgr = _get_event_manager()
     return {
+        "success": True,
         "resource_uri": "unifi://network/events",
         "summary_uri": "unifi://network/events/recent",
-        "buffer_size": mgr.buffer_size,
+        **_listener_state(mgr),
         "instructions": (
             "Call unifi_recent_events to read buffered events. The unifi-api "
             "service (if running) exposes /v1/streams/network/events for live "

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -13837,7 +13837,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by exact event_type key, client/device mac, and limit. Use this for real-time monitoring; use unifi_list_events for historical queries.",
+      "description": "Get recent events from the in-memory websocket buffer. This is fast (no API call) and returns events received via the real-time websocket stream. Supports filtering by exact event_type key, client/device mac, and limit. Use this for real-time monitoring; use unifi_list_events for historical queries. The response reports whether the listener is running (listening) and attached to the controller (attached, with last_error when not), the buffer occupancy (buffer_size) and its capacity (buffer_capacity); an empty buffer with attached=false is not 'no events'.",
       "name": "unifi_recent_events",
       "schema": {
         "input": {
@@ -14999,7 +14999,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns a handle describing how to subscribe to live network events. Provides the MCP resource URI for the event stream and pointers to the buffered-event tool. Use this to set up continuous event monitoring.",
+      "description": "Returns a handle describing how to subscribe to live network events. Provides the MCP resource URI for the event stream and pointers to the buffered-event tool, plus whether the websocket listener is running (listening) and attached (attached, last_error) and the buffer occupancy and capacity. Use this to set up continuous event monitoring.",
       "name": "unifi_subscribe_events",
       "schema": {
         "input": {

--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -381,21 +381,34 @@ class TestWebsocketLifecycle:
         controller.block = asyncio.Event()
         calls = {"n": 0}
 
+        controller.closed = asyncio.Event()
+
         async def _ws():
             calls["n"] += 1
             if fail_first is not None and calls["n"] == 1:
                 raise fail_first
             controller.started.set()
             await controller.block.wait()
+            controller.closed.set()
 
         controller.start_websocket = AsyncMock(side_effect=_ws)
         controller.messages.subscribe = MagicMock(return_value=MagicMock(name="unsub"))
+        # aiounifi stamps this on every frame it receives; None until the first one.
+        controller.connectivity.ws_message_received = None
         return controller
+
+    @staticmethod
+    def _frame_received(controller):
+        """The peer sent a frame on the open socket (what aiounifi records)."""
+        import datetime
+
+        controller.connectivity.ws_message_received = datetime.datetime.now(datetime.UTC)
 
     @pytest.fixture
     def cm(self):
         cm = MagicMock()
         cm.reconnect_blocked = False
+        cm.reconnect_cooldown_active = False
         cm.ensure_connected = AsyncMock(return_value=True)
         cm.reauthenticate = AsyncMock(return_value=True)
         cm.controller = self._controller()
@@ -515,7 +528,7 @@ class TestWebsocketLifecycle:
     async def test_loop_waits_out_the_auth_cooldown_without_touching_the_controller(self, cm, sleeps):
         from unifi_core.network.managers.event_manager import EventManager
 
-        cm.reconnect_blocked = True
+        cm.reconnect_cooldown_active = True
         sleeps.until = 3
         mgr = EventManager(cm)
         await mgr.start_listening()
@@ -580,16 +593,106 @@ class TestWebsocketHealth(TestWebsocketLifecycle):
         mgr = EventManager(cm)
         await mgr.start_listening()
         await self._wait(cm.controller.started)
+        self._frame_received(cm.controller)
 
         assert mgr.attached is True
         assert mgr.last_error is None
         await mgr.stop_listening()
 
     @pytest.mark.asyncio
+    async def test_attached_needs_a_confirmed_open_socket(self, cm):
+        """Maintainer probe 1: with the handshake held, the task is alive but no
+        socket is open, so ``attached`` must be false; a received frame is the
+        confirmation; a closure clears it again for the whole backoff."""
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)  # inside start_websocket, handshake never completed
+
+        assert mgr.is_listening is True
+        assert mgr.attached is False
+        assert mgr.last_error is None
+
+        self._frame_received(cm.controller)
+        assert mgr.attached is True
+
+        cm.controller.block.set()  # normal closure by the peer
+        await self._wait(cm.controller.closed)
+        assert mgr.attached is False
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_a_frame_from_a_previous_socket_does_not_count(self, cm):
+        """A stale timestamp from before this attach is not a confirmation."""
+        import datetime
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller.connectivity.ws_message_received = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            hours=1
+        )
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+
+        assert mgr.attached is False
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_loop_retries_once_the_auth_cooldown_has_expired(self, cm, sleeps):
+        """Maintainer probe 2: ``reconnect_blocked`` stays latched until a login
+        succeeds, but the circuit half-opens on a timer; the listener must let
+        the ConnectionManager's time-aware check decide, so one login attempt
+        happens after expiry."""
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.reconnect_blocked = True  # latched from an earlier terminal auth error
+        cm.reconnect_cooldown_active = False  # ...but the cool-down has expired
+        cm.ensure_connected = AsyncMock(return_value=False)  # the half-open attempt fails
+        sleeps.until = 1
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+
+        cm.ensure_connected.assert_awaited()
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_stop_unsubscribes_even_when_the_caller_is_cancelled(self, cm):
+        """Maintainer probe 3: a cancellation aimed at the stopping caller must
+        propagate AND the subscription must still be released."""
+        import asyncio
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        unsub = MagicMock(name="unsub")
+        cm.controller.messages.subscribe = MagicMock(return_value=unsub)
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+        entered = asyncio.Event()
+
+        async def _shutdown():
+            entered.set()
+            await mgr.stop_listening()
+
+        outer = asyncio.create_task(_shutdown())
+        await self._wait(entered)
+        outer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
+
+        assert outer.cancelled()
+        unsub.assert_called_once()
+        assert mgr.is_listening is False
+        assert mgr.attached is False
+
+    @pytest.mark.asyncio
     async def test_open_reconnect_circuit_is_reported_as_not_attached(self, cm, sleeps):
         from unifi_core.network.managers.event_manager import EventManager
 
-        cm.reconnect_blocked = True
+        cm.reconnect_cooldown_active = True
         sleeps.until = 1
         mgr = EventManager(cm)
         await mgr.start_listening()

--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -366,3 +366,448 @@ class TestEventManagerCommon:
 
         assert "connection reset" in str(exc.value)
         assert "v2 system-log probe" not in str(exc.value)
+
+
+class TestWebsocketLifecycle:
+    """start_listening subscribes, then runs aiounifi's blocking receive loop in
+    a background task that reconnects; stop_listening tears both down."""
+
+    @staticmethod
+    def _controller(*, fail_first: Exception | None = None):
+        import asyncio
+
+        controller = MagicMock()
+        controller.started = asyncio.Event()
+        controller.block = asyncio.Event()
+        calls = {"n": 0}
+
+        async def _ws():
+            calls["n"] += 1
+            if fail_first is not None and calls["n"] == 1:
+                raise fail_first
+            controller.started.set()
+            await controller.block.wait()
+
+        controller.start_websocket = AsyncMock(side_effect=_ws)
+        controller.messages.subscribe = MagicMock(return_value=MagicMock(name="unsub"))
+        return controller
+
+    @pytest.fixture
+    def cm(self):
+        cm = MagicMock()
+        cm.reconnect_blocked = False
+        cm.ensure_connected = AsyncMock(return_value=True)
+        cm.reauthenticate = AsyncMock(return_value=True)
+        cm.controller = self._controller()
+        return cm
+
+    class _Sleeps(list):
+        """Recorded backoff delays; ``reached`` is set once ``until`` are recorded."""
+
+        def __init__(self):
+            import asyncio
+
+            super().__init__()
+            self.until: int | None = None
+            self.reached = asyncio.Event()
+
+    @pytest.fixture
+    def sleeps(self, monkeypatch):
+        """Replace the loop's sleep with a recorder that still yields."""
+        import asyncio
+
+        from unifi_core.network.managers import event_manager as em
+
+        recorded = self._Sleeps()
+        real_sleep = asyncio.sleep
+
+        async def _sleep(delay):
+            recorded.append(delay)
+            if recorded.until is not None and len(recorded) >= recorded.until:
+                recorded.reached.set()
+            await real_sleep(0)
+
+        monkeypatch.setattr(em.asyncio, "sleep", _sleep)
+        return recorded
+
+    async def _wait(self, event):
+        import asyncio
+
+        await asyncio.wait_for(event.wait(), 1)
+
+    @pytest.mark.asyncio
+    async def test_start_subscribes_before_the_socket_and_returns_while_it_blocks(self, cm):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+
+        assert cm.controller.messages.subscribe.call_count == 1
+        assert mgr.is_listening is True
+        await self._wait(cm.controller.started)
+        assert cm.controller.start_websocket.await_count == 1
+
+        await mgr.stop_listening()
+        assert mgr.is_listening is False
+        cm.controller.messages.subscribe.return_value.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self, cm):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+
+        assert cm.controller.messages.subscribe.call_count == 1
+        assert cm.controller.start_websocket.await_count == 1
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_never_started_is_a_noop(self, cm):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+        await mgr.stop_listening()
+        assert mgr.is_listening is False
+
+    @pytest.mark.asyncio
+    async def test_loop_reconnects_and_resubscribes_on_a_new_controller(self, cm, sleeps):
+        """A reconnect replaces the aiounifi Controller object; the subscription
+        must move to the new one."""
+        from unifi_core.network.managers.event_manager import EventManager
+
+        first = self._controller(fail_first=RuntimeError("socket closed"))
+        second = self._controller()
+        cm.controller = first
+
+        async def _ensure():
+            if first.start_websocket.await_count:
+                cm.controller = second
+            return True
+
+        cm.ensure_connected = AsyncMock(side_effect=_ensure)
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(second.started)
+
+        assert first.messages.subscribe.call_count == 1
+        assert second.messages.subscribe.call_count == 1
+        first.messages.subscribe.return_value.assert_called_once()  # old subscription released
+        assert sleeps == [1]
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_backoff_doubles_to_a_cap_while_the_socket_keeps_failing(self, cm, sleeps):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller.start_websocket = AsyncMock(side_effect=RuntimeError("down"))
+        sleeps.until = 8
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+        await mgr.stop_listening()
+
+        assert sleeps[:8] == [1, 2, 4, 8, 16, 32, 60, 60]
+
+    @pytest.mark.asyncio
+    async def test_loop_waits_out_the_auth_cooldown_without_touching_the_controller(self, cm, sleeps):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.reconnect_blocked = True
+        sleeps.until = 3
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+        await mgr.stop_listening()
+
+        cm.ensure_connected.assert_not_awaited()
+        cm.controller.start_websocket.assert_not_awaited()
+        assert sleeps == sorted(sleeps)
+
+    @pytest.mark.asyncio
+    async def test_handshake_401_triggers_reauthentication(self, cm, sleeps):
+        import aiohttp
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        rejected = aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(), history=(), status=401, message="Unauthorized"
+        )
+        cm.controller = self._controller(fail_first=rejected)
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+        await mgr.stop_listening()
+
+        cm.reauthenticate.assert_awaited_once()
+
+    def test_buffer_capacity_comes_from_config(self, cm):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        assert EventManager(cm, config={"buffer_size": 5}).buffer_capacity == 5
+        assert EventManager(cm).buffer_capacity == 100
+
+
+class TestWebsocketHealth(TestWebsocketLifecycle):
+    """A running task is not an attached socket: the tools need to tell them apart."""
+
+    @pytest.mark.asyncio
+    async def test_a_socket_that_never_attaches_is_reported(self, cm, sleeps):
+        import aiohttp
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller.start_websocket = AsyncMock(
+            side_effect=aiohttp.WSServerHandshakeError(request_info=MagicMock(), history=(), status=404, message="nope")
+        )
+        sleeps.until = 2
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+
+        assert mgr.is_listening is True
+        assert mgr.attached is False
+        assert "WSServerHandshakeError" in mgr.last_error and "404" in mgr.last_error
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_an_attached_socket_clears_the_error(self, cm, sleeps):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller = self._controller(fail_first=RuntimeError("first"))
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+
+        assert mgr.attached is True
+        assert mgr.last_error is None
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_open_reconnect_circuit_is_reported_as_not_attached(self, cm, sleeps):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.reconnect_blocked = True
+        sleeps.until = 1
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+
+        assert mgr.attached is False
+        assert "circuit" in mgr.last_error
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_persistent_failure_escalates_to_error_once(self, cm, sleeps, caplog):
+        import logging
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller.start_websocket = AsyncMock(side_effect=RuntimeError("down"))
+        sleeps.until = 9
+        mgr = EventManager(cm)
+        with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+            await mgr.start_listening()
+            await self._wait(sleeps.reached)
+            await mgr.stop_listening()
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1 and "has not attached" in errors[0].getMessage()
+        assert "down" not in caplog.text or all(
+            r.levelno == logging.DEBUG for r in caplog.records if "down" in r.getMessage()
+        )
+
+    @pytest.mark.asyncio
+    async def test_reauthentication_failure_does_not_kill_the_task(self, cm, sleeps, caplog):
+        import logging
+
+        import aiohttp
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        rejected = aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(), history=(), status=401, message="Unauthorized"
+        )
+        cm.controller.start_websocket = AsyncMock(side_effect=rejected)
+        cm.reauthenticate = AsyncMock(side_effect=RuntimeError("login exploded"))
+        sleeps.until = 2
+        mgr = EventManager(cm)
+        with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+            await mgr.start_listening()
+            await self._wait(sleeps.reached)
+
+        assert mgr.is_listening is True
+        assert any("re-authentication failed" in r.getMessage() for r in caplog.records)
+        await mgr.stop_listening()
+
+    @pytest.mark.asyncio
+    async def test_a_task_that_dies_is_logged_at_error(self, cm, caplog):
+        """Nothing in the loop should escape, but if something does the death
+        is logged, not discovered at garbage collection."""
+        import asyncio
+        import logging
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+
+        async def _boom():
+            raise RuntimeError("escaped")
+
+        with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+            mgr._ws_task = asyncio.create_task(_boom())
+            mgr._ws_task.add_done_callback(mgr._on_task_done)
+            for _ in range(3):
+                await asyncio.sleep(0)
+            await mgr.stop_listening()
+
+        assert any(r.levelno == logging.ERROR and "RuntimeError" in r.getMessage() for r in caplog.records)
+
+    @staticmethod
+    def _closing_socket(cm, outcomes):
+        import asyncio
+
+        block = asyncio.Event()
+
+        async def _ws():
+            if outcomes:
+                outcome = outcomes.pop(0)
+                if outcome is not None:
+                    raise outcome
+                return  # accepted, then closed by the peer without an error
+            await block.wait()
+
+        cm.controller.start_websocket = AsyncMock(side_effect=_ws)
+
+    @pytest.mark.asyncio
+    async def test_a_stable_attachment_resets_the_backoff(self, cm, sleeps):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        clock = {"now": 0.0}
+
+        def _monotonic():
+            clock["now"] += 10.0  # every attachment looks long-lived
+            return clock["now"]
+
+        self._closing_socket(cm, [RuntimeError("a"), RuntimeError("b"), None, RuntimeError("c")])
+        sleeps.until = 4
+        mgr = EventManager(cm)
+        mgr._clock = _monotonic
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+        await mgr.stop_listening()
+
+        assert sleeps[:4] == [1, 2, 1, 2]
+        assert cm.controller.messages.subscribe.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_an_immediate_close_keeps_backing_off(self, cm, sleeps):
+        """A peer that accepts the socket and closes it at once must not be
+        polled every second."""
+        from unifi_core.network.managers.event_manager import EventManager
+
+        self._closing_socket(cm, [None, None, None, None])
+        sleeps.until = 4
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+
+        assert sleeps[:4] == [1, 2, 4, 8]
+        assert mgr.attached is False
+        assert "before it was stable" in mgr.last_error
+        await mgr.stop_listening()
+        assert mgr.last_error is None
+
+    @pytest.mark.asyncio
+    async def test_stop_re_raises_a_cancellation_aimed_at_the_caller(self, cm):
+        import asyncio
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+        entered = asyncio.Event()
+
+        async def _shutdown():
+            entered.set()
+            await mgr.stop_listening()
+            return "completed"
+
+        outer = asyncio.create_task(_shutdown())
+        await self._wait(entered)
+        outer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
+        assert outer.cancelled()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status,reauth", [(401, True), (403, True), (500, False)])
+    async def test_only_rejected_handshakes_reauthenticate(self, cm, sleeps, status, reauth):
+        import aiohttp
+
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller = self._controller(
+            fail_first=aiohttp.WSServerHandshakeError(request_info=MagicMock(), history=(), status=status, message="x")
+        )
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(cm.controller.started)
+        await mgr.stop_listening()
+
+        assert cm.reauthenticate.await_count == (1 if reauth else 0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("case", ["not_connected", "no_controller"])
+    async def test_connection_gaps_back_off_without_touching_the_socket(self, cm, sleeps, case):
+        from unifi_core.network.managers.event_manager import EventManager
+
+        if case == "not_connected":
+            cm.ensure_connected = AsyncMock(return_value=False)
+        else:
+            cm.controller = None
+        sleeps.until = 2
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeps.reached)
+        await mgr.stop_listening()
+
+        assert sleeps[:2] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_stop_interrupts_a_backoff_sleep(self, cm, monkeypatch):
+        import asyncio
+
+        from unifi_core.network.managers import event_manager as em
+        from unifi_core.network.managers.event_manager import EventManager
+
+        cm.controller.start_websocket = AsyncMock(side_effect=RuntimeError("down"))
+        sleeping = asyncio.Event()
+
+        async def _sleep(_delay):
+            sleeping.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(em.asyncio, "sleep", _sleep)
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await self._wait(sleeping)
+        await asyncio.wait_for(mgr.stop_listening(), 1)
+
+        assert mgr.is_listening is False
+
+    @pytest.mark.asyncio
+    async def test_start_after_stop_is_refused(self, cm):
+        """A stopped manager was dropped by its owner; a stale caller must not
+        revive it with a discarded connection."""
+        from unifi_core.network.managers.event_manager import EventManager
+
+        mgr = EventManager(cm)
+        await mgr.start_listening()
+        await mgr.stop_listening()
+        await mgr.start_listening()
+
+        assert mgr.is_listening is False

--- a/apps/network/tests/unit/test_event_manager.py
+++ b/apps/network/tests/unit/test_event_manager.py
@@ -769,7 +769,7 @@ class TestWebsocketHealth(TestWebsocketLifecycle):
         assert any(r.levelno == logging.ERROR and "RuntimeError" in r.getMessage() for r in caplog.records)
 
     @staticmethod
-    def _closing_socket(cm, outcomes):
+    def _closing_socket(cm, outcomes, *, receive_frame=False):
         import asyncio
 
         block = asyncio.Event()
@@ -779,6 +779,8 @@ class TestWebsocketHealth(TestWebsocketLifecycle):
                 outcome = outcomes.pop(0)
                 if outcome is not None:
                     raise outcome
+                if receive_frame:
+                    TestWebsocketHealth._frame_received(cm.controller)
                 return  # accepted, then closed by the peer without an error
             await block.wait()
 
@@ -794,7 +796,7 @@ class TestWebsocketHealth(TestWebsocketLifecycle):
             clock["now"] += 10.0  # every attachment looks long-lived
             return clock["now"]
 
-        self._closing_socket(cm, [RuntimeError("a"), RuntimeError("b"), None, RuntimeError("c")])
+        self._closing_socket(cm, [RuntimeError("a"), RuntimeError("b"), None, RuntimeError("c")], receive_frame=True)
         sleeps.until = 4
         mgr = EventManager(cm)
         mgr._clock = _monotonic

--- a/apps/network/tests/unit/test_runtime_event_config.py
+++ b/apps/network/tests/unit/test_runtime_event_config.py
@@ -1,0 +1,23 @@
+"""The runtime builds the one EventManager from config.network.events.
+
+The factories are lru_cached singletons; this test calls the undecorated
+functions so the process-wide instances (and the tests that assert on them)
+are left alone.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+
+def test_event_buffer_capacity_comes_from_the_env_var(monkeypatch):
+    from unifi_network_mcp import runtime
+
+    monkeypatch.setenv("UNIFI_NETWORK_EVENT_BUFFER_SIZE", "7")
+    monkeypatch.setattr(runtime, "get_config", runtime.get_config.__wrapped__)
+    monkeypatch.setattr(runtime, "get_connection_manager", lambda: MagicMock())
+
+    assert runtime.get_event_manager.__wrapped__().buffer_capacity == 7

--- a/apps/network/tests/unit/test_server_cleanup.py
+++ b/apps/network/tests/unit/test_server_cleanup.py
@@ -1,0 +1,34 @@
+"""Server teardown releases the controller after normal and failed startup."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [None, "initialize", "registration", "transport"])
+async def test_server_always_closes_its_connection(monkeypatch, failure):
+    from unifi_network_mcp import main
+
+    initialize = AsyncMock(return_value=False)
+    registration = AsyncMock()
+    transport = AsyncMock()
+    close = AsyncMock()
+    stages = {"initialize": initialize, "registration": registration, "transport": transport}
+    if failure:
+        stages[failure].side_effect = RuntimeError("startup failure")
+    monkeypatch.setattr(main.connection_manager, "initialize", initialize)
+    monkeypatch.setattr(main.connection_manager, "cleanup", close)
+    monkeypatch.setattr(main.event_manager, "stop_listening", AsyncMock())
+    monkeypatch.setattr("unifi_mcp_shared.bootstrap.assert_credentials_configured", lambda *a, **kw: None)
+    monkeypatch.setattr("unifi_mcp_shared.tool_registration.register_tools_for_mode", registration)
+    monkeypatch.setattr("unifi_mcp_shared.transport.run_transports", transport)
+    monkeypatch.setattr(
+        "unifi_mcp_shared.transport.resolve_http_config", lambda *a, **kw: (False, "http", "127.0.0.1", 3000)
+    )
+    if failure:
+        with pytest.raises(RuntimeError, match="startup failure"):
+            await main.main_async()
+    else:
+        await main.main_async()
+    close.assert_awaited_once()

--- a/apps/network/tests/unit/test_subscribe_events_tool.py
+++ b/apps/network/tests/unit/test_subscribe_events_tool.py
@@ -51,6 +51,82 @@ class TestUnifiRecentEvents:
         )
 
 
+class TestListenerState:
+    @pytest.mark.asyncio
+    async def test_recent_events_reports_a_running_listener(self, mock_event_manager):
+        from unifi_network_mcp.tools.events import unifi_recent_events
+
+        mock_event_manager.get_recent_from_buffer.return_value = []
+        mock_event_manager.buffer_size = 0
+        mock_event_manager.buffer_capacity = 100
+        mock_event_manager.is_listening = True
+        mock_event_manager.attached = True
+        mock_event_manager.last_error = None
+
+        result = await unifi_recent_events()
+
+        assert result["success"] is True
+        assert result["listening"] is True
+        assert result["attached"] is True
+        assert result["buffer_capacity"] == 100
+        assert "hint" not in result
+
+    @pytest.mark.asyncio
+    async def test_recent_events_hints_when_the_listener_is_not_running(self, mock_event_manager):
+        """An empty buffer with no listener is not "no events"; say so."""
+        from unifi_network_mcp.tools.events import unifi_recent_events
+
+        mock_event_manager.get_recent_from_buffer.return_value = []
+        mock_event_manager.buffer_size = 0
+        mock_event_manager.buffer_capacity = 100
+        mock_event_manager.is_listening = False
+
+        result = await unifi_recent_events()
+
+        assert result["listening"] is False
+        assert "UNIFI_NETWORK_WEBSOCKET_ENABLED" in result["hint"]
+        assert "unifi_list_events" in result["hint"]
+
+    @pytest.mark.asyncio
+    async def test_recent_events_hints_when_the_listener_never_attached(self, mock_event_manager):
+        from unifi_network_mcp.tools.events import unifi_recent_events
+
+        mock_event_manager.get_recent_from_buffer.return_value = []
+        mock_event_manager.buffer_size = 0
+        mock_event_manager.buffer_capacity = 100
+        mock_event_manager.is_listening = True
+        mock_event_manager.attached = False
+        mock_event_manager.last_error = "WSServerHandshakeError (HTTP 404)"
+
+        result = await unifi_recent_events()
+
+        assert result["listening"] is True
+        assert result["attached"] is False
+        assert result["last_error"] == "WSServerHandshakeError (HTTP 404)"
+        assert "has not attached" in result["hint"]
+
+    def test_tools_and_main_share_one_event_manager(self):
+        from unifi_network_mcp import runtime
+        from unifi_network_mcp.tools import events
+
+        assert events._get_event_manager() is runtime.event_manager
+
+    @pytest.mark.asyncio
+    async def test_subscribe_events_reports_listener_state(self, mock_event_manager):
+        from unifi_network_mcp.tools.events import unifi_subscribe_events
+
+        mock_event_manager.buffer_size = 0
+        mock_event_manager.buffer_capacity = 100
+        mock_event_manager.is_listening = False
+
+        result = await unifi_subscribe_events()
+
+        assert result["success"] is True
+        assert result["listening"] is False
+        assert result["buffer_capacity"] == 100
+        assert "hint" in result
+
+
 class TestUnifiSubscribeEvents:
     @pytest.mark.asyncio
     async def test_unifi_subscribe_events_returns_handle_dict(self, mock_event_manager):

--- a/apps/network/tests/unit/test_websocket_wiring.py
+++ b/apps/network/tests/unit/test_websocket_wiring.py
@@ -1,0 +1,80 @@
+"""Guard the call site: `main_async` must start and stop the event listener.
+
+`EventManager.start_listening` existed and was never called by the Network
+server, so the websocket buffer behind `unifi_recent_events` could not fill in
+production. These tests drive `main_async` and assert on what it awaits.
+"""
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+from unifi_network_mcp import main as network_main
+from unifi_network_mcp.runtime import config
+
+
+@contextmanager
+def _startup(
+    *,
+    connected: bool,
+    websocket_enabled: bool,
+    listener: AsyncMock | None = None,
+    transports: AsyncMock | None = None,
+):
+    events = dict(getattr(config.network, "events", {}) or {})
+    events["websocket_enabled"] = websocket_enabled
+    with (
+        patch.object(config.network, "events", events),
+        patch("unifi_mcp_shared.bootstrap.assert_credentials_configured"),
+        patch.object(network_main.connection_manager, "initialize", AsyncMock(return_value=connected)),
+        patch.object(network_main.event_manager, "start_listening", listener or AsyncMock()) as started,
+        patch.object(network_main.event_manager, "stop_listening", AsyncMock()) as stopped,
+        patch("unifi_mcp_shared.tool_registration.register_tools_for_mode", AsyncMock()),
+        patch("unifi_mcp_shared.transport.resolve_http_config", return_value=(False, "http", "0.0.0.0", 3000)),
+        patch("unifi_mcp_shared.transport.run_transports", transports or AsyncMock()) as ran,
+    ):
+        yield started, stopped, ran
+
+
+def test_the_listener_is_started_on_a_successful_websocket_enabled_startup() -> None:
+    with _startup(connected=True, websocket_enabled=True) as (started, _, ran):
+        asyncio.run(network_main.main_async())
+        started.assert_awaited_once()
+        assert ran.await_count == 1, "startup never reached its transports"
+
+
+def test_the_listener_is_not_started_when_the_connection_fails() -> None:
+    with _startup(connected=False, websocket_enabled=True) as (started, _, _):
+        asyncio.run(network_main.main_async())
+        started.assert_not_awaited()
+
+
+def test_the_listener_is_not_started_when_the_websocket_is_disabled() -> None:
+    with _startup(connected=True, websocket_enabled=False) as (started, _, _):
+        asyncio.run(network_main.main_async())
+        started.assert_not_awaited()
+
+
+def test_a_listener_failure_does_not_take_the_server_down() -> None:
+    failing = AsyncMock(side_effect=RuntimeError("no websocket"))
+    with _startup(connected=True, websocket_enabled=True, listener=failing) as (started, _, ran):
+        asyncio.run(network_main.main_async())
+        started.assert_awaited_once()
+        assert ran.await_count == 1, "a websocket failure stopped the server starting"
+
+
+def test_the_listener_is_stopped_when_the_transports_return() -> None:
+    with _startup(connected=True, websocket_enabled=True) as (_, stopped, _):
+        asyncio.run(network_main.main_async())
+        stopped.assert_awaited_once()
+
+
+def test_the_listener_is_stopped_when_the_transports_fail() -> None:
+    """The background socket task must not outlive the server on an error exit."""
+    crashing = AsyncMock(side_effect=RuntimeError("bind failed"))
+    with _startup(connected=True, websocket_enabled=True, transports=crashing) as (_, stopped, _):
+        try:
+            asyncio.run(network_main.main_async())
+        except RuntimeError:
+            pass
+        stopped.assert_awaited_once()

--- a/apps/protect/src/unifi_protect_mcp/main.py
+++ b/apps/protect/src/unifi_protect_mcp/main.py
@@ -60,69 +60,75 @@ async def main_async():
     check_unknown_policy_env_vars("protect", logger, policy_gates(), PROTECT_CATEGORY_MAP)
     assert_credentials_configured(config, plugin_name="unifi-protect", env_prefix="PROTECT", logger=logger)
 
-    # Initialize the global Protect connection
-    logger.info("Initializing global Protect connection from main_async...")
-    if not await connection_manager.initialize():
-        logger.error("Failed to connect to UniFi Protect. Tool functionality may be impaired.")
-    else:
-        logger.info("Global Protect connection initialized successfully from main_async.")
-
-        # Start the websocket event listener if enabled and connection succeeded
-        ws_enabled_raw = config.protect.events.get("websocket_enabled", True) if hasattr(config, "protect") else True
-        ws_enabled = parse_config_bool(ws_enabled_raw)
-        if ws_enabled:
-            try:
-                event_manager.set_server(server)
-                await event_manager.start_listening()
-                logger.info("Protect event websocket listener started.")
-            except Exception as ws_exc:
-                logger.error(
-                    "Failed to start event websocket listener: %s. "
-                    "Real-time events will be unavailable; REST queries still work.",
-                    ws_exc,
-                    exc_info=True,
-                )
-        else:
-            logger.info("Protect event websocket disabled via config.")
-
-    # ---- Register MCP resources ----
     try:
-        import unifi_protect_mcp.resources.events  # noqa: F401
-        import unifi_protect_mcp.resources.snapshots  # noqa: F401
+        # Initialize the global Protect connection
+        logger.info("Initializing global Protect connection from main_async...")
+        if not await connection_manager.initialize():
+            logger.error("Failed to connect to UniFi Protect. Tool functionality may be impaired.")
+        else:
+            logger.info("Global Protect connection initialized successfully from main_async.")
 
-        logger.info("MCP resources registered (events, snapshots).")
-    except Exception as res_exc:
-        logger.error("Failed to register MCP resources: %s", res_exc, exc_info=True)
+            # Start the websocket event listener if enabled and connection succeeded
+            ws_enabled_raw = config.protect.events.get("websocket_enabled", True) if hasattr(config, "protect") else True
+            ws_enabled = parse_config_bool(ws_enabled_raw)
+            if ws_enabled:
+                try:
+                    event_manager.set_server(server)
+                    await event_manager.start_listening()
+                    logger.info("Protect event websocket listener started.")
+                except Exception as ws_exc:
+                    logger.error(
+                        "Failed to start event websocket listener: %s. "
+                        "Real-time events will be unavailable; REST queries still work.",
+                        ws_exc,
+                        exc_info=True,
+                    )
+            else:
+                logger.info("Protect event websocket disabled via config.")
 
-    # ---- Register tools ----
-    await register_tools_for_mode(
-        mode=UNIFI_TOOL_REGISTRATION_MODE,
-        server=server,
-        original_tool_decorator=_original_tool_decorator,
-        tool_index_handler=tool_index_handler,
-        start_async_tool=start_async_tool,
-        get_job_status=get_job_status,
-        register_tool=register_tool,
-        tool_module_map=TOOL_MODULE_MAP,
-        setup_lazy_loading=setup_lazy_loading,
-        base_package="unifi_protect_mcp.tools",
-        config=config,
-        logger=logger,
-        support_bundle_handler=support_bundle_service.generate,
-        prefix="protect",
-        server_label="UniFi Protect",
-    )
+        # ---- Register MCP resources ----
+        try:
+            import unifi_protect_mcp.resources.events  # noqa: F401
+            import unifi_protect_mcp.resources.snapshots  # noqa: F401
 
-    # ---- Start transports ----
-    http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3001, logger=logger)
-    await run_transports(
-        server=server,
-        http_enabled=http_enabled,
-        host=host,
-        port=port,
-        http_transport=http_transport,
-        logger=logger,
-    )
+            logger.info("MCP resources registered (events, snapshots).")
+        except Exception as res_exc:
+            logger.error("Failed to register MCP resources: %s", res_exc, exc_info=True)
+
+        # ---- Register tools ----
+        await register_tools_for_mode(
+            mode=UNIFI_TOOL_REGISTRATION_MODE,
+            server=server,
+            original_tool_decorator=_original_tool_decorator,
+            tool_index_handler=tool_index_handler,
+            start_async_tool=start_async_tool,
+            get_job_status=get_job_status,
+            register_tool=register_tool,
+            tool_module_map=TOOL_MODULE_MAP,
+            setup_lazy_loading=setup_lazy_loading,
+            base_package="unifi_protect_mcp.tools",
+            config=config,
+            logger=logger,
+            support_bundle_handler=support_bundle_service.generate,
+            prefix="protect",
+            server_label="UniFi Protect",
+        )
+
+        # ---- Start transports ----
+        http_enabled, http_transport, host, port = resolve_http_config(config.server, default_port=3001, logger=logger)
+        await run_transports(
+            server=server,
+            http_enabled=http_enabled,
+            host=host,
+            port=port,
+            http_transport=http_transport,
+            logger=logger,
+        )
+    finally:
+        try:
+            await event_manager.stop_listening()
+        finally:
+            await connection_manager.close()
 
 
 def main():

--- a/apps/protect/src/unifi_protect_mcp/main.py
+++ b/apps/protect/src/unifi_protect_mcp/main.py
@@ -69,7 +69,9 @@ async def main_async():
             logger.info("Global Protect connection initialized successfully from main_async.")
 
             # Start the websocket event listener if enabled and connection succeeded
-            ws_enabled_raw = config.protect.events.get("websocket_enabled", True) if hasattr(config, "protect") else True
+            ws_enabled_raw = (
+                config.protect.events.get("websocket_enabled", True) if hasattr(config, "protect") else True
+            )
             ws_enabled = parse_config_bool(ws_enabled_raw)
             if ws_enabled:
                 try:

--- a/apps/protect/tests/unit/test_server_cleanup.py
+++ b/apps/protect/tests/unit/test_server_cleanup.py
@@ -1,0 +1,34 @@
+"""Server teardown releases the controller after normal and failed startup."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [None, "initialize", "registration", "transport"])
+async def test_server_always_closes_its_connection(monkeypatch, failure):
+    from unifi_protect_mcp import main
+
+    initialize = AsyncMock(return_value=False)
+    registration = AsyncMock()
+    transport = AsyncMock()
+    close = AsyncMock()
+    stages = {"initialize": initialize, "registration": registration, "transport": transport}
+    if failure:
+        stages[failure].side_effect = RuntimeError("startup failure")
+    monkeypatch.setattr(main.connection_manager, "initialize", initialize)
+    monkeypatch.setattr(main.connection_manager, "close", close)
+    monkeypatch.setattr(main.event_manager, "stop_listening", AsyncMock())
+    monkeypatch.setattr("unifi_mcp_shared.bootstrap.assert_credentials_configured", lambda *a, **kw: None)
+    monkeypatch.setattr("unifi_mcp_shared.tool_registration.register_tools_for_mode", registration)
+    monkeypatch.setattr("unifi_mcp_shared.transport.run_transports", transport)
+    monkeypatch.setattr(
+        "unifi_mcp_shared.transport.resolve_http_config", lambda *a, **kw: (False, "http", "127.0.0.1", 3000)
+    )
+    if failure:
+        with pytest.raises(RuntimeError, match="startup failure"):
+            await main.main_async()
+    else:
+        await main.main_async()
+    close.assert_awaited_once()

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -746,6 +746,15 @@ class ConnectionManager:
 
         return True
 
+    async def reauthenticate(self) -> bool:
+        """Refresh the controller login for the current session generation.
+
+        For callers outside ``request()`` that learn the session is stale on
+        their own, such as the event websocket after a rejected handshake.
+        Honours the reconnect circuit like every other login path.
+        """
+        return await self._reauthenticate(self._auth_generation)
+
     async def _reauthenticate(self, expected_generation: int) -> bool:
         """Refresh an expired controller login once, deduplicating concurrent attempts."""
         if self._reconnect_block_active():

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -492,6 +492,17 @@ class ConnectionManager:
         self._reconnect_block_count = 0
 
     @property
+    def reconnect_cooldown_active(self) -> bool:
+        """True while the auth circuit's cool-down is running.
+
+        Unlike :attr:`reconnect_blocked`, which stays latched until a login
+        succeeds, this half-opens on the timer: a caller that retries on its
+        own (the event websocket) consults this and gets one attempt after
+        expiry instead of waiting for a process restart.
+        """
+        return self._reconnect_block_active() is not None
+
+    @property
     def reconnect_blocked(self) -> bool:
         """Whether the last authentication attempt failed terminally with no success since."""
         return self._reconnect_block_error is not None

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -128,6 +128,11 @@ class EventManager:
         self._last_error: str | None = None
         self._attach_failures = 0
         self._clock = time.monotonic  # injectable for tests; the loop's clock is untouched
+        # The socket currently being attached: aiounifi's connectivity object
+        # (it stamps ws_message_received on every frame) and the stamp it held
+        # when this attempt began. None outside an attempt (backoff, stopped).
+        self._ws_connectivity: Any = None
+        self._ws_frame_baseline: Any = None
 
     # ------------------------------------------------------------------
     # Websocket lifecycle
@@ -147,13 +152,20 @@ class EventManager:
 
     @property
     def attached(self) -> bool:
-        """True when the task is alive and its current attach is in progress or open.
+        """True only while a frame has been received on the socket now open.
 
-        A running task is not an open socket: a controller that rejects the
-        handshake forever, or accepts and closes at once, keeps the task alive
-        and the buffer empty; both leave ``last_error`` set.
+        A running task is not an open socket: a controller that holds the
+        handshake, rejects it, or accepts and closes at once keeps the task
+        alive and the buffer empty. aiounifi exposes no open/close callback,
+        but it stamps ``ws_message_received`` on every frame, and the
+        controller sends sync frames continuously, so a stamp that changed
+        since the current attempt began is the confirmation (a stamp left by
+        an earlier socket does not count). Cleared the moment
+        ``start_websocket`` returns or raises, for the whole backoff.
         """
-        return self.is_listening and self._last_error is None
+        if not self.is_listening or self._ws_connectivity is None:
+            return False
+        return getattr(self._ws_connectivity, "ws_message_received", None) != self._ws_frame_baseline
 
     @property
     def last_error(self) -> str | None:
@@ -185,28 +197,41 @@ class EventManager:
         logger.info("[network-event-mgr] websocket listener started")
 
     async def stop_listening(self) -> None:
-        """Stop the background websocket task and drop the subscription."""
+        """Stop the background websocket task and drop the subscription.
+
+        The subscription is released in ``finally``: a cancellation aimed at
+        the stopping caller (a second interrupt at shutdown) still propagates,
+        but never leaves the controller holding our callback.
+        """
         self._stopping = True
         self._closed = True
         task, self._ws_task = self._ws_task, None
-        if task is not None and not task.done():
-            current = asyncio.current_task()
-            cancelling_before = current.cancelling() if current is not None else 0
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                # Re-raise when the cancellation was aimed at the caller, not
-                # at the task we just cancelled (a second interrupt at shutdown).
-                if current is not None and current.cancelling() > cancelling_before:
-                    raise
-            except Exception as exc:
-                logger.error("[network-event-mgr] websocket loop ended with %s", type(exc).__name__)
-                logger.debug("[network-event-mgr] websocket loop failure", exc_info=exc)
-        self._unsubscribe()
-        self._last_error = None
-        if task is not None:
-            logger.info("[network-event-mgr] websocket listener stopped")
+        try:
+            if task is not None and not task.done():
+                current = asyncio.current_task()
+                cancelling_before = current.cancelling() if current is not None else 0
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    # Re-raise when the cancellation was aimed at the caller,
+                    # not at the task we just cancelled.
+                    if current is not None and current.cancelling() > cancelling_before:
+                        raise
+                except Exception as exc:
+                    logger.error("[network-event-mgr] websocket loop ended with %s", type(exc).__name__)
+                    logger.debug("[network-event-mgr] websocket loop failure", exc_info=exc)
+        finally:
+            self._unsubscribe()
+            self._socket_closed()
+            self._last_error = None
+            if task is not None:
+                logger.info("[network-event-mgr] websocket listener stopped")
+
+    def _socket_closed(self) -> None:
+        """Forget the current attempt: nothing is attached until the next frame."""
+        self._ws_connectivity = None
+        self._ws_frame_baseline = None
 
     @staticmethod
     def _on_task_done(task: "asyncio.Task[None]") -> None:
@@ -265,7 +290,10 @@ class EventManager:
         while not self._stopping:
             needs_reauth = False
             try:
-                if self._cm.reconnect_blocked:
+                # The circuit half-opens on a timer; ``reconnect_blocked``
+                # stays latched until a login succeeds, so it must not gate
+                # the retry or an expired cool-down would never be tried.
+                if self._cm.reconnect_cooldown_active:
                     raise ConnectionError("reconnect circuit open")
                 if not await self._cm.ensure_connected():
                     raise ConnectionError("controller not connected")
@@ -275,7 +303,14 @@ class EventManager:
                 self._subscribe(controller)
                 self._last_error = None
                 attached_at = self._clock()
-                await controller.start_websocket()
+                self._ws_connectivity = getattr(controller, "connectivity", None)
+                self._ws_frame_baseline = getattr(self._ws_connectivity, "ws_message_received", None)
+                try:
+                    await controller.start_websocket()
+                finally:
+                    # Returned or raised: the socket is closed either way, and
+                    # nothing is attached until the next attempt's first frame.
+                    self._socket_closed()
                 # Closed by the peer without an error. Only a socket that
                 # stayed up counts as a success; an accept-then-close is a
                 # failed attach and backs off like one.

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -4,11 +4,13 @@ Manages event log and alarm operations using the v2 system-log API
 (UniFi Network 10.x+). Falls back to legacy /stat/event for older controllers.
 """
 
+import asyncio
 import logging
 import time
 from collections import deque
 from typing import Any, Callable, Dict, List, Optional
 
+import aiohttp
 from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.message import MessageKey
 
@@ -33,6 +35,10 @@ class EventBuffer:
     def __init__(self, max_size: int = 100, ttl_seconds: int = 300) -> None:
         self._buffer: deque[dict[str, Any]] = deque(maxlen=max_size)
         self._ttl = ttl_seconds
+
+    @property
+    def capacity(self) -> int:
+        return self._buffer.maxlen or 0
 
     def add(self, event: dict[str, Any]) -> None:
         """Add *event* to the buffer, stamping it with the current time."""
@@ -115,36 +121,213 @@ class EventManager:
         )
         self._subscribers: list[Callable[[dict], None]] = []
         self._ws_unsub: Callable[[], None] | None = None
+        self._subscribed_controller: Any = None
+        self._ws_task: asyncio.Task[None] | None = None
+        self._stopping = False
+        self._closed = False
+        self._last_error: str | None = None
+        self._attach_failures = 0
+        self._clock = time.monotonic  # injectable for tests; the loop's clock is untouched
 
     # ------------------------------------------------------------------
     # Websocket lifecycle
     # ------------------------------------------------------------------
 
+    # Reconnect backoff bounds, in seconds, and how long a socket must stay
+    # attached before the backoff resets (a peer that accepts then closes at
+    # once must not be polled every second).
+    _BACKOFF_INITIAL = 1.0
+    _BACKOFF_MAX = 60.0
+    _STABLE_SECONDS = 5.0
+
+    @property
+    def is_listening(self) -> bool:
+        """True while the background websocket task is alive."""
+        return self._ws_task is not None and not self._ws_task.done()
+
+    @property
+    def attached(self) -> bool:
+        """True when the task is alive and its current attach is in progress or open.
+
+        A running task is not an open socket: a controller that rejects the
+        handshake forever, or accepts and closes at once, keeps the task alive
+        and the buffer empty; both leave ``last_error`` set.
+        """
+        return self.is_listening and self._last_error is None
+
+    @property
+    def last_error(self) -> str | None:
+        """Class (and HTTP status) of the last attach failure, or ``None``."""
+        return self._last_error
+
     async def start_listening(self) -> None:
-        """Open the aiounifi websocket and subscribe to event/alert messages.
+        """Subscribe to event/alert messages and run the websocket in the background.
 
         aiounifi exposes events through ``Controller.messages`` (a
-        ``MessageHandler``). ``messages.subscribe(callback, message_filter)``
-        returns an unsubscribe callable. We filter to ``EVENT`` + ``ALERT``
-        so only event-log payloads flow through.
+        ``MessageHandler``); ``messages.subscribe(callback, message_filter)``
+        returns an unsubscribe callable. ``Controller.start_websocket()`` is
+        the blocking receive loop with no reconnect of its own, so it runs in
+        a task that reconnects with backoff, re-subscribes when a reconnect
+        replaces the Controller object, and re-logs-in when the handshake is
+        rejected (aiounifi reuses the cookie captured at login). Idempotent.
         """
-        controller = self._cm.controller
-        await controller.start_websocket()
+        if self.is_listening:
+            return
+        if self._closed:
+            # Stopped by its owner (shutdown, or the API dropping the manager
+            # on credential rotation); a late caller must not revive it.
+            logger.debug("[network-event-mgr] start_listening ignored on a stopped manager")
+            return
+        self._stopping = False
+        self._subscribe(self._cm.controller)
+        self._ws_task = asyncio.create_task(self._run_websocket(), name="network-event-websocket")
+        self._ws_task.add_done_callback(self._on_task_done)
+        logger.info("[network-event-mgr] websocket listener started")
+
+    async def stop_listening(self) -> None:
+        """Stop the background websocket task and drop the subscription."""
+        self._stopping = True
+        self._closed = True
+        task, self._ws_task = self._ws_task, None
+        if task is not None and not task.done():
+            current = asyncio.current_task()
+            cancelling_before = current.cancelling() if current is not None else 0
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                # Re-raise when the cancellation was aimed at the caller, not
+                # at the task we just cancelled (a second interrupt at shutdown).
+                if current is not None and current.cancelling() > cancelling_before:
+                    raise
+            except Exception as exc:
+                logger.error("[network-event-mgr] websocket loop ended with %s", type(exc).__name__)
+                logger.debug("[network-event-mgr] websocket loop failure", exc_info=exc)
+        self._unsubscribe()
+        self._last_error = None
+        if task is not None:
+            logger.info("[network-event-mgr] websocket listener stopped")
+
+    @staticmethod
+    def _on_task_done(task: "asyncio.Task[None]") -> None:
+        """Nothing in the loop should escape; if something does, say so now."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("[network-event-mgr] websocket task died: %s", type(exc).__name__)
+            logger.debug("[network-event-mgr] websocket task failure", exc_info=exc)
+
+    def _subscribe(self, controller: Any) -> None:
+        """Bind the message subscription to *controller*, releasing any previous one."""
+        if controller is None or controller is self._subscribed_controller:
+            return
+        self._unsubscribe()
         self._ws_unsub = controller.messages.subscribe(
             self._on_ws_event,
             (MessageKey.EVENT, MessageKey.ALERT),
         )
-        logger.info("[network-event-mgr] websocket subscription started")
+        self._subscribed_controller = controller
 
-    async def stop_listening(self) -> None:
-        """Unsubscribe from the websocket message handler."""
+    def _unsubscribe(self) -> None:
         if self._ws_unsub is not None:
             try:
                 self._ws_unsub()
             except Exception:
                 logger.debug("[network-event-mgr] error unsubscribing", exc_info=True)
-            self._ws_unsub = None
-            logger.info("[network-event-mgr] websocket subscription stopped")
+        self._ws_unsub = None
+        self._subscribed_controller = None
+
+    @staticmethod
+    def _is_rejected_handshake(exc: BaseException) -> bool:
+        return isinstance(exc, aiohttp.WSServerHandshakeError) and exc.status in (401, 403)
+
+    @staticmethod
+    def _describe(exc: BaseException) -> str:
+        """Class name, plus the HTTP status of a handshake error or the text of
+        our own ConnectionError; never aiounifi's messages, which quote the URL."""
+        if isinstance(exc, aiohttp.WSServerHandshakeError):
+            return f"{type(exc).__name__} (HTTP {exc.status})"
+        if type(exc) is ConnectionError:
+            return f"ConnectionError ({exc})"
+        return type(exc).__name__
+
+    async def _run_websocket(self) -> None:
+        """Keep the websocket attached until stopped.
+
+        The loop never spins against the controller: while the connection
+        manager's reconnect circuit is open it only sleeps, and every failure
+        backs off (doubling to ``_BACKOFF_MAX``) until an attach succeeds. A
+        rejected handshake (401/403) triggers one re-login per attempt, since
+        aiounifi reuses the cookie captured at login.
+        """
+        backoff = self._BACKOFF_INITIAL
+        while not self._stopping:
+            needs_reauth = False
+            try:
+                if self._cm.reconnect_blocked:
+                    raise ConnectionError("reconnect circuit open")
+                if not await self._cm.ensure_connected():
+                    raise ConnectionError("controller not connected")
+                controller = self._cm.controller
+                if controller is None:
+                    raise ConnectionError("controller not available")
+                self._subscribe(controller)
+                self._last_error = None
+                attached_at = self._clock()
+                await controller.start_websocket()
+                # Closed by the peer without an error. Only a socket that
+                # stayed up counts as a success; an accept-then-close is a
+                # failed attach and backs off like one.
+                if self._clock() - attached_at < self._STABLE_SECONDS:
+                    raise ConnectionError("closed by the controller before it was stable")
+                backoff = self._BACKOFF_INITIAL
+                self._attach_failures = 0
+                logger.info("[network-event-mgr] websocket closed by the controller; reconnecting")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._last_error = self._describe(exc)
+                self._attach_failures += 1
+                needs_reauth = self._is_rejected_handshake(exc)
+                logger.debug("[network-event-mgr] websocket attach failed", exc_info=True)
+                if backoff >= self._BACKOFF_MAX and self._attach_failures == self._failures_at_max_backoff():
+                    logger.error(
+                        "[network-event-mgr] websocket has not attached after %d attempts (%s); "
+                        "unifi_recent_events will stay empty until it does",
+                        self._attach_failures,
+                        self._last_error,
+                    )
+                else:
+                    logger.warning(
+                        "[network-event-mgr] websocket attach failed (%s); retrying in %.0fs",
+                        self._last_error,
+                        backoff,
+                    )
+            if self._stopping:
+                break
+            if needs_reauth:
+                await self._reauthenticate_quietly()
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, self._BACKOFF_MAX)
+
+    def _failures_at_max_backoff(self) -> int:
+        """The attempt count at which backoff first reaches its cap (escalate once)."""
+        steps, value = 0, self._BACKOFF_INITIAL
+        while value < self._BACKOFF_MAX:
+            value *= 2
+            steps += 1
+        return steps + 1
+
+    async def _reauthenticate_quietly(self) -> None:
+        """Re-login after a rejected handshake; its own failure must not end the loop."""
+        try:
+            ok = await self._cm.reauthenticate()
+        except Exception as exc:
+            logger.warning("[network-event-mgr] re-authentication failed: %s", type(exc).__name__)
+            return
+        if not ok:
+            logger.warning("[network-event-mgr] re-authentication failed; the reconnect circuit may be open")
 
     # ------------------------------------------------------------------
     # Event ingestion + fan-out
@@ -228,7 +411,12 @@ class EventManager:
 
     @property
     def buffer_size(self) -> int:
+        """Current occupancy of the ring buffer (not its capacity)."""
         return len(self._buffer)
+
+    @property
+    def buffer_capacity(self) -> int:
+        return self._buffer.capacity
 
     async def _detect_api_version(self) -> bool:
         """Detect whether the controller supports the v2 system-log API.

--- a/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/event_manager.py
@@ -20,6 +20,10 @@ from unifi_core.network.managers.connection_manager import ConnectionManager
 logger = logging.getLogger("unifi-network-mcp")
 
 
+class _ListenerStateError(ConnectionError):
+    """An internal listener diagnostic constructed only from fixed messages."""
+
+
 # ---------------------------------------------------------------------------
 # EventBuffer
 # ---------------------------------------------------------------------------
@@ -220,7 +224,6 @@ class EventManager:
                         raise
                 except Exception as exc:
                     logger.error("[network-event-mgr] websocket loop ended with %s", type(exc).__name__)
-                    logger.debug("[network-event-mgr] websocket loop failure", exc_info=exc)
         finally:
             self._unsubscribe()
             self._socket_closed()
@@ -241,7 +244,6 @@ class EventManager:
         exc = task.exception()
         if exc is not None:
             logger.error("[network-event-mgr] websocket task died: %s", type(exc).__name__)
-            logger.debug("[network-event-mgr] websocket task failure", exc_info=exc)
 
     def _subscribe(self, controller: Any) -> None:
         """Bind the message subscription to *controller*, releasing any previous one."""
@@ -258,8 +260,8 @@ class EventManager:
         if self._ws_unsub is not None:
             try:
                 self._ws_unsub()
-            except Exception:
-                logger.debug("[network-event-mgr] error unsubscribing", exc_info=True)
+            except Exception as exc:
+                logger.debug("[network-event-mgr] error unsubscribing: %s", type(exc).__name__)
         self._ws_unsub = None
         self._subscribed_controller = None
 
@@ -269,11 +271,10 @@ class EventManager:
 
     @staticmethod
     def _describe(exc: BaseException) -> str:
-        """Class name, plus the HTTP status of a handshake error or the text of
-        our own ConnectionError; never aiounifi's messages, which quote the URL."""
+        """Class name and handshake status; exception messages can contain private data."""
         if isinstance(exc, aiohttp.WSServerHandshakeError):
             return f"{type(exc).__name__} (HTTP {exc.status})"
-        if type(exc) is ConnectionError:
+        if isinstance(exc, _ListenerStateError):
             return f"ConnectionError ({exc})"
         return type(exc).__name__
 
@@ -294,12 +295,12 @@ class EventManager:
                 # stays latched until a login succeeds, so it must not gate
                 # the retry or an expired cool-down would never be tried.
                 if self._cm.reconnect_cooldown_active:
-                    raise ConnectionError("reconnect circuit open")
+                    raise _ListenerStateError("reconnect circuit open")
                 if not await self._cm.ensure_connected():
-                    raise ConnectionError("controller not connected")
+                    raise _ListenerStateError("controller not connected")
                 controller = self._cm.controller
                 if controller is None:
-                    raise ConnectionError("controller not available")
+                    raise _ListenerStateError("controller not available")
                 self._subscribe(controller)
                 self._last_error = None
                 attached_at = self._clock()
@@ -308,14 +309,18 @@ class EventManager:
                 try:
                     await controller.start_websocket()
                 finally:
+                    stable = self.attached and self._clock() - attached_at >= self._STABLE_SECONDS
+                    if stable:
+                        backoff = self._BACKOFF_INITIAL
+                        self._attach_failures = 0
                     # Returned or raised: the socket is closed either way, and
                     # nothing is attached until the next attempt's first frame.
                     self._socket_closed()
                 # Closed by the peer without an error. Only a socket that
                 # stayed up counts as a success; an accept-then-close is a
                 # failed attach and backs off like one.
-                if self._clock() - attached_at < self._STABLE_SECONDS:
-                    raise ConnectionError("closed by the controller before it was stable")
+                if not stable:
+                    raise _ListenerStateError("closed by the controller before it was stable")
                 backoff = self._BACKOFF_INITIAL
                 self._attach_failures = 0
                 logger.info("[network-event-mgr] websocket closed by the controller; reconnecting")
@@ -325,7 +330,6 @@ class EventManager:
                 self._last_error = self._describe(exc)
                 self._attach_failures += 1
                 needs_reauth = self._is_rejected_handshake(exc)
-                logger.debug("[network-event-mgr] websocket attach failed", exc_info=True)
                 if backoff >= self._BACKOFF_MAX and self._attach_failures == self._failures_at_max_backoff():
                     logger.error(
                         "[network-event-mgr] websocket has not attached after %d attempts (%s); "

--- a/packages/unifi-core/src/unifi_core/protect/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/connection_manager.py
@@ -101,7 +101,7 @@ class ProtectConnectionManager:
         )
 
         async def _connect() -> None:
-            self._client = ProtectApiClient(
+            client = ProtectApiClient(
                 host=self.host,
                 port=self.port,
                 username=self.username,
@@ -110,7 +110,14 @@ class ProtectConnectionManager:
                 verify_ssl=self.verify_ssl,
             )
             # update() authenticates + fetches the full bootstrap (NVR, cameras, etc.)
-            await self._client.update()
+            try:
+                await client.update()
+            except BaseException:
+                # A failed or cancelled bootstrap must not orphan the SDK's
+                # session when a later retry creates another client.
+                await self._dispose_client(client)
+                raise
+            self._client = client
 
         self._support_attempt = connection_attempt_started()
         try:
@@ -135,6 +142,14 @@ class ProtectConnectionManager:
             self._initialized = False
             return False
 
+    @staticmethod
+    async def _dispose_client(client: ProtectApiClient) -> None:
+        for operation in ("async_disconnect_ws", "close_session"):
+            try:
+                await getattr(client, operation)()
+            except Exception as exc:
+                logger.debug("[protect-cm] %s failed: %s", operation, type(exc).__name__)
+
     async def close(self) -> None:
         """Gracefully shut down websocket, client session, and API session."""
         if self._ws_unsub is not None:
@@ -145,14 +160,7 @@ class ProtectConnectionManager:
             self._ws_unsub = None
 
         if self._client is not None:
-            try:
-                await self._client.async_disconnect_ws()
-            except Exception:
-                logger.debug("[protect-cm] Error disconnecting websocket", exc_info=True)
-            try:
-                await self._client.close_session()
-            except Exception:
-                logger.debug("[protect-cm] Error closing client session", exc_info=True)
+            await self._dispose_client(self._client)
             self._client = None
 
         if self._api_session is not None and not self._api_session.closed:

--- a/packages/unifi-core/tests/network/managers/test_connection_manager_reauthenticate.py
+++ b/packages/unifi-core/tests/network/managers/test_connection_manager_reauthenticate.py
@@ -17,3 +17,23 @@ async def test_reauthenticate_refreshes_the_current_session_generation():
     assert await manager.reauthenticate() is True
 
     manager._reauthenticate.assert_awaited_once_with(3)
+
+
+def test_reconnect_cooldown_active_half_opens_on_the_timer(monkeypatch):
+    """``reconnect_blocked`` stays latched until a login succeeds (the audit
+    signal); ``reconnect_cooldown_active`` is the time-aware gate a retrying
+    caller must consult, and it clears when the cool-down expires."""
+    from unifi_core.network.managers import connection_manager as cm_module
+
+    manager = ConnectionManager("192.168.1.1", "admin", "secret")
+    now = {"t": 1000.0}
+    monkeypatch.setattr(cm_module._time, "monotonic", lambda: now["t"])
+
+    assert manager.reconnect_cooldown_active is False
+    manager._block_automatic_reconnect(RuntimeError("401"))
+    assert manager.reconnect_blocked is True
+    assert manager.reconnect_cooldown_active is True
+
+    now["t"] = manager._reconnect_block_until + 1
+    assert manager.reconnect_blocked is True
+    assert manager.reconnect_cooldown_active is False

--- a/packages/unifi-core/tests/network/managers/test_connection_manager_reauthenticate.py
+++ b/packages/unifi-core/tests/network/managers/test_connection_manager_reauthenticate.py
@@ -1,0 +1,19 @@
+"""``ConnectionManager.reauthenticate`` is the public entry the event websocket
+loop uses after a 401 handshake: aiounifi reuses the login cookie captured at
+login and never re-logs-in on its own."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from unifi_core.network.managers.connection_manager import ConnectionManager
+
+
+@pytest.mark.asyncio
+async def test_reauthenticate_refreshes_the_current_session_generation():
+    manager = ConnectionManager("192.168.1.1", "admin", "secret")
+    manager._auth_generation = 3
+    manager._reauthenticate = AsyncMock(return_value=True)
+
+    assert await manager.reauthenticate() is True
+
+    manager._reauthenticate.assert_awaited_once_with(3)

--- a/packages/unifi-core/tests/network/managers/test_event_manager_streaming.py
+++ b/packages/unifi-core/tests/network/managers/test_event_manager_streaming.py
@@ -9,6 +9,7 @@ from unifi_core.network.managers.event_manager import EventManager
 def _make_manager_with_mock_cm() -> EventManager:
     cm = MagicMock()
     cm.reconnect_blocked = False
+    cm.reconnect_cooldown_active = False
     cm.ensure_connected = AsyncMock(return_value=True)
     cm.controller = MagicMock()
     cm.controller.start_websocket = AsyncMock()

--- a/packages/unifi-core/tests/network/managers/test_event_manager_streaming.py
+++ b/packages/unifi-core/tests/network/managers/test_event_manager_streaming.py
@@ -8,6 +8,8 @@ from unifi_core.network.managers.event_manager import EventManager
 
 def _make_manager_with_mock_cm() -> EventManager:
     cm = MagicMock()
+    cm.reconnect_blocked = False
+    cm.ensure_connected = AsyncMock(return_value=True)
     cm.controller = MagicMock()
     cm.controller.start_websocket = AsyncMock()
     cm.controller.messages = MagicMock()
@@ -76,11 +78,22 @@ def test_get_recent_from_buffer_returns_buffered() -> None:
 
 @pytest.mark.asyncio
 async def test_start_listening_calls_controller_start_websocket() -> None:
+    """The receive loop runs in a background task; start_listening returns at once."""
+    import asyncio
+
     mgr = _make_manager_with_mock_cm()
+    started = asyncio.Event()
+
+    async def _ws():
+        started.set()
+        await asyncio.Event().wait()
+
+    mgr._cm.controller.start_websocket = AsyncMock(side_effect=_ws)
     await mgr.start_listening()
-    mgr._cm.controller.start_websocket.assert_awaited_once()
-    # subscribe was called to register _on_ws_event handler
+    # subscribe is registered before the loop starts
     mgr._cm.controller.messages.subscribe.assert_called_once()
+    await asyncio.wait_for(started.wait(), 1)
+    await mgr.stop_listening()
 
 
 @pytest.mark.asyncio

--- a/packages/unifi-core/tests/protect/test_connection_cleanup.py
+++ b/packages/unifi-core/tests/protect/test_connection_cleanup.py
@@ -1,0 +1,48 @@
+"""Failed bootstrap attempts must release their SDK clients before retrying."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.protect.managers import connection_manager as module
+
+
+@pytest.mark.asyncio
+async def test_failed_retries_close_every_client(monkeypatch):
+    clients = [MagicMock() for _ in range(3)]
+    for client in clients:
+        client.update = AsyncMock(side_effect=RuntimeError("bootstrap failed"))
+        client.async_disconnect_ws = AsyncMock()
+        client.close_session = AsyncMock()
+    monkeypatch.setattr(module, "ProtectApiClient", MagicMock(side_effect=clients))
+
+    async def retry(call, **kwargs):
+        for _ in range(3):
+            try:
+                await call()
+            except RuntimeError:
+                continue
+        raise RuntimeError("retries exhausted")
+
+    monkeypatch.setattr(module, "retry_with_backoff", retry)
+    manager = module.ProtectConnectionManager(host="controller.invalid", username="test", password="test")
+    assert await manager.initialize() is False
+    assert manager._client is None
+    for client in clients:
+        client.async_disconnect_ws.assert_awaited_once()
+        client.close_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_bootstrap_closes_client_and_propagates(monkeypatch):
+    client = MagicMock()
+    client.update = AsyncMock(side_effect=asyncio.CancelledError())
+    client.async_disconnect_ws = AsyncMock()
+    client.close_session = AsyncMock()
+    monkeypatch.setattr(module, "ProtectApiClient", MagicMock(return_value=client))
+    manager = module.ProtectConnectionManager(host="controller.invalid", username="test", password="test")
+    with pytest.raises(asyncio.CancelledError):
+        await manager.initialize()
+    client.async_disconnect_ws.assert_awaited_once()
+    client.close_session.assert_awaited_once()
+    assert manager._client is None


### PR DESCRIPTION
Network's websocket event buffer was never started by the MCP server, and the listener subscribed only after awaiting the receive loop. The server now starts one runtime event manager, subscribes before receiving, and runs the socket in an owned background task with bounded reconnect backoff and session reauthentication.

The buffered-event and subscription tools report listener state, attachment, buffer occupancy/capacity, and a diagnostic when the stream is unavailable. Attachment requires a frame received on the current socket; resetting reconnect backoff also requires a stable attachment. Operators can disable the listener with `UNIFI_NETWORK_WEBSOCKET_ENABLED`. Buffer size and TTL are configurable and documented.

The API manager factory now owns listener startup and disposal, including managers created after credential rotation. Discarding a manager terminates its SSE streams so clients can reconnect; old callbacks and old stream cleanup cannot affect the replacement manager. All three MCP servers now close their controller sessions after normal shutdown or startup/transport failures. Failed or cancelled Protect initialization also closes each partially constructed SDK client before retrying. Healing a blocked API connection evicts only the managers attached to that connection, preserving healthy sibling streams. Websocket diagnostics expose exception classes/statuses rather than raw exception details.

Addresses the event-listener portion of #635. Other portions remain separate.

Validation:

- Focused Network lifecycle/tool tests: 83 passed; focused API factory/SSE/lifespan tests: 38 passed.
- Integrated with the published startup security fix; Shared >=0.6.17 remains required. Full `make pre-commit` passed; the final API suite passed all 1,470 tests, and all 14 GitHub checks passed on c567a6010ae42988213baf5c001595ec33dc275d.
- Independently built Core and app wheels, installed outside the checkout with published Shared 0.6.17, and exercised the actual MCP stdio startup against the controller. Enabled: listening and attached, normal controller read succeeded. Disabled: neither listening nor attached, normal controller read succeeded. Both shutdowns produced no unclosed-session warning.
- No event arrived during the live observation window. That run proves real attachment and cleanup; event ingestion, reconnect timing, cancellation, and credential-rotation stream delivery are covered by deterministic tests.

Installed-wheel safe matrix: Network 162 successful checks, Protect 59, Access 44; zero failures, all disposable resources cleaned up. Approval-required operations were not executed.

Publication requires releasing the new Core 0.4.49 code first and raising Network/API Core dependency floors before app releases. The source-wheel check used the Core wheel built from this branch; it is not evidence that the published Core package already contains these changes.
