### PR TITLE
fix(release): require Core 0.4.43 and package API log templates

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -15,8 +15,9 @@ dependencies = [
     # 0.4.34; Protect camera detail fields require Core 0.4.35; traffic-flow
     # DPI name enrichment requires Core 0.4.36; exact Network event-key
     # filtering and discovery require Core 0.4.37; explicit zero event limits
-    # require Core 0.4.39.
-    "unifi-core[network,protect,access]>=0.4.40,<0.5",
+    # require Core 0.4.39. UTC device timestamps in action read views require
+    # Core 0.4.43.
+    "unifi-core[network,protect,access]>=0.4.43,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -78,8 +78,12 @@ version-file = "src/unifi_api/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/unifi_api"]
+# The repository's logs/ ignore rule also matches these packaged HTML templates.
+# Artifacts bypass VCS ignores without adding duplicate force-include entries.
+artifacts = ["src/unifi_api/templates/admin/logs/*.html"]
 
 [tool.hatch.build.targets.sdist]
+artifacts = ["src/unifi_api/templates/admin/logs/*.html"]
 include = [
     "/src/unifi_api",
     "/alembic",

--- a/apps/api/tests/test_admin_template_packaging.py
+++ b/apps/api/tests/test_admin_template_packaging.py
@@ -1,0 +1,84 @@
+"""Admin templates must survive repository builds and source distribution installs."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATE_ROOT = REPO_ROOT / "apps/api/src/unifi_api/templates"
+
+
+def test_admin_templates_survive_wheel_and_sdist_builds(tmp_path: Path) -> None:
+    # Build in the repository: copying the app elsewhere hides VCS-ignore bugs.
+    direct = tmp_path / "direct"
+    subprocess.run(
+        ["uv", "build", "--package", "unifi-api-server", "--wheel", "--sdist", "--out-dir", str(direct)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    expected = {
+        f"unifi_api/templates/{path.relative_to(TEMPLATE_ROOT).as_posix()}": path.read_bytes()
+        for path in TEMPLATE_ROOT.rglob("*.html")
+    }
+    sdist = next(direct.glob("unifi_api_server-*.tar.gz"))
+    with tarfile.open(sdist) as archive:
+        names = archive.getnames()
+        prefix = names[0].split("/")[0]
+        for name, content in expected.items():
+            member = f"{prefix}/src/{name}"
+            assert names.count(member) == 1, member
+            packaged = archive.extractfile(member)
+            assert packaged is not None
+            assert packaged.read() == content, member
+
+    rebuilt = tmp_path / "rebuilt"
+    subprocess.run(
+        ["uv", "build", str(sdist), "--wheel", "--out-dir", str(rebuilt)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for directory in (direct, rebuilt):
+        wheel = next(directory.glob("unifi_api_server-*.whl"))
+        unpacked = directory / "unpacked"
+        with zipfile.ZipFile(wheel) as archive:
+            names = archive.namelist()
+            for name, content in expected.items():
+                assert names.count(name) == 1, name
+                assert archive.read(name) == content, name
+            archive.extractall(unpacked)
+
+        # Load the wheel's production renderer, never the editable source tree.
+        probe = """
+import sys
+from pathlib import Path
+from starlette.requests import Request
+
+sys.path.insert(0, sys.argv[1])
+from unifi_api.routes.admin import _common
+assert Path(_common.__file__).is_relative_to(Path(sys.argv[1]))
+request = Request({"type": "http", "method": "GET", "path": "/admin/logs", "headers": []})
+page = _common.render(request, "logs/list.html")
+assert b"Application logs" in page.body and b"logs-filters" in page.body
+assert page.headers["cache-control"] == "no-store"
+rows = _common.render(request, "logs/_rows.html", {
+    "rows": [{"ts": "2026-01-01", "level": "ERROR", "logger": "probe", "event": "<packaged>"}],
+    "next_offset": None,
+})
+assert b"&lt;packaged&gt;" in rows.body
+assert b"<packaged>" not in rows.body
+"""
+        subprocess.run(
+            [sys.executable, "-I", "-c", probe, str(unpacked)],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -14,8 +14,9 @@ dependencies = [
     # requires the dual-API bridge added in Core 0.4.32. WLAN schedule-window
     # validation requires Core 0.4.34. Traffic-flow DPI name enrichment
     # requires Core 0.4.36. Exact event-key filtering and discovery require
-    # Core 0.4.37; explicit zero event limits require Core 0.4.39.
-    "unifi-core[network]>=0.4.42,<0.5",
+    # Core 0.4.37; explicit zero event limits require Core 0.4.39. UTC device
+    # timestamps and expanded site settings require Core 0.4.43.
+    "unifi-core[network]>=0.4.43,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
     # Protect managers in unifi-core import uiprotect; pull it in via the
     # [protect] extra rather than declaring uiprotect here directly. Camera
     # detail fields require Core 0.4.35; explicit zero event limits require
-    # Core 0.4.39.
-    "unifi-core[protect]>=0.4.42,<0.5",
+    # Core 0.4.39; sensor summary field preservation requires Core 0.4.43.
+    "unifi-core[protect]>=0.4.43,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
App upgrades could retain an older Core release and miss the community fixes merged in #637, #644, and #653. Require published Core 0.4.43 in Network, Protect, and API so installed consumers receive UTC device timestamps, the Network site-settings projection, and preserved Protect sensor summaries. Extras, upper bounds, and other dependencies stay unchanged; the lockfile is unchanged.

Release verification also found that building the API from the repository omits four admin-log HTML templates. A narrow artifacts rule includes them in wheels and source distributions. The new regression builds from the repository, rebuilds a wheel from the source archive, verifies every HTML template appears exactly once with matching bytes, and renders the packaged log page and row fragments with escaping intact. Existing API PR and release workflows run this test.

Validation:

- The seven merged community PRs passed combined full-repository checks, installed MCP discovery, live safe smoke for Network (160), Protect (59), and Access (44), plus 38 installed REST/GraphQL checks. All temporary resources and sessions were cleaned up.
- Core 0.4.43 is published; a fresh PyPI install verified all three corrected projections.
- Consumer wheel metadata and fresh installed dependencies passed; runtime dependency versions match the live-tested combination.
- The packaging regression failed before the fix and passed afterward. Direct and source-rebuilt wheels contain all templates; installed production log rendering passed.
- Final revision 9078813167 passed independent review with no findings, make pre-commit, a clean generated-file diff, and all 18 GitHub checks including pin alignment, container builds, and CodeQL.
