### PR TITLE
feat: warn on unrecognized policy variables at app startup

### DIFF
--- a/apps/access/docs/troubleshooting.md
+++ b/apps/access/docs/troubleshooting.md
@@ -96,6 +96,21 @@ current policy variable named in the error, and restart the server.
 export UNIFI_POLICY_ACCESS_DOORS_UPDATE=true
 ```
 
+### Policy variable set but the action is still denied
+
+**Cause:** The variable name does not match a gate this server registers, so it
+is never read. Category names in `UNIFI_POLICY_ACCESS_<CATEGORY>_<ACTION>`
+are the config keys listed in [permissions.md](permissions.md), which differ from
+the `permission_category` shorthand in `tools_manifest.json`.
+
+**Fix:** At startup the server logs every unrecognized `UNIFI_POLICY_*` variable
+with the closest valid names:
+```
+[policy] Unrecognized env var UNIFI_POLICY_ACCESS_DOOR_UPDATE: no gate in the access tool manifest matches it. Did you mean UNIFI_POLICY_ACCESS_DOORS_UPDATE, ...?
+```
+Rename the variable to the suggested name and restart the server. The same applies
+in the deny direction: a misnamed variable set to `false` blocks nothing.
+
 ### No tools visible at all
 
 **Check:**

--- a/apps/access/src/unifi_access_mcp/categories.py
+++ b/apps/access/src/unifi_access_mcp/categories.py
@@ -8,6 +8,7 @@ Also provides:
 - ``TOOL_MODULE_MAP`` for lazy/on-demand tool loading
 """
 
+from functools import cache
 from pathlib import Path
 from typing import Callable, Dict
 
@@ -18,6 +19,7 @@ from unifi_mcp_shared.lazy_tools import (
 from unifi_mcp_shared.lazy_tools import (
     setup_lazy_loading as _shared_setup_lazy_loading,
 )
+from unifi_mcp_shared.tool_index import policy_gates_from_manifest
 
 # ---------------------------------------------------------------------------
 # Permission category mapping
@@ -46,14 +48,24 @@ _MANIFEST_PATH = Path(__file__).parent / "tools_manifest.json"
 _MANIFEST_FALLBACK = Path("apps/access/src/unifi_access_mcp/tools_manifest.json")
 
 
+def _manifest_path() -> Path:
+    return _MANIFEST_PATH if _MANIFEST_PATH.exists() else _MANIFEST_FALLBACK
+
+
 def _build_tool_module_map() -> Dict[str, str]:
     """Build tool-to-module mapping for the access app."""
-    manifest = _MANIFEST_PATH if _MANIFEST_PATH.exists() else _MANIFEST_FALLBACK
+    manifest = _manifest_path()
     return build_tool_module_map("unifi_access_mcp.tools", manifest_path=str(manifest), tool_prefix="access_")
 
 
 # Build the tool map at module load time
 TOOL_MODULE_MAP: Dict[str, str] = _build_tool_module_map()
+
+
+@cache
+def policy_gates() -> frozenset[tuple[str, str]]:
+    """(permission_category, permission_action) pairs the manifest's tools gate on."""
+    return policy_gates_from_manifest(_manifest_path())
 
 
 def setup_lazy_loading(server, tool_decorator: Callable) -> LazyToolLoader:

--- a/apps/access/src/unifi_access_mcp/main.py
+++ b/apps/access/src/unifi_access_mcp/main.py
@@ -11,7 +11,7 @@ from unifi_access_mcp.bootstrap import (
     UNIFI_TOOL_REGISTRATION_MODE,
     logger,
 )  # ensures logging/env setup early
-from unifi_access_mcp.categories import ACCESS_CATEGORY_MAP, TOOL_MODULE_MAP, setup_lazy_loading
+from unifi_access_mcp.categories import ACCESS_CATEGORY_MAP, TOOL_MODULE_MAP, policy_gates, setup_lazy_loading
 from unifi_access_mcp.jobs import get_job_status, start_async_tool
 
 # Shared singletons
@@ -46,7 +46,7 @@ logger.debug("Access MCP server module loaded; singletons initialised.")
 
 async def main_async():
     """Main asynchronous function to setup and run the server."""
-    from unifi_core.policy_gate import check_deprecated_env_vars
+    from unifi_core.policy_gate import check_deprecated_env_vars, check_unknown_policy_env_vars
     from unifi_mcp_shared.bootstrap import assert_credentials_configured
     from unifi_mcp_shared.server_lifecycle import apply_log_level, install_asyncio_exception_handler
     from unifi_mcp_shared.tool_registration import register_tools_for_mode
@@ -55,6 +55,7 @@ async def main_async():
     install_asyncio_exception_handler(logger)
     apply_log_level(config, "unifi-access-mcp")
     check_deprecated_env_vars("access", logger)
+    check_unknown_policy_env_vars("access", logger, policy_gates(), ACCESS_CATEGORY_MAP)
     assert_credentials_configured(config, plugin_name="unifi-access", env_prefix="ACCESS", logger=logger)
 
     # Initialize the global Access connection

--- a/apps/access/tests/unit/test_policy_gates.py
+++ b/apps/access/tests/unit/test_policy_gates.py
@@ -1,0 +1,32 @@
+"""Startup scan of UNIFI_POLICY_* names against the gates this server's manifest registers."""
+
+import logging
+import os
+
+import pytest
+
+from unifi_access_mcp.categories import ACCESS_CATEGORY_MAP, policy_gates
+from unifi_core.policy_gate import check_unknown_policy_env_vars
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("UNIFI_POLICY_"):
+            monkeypatch.delenv(key)
+
+
+def test_manifest_gates_use_the_shorthand_category():
+    assert ("door", "update") in policy_gates()
+
+
+def test_shorthand_category_in_env_var_warns_and_names_the_config_key(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_ACCESS_DOOR_UPDATE", "true")
+    monkeypatch.setenv("UNIFI_POLICY_ACCESS_DOORS_UPDATE", "true")
+    logger = logging.getLogger("test_policy_gates")
+
+    with caplog.at_level(logging.WARNING, logger="test_policy_gates"):
+        unknown = check_unknown_policy_env_vars("access", logger, policy_gates(), ACCESS_CATEGORY_MAP)
+
+    assert unknown == ["UNIFI_POLICY_ACCESS_DOOR_UPDATE"]
+    assert "UNIFI_POLICY_ACCESS_DOORS_UPDATE" in caplog.text

--- a/apps/access/tests/unit/test_websocket_wiring.py
+++ b/apps/access/tests/unit/test_websocket_wiring.py
@@ -13,6 +13,7 @@ to catch.
 """
 
 import asyncio
+import logging
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
@@ -69,3 +70,12 @@ def test_a_listener_failure_does_not_take_the_server_down() -> None:
     with _startup(connected=True, websocket_enabled=True, listener=failing) as (started, transports):
         started.assert_awaited_once()
         assert transports.await_count == 1, "a websocket failure stopped the server starting"
+
+
+def test_startup_warns_about_an_unrecognized_policy_variable(monkeypatch, caplog) -> None:
+    """The scan runs from `main_async`, not only from its own unit tests."""
+    monkeypatch.setenv("UNIFI_POLICY_ACCESS_DOOR_UPDATE", "true")
+    with caplog.at_level(logging.WARNING), _startup(connected=True, websocket_enabled=False):
+        pass
+    assert "UNIFI_POLICY_ACCESS_DOOR_UPDATE" in caplog.text
+    assert "UNIFI_POLICY_ACCESS_DOORS_UPDATE" in caplog.text

--- a/apps/network/docs/troubleshooting.md
+++ b/apps/network/docs/troubleshooting.md
@@ -86,6 +86,21 @@ denying the call:
 export UNIFI_POLICY_NETWORK_NETWORKS_CREATE=true
 ```
 
+### Policy variable set but the action is still denied
+
+**Cause:** The variable name does not match a gate this server registers, so it
+is never read. Category names in `UNIFI_POLICY_NETWORK_<CATEGORY>_<ACTION>`
+are the config keys listed in [permissions.md](permissions.md), which differ from
+the `permission_category` shorthand in `tools_manifest.json`.
+
+**Fix:** At startup the server logs every unrecognized `UNIFI_POLICY_*` variable
+with the closest valid names:
+```
+[policy] Unrecognized env var UNIFI_POLICY_NETWORK_CLIENT_GROUP_DELETE: no gate in the network tool manifest matches it. Did you mean UNIFI_POLICY_NETWORK_CLIENT_GROUPS_DELETE, ...?
+```
+Rename the variable to the suggested name and restart the server. The same applies
+in the deny direction: a misnamed variable set to `false` blocks nothing.
+
 ### No tools visible at all
 
 **Check:**

--- a/apps/network/src/unifi_network_mcp/categories.py
+++ b/apps/network/src/unifi_network_mcp/categories.py
@@ -8,6 +8,7 @@ Also provides:
 - ``TOOL_MODULE_MAP`` for lazy/on-demand tool loading
 """
 
+from functools import cache
 from pathlib import Path
 from typing import Callable, Dict
 
@@ -18,6 +19,7 @@ from unifi_mcp_shared.lazy_tools import (
 from unifi_mcp_shared.lazy_tools import (
     setup_lazy_loading as _shared_setup_lazy_loading,
 )
+from unifi_mcp_shared.tool_index import policy_gates_from_manifest
 
 # ---------------------------------------------------------------------------
 # Permission category mapping
@@ -67,14 +69,24 @@ _MANIFEST_PATH = Path(__file__).parent / "tools_manifest.json"
 _MANIFEST_FALLBACK = Path("apps/network/src/unifi_network_mcp/tools_manifest.json")
 
 
+def _manifest_path() -> Path:
+    return _MANIFEST_PATH if _MANIFEST_PATH.exists() else _MANIFEST_FALLBACK
+
+
 def _build_tool_module_map() -> Dict[str, str]:
     """Build tool-to-module mapping for the network app."""
-    manifest = _MANIFEST_PATH if _MANIFEST_PATH.exists() else _MANIFEST_FALLBACK
+    manifest = _manifest_path()
     return build_tool_module_map("unifi_network_mcp.tools", manifest_path=str(manifest))
 
 
 # Build the tool map at module load time
 TOOL_MODULE_MAP: Dict[str, str] = _build_tool_module_map()
+
+
+@cache
+def policy_gates() -> frozenset[tuple[str, str]]:
+    """(permission_category, permission_action) pairs the manifest's tools gate on."""
+    return policy_gates_from_manifest(_manifest_path())
 
 
 def setup_lazy_loading(server, tool_decorator: Callable) -> LazyToolLoader:

--- a/apps/network/src/unifi_network_mcp/main.py
+++ b/apps/network/src/unifi_network_mcp/main.py
@@ -12,7 +12,7 @@ from unifi_network_mcp.bootstrap import (
     UNIFI_TOOL_REGISTRATION_MODE,
     logger,
 )  # ensures logging/env setup early
-from unifi_network_mcp.categories import NETWORK_CATEGORY_MAP, TOOL_MODULE_MAP, setup_lazy_loading
+from unifi_network_mcp.categories import NETWORK_CATEGORY_MAP, TOOL_MODULE_MAP, policy_gates, setup_lazy_loading
 from unifi_network_mcp.jobs import get_job_status, start_async_tool
 
 # Shared singletons
@@ -46,7 +46,7 @@ logger.info("Using global Manager instances.")
 
 async def main_async():
     """Main asynchronous function to setup and run the server."""
-    from unifi_core.policy_gate import check_deprecated_env_vars
+    from unifi_core.policy_gate import check_deprecated_env_vars, check_unknown_policy_env_vars
     from unifi_mcp_shared.bootstrap import assert_credentials_configured
     from unifi_mcp_shared.server_lifecycle import apply_log_level, install_asyncio_exception_handler
     from unifi_mcp_shared.tool_registration import register_tools_for_mode
@@ -55,6 +55,7 @@ async def main_async():
     install_asyncio_exception_handler(logger)
     apply_log_level(config, "unifi-network-mcp")
     check_deprecated_env_vars("network", logger)
+    check_unknown_policy_env_vars("network", logger, policy_gates(), NETWORK_CATEGORY_MAP)
     assert_credentials_configured(config, plugin_name="unifi-network", env_prefix="NETWORK", logger=logger)
 
     # Initialize the global Unifi connection

--- a/apps/network/tests/unit/test_policy_gates.py
+++ b/apps/network/tests/unit/test_policy_gates.py
@@ -1,0 +1,32 @@
+"""Startup scan of UNIFI_POLICY_* names against the gates this server's manifest registers."""
+
+import logging
+import os
+
+import pytest
+
+from unifi_core.policy_gate import check_unknown_policy_env_vars
+from unifi_network_mcp.categories import NETWORK_CATEGORY_MAP, policy_gates
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("UNIFI_POLICY_"):
+            monkeypatch.delenv(key)
+
+
+def test_manifest_gates_use_the_shorthand_category():
+    assert ("client_group", "delete") in policy_gates()
+
+
+def test_shorthand_category_in_env_var_warns_and_names_the_config_key(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_NETWORK_CLIENT_GROUP_DELETE", "true")
+    monkeypatch.setenv("UNIFI_POLICY_NETWORK_CLIENT_GROUPS_DELETE", "true")
+    logger = logging.getLogger("test_policy_gates")
+
+    with caplog.at_level(logging.WARNING, logger="test_policy_gates"):
+        unknown = check_unknown_policy_env_vars("network", logger, policy_gates(), NETWORK_CATEGORY_MAP)
+
+    assert unknown == ["UNIFI_POLICY_NETWORK_CLIENT_GROUP_DELETE"]
+    assert "UNIFI_POLICY_NETWORK_CLIENT_GROUPS_DELETE" in caplog.text

--- a/apps/protect/docs/troubleshooting.md
+++ b/apps/protect/docs/troubleshooting.md
@@ -79,6 +79,21 @@ current policy variable named in the error, and restart the server.
 export UNIFI_POLICY_PROTECT_CAMERAS_UPDATE=true
 ```
 
+### Policy variable set but the action is still denied
+
+**Cause:** The variable name does not match a gate this server registers, so it
+is never read. Category names in `UNIFI_POLICY_PROTECT_<CATEGORY>_<ACTION>`
+are the config keys listed in [permissions.md](permissions.md), which differ from
+the `permission_category` shorthand in `tools_manifest.json`.
+
+**Fix:** At startup the server logs every unrecognized `UNIFI_POLICY_*` variable
+with the closest valid names:
+```
+[policy] Unrecognized env var UNIFI_POLICY_PROTECT_CAMERA_UPDATE: no gate in the protect tool manifest matches it. Did you mean UNIFI_POLICY_PROTECT_CAMERAS_UPDATE, ...?
+```
+Rename the variable to the suggested name and restart the server. The same applies
+in the deny direction: a misnamed variable set to `false` blocks nothing.
+
 ### No tools visible at all
 
 **Check:**

--- a/apps/protect/src/unifi_protect_mcp/categories.py
+++ b/apps/protect/src/unifi_protect_mcp/categories.py
@@ -8,6 +8,7 @@ Also provides:
 - ``TOOL_MODULE_MAP`` for lazy/on-demand tool loading
 """
 
+from functools import cache
 from pathlib import Path
 from typing import Callable, Dict
 
@@ -18,6 +19,7 @@ from unifi_mcp_shared.lazy_tools import (
 from unifi_mcp_shared.lazy_tools import (
     setup_lazy_loading as _shared_setup_lazy_loading,
 )
+from unifi_mcp_shared.tool_index import policy_gates_from_manifest
 
 # ---------------------------------------------------------------------------
 # Permission category mapping
@@ -50,14 +52,24 @@ _MANIFEST_PATH = Path(__file__).parent / "tools_manifest.json"
 _MANIFEST_FALLBACK = Path("apps/protect/src/unifi_protect_mcp/tools_manifest.json")
 
 
+def _manifest_path() -> Path:
+    return _MANIFEST_PATH if _MANIFEST_PATH.exists() else _MANIFEST_FALLBACK
+
+
 def _build_tool_module_map() -> Dict[str, str]:
     """Build tool-to-module mapping for the protect app."""
-    manifest = _MANIFEST_PATH if _MANIFEST_PATH.exists() else _MANIFEST_FALLBACK
+    manifest = _manifest_path()
     return build_tool_module_map("unifi_protect_mcp.tools", manifest_path=str(manifest), tool_prefix="protect_")
 
 
 # Build the tool map at module load time
 TOOL_MODULE_MAP: Dict[str, str] = _build_tool_module_map()
+
+
+@cache
+def policy_gates() -> frozenset[tuple[str, str]]:
+    """(permission_category, permission_action) pairs the manifest's tools gate on."""
+    return policy_gates_from_manifest(_manifest_path())
 
 
 def setup_lazy_loading(server, tool_decorator: Callable) -> LazyToolLoader:

--- a/apps/protect/src/unifi_protect_mcp/main.py
+++ b/apps/protect/src/unifi_protect_mcp/main.py
@@ -12,7 +12,7 @@ from unifi_protect_mcp.bootstrap import (
     UNIFI_TOOL_REGISTRATION_MODE,
     logger,
 )  # ensures logging/env setup early
-from unifi_protect_mcp.categories import PROTECT_CATEGORY_MAP, TOOL_MODULE_MAP, setup_lazy_loading
+from unifi_protect_mcp.categories import PROTECT_CATEGORY_MAP, TOOL_MODULE_MAP, policy_gates, setup_lazy_loading
 from unifi_protect_mcp.jobs import get_job_status, start_async_tool
 
 # Shared singletons
@@ -48,7 +48,7 @@ logger.info("Using global Manager instances.")
 
 async def main_async():
     """Main asynchronous function to setup and run the server."""
-    from unifi_core.policy_gate import check_deprecated_env_vars
+    from unifi_core.policy_gate import check_deprecated_env_vars, check_unknown_policy_env_vars
     from unifi_mcp_shared.bootstrap import assert_credentials_configured
     from unifi_mcp_shared.server_lifecycle import apply_log_level, install_asyncio_exception_handler
     from unifi_mcp_shared.tool_registration import register_tools_for_mode
@@ -57,6 +57,7 @@ async def main_async():
     install_asyncio_exception_handler(logger)
     apply_log_level(config, "unifi-protect-mcp")
     check_deprecated_env_vars("protect", logger)
+    check_unknown_policy_env_vars("protect", logger, policy_gates(), PROTECT_CATEGORY_MAP)
     assert_credentials_configured(config, plugin_name="unifi-protect", env_prefix="PROTECT", logger=logger)
 
     # Initialize the global Protect connection

--- a/apps/protect/tests/unit/test_policy_gates.py
+++ b/apps/protect/tests/unit/test_policy_gates.py
@@ -1,0 +1,32 @@
+"""Startup scan of UNIFI_POLICY_* names against the gates this server's manifest registers."""
+
+import logging
+import os
+
+import pytest
+
+from unifi_core.policy_gate import check_unknown_policy_env_vars
+from unifi_protect_mcp.categories import PROTECT_CATEGORY_MAP, policy_gates
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("UNIFI_POLICY_"):
+            monkeypatch.delenv(key)
+
+
+def test_manifest_gates_use_the_shorthand_category():
+    assert ("camera", "update") in policy_gates()
+
+
+def test_shorthand_category_in_env_var_warns_and_names_the_config_key(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_CAMERA_UPDATE", "true")
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_CAMERAS_UPDATE", "true")
+    logger = logging.getLogger("test_policy_gates")
+
+    with caplog.at_level(logging.WARNING, logger="test_policy_gates"):
+        unknown = check_unknown_policy_env_vars("protect", logger, policy_gates(), PROTECT_CATEGORY_MAP)
+
+    assert unknown == ["UNIFI_POLICY_PROTECT_CAMERA_UPDATE"]
+    assert "UNIFI_POLICY_PROTECT_CAMERAS_UPDATE" in caplog.text

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -232,6 +232,13 @@ repository root, run `make -C apps/network manifest`,
 `make -C apps/protect manifest`, or `make -C apps/access manifest` for the
 affected server.
 
+### A `UNIFI_POLICY_` variable not taking effect
+At startup each server compares every `UNIFI_POLICY_*` variable with the gates its tools
+register and logs a warning naming each variable no gate matches, with the closest valid
+names. Check stderr for `[policy] Unrecognized env var`. The `<CATEGORY>` segment is the
+server's config key from its `permissions.md` (`CAMERAS`, `CLIENT_GROUPS`), not the
+`permission_category` shorthand in `tools_manifest.json` (`camera`, `client_group`).
+
 ### Legacy variables not taking effect
 Ensure the variable name matches the old format exactly (`UNIFI_PERMISSIONS_<CAT>_<ACTION>`). Check stderr logs for the deprecation warning confirming the variable was detected. If the new `UNIFI_POLICY_` variable is also set, the new one takes precedence.
 


### PR DESCRIPTION
A mistyped `UNIFI_POLICY_*` name is ignored by policy evaluation. Network, Protect, and Access now warn at startup with suggested registered names, helping operators discover ineffective policy settings. The warning reports names only and does not alter permission behavior.

The app startup wiring uses the Core and Shared helpers already published in Core 0.4.47 and Shared 0.6.15, which satisfy the app dependency floors. The documented plural category names remain unchanged.

Closes #609
Closes #610

Validation on 6cbf321a96efc3ea3939f2cda15f41daa6544025: full `make pre-commit` passed, GitHub checks passed, and the three apps' focused policy/startup tests passed. Independently built and installed the Network wheel outside the checkout with published dependencies. Both launches completed a real read-only controller request over MCP stdio:

```json
{"corrected": false, "warning_count": 1, "controller_read_success": true}
{"corrected": true, "warning_count": 0, "controller_read_success": true}
{"unifi-network-mcp": "0.32.2.dev5+g6cbf321a", "unifi-core": "0.4.47", "unifi-mcp-shared": "0.6.15"}
```

The typo warning suggested the correct configuration name without logging its value. Live startup proof covers Network; Protect and Access startup wiring is covered by tests. App publication will be batched with the remaining verified queue work.
