### PR TITLE
fix: guide callers to accepted MAC argument names

### DIFF
--- a/apps/network/src/unifi_network_mcp/tools/clients.py
+++ b/apps/network/src/unifi_network_mcp/tools/clients.py
@@ -71,7 +71,12 @@ async def lookup_by_ip(
         "include_offline=true for historical clients. Use search to filter by "
         "name/hostname/IP/MAC (case-insensitive). For a single client's full raw "
         "object, use unifi_get_client_details. For IP-to-client lookup, use "
-        "unifi_lookup_by_ip."
+        "unifi_lookup_by_ip. Pass an entry's mac to the client tools as "
+        "mac_address (unifi_get_client_details, unifi_block_client, "
+        "unifi_rename_client, ...), as client_mac (unifi_get_client_sessions, "
+        "unifi_get_client_dpi_traffic, unifi_get_client_wifi_details) or as mac "
+        "(unifi_recent_events); the parameter name differs per tool and each tool "
+        "accepts only its own."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
@@ -168,7 +173,11 @@ async def get_client_details(
 
 @server.tool(
     name="unifi_list_blocked_clients",
-    description="Lists clients/devices currently blocked from the network. Each entry includes mac, hostname, name, last_seen, blocked.",
+    description=(
+        "Lists clients/devices currently blocked from the network. Each entry includes "
+        "mac, hostname, name, last_seen, blocked. Pass an entry's mac to "
+        "unifi_unblock_client as mac_address."
+    ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )
 async def list_blocked_clients() -> Dict[str, Any]:

--- a/apps/network/src/unifi_network_mcp/tools/devices.py
+++ b/apps/network/src/unifi_network_mcp/tools/devices.py
@@ -43,7 +43,14 @@ logger = logging.getLogger(__name__)
         "Use search to filter by name, IP, or MAC (case-insensitive). "
         "Set include_details=true for additional per-device fields: by default (summary=true) "
         "compressed radio/port summaries; set summary=false to return the full raw tables "
-        "(radio_table, port_table, network_table, system_stats, wan1/wan2)."
+        "(radio_table, port_table, network_table, system_stats, wan1/wan2). "
+        "Pass an entry's MAC to the device tools as mac_address "
+        "(unifi_get_device_details, unifi_reboot_device, unifi_rename_device, "
+        "unifi_upgrade_device, ...), as device_mac (unifi_get_switch_ports, "
+        "unifi_get_port_stats, unifi_set_switch_port_profile, unifi_locate_device, ...) "
+        "or as ap_mac on the RF tools (unifi_trigger_rf_scan, unifi_get_rf_scan_results), "
+        "which take the access point to scan from; the parameter name differs per tool "
+        "and each tool accepts only its own."
     ),
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
 )

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -10943,7 +10943,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Lists clients/devices currently blocked from the network. Each entry includes mac, hostname, name, last_seen, blocked.",
+      "description": "Lists clients/devices currently blocked from the network. Each entry includes mac, hostname, name, last_seen, blocked. Pass an entry's mac to unifi_unblock_client as mac_address.",
       "name": "unifi_list_blocked_clients",
       "schema": {
         "input": {
@@ -11111,7 +11111,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns connected clients with mac, name, hostname, ip, status (online/offline), connection type (wired/wireless), and for wireless clients: ssid, signal_dbm, channel, radio. Filter by filter_type (all/wired/wireless), set include_offline=true for historical clients. Use search to filter by name/hostname/IP/MAC (case-insensitive). For a single client's full raw object, use unifi_get_client_details. For IP-to-client lookup, use unifi_lookup_by_ip.",
+      "description": "Returns connected clients with mac, name, hostname, ip, status (online/offline), connection type (wired/wireless), and for wireless clients: ssid, signal_dbm, channel, radio. Filter by filter_type (all/wired/wireless), set include_offline=true for historical clients. Use search to filter by name/hostname/IP/MAC (case-insensitive). For a single client's full raw object, use unifi_get_client_details. For IP-to-client lookup, use unifi_lookup_by_ip. Pass an entry's mac to the client tools as mac_address (unifi_get_client_details, unifi_block_client, unifi_rename_client, ...), as client_mac (unifi_get_client_sessions, unifi_get_client_dpi_traffic, unifi_get_client_wifi_details) or as mac (unifi_recent_events); the parameter name differs per tool and each tool accepts only its own.",
       "name": "unifi_list_clients",
       "schema": {
         "input": {
@@ -11300,7 +11300,7 @@
         "openWorldHint": false,
         "readOnlyHint": true
       },
-      "description": "Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_category (ap/switch/gateway/pdu), upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). Note: device_type=ap correctly excludes USP Smart Power strips. Use search to filter by name, IP, or MAC (case-insensitive). Set include_details=true for additional per-device fields: by default (summary=true) compressed radio/port summaries; set summary=false to return the full raw tables (radio_table, port_table, network_table, system_stats, wan1/wan2).",
+      "description": "Returns adopted device inventory with MAC, name, model, IP, firmware version, uptime, status (online/offline/upgrading/etc), device_category (ap/switch/gateway/pdu), upgradable flag, connection_network, uplink topology, load_avg, mem_pct, and model_eol. Filter by device_type (ap/switch/gateway/pdu) and status (online/offline/pending/upgrading). Note: device_type=ap correctly excludes USP Smart Power strips. Use search to filter by name, IP, or MAC (case-insensitive). Set include_details=true for additional per-device fields: by default (summary=true) compressed radio/port summaries; set summary=false to return the full raw tables (radio_table, port_table, network_table, system_stats, wan1/wan2). Pass an entry's MAC to the device tools as mac_address (unifi_get_device_details, unifi_reboot_device, unifi_rename_device, unifi_upgrade_device, ...), as device_mac (unifi_get_switch_ports, unifi_get_port_stats, unifi_set_switch_port_profile, unifi_locate_device, ...) or as ap_mac on the RF tools (unifi_trigger_rf_scan, unifi_get_rf_scan_results), which take the access point to scan from; the parameter name differs per tool and each tool accepts only its own.",
       "name": "unifi_list_devices",
       "schema": {
         "input": {

--- a/apps/network/tests/unit/test_mac_parameter_guidance.py
+++ b/apps/network/tests/unit/test_mac_parameter_guidance.py
@@ -1,0 +1,94 @@
+"""The MAC parameter is spelled four ways across the Network tools (#635).
+
+The canonical names are not changed and no alias is accepted. Instead the list
+tools that hand a caller a MAC say which parameter the next call takes, so the
+spelling is chosen from the description rather than guessed and rejected.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+MANIFEST = pathlib.Path(__file__).resolve().parents[2] / "src" / "unifi_network_mcp" / "tools_manifest.json"
+
+
+@pytest.fixture(scope="module")
+def descriptions() -> dict[str, str]:
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    return {tool["name"]: tool.get("description", "") for tool in data["tools"]}
+
+
+@pytest.mark.parametrize(
+    ("tool", "expected"),
+    [
+        ("unifi_list_clients", ("mac_address", "client_mac", "unifi_get_client_details")),
+        ("unifi_list_devices", ("mac_address", "device_mac", "unifi_get_device_details")),
+        ("unifi_list_blocked_clients", ("mac_address", "unifi_unblock_client")),
+    ],
+)
+def test_list_description_names_the_next_call_parameter(
+    descriptions: dict[str, str], tool: str, expected: tuple[str, ...]
+) -> None:
+    description = descriptions[tool]
+    for token in expected:
+        assert token in description, f"{tool} description does not mention {token}"
+
+
+@pytest.mark.parametrize(
+    ("tool", "parameter"),
+    [
+        ("unifi_get_client_details", "mac_address"),
+        ("unifi_get_client_sessions", "client_mac"),
+        ("unifi_get_switch_ports", "device_mac"),
+        ("unifi_unblock_client", "mac_address"),
+        ("unifi_get_device_details", "mac_address"),
+    ],
+)
+def test_the_named_parameters_are_the_real_ones(tool: str, parameter: str) -> None:
+    """A description that names a parameter the tool does not take is worse than none."""
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    entry = next(t for t in data["tools"] if t["name"] == tool)
+    assert parameter in entry["schema"]["input"]["properties"]
+
+
+def test_every_tool_named_in_those_descriptions_exists(descriptions: dict[str, str]) -> None:
+    """A description that points at a tool this server does not have sends a caller nowhere."""
+    import re
+
+    known = set(descriptions)
+    for tool in ("unifi_list_clients", "unifi_list_devices", "unifi_list_blocked_clients"):
+        named = set(re.findall(r"\bunifi_[a-z0-9_]+", descriptions[tool])) - {tool}
+        assert named, f"{tool} names no follow-up tool"
+        assert named <= known, f"{tool} names tools that do not exist: {sorted(named - known)}"
+
+
+@pytest.mark.parametrize("tool", ["unifi_list_clients", "unifi_list_devices", "unifi_list_blocked_clients"])
+def test_the_registered_description_matches_the_manifest(descriptions: dict[str, str], tool: str) -> None:
+    """The two are both live: eager registration serves the decorator string, lazy mode
+    serves the manifest. A description edited in one and not regenerated into the other
+    would leave half the callers reading the old text."""
+    import unifi_network_mcp.tools.clients  # noqa: F401
+    import unifi_network_mcp.tools.devices  # noqa: F401
+    from unifi_network_mcp.runtime import server
+
+    registered = server._tool_manager.get_tool(tool)
+    assert registered.description == descriptions[tool]
+
+
+def test_every_mac_spelling_in_use_is_named_by_one_of_the_descriptions(descriptions: dict[str, str]) -> None:
+    """The descriptions enumerate parameter names, so they read as exhaustive. A fifth
+    spelling appearing on some tool and named nowhere is worse than no enumeration."""
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    spellings = {"mac", "mac_address", "client_mac", "device_mac", "ap_mac"}
+    in_use = set()
+    for entry in data["tools"]:
+        in_use |= spellings & set(entry.get("schema", {}).get("input", {}).get("properties", {}))
+
+    named = " ".join(descriptions[t] for t in ("unifi_list_clients", "unifi_list_devices"))
+    missing = sorted(name for name in in_use if name not in named)
+
+    assert in_use, "no MAC parameters found at all; the manifest fixture is wrong"
+    assert not missing, f"no list description names {missing}"

--- a/apps/network/tests/unit/test_mac_parameter_guidance.py
+++ b/apps/network/tests/unit/test_mac_parameter_guidance.py
@@ -1,4 +1,4 @@
-"""The MAC parameter is spelled four ways across the Network tools (#635).
+"""The MAC parameter is spelled four ways across the Network tools.
 
 The canonical names are not changed and no alias is accepted. Instead the list
 tools that hand a caller a MAC say which parameter the next call takes, so the

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/strict_dispatch.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/strict_dispatch.py
@@ -9,6 +9,8 @@ This subclass overrides :meth:`call_tool` to diff incoming ``arguments`` keys
 against the tool's declared input schema (loaded from ``tools_manifest.json``)
 BEFORE pydantic sees them. Unknown keys raise ``ToolError`` with a structured
 message naming the offending key(s) and the valid set so an LLM can self-correct.
+When a rejected key is another spelling of this tool's MAC parameter, the message
+also names the parameter to use — guidance only; the key itself stays invalid.
 
 Operates as composition (no FastMCP internals patched). Self-retires once
 upstream lands ``extra="forbid"`` — the override becomes a no-op guard.
@@ -26,6 +28,35 @@ from mcp.server.mcpserver.exceptions import ToolError
 from unifi_core.redaction import redaction_marker_paths
 
 logger = logging.getLogger(__name__)
+
+# The same value — the MAC of the thing the call is about — is spelled four ways
+# across the Network tools (``mac_address``, ``client_mac``, ``device_mac``,
+# ``mac``), so a caller that carries the spelling from one tool to the next gets a
+# bare "unknown argument" and no way to tell which one this tool wants. The
+# canonical contract does not change: the call still fails, the message just says
+# what to send instead.
+#
+# ``ap_mac`` is deliberately absent. It names a different thing — the access point
+# to scan from, not the subject of the call — so telling a caller holding a client
+# MAC to resend it as ``ap_mac`` would turn a rejected call into a wrong answer,
+# which is what this module exists to prevent.
+_MAC_ARGUMENT_SPELLINGS = frozenset({"mac", "mac_address", "client_mac", "device_mac"})
+
+
+def _mac_parameter_hint(tool_name: str, unknown: set[str], allowed: frozenset[str], arguments: dict[str, Any]) -> str:
+    """Name this tool's MAC parameter when a rejected key is another spelling of it.
+
+    Empty string when no rejected key is a MAC spelling, when the tool takes no MAC
+    parameter or more than one (then there is nothing to point at), or when the
+    caller already sent the right one — repeating it back invites a retry that
+    changes nothing.
+    """
+    if not unknown & _MAC_ARGUMENT_SPELLINGS:
+        return ""
+    canonical = sorted(allowed & _MAC_ARGUMENT_SPELLINGS)
+    if len(canonical) != 1 or canonical[0] in arguments:
+        return ""
+    return " '%s' takes the MAC address as '%s'." % (tool_name, canonical[0])
 
 
 class StrictKwargFastMCP(MCPServer):
@@ -81,8 +112,10 @@ class StrictKwargFastMCP(MCPServer):
             if unknown:
                 unknown_str = ", ".join(sorted(unknown))
                 valid_str = ", ".join(sorted(allowed))
+                hint = _mac_parameter_hint(name, unknown, allowed, arguments)
                 raise ToolError(
-                    f"Invalid params for '{name}': unknown arguments {{{unknown_str}}}. Valid arguments: [{valid_str}]."
+                    f"Invalid params for '{name}': unknown arguments {{{unknown_str}}}. "
+                    f"Valid arguments: [{valid_str}].{hint}"
                 )
         marker_paths = redaction_marker_paths(arguments)
         if marker_paths:

--- a/packages/unifi-mcp-shared/tests/test_strict_dispatch.py
+++ b/packages/unifi-mcp-shared/tests/test_strict_dispatch.py
@@ -270,3 +270,115 @@ def test_loader_treats_tools_without_input_schema_as_zero_arg(
     assert allowed["unifi_partial"] == frozenset()
     assert allowed["unifi_normal"] == frozenset({"x"})
     assert any("had no input schema" in record.message for record in caplog.records)
+
+
+# -----------------------------
+# MAC parameter guidance (#635)
+# -----------------------------
+
+
+@pytest.fixture
+def mac_manifest(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Tools whose MAC parameter is spelled four different ways across the server."""
+    tools = [
+        _make_tool("unifi_get_client_details", {"mac_address": {"type": "string"}}),
+        _make_tool("unifi_get_client_sessions", {"client_mac": {"type": "string"}, "limit": {"type": "integer"}}),
+        _make_tool("unifi_get_switch_ports", {"device_mac": {"type": "string"}}),
+        _make_tool("unifi_recent_events", {"mac": {"type": "string"}}),
+        _make_tool("unifi_list_networks", {"site": {"type": "string"}}),
+        _make_tool("unifi_trigger_rf_scan", {"ap_mac": {"type": "string"}}),
+        _make_tool("unifi_two_macs", {"client_mac": {"type": "string"}, "device_mac": {"type": "string"}}),
+    ]
+    return _write_manifest(tmp_path, tools)
+
+
+@pytest.mark.parametrize(
+    ("tool", "rejected", "canonical"),
+    [
+        ("unifi_get_client_details", "client_mac", "mac_address"),
+        ("unifi_get_client_details", "device_mac", "mac_address"),
+        ("unifi_get_client_details", "mac", "mac_address"),
+        ("unifi_get_client_sessions", "mac_address", "client_mac"),
+        ("unifi_get_switch_ports", "mac_address", "device_mac"),
+        ("unifi_recent_events", "mac_address", "mac"),
+    ],
+)
+async def test_mac_spelling_error_names_the_canonical_parameter(
+    mac_manifest: pathlib.Path, tool: str, rejected: str, canonical: str
+) -> None:
+    """The MAC parameter is spelled differently across tools; the rejection says which one this tool takes."""
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool(tool, {rejected: "aa:bb:cc:dd:ee:ff"})
+    msg = str(excinfo.value)
+    assert f"unknown arguments {{{rejected}}}" in msg
+    assert f"'{tool}' takes the MAC address as '{canonical}'." in msg
+
+
+async def test_mac_hint_is_absent_for_a_non_mac_argument(mac_manifest: pathlib.Path) -> None:
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("unifi_get_client_details", {"hostname": "x"})
+    assert "takes the MAC address as" not in str(excinfo.value)
+
+
+async def test_mac_hint_is_absent_when_the_tool_takes_two_mac_parameters(mac_manifest: pathlib.Path) -> None:
+    """Two candidates and nothing to choose between them; guessing is worse than silence."""
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("unifi_two_macs", {"mac_address": "aa:bb:cc:dd:ee:ff"})
+    assert "takes the MAC address as" not in str(excinfo.value)
+
+
+async def test_ap_mac_is_not_treated_as_a_spelling_of_the_subject_mac(mac_manifest: pathlib.Path) -> None:
+    """ap_mac names the access point to scan FROM, not the subject of the call. Pointing
+    a caller at it would turn a rejected call into a wrong answer."""
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("unifi_trigger_rf_scan", {"client_mac": "aa:bb:cc:dd:ee:ff"})
+    assert "takes the MAC address as" not in str(excinfo.value)
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("unifi_get_client_sessions", {"ap_mac": "aa:bb:cc:dd:ee:ff"})
+    assert "takes the MAC address as" not in str(excinfo.value)
+
+
+async def test_mac_hint_is_absent_when_the_canonical_name_was_already_sent(mac_manifest: pathlib.Path) -> None:
+    """Repeating back a parameter the caller supplied invites a retry that changes nothing."""
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool(
+            "unifi_get_client_details", {"mac_address": "aa:bb:cc:dd:ee:ff", "client_mac": "11:22:33:44:55:66"}
+        )
+    msg = str(excinfo.value)
+    assert "unknown arguments {client_mac}" in msg
+    assert "takes the MAC address as" not in msg
+
+
+async def test_mac_hint_is_absent_when_the_tool_has_no_mac_parameter(mac_manifest: pathlib.Path) -> None:
+    """A MAC spelling sent to a tool that takes no MAC is still just an unknown argument."""
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("unifi_list_networks", {"mac_address": "aa:bb:cc:dd:ee:ff"})
+    assert "takes the MAC address as" not in str(excinfo.value)
+
+
+async def test_mac_hint_does_not_disturb_the_rest_of_the_message(mac_manifest: pathlib.Path) -> None:
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with pytest.raises(ToolError) as excinfo:
+        await server.call_tool("unifi_get_client_sessions", {"mac_address": "aa:bb:cc:dd:ee:ff", "bogus": 1})
+    assert str(excinfo.value) == (
+        "Invalid params for 'unifi_get_client_sessions': "
+        "unknown arguments {bogus, mac_address}. "
+        "Valid arguments: [client_mac, limit]. "
+        "'unifi_get_client_sessions' takes the MAC address as 'client_mac'."
+    )
+
+
+async def test_mac_spelling_is_not_accepted_as_an_alias(mac_manifest: pathlib.Path) -> None:
+    """Guidance only: the canonical contract is unchanged, so the call still fails."""
+    server = StrictKwargFastMCP("test", tools_manifest_path=mac_manifest)
+    with patch.object(FastMCP, "call_tool", new=AsyncMock(return_value=[])) as super_mock:
+        with pytest.raises(ToolError):
+            await server.call_tool("unifi_get_client_details", {"client_mac": "aa:bb:cc:dd:ee:ff"})
+    super_mock.assert_not_awaited()

--- a/packages/unifi-mcp-shared/tests/test_strict_dispatch.py
+++ b/packages/unifi-mcp-shared/tests/test_strict_dispatch.py
@@ -273,7 +273,7 @@ def test_loader_treats_tools_without_input_schema_as_zero_arg(
 
 
 # -----------------------------
-# MAC parameter guidance (#635)
+# MAC parameter guidance
 # -----------------------------
 
 


### PR DESCRIPTION
Network tools use several MAC argument names. When a caller supplies a different MAC spelling, strict dispatch now adds the tool's accepted parameter name to the existing unknown-argument error. It offers a hint only when exactly one MAC parameter is accepted and the caller has not already provided it. Ambiguous cases retain the existing error.

Client, blocked-client, and device list descriptions now identify the parameter names accepted by their follow-up tools. The generated Network manifest includes those descriptions. No aliases are accepted, no arguments are rewritten, and schemas and permission handling are unchanged.

Addresses the MAC argument discovery portion of #635. Other portions of that issue remain separate; this PR does not close the whole issue.

Validation: Shared strict-dispatch regression tests cover accepted, unknown, ambiguous, and conflicting spellings. Network tests check manifest guidance. Independently installed Shared and Network wheels passed real read-only MCP checks in eager, lazy, and meta-only registration modes: the wrong spelling was rejected with the canonical-name hint, retrying with that name succeeded, and the supplied MAC was not echoed in the error.

Full `make pre-commit`, all GitHub checks, and a fresh installed-wheel repeat of all three registration-mode probes passed on 5b12776b81f69f508ec75f691eacd6e1e22db37e. Publish the Shared change first, then require that released Shared version in downstream app metadata before app publication.
