### PR TITLE
feat(core): add the policy-gate helpers behind the unknown UNIFI_POLICY_* warning

### DIFF
--- a/packages/unifi-core/src/unifi_core/policy.py
+++ b/packages/unifi-core/src/unifi_core/policy.py
@@ -10,6 +10,7 @@ from unifi_core.policy_gate import (
     _TRUTHY,
     PolicyGateChecker,
     check_deprecated_env_vars,
+    check_unknown_policy_env_vars,
     resolve_permission_mode,
 )
 
@@ -82,6 +83,7 @@ def _get_nested_config_value(config: Any | None, path: tuple[str, ...]) -> Any |
 __all__ = [
     "PolicyGateChecker",
     "check_deprecated_env_vars",
+    "check_unknown_policy_env_vars",
     "resolve_permission_mode",
     "should_redact_sensitive_fields",
 ]

--- a/packages/unifi-core/src/unifi_core/policy_gate.py
+++ b/packages/unifi-core/src/unifi_core/policy_gate.py
@@ -11,12 +11,19 @@ Permission mode controls mutation handling:
     UNIFI_<SERVER>_TOOL_PERMISSION_MODE=confirm|bypass  - per-server
 """
 
+import difflib
 import logging
 import os
+from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
 VALID_PERMISSION_MODES = ("confirm", "bypass")
+_POLICY_PREFIX = "UNIFI_POLICY_"
+# Servers that share the UNIFI_POLICY_ namespace; a variable whose first
+# segment names another one of these is left to that server's own scan.
+_SERVER_PREFIXES = frozenset({"NETWORK", "PROTECT", "ACCESS"})
+_MAX_REPORTED_UNKNOWN = 20
 _TRUTHY = frozenset(("true", "1", "yes", "on"))
 _FALSY = frozenset(("false", "0", "no", "off"))
 
@@ -36,6 +43,16 @@ class PolicyGateChecker:
         """Resolve category shorthand to config key."""
         return self.category_map.get(category, category)
 
+    def env_var_names(self, category: str, action: str) -> list[str]:
+        """Env vars that gate *action* on *category*, most specific first."""
+        config_key = self._resolve_category(category).upper()
+        action_upper = action.upper()
+        return [
+            f"{_POLICY_PREFIX}{self.server_prefix}_{config_key}_{action_upper}",
+            f"{_POLICY_PREFIX}{self.server_prefix}_{action_upper}",
+            f"{_POLICY_PREFIX}{action_upper}",
+        ]
+
     def check(self, category: str, action: str) -> bool:
         """Check if an action is allowed by policy gates.
 
@@ -46,17 +63,7 @@ class PolicyGateChecker:
         if action.lower() == "read":
             return True
 
-        config_key = self._resolve_category(category).upper()
-        action_upper = action.upper()
-
-        # Most specific wins: category > server > global
-        env_vars = [
-            f"UNIFI_POLICY_{self.server_prefix}_{config_key}_{action_upper}",
-            f"UNIFI_POLICY_{self.server_prefix}_{action_upper}",
-            f"UNIFI_POLICY_{action_upper}",
-        ]
-
-        for var in env_vars:
+        for var in self.env_var_names(category, action):
             value = os.environ.get(var)
             if value is not None:
                 normalized = value.strip().lower()
@@ -68,7 +75,7 @@ class PolicyGateChecker:
                 return result
 
         # 4. Backwards compat: old UNIFI_PERMISSIONS_ format
-        old_var = f"UNIFI_PERMISSIONS_{config_key}_{action_upper}"
+        old_var = f"UNIFI_PERMISSIONS_{self._resolve_category(category).upper()}_{action.upper()}"
         old_value = os.environ.get(old_var)
         if old_value is not None:
             normalized = old_value.strip().lower()
@@ -79,9 +86,7 @@ class PolicyGateChecker:
 
     def denial_message(self, category: str, action: str) -> str:
         """Build a user-friendly denial message with enable hint."""
-        config_key = self._resolve_category(category).upper()
-        action_upper = action.upper()
-        enable_var = f"UNIFI_POLICY_{self.server_prefix}_{config_key}_{action_upper}"
+        enable_var = self.env_var_names(category, action)[0]
         return f"{action.capitalize()} is disabled by policy for {category}. Set {enable_var}=true to enable."
 
 
@@ -132,3 +137,60 @@ def check_deprecated_env_vars(server_prefix: str, logger) -> None:
     # Also check UNIFI_AUTO_CONFIRM
     if os.environ.get("UNIFI_AUTO_CONFIRM"):
         logger.warning("[permissions] UNIFI_AUTO_CONFIRM is deprecated. Use UNIFI_TOOL_PERMISSION_MODE=bypass instead.")
+
+
+def check_unknown_policy_env_vars(
+    server_prefix: str,
+    logger,
+    gates: Iterable[tuple[str, str]],
+    category_map: dict[str, str] | None = None,
+) -> list[str]:
+    """Warn at startup about UNIFI_POLICY_* env vars no registered gate matches.
+
+    *gates* are the ``(permission_category, permission_action)`` pairs the
+    server's tools register, as the manifest records them; *category_map* is
+    the server's shorthand-to-config-key map, so valid names are built exactly
+    as :class:`PolicyGateChecker` builds them. Read actions are never gated.
+
+    A variable is reported when it matches no registered gate, unless its first
+    segment names another known server. Variable names are logged, values are
+    not. Warns only; returns the unrecognized names.
+    """
+    checker = PolicyGateChecker(server_prefix, category_map)
+    valid = {
+        name
+        for category, action in gates
+        if action.lower() != "read"
+        for name in checker.env_var_names(category, action)
+    }
+    if not valid:
+        logger.warning("[policy] No policy gates registered for %s; skipping the UNIFI_POLICY_* scan", server_prefix)
+        return []
+    other_servers = _SERVER_PREFIXES - {checker.server_prefix}
+    unknown = [
+        name
+        for name in sorted(os.environ)
+        if name.startswith(_POLICY_PREFIX)
+        and name not in valid
+        and name[len(_POLICY_PREFIX) :].split("_", 1)[0] not in other_servers
+    ]
+    valid_sorted = sorted(valid)
+    for name in unknown[:_MAX_REPORTED_UNKNOWN]:
+        suggestions = difflib.get_close_matches(name, valid_sorted, n=3, cutoff=0.6)
+        hint = (
+            f"Did you mean {', '.join(suggestions)}?"
+            if suggestions
+            else "Valid names are listed in the server's permissions documentation."
+        )
+        logger.warning(
+            "[policy] Unrecognized env var %s: no gate in the %s tool manifest matches it. %s",
+            name.replace("\n", "\\n").replace("\r", "\\r"),
+            server_prefix.lower(),
+            hint,
+        )
+    if len(unknown) > _MAX_REPORTED_UNKNOWN:
+        logger.warning(
+            "[policy] %d more unrecognized UNIFI_POLICY_* variables not listed",
+            len(unknown) - _MAX_REPORTED_UNKNOWN,
+        )
+    return unknown

--- a/packages/unifi-core/tests/test_policy_gate.py
+++ b/packages/unifi-core/tests/test_policy_gate.py
@@ -1,0 +1,150 @@
+"""Tests for the startup scan of unrecognized UNIFI_POLICY_* env vars."""
+
+import logging
+import os
+
+import pytest
+from unifi_core.policy_gate import PolicyGateChecker, check_unknown_policy_env_vars
+
+LOGGER = logging.getLogger("unifi_core.policy_gate")
+
+# (permission_category, permission_action) pairs as the manifest records them,
+# and the category map that turns the shorthand into the env var's config key.
+PROTECT_GATES = [
+    ("camera", "update"),
+    ("light", "update"),
+    ("alarm", "create"),
+    ("alarm", "delete"),
+]
+PROTECT_MAP = {"camera": "cameras", "light": "lights"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("UNIFI_POLICY_"):
+            monkeypatch.delenv(key)
+
+
+def _run(server_prefix, gates, caplog, category_map=PROTECT_MAP):
+    with caplog.at_level(logging.WARNING, logger="unifi_core.policy_gate"):
+        return check_unknown_policy_env_vars(server_prefix, LOGGER, gates, category_map)
+
+
+def test_env_var_names_resolve_the_category_and_order_most_specific_first():
+    checker = PolicyGateChecker("protect", PROTECT_MAP)
+
+    assert checker.env_var_names("camera", "update") == [
+        "UNIFI_POLICY_PROTECT_CAMERAS_UPDATE",
+        "UNIFI_POLICY_PROTECT_UPDATE",
+        "UNIFI_POLICY_UPDATE",
+    ]
+
+
+def test_denial_message_names_the_config_key_form(caplog):
+    checker = PolicyGateChecker("protect", PROTECT_MAP)
+
+    assert "Set UNIFI_POLICY_PROTECT_CAMERAS_UPDATE=true" in checker.denial_message("camera", "update")
+    assert "UNIFI_POLICY_PROTECT_CAMERAS_READ" in checker.denial_message("camera", "read")
+
+
+def test_unknown_category_warns_and_names_the_nearest_valid_var(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_CAMERA_UPDATE", "true")
+
+    unknown = _run("protect", PROTECT_GATES, caplog)
+
+    assert unknown == ["UNIFI_POLICY_PROTECT_CAMERA_UPDATE"]
+    assert "UNIFI_POLICY_PROTECT_CAMERA_UPDATE" in caplog.text
+    assert "UNIFI_POLICY_PROTECT_CAMERAS_UPDATE" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "UNIFI_POLICY_PROTECT_CAMERAS_UPDATE",  # registered category gate
+        "UNIFI_POLICY_PROTECT_ALARM_DELETE",  # category not in the map, used as is
+        "UNIFI_POLICY_PROTECT_UPDATE",  # server-level action
+        "UNIFI_POLICY_DELETE",  # global action
+        "UNIFI_POLICY_NETWORK_CLIENT_GROUP_DELETE",  # another server's variable
+        "UNIFI_POLICY_ACCESS_DOOR_UPDATE",  # another server's variable
+        "UNIFI_PERMISSIONS_CAMERA_UPDATE",  # deprecated prefix, handled elsewhere
+    ],
+)
+def test_recognized_or_out_of_scope_vars_do_not_warn(var, monkeypatch, caplog):
+    monkeypatch.setenv(var, "true")
+
+    assert _run("protect", PROTECT_GATES, caplog) == []
+    assert caplog.text == ""
+
+
+def test_action_no_tool_registers_for_that_category_warns(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_CAMERAS_DELETE", "true")
+
+    assert _run("protect", PROTECT_GATES, caplog) == ["UNIFI_POLICY_PROTECT_CAMERAS_DELETE"]
+    assert "UNIFI_POLICY_PROTECT_CAMERAS_UPDATE" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "UNIFI_POLICY_PROTEKT_CAMERAS_UPDATE",  # misspelled server segment
+        "UNIFI_POLICY_PROTECTCAMERAS_UPDATE",  # missing underscore
+        "UNIFI_POLICY_CAMERAS_UPDATE",  # server segment dropped
+    ],
+)
+def test_var_whose_first_segment_is_not_a_known_server_warns(var, monkeypatch, caplog):
+    monkeypatch.setenv(var, "false")
+
+    assert _run("protect", PROTECT_GATES, caplog) == [var]
+    assert "UNIFI_POLICY_PROTECT_CAMERAS_UPDATE" in caplog.text
+
+
+def test_misspelled_global_action_warns(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_UPDAET", "false")
+
+    assert _run("protect", PROTECT_GATES, caplog) == ["UNIFI_POLICY_UPDAET"]
+    assert "UNIFI_POLICY_UPDATE" in caplog.text
+
+
+def test_read_gates_are_never_valid_because_reads_are_not_gated(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_ACCESS_DOORS_READ", "false")
+
+    unknown = _run("access", [("door", "read"), ("door", "update")], caplog, {"door": "doors"})
+
+    assert unknown == ["UNIFI_POLICY_ACCESS_DOORS_READ"]
+    assert "UNIFI_POLICY_ACCESS_DOORS_UPDATE" in caplog.text
+
+
+def test_unknown_var_with_no_close_match_still_names_the_var(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_ZZZZZZZZ_QQQQQQ", "true")
+
+    assert _run("protect", PROTECT_GATES, caplog) == ["UNIFI_POLICY_PROTECT_ZZZZZZZZ_QQQQQQ"]
+    assert "UNIFI_POLICY_PROTECT_ZZZZZZZZ_QQQQQQ" in caplog.text
+
+
+@pytest.mark.parametrize("gates", [[], [("camera", "read")]], ids=["no gates", "only read gates"])
+def test_no_mutating_gates_skips_the_scan_and_says_so(gates, monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_CAMERA_UPDATE", "true")
+
+    assert _run("protect", gates, caplog) == []
+    assert "UNIFI_POLICY_PROTECT_CAMERA_UPDATE" not in caplog.text
+    assert "skipping the UNIFI_POLICY_* scan" in caplog.text
+
+
+def test_newlines_in_a_variable_name_are_escaped_in_the_log(monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_POLICY_PROTECT_X\nCRITICAL forged line", "true")
+
+    _run("protect", PROTECT_GATES, caplog)
+
+    assert "\nCRITICAL" not in caplog.text
+    assert "UNIFI_POLICY_PROTECT_X\\nCRITICAL forged line" in caplog.text
+
+
+def test_reporting_is_capped_with_a_summary_line(monkeypatch, caplog):
+    names = [f"UNIFI_POLICY_PROTECT_BOGUS{i:02d}_UPDATE" for i in range(23)]
+    for name in names:
+        monkeypatch.setenv(name, "true")
+
+    assert _run("protect", PROTECT_GATES, caplog) == names
+    assert caplog.text.count("Unrecognized env var") == 20
+    assert "3 more unrecognized UNIFI_POLICY_* variables not listed" in caplog.text

--- a/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
+++ b/packages/unifi-mcp-shared/src/unifi_mcp_shared/tool_index.py
@@ -306,10 +306,37 @@ def _load_manifest_cached(manifest_path: Path) -> Dict[str, Any] | None:
     except Exception as e:
         logger.warning("Failed to load tool manifest: %s, falling back to runtime", e)
         return None
+    if not isinstance(manifest, dict):
+        logger.warning("Tool manifest at %s is not a JSON object, falling back to runtime", manifest_path)
+        return None
 
     logger.debug("Loaded tool index from manifest: %d tools", manifest.get("count", 0))
     _MANIFEST_CACHE[manifest_path] = manifest
     return manifest
+
+
+def policy_gates_from_manifest(manifest_path: Path) -> frozenset[tuple[str, str]]:
+    """Return the ``(permission_category, permission_action)`` pairs a manifest's tools register.
+
+    Categories are the manifest shorthand; resolve them through the server's
+    category map (``PolicyGateChecker``) before building env var names.
+    A missing or unreadable manifest yields no gates.
+    """
+    manifest = _load_manifest_cached(manifest_path)
+    if manifest is None:
+        return frozenset()
+    tools = manifest.get("tools")
+    if not isinstance(tools, list):
+        return frozenset()
+    gates = set()
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        category = tool.get("permission_category")
+        action = tool.get("permission_action")
+        if isinstance(category, str) and isinstance(action, str) and category and action:
+            gates.add((category, action))
+    return frozenset(gates)
 
 
 def _tools_from_registry() -> list:

--- a/packages/unifi-mcp-shared/tests/test_policy_gates.py
+++ b/packages/unifi-mcp-shared/tests/test_policy_gates.py
@@ -1,0 +1,61 @@
+"""Tests for reading policy gates out of a tools manifest."""
+
+import json
+
+import pytest
+from unifi_mcp_shared.tool_index import policy_gates_from_manifest
+
+
+def _write_manifest(tmp_path, tools):
+    path = tmp_path / "tools_manifest.json"
+    path.write_text(json.dumps({"count": len(tools), "tools": tools, "module_map": {}}))
+    return path
+
+
+def test_returns_the_manifest_category_and_action_pairs(tmp_path):
+    path = _write_manifest(
+        tmp_path,
+        [
+            {"name": "protect_update_camera", "permission_category": "camera", "permission_action": "update"},
+            {"name": "unifi_delete_client_group", "permission_category": "client_group", "permission_action": "delete"},
+            {"name": "protect_arm_alarm", "permission_category": "alarm", "permission_action": "update"},
+        ],
+    )
+
+    assert policy_gates_from_manifest(path) == frozenset(
+        {("camera", "update"), ("client_group", "delete"), ("alarm", "update")}
+    )
+
+
+def test_tools_without_a_full_permission_pair_are_skipped(tmp_path):
+    path = _write_manifest(
+        tmp_path,
+        [
+            {"name": "protect_list_cameras"},
+            {"name": "protect_get_camera", "permission_category": "camera"},
+        ],
+    )
+
+    assert policy_gates_from_manifest(path) == frozenset()
+
+
+def test_missing_manifest_yields_no_gates(tmp_path):
+    assert policy_gates_from_manifest(tmp_path / "missing.json") == frozenset()
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        ["not", "an", "object"],
+        {"tools": "not a list"},
+        {"tools": ["not a dict", None]},
+        {"tools": [{"name": "x", "permission_category": ["camera"], "permission_action": "update"}]},
+        {"tools": [{"name": "x", "permission_category": 7, "permission_action": "update"}]},
+        {"tools": [{"name": "x", "permission_category": "camera", "permission_action": None}]},
+    ],
+)
+def test_malformed_manifest_shapes_yield_no_gates_instead_of_raising(tmp_path, manifest):
+    path = tmp_path / "tools_manifest.json"
+    path.write_text(json.dumps(manifest))
+
+    assert policy_gates_from_manifest(path) == frozenset()


### PR DESCRIPTION
## Summary

Foundation half of #652, split out so Core and Shared can ship before any app depends on the new symbols. No app changes.

- **Core** (`unifi_core.policy_gate`): `PolicyGateChecker.env_var_names(category, action)` is the single naming rule, used by `check`, `denial_message` and the new `check_unknown_policy_env_vars`, which warns at startup about `UNIFI_POLICY_*` variables no registered gate matches. Names are logged, values are not; newlines in a name are escaped; reporting stops after twenty with a count; a variable whose first segment names another known server is left to that server. Re-exported from `unifi_core.policy`.
- **Shared** (`unifi_mcp_shared.tool_index`): `policy_gates_from_manifest(path)` returns the `(permission_category, permission_action)` pairs a tools manifest registers; a missing or malformed manifest yields no gates. `_load_manifest_cached` now rejects a manifest that is not a JSON object instead of caching it.

This is the package half of the revision you reviewed at `c5afae01` on #652 ("no enforcement or privacy defect in the scanner"), with two cosmetic changes since: the scan builds the unknown list first and logs the first twenty from it, and two tests that exercised the same branch are one parametrized test.

Nothing calls these helpers yet. #652 will be rebased onto this with the Network, Protect and Access floors raised to the Core and Shared releases that contain them, then the installed smoke you asked for runs on our plugin install.

Refs #609
Refs #610
Refs #652

## Type of change

- [ ] `fix:` bug fix
- [x] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [ ] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [ ] Network MCP server
- [ ] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [ ] API server
- [x] Shared packages
- [ ] Plugin packaging
- [ ] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. (No tool changes; manifests unchanged.)
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. (No user-visible change until the apps call the helpers; the docs ride with #652.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- Red/green: `packages/unifi-core/tests/test_policy_gate.py` and `packages/unifi-mcp-shared/tests/test_policy_gates.py` fail to collect against `main`'s package sources (ImportError on the new symbols) and pass with this branch.
- Core: 1915 passed. Shared: 436 passed. Separate pytest processes.
- App policy/permission tests at `main` run against this branch: network 111, protect 5, access 11 passed (the `check` refactor is behaviour-preserving for existing callers).
- `make pre-commit`: exit 0 (format, generate with no diff, lint, core/shared/catalog/docs/relay/protocol-smoke/worker suites, check-generated, worker typecheck). Pre-push CI mirror: lint gates, check-generated, core, shared, relay, network, protect, access suites passed.

## Notes for reviewers

One sequencing question for the rest of this batch, asked once here rather than on every PR. Several open PRs need a Core or Shared symbol published before their app change is installable (#642, #649, #645, #647, #650, #654 carry the same finding). Do you prefer contributor-split foundation PRs like this one, with the app PR floor-bumped after the release, or the #657 pattern where you cut the release and raise the floors in one maintainer commit? I will follow whichever you name for the remaining PRs.
