### PR TITLE
fix(core): resolve client lookups via /stat/user past the /rest/user cap

### DIFF
--- a/apps/network/tests/unit/test_mac_case_insensitivity.py
+++ b/apps/network/tests/unit/test_mac_case_insensitivity.py
@@ -44,7 +44,8 @@ def mock_connection():
         return await getattr(_c.controller, name).update()
 
     conn.refresh_handler = _refresh_handler
-    conn.request = AsyncMock(return_value=None)
+    # An empty list answers the per-MAC /stat/user fallback as a soft miss.
+    conn.request = AsyncMock(return_value=[])
     return conn
 
 

--- a/packages/unifi-core/src/unifi_core/mac.py
+++ b/packages/unifi-core/src/unifi_core/mac.py
@@ -29,7 +29,14 @@ turns into a request the controller may still reject, later and more quietly.
 import re
 from typing import Any, Optional
 
-__all__ = ["normalize_mac", "mac_equal", "looks_like_mac", "normalize_mac_list"]
+__all__ = [
+    "normalize_mac",
+    "mac_equal",
+    "looks_like_mac",
+    "normalize_mac_list",
+    "canonical_mac",
+    "mask_macs",
+]
 
 # Six hex pairs separated by ':' or '-', or twelve bare hex digits.
 _MAC_RE = re.compile(r"^(?:[0-9a-f]{2}([:-]))(?:[0-9a-f]{2}\1){4}[0-9a-f]{2}$|^[0-9a-f]{12}$")
@@ -102,6 +109,39 @@ def mac_equal(a: Any, b: Any) -> bool:
     # semantics: case-folding one here can select a different controller
     # resource whose identifier differs only by case.
     return isinstance(a, str) and isinstance(b, str) and bool(a) and a == b
+
+
+def canonical_mac(value: Any) -> Optional[str]:
+    """Return *value* as lowercase colon-separated pairs, or ``None`` if not a MAC.
+
+    The form for a request path such as ``/stat/user/<mac>``: our convention
+    (the controller accepts dashed and bare-hex forms too), and the rewrite
+    :func:`normalize_mac` deliberately declines to make.
+    """
+    digits = _mac_digits(value)
+    if digits is None:
+        return None
+    return ":".join(digits[i : i + 2] for i in range(0, 12, 2))
+
+
+# A MAC token inside free text: six pairs with one separator style, or twelve
+# bare hex digits, not adjoining another hex digit. Separators are allowed on
+# either side because aiounifi writes "...stat/user/<mac>: Cannot connect".
+_MAC_TOKEN_RE = re.compile(
+    r"(?<![0-9a-f])(?:[0-9a-f]{2}([:-])(?:[0-9a-f]{2}\1){4}[0-9a-f]{2}|[0-9a-f]{12})(?![0-9a-f])",
+    re.IGNORECASE,
+)
+
+
+def mask_macs(text: str) -> str:
+    """Return *text* with every MAC-shaped token replaced by ``[redacted]``.
+
+    For log lines that quote a request path, a URL or an exception message:
+    ``/stat/user/<mac>`` and ``/stat/device/<mac>`` put the address in the path
+    itself and aiounifi repeats the URL in its error text, and the privacy rule
+    for the client and device paths is that an address never reaches a log.
+    """
+    return _MAC_TOKEN_RE.sub("[redacted]", text)
 
 
 def normalize_mac_list(values: Any) -> Any:

--- a/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
@@ -5,13 +5,23 @@ from typing import Any, List, Optional
 from aiounifi.models.api import ApiRequest
 from aiounifi.models.client import Client
 
-from unifi_core.exceptions import UniFiNotFoundError
-from unifi_core.mac import mac_equal, normalize_mac
-from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
+from unifi_core.mac import canonical_mac, mac_equal, normalize_mac
+from unifi_core.network.managers.connection_manager import (
+    ConnectionManager,
+    controller_error_code,
+    response_status,
+)
 
 logger = logging.getLogger("unifi-network-mcp")
 
 CACHE_PREFIX_CLIENTS = "clients"
+
+# The controller caps GET /rest/user at this many rows; a client past the
+# window is absent from the list scan although the controller has its record,
+# so get_client_details falls back to the per-MAC GET /stat/user/<mac>.
+REST_USER_ROW_CAP = 3000
+UNKNOWN_USER_CODE = "api.err.UnknownUser"
 
 
 class ClientManager:
@@ -116,7 +126,7 @@ class ClientManager:
         raw = getattr(c, "raw", None)
         return raw if isinstance(raw, dict) else {}
 
-    async def get_client_details(self, client_mac: str) -> Any:
+    async def get_client_details(self, client_mac: str, *, existence_only: bool = False) -> Any:
         """Get detailed information for a specific client by MAC address.
 
         Returns a merged view combining /stat/sta (live data: fresh
@@ -126,7 +136,11 @@ class ClientManager:
         offline clients (not in /stat/sta) it falls back to just /rest/user.
 
         Each endpoint is queried independently so a transient failure on
-        one does not block the lookup.
+        one does not block the lookup. Whenever the /rest/user scan misses a
+        MAC-shaped identifier, the authoritative per-MAC GET /stat/user/<mac>
+        is consulted (see ``REST_USER_ROW_CAP``). With ``existence_only`` a
+        live /stat/sta record is proof enough and the per-MAC request is
+        skipped; callers that need ``_id`` leave it off.
 
         Returns:
             An object with stable ``.mac`` and ``.raw`` attributes so
@@ -135,11 +149,13 @@ class ClientManager:
             it came from.
 
         Raises:
-            UniFiNotFoundError: If at least one endpoint succeeded and
-                neither contained the requested MAC.
-            Original underlying exception: If *both* endpoints failed
-                (e.g., controller offline) — re-raised so callers see an
-                accurate failure cause instead of a misleading not-found.
+            UniFiNotFoundError: The controller reports the MAC unknown, or
+                nothing found it.
+            UniFiOperationError: The lists missed and the per-MAC lookup
+                failed for another reason, so existence is undetermined.
+            Original underlying exception: Both list endpoints failed
+                (e.g., controller offline), re-raised so callers see the
+                real cause instead of a misleading not-found.
         """
         client_mac = normalize_mac(client_mac) or client_mac
         active_record: Optional[Any] = None
@@ -166,11 +182,43 @@ class ClientManager:
             user_error = e
             logger.debug("/rest/user fetch failed during get_client_details: %s", type(e).__name__)
 
+        lookup_error: Optional[Exception] = None
+        path_mac = canonical_mac(client_mac)
+        # A live record already proves existence; only callers that need the
+        # user-table fields (``_id``) pay for the per-MAC request then.
+        live_is_enough = existence_only and active_record is not None
+        if user_record is None and path_mac is not None and not live_is_enough:
+            try:
+                user_record = await self._get_user_by_mac(path_mac)
+            except Exception as e:
+                if response_status(e) == 404:
+                    # aiounifi raises ResponseError for HTTP 404 and 429 alike;
+                    # only the reported status decides (never the URL or body
+                    # text). A 404 means the controller does not serve
+                    # /stat/user, which is no answer, so the lists' verdict
+                    # stands.
+                    logger.debug("/stat/user is not served by this controller: %s", type(e).__name__)
+                else:
+                    lookup_error = e
+                    logger.debug("/stat/user lookup failed during get_client_details: %s", type(e).__name__)
+
         if active_record is None and user_record is None:
+            if lookup_error is not None and controller_error_code(lookup_error) == UNKNOWN_USER_CODE:
+                # The per-MAC endpoint is authoritative: the controller has no
+                # record for this MAC, whatever the list scans did.
+                raise UniFiNotFoundError("client", client_mac)
             if active_error is not None and user_error is not None:
-                # Both endpoints failed — surface the underlying connectivity/
-                # outage error rather than misreporting it as a not-found.
+                # Both list endpoints failed — surface the underlying
+                # connectivity/outage error rather than misreporting it as a
+                # not-found.
                 raise active_error
+            if lookup_error is not None:
+                raise UniFiOperationError(
+                    f"client '{client_mac}' could not be resolved through the online (/stat/sta) or "
+                    f"user (/rest/user, capped at {REST_USER_ROW_CAP} rows) lists, and the per-MAC "
+                    f"lookup (/stat/user) failed with {type(lookup_error).__name__}; "
+                    "existence could not be determined"
+                ) from lookup_error
             raise UniFiNotFoundError("client", client_mac)
 
         active_raw = self._raw_of(active_record)
@@ -193,6 +241,23 @@ class ClientManager:
             return SimpleNamespace(mac=self._mac_of(single), raw=single_raw)
         return single
 
+    async def _get_user_by_mac(self, path_mac: str) -> Optional[dict]:
+        """Fetch one user-table record via GET /stat/user/<mac>, or ``None`` for an empty list.
+
+        A reply that is not a list of records (a non-JSON page from a proxy or
+        a restarting controller decodes to nothing) is a failed lookup, raised
+        as :class:`UniFiOperationError` so it is never read as a not-found.
+        Controller errors propagate as raised; the caller decides whether
+        ``api.err.UnknownUser`` means not-found.
+        """
+        response = await self._connection.request(ApiRequest(method="get", path=f"/stat/user/{path_mac}"))
+        if not isinstance(response, list) or (response and not isinstance(response[0], dict)):
+            raise UniFiOperationError(f"/stat/user reply had unexpected shape {type(response).__name__}")
+        if not response:
+            logger.debug("/stat/user answered with no record")
+            return None
+        return response[0]
+
     async def block_client(self, client_mac: str) -> bool:
         """Block a client by MAC address.
 
@@ -200,7 +265,7 @@ class ClientManager:
             UniFiNotFoundError: If the client does not exist.
         """
         client_mac = normalize_mac(client_mac) or client_mac
-        await self.get_client_details(client_mac)  # existence check; raises on miss
+        await self.get_client_details(client_mac, existence_only=True)  # raises on miss
         try:
             # Construct ApiRequest
             api_request = ApiRequest(
@@ -224,7 +289,7 @@ class ClientManager:
             UniFiNotFoundError: If the client does not exist.
         """
         client_mac = normalize_mac(client_mac) or client_mac
-        await self.get_client_details(client_mac)  # existence check; raises on miss
+        await self.get_client_details(client_mac, existence_only=True)  # raises on miss
         try:
             # Construct ApiRequest
             api_request = ApiRequest(
@@ -281,7 +346,7 @@ class ClientManager:
             UniFiNotFoundError: If the client does not exist.
         """
         client_mac = normalize_mac(client_mac) or client_mac
-        await self.get_client_details(client_mac)  # existence check; raises on miss
+        await self.get_client_details(client_mac, existence_only=True)  # raises on miss
         try:
             api_request = ApiRequest(
                 method="post",
@@ -338,7 +403,7 @@ class ClientManager:
             UniFiNotFoundError: If the client does not exist.
         """
         client_mac = normalize_mac(client_mac) or client_mac
-        await self.get_client_details(client_mac)  # existence check; raises on miss
+        await self.get_client_details(client_mac, existence_only=True)  # raises on miss
         try:
             payload = {"mac": client_mac, "cmd": "authorize-guest", "minutes": minutes}
             if up_kbps is not None:
@@ -366,7 +431,7 @@ class ClientManager:
             UniFiNotFoundError: If the client does not exist.
         """
         client_mac = normalize_mac(client_mac) or client_mac
-        await self.get_client_details(client_mac)  # existence check; raises on miss
+        await self.get_client_details(client_mac, existence_only=True)  # raises on miss
         try:
             api_request = ApiRequest(
                 method="post",

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -3,11 +3,13 @@ import logging
 import re
 import time
 import time as _time
+import traceback
 from typing import Any, Dict, Optional
 
 import aiohttp
 from aiounifi.controller import Controller
 from aiounifi.errors import (
+    AiounifiException,
     AuthenticationRateLimitError,
     Forbidden,
     LoginRequired,
@@ -20,6 +22,7 @@ from aiounifi.errors import (
 from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.configuration import Configuration
 
+from unifi_core.mac import mask_macs
 from unifi_core.support_bundle import (
     ConnectivityProbe,
     SafeConnectionAttempt,
@@ -43,8 +46,52 @@ _RECONNECT_BLOCK_MAX_SECONDS = 900.0
 # aiounifi v92 logs the complete login JSON (including password) at DEBUG.
 # Keep that dependency logger at INFO even when application diagnostics use DEBUG.
 _aiounifi_connectivity_logger = logging.getLogger("aiounifi.interfaces.connectivity")
+
+
 if _aiounifi_connectivity_logger.level == logging.NOTSET or _aiounifi_connectivity_logger.level < logging.INFO:
     _aiounifi_connectivity_logger.setLevel(logging.INFO)
+
+
+# aiounifi's ResponseError carries no status attribute. Its message is built as
+# ``Call <url> received <status>[ <reason>|: <body>]`` (interfaces/connectivity.py),
+# and the URL contains no whitespace, so the status is the first three-digit
+# token after the first whitespace-free run following "Call ". The URL and the
+# body may contain any digits and are never consulted.
+_RESPONSE_STATUS_RE = re.compile(r"^Call \S+ received (\d{3})(?!\d)")
+
+
+def response_status(exc: BaseException) -> Optional[int]:
+    """Return the HTTP status a :class:`ResponseError` reports, else ``None``.
+
+    aiounifi raises the same class for 404 and 429 and does not expose the
+    status, so this reads the status-bearing segment of its message and only
+    that segment: a 429 from a host named ``controller404.example`` is 429.
+    """
+    if not isinstance(exc, ResponseError):
+        return None
+    match = _RESPONSE_STATUS_RE.match(str(exc))
+    return int(match.group(1)) if match else None
+
+
+def controller_error_code(exc: BaseException) -> Optional[str]:
+    """Return the ``api.err.*`` code of a controller-reported error, else ``None``.
+
+    aiounifi raises a bare :class:`AiounifiException` carrying the decoded body
+    for any ``meta.rc == "error"`` it has no specific class for, e.g.
+    ``{"meta": {"rc": "error", "mac": <input>, "msg": "api.err.UnknownUser"}, "data": []}``.
+    Only a bare instance qualifies (the mapped auth errors are subclasses and
+    keep their ERROR logging) and only a value shaped like a code is returned:
+    the body can echo request values such as a MAC, so callers log the code,
+    never ``str(exc)``.
+    """
+    if type(exc) is not AiounifiException or not exc.args:
+        return None
+    body = exc.args[0]
+    meta = body.get("meta") if isinstance(body, dict) else None
+    msg = meta.get("msg") if isinstance(meta, dict) else None
+    if not isinstance(msg, str) or not msg.startswith("api.err.") or not msg.replace(".", "").isalnum():
+        return None
+    return msg
 
 
 async def detect_unifi_os_pre_login(
@@ -296,8 +343,12 @@ class ConnectionManager:
         return f"{proto}://{self.host}:{self.port}"
 
     def _sanitize_connection_error(self, error: BaseException) -> str:
-        """Return a user-facing connection error without configured secrets."""
-        message = str(error) or type(error).__name__
+        """Return a user-facing connection error without configured secrets or addresses."""
+        return self._sanitize_text(str(error) or type(error).__name__)
+
+    def _sanitize_text(self, text: str) -> str:
+        """Mask MAC addresses and the configured credentials in *text*."""
+        message = mask_macs(text)
         for secret in (self.password, self.username):
             if secret:
                 pattern = rf"(?<![A-Za-z0-9_-]){re.escape(secret)}(?![A-Za-z0-9_-])"
@@ -339,7 +390,7 @@ class ConnectionManager:
         if isinstance(error, RequestError):
             return "mfa" in message or "totp" in message
         if isinstance(error, ResponseError):
-            return "received 429" in message
+            return response_status(error) == 429
         return False
 
     def _block_automatic_reconnect(self, error: BaseException) -> str:
@@ -732,6 +783,37 @@ class ConnectionManager:
                 await self._discard_connection()
                 raise
 
+    def _log_request_failure(
+        self,
+        level: int,
+        what: str,
+        api_request: ApiRequest | ApiRequestV2,
+        detail: str,
+        *,
+        with_traceback: bool = False,
+    ) -> None:
+        """Log a failed request with every address and credential masked.
+
+        ``/stat/user/<mac>`` carries the address in the path itself and
+        aiounifi repeats the URL in its error text, so the path, the detail and
+        the traceback all pass through :meth:`_sanitize_text`. The traceback is
+        rendered here so it passes the mask too; ``exc_info=True`` would append
+        it unmasked.
+        """
+        if not logger.isEnabledFor(level):
+            return
+        message = f"{what}: %s %s - %s"
+        args = [api_request.method.upper(), mask_macs(api_request.path), self._sanitize_text(detail)]
+        if with_traceback:
+            message += "\n%s"
+            args.append(self._sanitize_text(traceback.format_exc()))
+        logger.log(level, message, *args)
+
+    @staticmethod
+    def _rejection_level(api_request: ApiRequest | ApiRequestV2) -> int:
+        """A controller's negative answer is routine on a read, worth a warning on a write."""
+        return logging.INFO if api_request.method.lower() == "get" else logging.WARNING
+
     async def request(self, api_request: ApiRequest | ApiRequestV2, return_raw: bool = False) -> Any:
         """Make a request to the controller API, handling raw responses."""
         if not await self.ensure_connected() or not self.controller:
@@ -804,11 +886,8 @@ class ConnectionManager:
                     return retry_response if return_raw else retry_response.get("data")
                 except Exception as retry_e:
                     retry_error = self._sanitize_connection_error(retry_e)
-                    logger.error(
-                        "API request failed even after re-authentication: %s %s - %s",
-                        api_request.method.upper(),
-                        api_request.path,
-                        retry_error,
+                    self._log_request_failure(
+                        logging.ERROR, "API request failed even after re-authentication", api_request, retry_error
                     )
                     # A second LoginRequired means the refreshed session was not
                     # accepted. Treat it as terminal so later tool calls cannot
@@ -821,7 +900,14 @@ class ConnectionManager:
             else:
                 raise self._not_connected_error()
         except (RequestError, ResponseError, aiohttp.ClientError) as e:
-            logger.error("API request error: %s %s - %s", api_request.method.upper(), api_request.path, e)
+            if response_status(e) == 404:
+                # The controller answered: it does not serve this path. That is
+                # a negative reply the caller interprets, not a transport fault.
+                self._log_request_failure(
+                    self._rejection_level(api_request), "Controller answered 404", api_request, str(e)
+                )
+            else:
+                self._log_request_failure(logging.ERROR, "API request error", api_request, str(e))
             try:
                 from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 
@@ -839,13 +925,19 @@ class ConnectionManager:
                 pass
             raise
         except Exception as e:
-            logger.error(
-                "Unexpected error during API request: %s %s - %s",
-                api_request.method.upper(),
-                api_request.path,
-                e,
-                exc_info=True,
-            )
+            code = controller_error_code(e)
+            if code is not None:
+                # A controller-reported api.err.* is a negative reply, not an
+                # operator event: routine on a read (an unknown MAC on a
+                # per-MAC lookup), worth a warning on a write. The body can
+                # echo request values, so only the code is logged.
+                self._log_request_failure(
+                    self._rejection_level(api_request), "Controller rejected request", api_request, code
+                )
+            else:
+                self._log_request_failure(
+                    logging.ERROR, "Unexpected error during API request", api_request, str(e), with_traceback=True
+                )
             try:
                 from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -154,7 +154,7 @@ class StatsManager:
         granularity: str = "hourly",
     ) -> List[Dict[str, Any]]:
         """Resolve a public MAC-or-id client identifier before fetching stats."""
-        client = await self._client_manager.get_client_details(client_id)
+        client = await self._client_manager.get_client_details(client_id, existence_only=True)
         raw = client.raw if hasattr(client, "raw") else client
         client_mac = raw.get("mac", client_id)
         return await self.get_client_stats(

--- a/packages/unifi-core/tests/network/managers/test_catalog_bridge_methods.py
+++ b/packages/unifi-core/tests/network/managers/test_catalog_bridge_methods.py
@@ -63,7 +63,7 @@ async def test_client_stats_bridge_resolves_controller_id_to_mac() -> None:
     result = await manager.get_client_stats_for_identifier("client-object-id", duration_hours=24)
 
     assert result == [{"rx_bytes": 1}]
-    client_manager.get_client_details.assert_awaited_once_with("client-object-id")
+    client_manager.get_client_details.assert_awaited_once_with("client-object-id", existence_only=True)
     manager.get_client_stats.assert_awaited_once_with("aa:bb:cc:dd:ee:ff", duration_hours=24, granularity="hourly")
 
 

--- a/packages/unifi-core/tests/network/managers/test_client_manager_stat_user.py
+++ b/packages/unifi-core/tests/network/managers/test_client_manager_stat_user.py
@@ -1,0 +1,366 @@
+"""``ClientManager.get_client_details`` past the ``/rest/user`` row cap.
+
+The controller caps ``GET /rest/user`` at 3,000 rows. A client past that
+window is absent from the list scan although the controller has its record,
+so the manager falls back to the authoritative per-MAC ``GET /stat/user/<mac>``:
+200 with the record for a known MAC, HTTP 400 ``api.err.UnknownUser`` for an
+unknown one. Any other failure of that request leaves existence undetermined
+and must never be reported as a not-found.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiounifi.errors import AiounifiException, RequestError, ResponseError
+from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
+from unifi_core.network.managers.client_manager import ClientManager
+
+MAC = "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.fixture
+def mock_connection():
+    conn = MagicMock()
+    conn.site = "default"
+    conn.get_cached = MagicMock(return_value=None)
+    conn._update_cache = MagicMock()
+    conn._invalidate_cache = MagicMock()
+    conn.ensure_connected = AsyncMock(return_value=True)
+
+    async def _refresh_handler(name, _c=conn):
+        return await getattr(_c.controller, name).update()
+
+    conn.refresh_handler = _refresh_handler
+    conn.controller = MagicMock()
+    conn.controller.clients = MagicMock()
+    conn.controller.clients.update = AsyncMock()
+    conn.controller.clients.values = MagicMock(return_value=[])
+    conn.controller.clients_all = MagicMock()
+    conn.controller.clients_all.update = AsyncMock()
+    conn.controller.clients_all.values = MagicMock(return_value=[])
+    conn.request = AsyncMock(return_value=None)
+    return conn
+
+
+def _client(mac: str, **extra):
+    obj = MagicMock()
+    obj.mac = mac
+    obj.raw = {"mac": mac, **extra}
+    return obj
+
+
+def _unknown_user(mac: str) -> AiounifiException:
+    return AiounifiException({"meta": {"rc": "error", "mac": mac, "msg": "api.err.UnknownUser"}, "data": []})
+
+
+def _route_stat_user(mock_connection, *, record=None, error=None):
+    """Answer ``/stat/user/<mac>`` and leave the list fallbacks at ``None``.
+
+    Returns a namespace recording the ``/stat/user/`` paths issued and the
+    ``(path, data)`` of every PUT, which is what the assertions look at.
+    """
+    seen = SimpleNamespace(stat_user=[], puts=[])
+
+    async def _request(req):
+        if req.method == "put":
+            seen.puts.append((req.path, req.data))
+        if req.path.startswith("/stat/user/"):
+            seen.stat_user.append(req.path)
+            if error is not None:
+                raise error
+            return [record] if record is not None else []
+        return None
+
+    mock_connection.request = AsyncMock(side_effect=_request)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_resolves_via_stat_user_when_both_lists_miss(mock_connection):
+    mac = MAC
+    seen = _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001", "noted": True})
+
+    result = await ClientManager(mock_connection).get_client_details(mac)
+
+    assert result.mac == mac
+    assert result.raw["_id"] == "u-3001"
+    assert seen.stat_user == [f"/stat/user/{mac}"]
+
+
+@pytest.mark.asyncio
+async def test_stat_user_supplies_id_for_active_client_missing_from_rest_user(mock_connection):
+    """An online client past the cap is in /stat/sta but not /rest/user; the
+    per-MAC record supplies the ``_id`` that rename and set_ip need, and the
+    live fields still win on overlap."""
+    mac = MAC
+    mock_connection.controller.clients.values.return_value = [_client(mac, signal=-50, uptime=99)]
+    _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001", "uptime": 1})
+
+    result = await ClientManager(mock_connection).get_client_details(mac)
+
+    assert result.raw["_id"] == "u-3001"
+    assert result.raw["signal"] == -50
+    assert result.raw["uptime"] == 99
+
+
+@pytest.mark.asyncio
+async def test_stat_user_unknown_user_raises_not_found(mock_connection):
+    mac = MAC
+    _route_stat_user(mock_connection, error=_unknown_user(mac))
+
+    with pytest.raises(UniFiNotFoundError):
+        await ClientManager(mock_connection).get_client_details(mac)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_network_error_is_not_reported_as_not_found(mock_connection):
+
+    mac = MAC
+    cause = RuntimeError("boom")
+    _route_stat_user(mock_connection, error=cause)
+
+    with pytest.raises(UniFiOperationError) as excinfo:
+        await ClientManager(mock_connection).get_client_details(mac)
+
+    assert "could not be determined" in str(excinfo.value)
+    assert "3000" in str(excinfo.value)
+    assert excinfo.value.__cause__ is cause
+
+
+@pytest.mark.asyncio
+async def test_stat_user_skipped_for_non_mac_identifier(mock_connection):
+    """stats_manager passes a client ``_id`` through this path; an opaque id
+    must not be sent to /stat/user/."""
+    seen = _route_stat_user(mock_connection, record={"mac": MAC, "_id": "u-1"})
+
+    with pytest.raises(UniFiNotFoundError):
+        await ClientManager(mock_connection).get_client_details("5f1e2d3c4b5a697877665544")
+
+    assert seen.stat_user == []
+
+
+@pytest.mark.asyncio
+async def test_stat_user_uses_canonical_colon_path(mock_connection):
+    """Our convention, not a controller requirement: the controller accepts
+    any spelling, and its own payloads are lowercase colon-separated."""
+    seen = _route_stat_user(mock_connection, record={"mac": MAC, "_id": "u-1"})
+
+    await ClientManager(mock_connection).get_client_details("AA-BB-CC-DD-EE-FF")
+
+    assert seen.stat_user == ["/stat/user/aa:bb:cc:dd:ee:ff"]
+
+
+@pytest.mark.asyncio
+async def test_rename_client_works_for_client_only_reachable_via_stat_user(mock_connection):
+    mac = MAC
+    seen = _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001"})
+
+    assert await ClientManager(mock_connection).rename_client(mac, "printer") is True
+
+    assert seen.puts == [("/rest/user/u-3001", {"name": "printer"})]
+
+
+@pytest.mark.asyncio
+async def test_reraises_list_error_when_both_lists_and_stat_user_raise(mock_connection):
+    """Outage semantics are unchanged: when every endpoint fails, callers see
+    the list error, not a not-found and not the per-MAC error."""
+    mock_connection.controller.clients.update.side_effect = RuntimeError("list boom")
+    mock_connection.controller.clients_all.update.side_effect = RuntimeError("list boom")
+    _route_stat_user(mock_connection, error=RuntimeError("per-mac boom"))
+
+    with pytest.raises(RuntimeError, match="list boom"):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_existence_checks_stop_at_the_live_record(mock_connection):
+    """block/unblock/kick/guest-auth only need to know the client exists; an
+    online client past the cap must not cost them a per-MAC request."""
+    mac = MAC
+    mock_connection.controller.clients.values.return_value = [_client(mac, signal=-50)]
+    seen = _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001"})
+
+    await ClientManager(mock_connection).block_client(mac)
+
+    assert seen.stat_user == []
+
+
+@pytest.mark.asyncio
+async def test_existence_check_still_falls_back_when_both_lists_miss(mock_connection):
+    mac = MAC
+    seen = _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001"})
+
+    await ClientManager(mock_connection).block_client(mac)
+
+    assert seen.stat_user == [f"/stat/user/{mac}"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reply", [None, {}, "html", ["str"]])
+async def test_unexpected_stat_user_reply_is_not_reported_as_not_found(mock_connection, reply):
+    """A non-JSON or malformed reply (proxy interstitial, controller mid-restart)
+    is a failed lookup, not a fact about the client."""
+
+    mock_connection.request = AsyncMock(return_value=reply)
+
+    with pytest.raises(UniFiOperationError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_empty_stat_user_reply_is_a_soft_miss(mock_connection):
+    _route_stat_user(mock_connection)
+
+    with pytest.raises(UniFiNotFoundError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_404_keeps_the_list_verdict(mock_connection):
+    """A controller that does not serve /stat/user answers 404 (aiounifi
+    ResponseError); that is no answer, so the lists' not-found stands."""
+
+    _route_stat_user(mock_connection, error=ResponseError("Call https://c/stat/user/x received 404 Not Found"))
+
+    with pytest.raises(UniFiNotFoundError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_unknown_user_wins_over_list_errors(mock_connection):
+    mac = MAC
+    mock_connection.controller.clients.update.side_effect = RuntimeError("list boom")
+    mock_connection.controller.clients_all.update.side_effect = RuntimeError("list boom")
+    _route_stat_user(mock_connection, error=_unknown_user(mac))
+
+    with pytest.raises(UniFiNotFoundError):
+        await ClientManager(mock_connection).get_client_details(mac)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_resolves_when_rest_user_raised(mock_connection):
+    mac = MAC
+    mock_connection.controller.clients_all.update.side_effect = RuntimeError("boom")
+    _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001"})
+
+    result = await ClientManager(mock_connection).get_client_details(mac)
+
+    assert result.raw["_id"] == "u-3001"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda mgr, mac: mgr.block_client(mac),
+        lambda mgr, mac: mgr.unblock_client(mac),
+        lambda mgr, mac: mgr.force_reconnect_client(mac),
+        lambda mgr, mac: mgr.authorize_guest(mac, 60),
+        lambda mgr, mac: mgr.unauthorize_guest(mac),
+    ],
+    ids=["block", "unblock", "kick", "authorize", "unauthorize"],
+)
+async def test_every_existence_only_caller_skips_the_per_mac_request(mock_connection, call):
+    mac = MAC
+    mock_connection.controller.clients.values.return_value = [_client(mac, signal=-50)]
+    seen = _route_stat_user(mock_connection, record={"mac": mac, "_id": "u-3001"})
+
+    await call(ClientManager(mock_connection), mac)
+
+    assert seen.stat_user == []
+
+
+@pytest.mark.asyncio
+async def test_stat_user_429_is_not_reported_as_not_found(mock_connection):
+    """aiounifi raises the same ResponseError for HTTP 429; only a 404 is
+    "no such endpoint"."""
+
+    _route_stat_user(mock_connection, error=ResponseError("Call https://c/stat/user/x received 429: b''"))
+
+    with pytest.raises(UniFiOperationError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+# --- the HTTP status of a ResponseError -------------------------------------
+# aiounifi raises one ResponseError class for HTTP 404 and 429 and carries no
+# status attribute; its message is ``Call <url> received <status>[: <body>]``.
+# Only that status segment may decide; the URL and the body can contain 404.
+
+
+@pytest.mark.asyncio
+async def test_stat_user_429_from_a_host_named_404_is_not_reported_as_not_found(mock_connection):
+    """The maintainer's reproduction: a 429 whose URL host carries the digits
+    404 must not become a not-found."""
+    url = f"https://controller404.example/proxy/network/api/s/default/stat/user/{MAC}"
+    _route_stat_user(mock_connection, error=ResponseError(f"Call {url} received 429: b''"))
+
+    with pytest.raises(UniFiOperationError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_429_whose_body_mentions_404_is_not_reported_as_not_found(mock_connection):
+    url = f"https://c/proxy/network/api/s/default/stat/user/{MAC}"
+    body = b'{"code":"RATE_LIMITED","message":"see error 404 docs"}'
+    _route_stat_user(mock_connection, error=ResponseError(f"Call {url} received 429: {body!r}"))
+
+    with pytest.raises(UniFiOperationError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_404_from_a_host_named_429_keeps_the_list_verdict(mock_connection):
+    url = f"https://controller429.example/proxy/network/api/s/default/stat/user/{MAC}"
+    _route_stat_user(mock_connection, error=ResponseError(f"Call {url} received 404 Not Found"))
+
+    with pytest.raises(UniFiNotFoundError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_response_error_without_a_status_is_undetermined(mock_connection):
+    """A ResponseError that carries no status segment is not a 404."""
+    _route_stat_user(mock_connection, error=ResponseError("invalid response, expected 404 or json"))
+
+    with pytest.raises(UniFiOperationError):
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+
+@pytest.mark.asyncio
+async def test_stat_user_transport_error_with_404_in_the_url_is_undetermined(mock_connection):
+    """aiounifi's transport error quotes the URL too; it is never a not-found."""
+    url = f"https://controller404.example/proxy/network/api/s/default/stat/user/{MAC}"
+    cause = RequestError(f"Error requesting data from {url}: Cannot connect to host")
+    _route_stat_user(mock_connection, error=cause)
+
+    with pytest.raises(UniFiOperationError) as excinfo:
+        await ClientManager(mock_connection).get_client_details(MAC)
+
+    assert excinfo.value.__cause__ is cause
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("Call https://c/api/s/default/stat/user/x received 404 Not Found", 404),
+        ("Call https://controller404.example/stat/user/x received 429: b''", 429),
+        ("Call https://c/stat/user/x received 429: b'received 404'", 429),
+        ("Call https://c/stat/user/x received 503 service unavailable", 503),
+        ("received 404", None),
+        ("Call https://c/stat/user/x received 4040", None),
+        ("plain text 404", None),
+        ("", None),
+    ],
+)
+def test_response_status_reads_only_the_status_segment(message, expected):
+    from unifi_core.network.managers.connection_manager import response_status
+
+    assert response_status(ResponseError(message)) == expected
+
+
+def test_response_status_ignores_other_exception_types():
+    from unifi_core.network.managers.connection_manager import response_status
+
+    assert response_status(RequestError("Call https://c/x received 404 Not Found")) is None
+    assert response_status(RuntimeError("Call https://c/x received 404 Not Found")) is None

--- a/packages/unifi-core/tests/network/managers/test_connection_manager_request_logging.py
+++ b/packages/unifi-core/tests/network/managers/test_connection_manager_request_logging.py
@@ -1,0 +1,200 @@
+"""``ConnectionManager.request`` failure logging.
+
+Two rules meet here. Operators need permission denials, login lockouts and
+transport failures at ERROR with diagnostics. The privacy rule for the Network
+client and device paths says a MAC address never reaches a log line, and
+``/stat/user/<mac>`` puts the address in the request path itself.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiounifi.errors import (
+    AiounifiException,
+    AuthenticationRateLimitError,
+    Forbidden,
+    LoginRequired,
+    NoPermission,
+    RequestError,
+    ResponseError,
+    Unauthorized,
+)
+from aiounifi.models.api import ApiRequest
+from unifi_core.network.managers.connection_manager import ConnectionManager
+
+MAC = "aa:bb:cc:dd:ee:ff"
+
+
+class _Session:
+    closed = False
+
+    async def close(self):
+        return None
+
+
+def _manager(error: BaseException) -> ConnectionManager:
+    manager = ConnectionManager("192.168.1.1", "admin", "secret")
+    controller = MagicMock()
+    controller.connectivity.config.session = _Session()
+
+    async def _request(_req):
+        raise error
+
+    controller.request = _request
+    manager.controller = controller
+    manager._aiohttp_session = controller.connectivity.config.session
+    manager._initialized = True
+    return manager
+
+
+def _unknown_user() -> AiounifiException:
+    return AiounifiException({"meta": {"rc": "error", "mac": MAC, "msg": "api.err.UnknownUser"}, "data": []})
+
+
+@pytest.fixture
+def diagnostics_on(monkeypatch):
+    monkeypatch.setattr("unifi_core.diagnostics.diagnostics_enabled", lambda: True)
+    log_api_request = MagicMock()
+    monkeypatch.setattr("unifi_core.diagnostics.log_api_request", log_api_request)
+    return log_api_request
+
+
+@pytest.mark.asyncio
+async def test_controller_reported_error_logs_the_code_only(caplog, diagnostics_on):
+    """A controller ``api.err.*`` answer is a normal negative reply, not an
+    operator event: no ERROR, no traceback, and the body (which echoes the
+    requested MAC) never reaches the log. The error code alone is logged."""
+    manager = _manager(_unknown_user())
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(AiounifiException):
+            await manager.request(ApiRequest(method="get", path=f"/stat/user/{MAC}"))
+
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert all(r.exc_info is None for r in caplog.records)
+    assert MAC not in caplog.text and "aabbccddeeff" not in caplog.text
+    assert "api.err.UnknownUser" in caplog.text
+    assert "'data'" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_type", [Forbidden, NoPermission, AuthenticationRateLimitError, Unauthorized])
+async def test_other_aiounifi_errors_keep_error_logging_and_diagnostics(caplog, diagnostics_on, error_type):
+    manager = _manager(error_type("denied"))
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(error_type):
+            await manager.request(ApiRequest(method="put", path="/rest/firewallpolicy/abc"))
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors
+    assert "Traceback (most recent call last)" in caplog.text
+    diagnostics_on.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        RequestError("timeout"),
+        RuntimeError("boom"),
+        ResponseError(f"Call https://c/proxy/network/api/s/default/stat/user/{MAC} received 429: b''"),
+        RequestError(f"Error requesting data from https://c/api/s/default/stat/user/{MAC}: Cannot connect to host"),
+        Forbidden(f"Call https://c/proxy/network/api/s/default/stat/user/{MAC} received 403 Forbidden"),
+        AiounifiException({"meta": {"rc": "error", "msg": f"bad station {MAC}"}, "data": []}),
+    ],
+)
+async def test_failed_request_never_logs_a_mac_bearing_path(caplog, error):
+    """Transport and unexpected failures stay at ERROR, with the address
+    masked in the path and in the exception message (aiounifi quotes the URL)."""
+    manager = _manager(error)
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(type(error)):
+            await manager.request(ApiRequest(method="get", path=f"/stat/user/{MAC}"))
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert MAC not in caplog.text and "aabbccddeeff" not in caplog.text
+    assert "/stat/user/[redacted]" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_404_answer_on_a_read_is_not_an_operator_event(caplog):
+    """A controller that does not serve a path answers 404; the caller decides
+    what that means, so the log line is INFO, masked, without a traceback."""
+    url = f"https://c/proxy/network/api/s/default/stat/user/{MAC}"
+    manager = _manager(ResponseError(f"Call {url} received 404 Not Found"))
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(ResponseError):
+            await manager.request(ApiRequest(method="get", path=f"/stat/user/{MAC}"))
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert "Controller answered 404" in caplog.text
+    assert MAC not in caplog.text and "/stat/user/[redacted]" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_failure_logs_mask_the_configured_credentials(caplog):
+    """The same sanitizer that guards the stored connection error guards the
+    request failure lines: a credential echoed by the library never lands."""
+    manager = _manager(RequestError("Error requesting data: login for admin with secret rejected"))
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(RequestError):
+            await manager.request(ApiRequest(method="get", path="/stat/sta"))
+
+    assert "secret" not in caplog.text
+    assert "<redacted>" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_rejected_write_logs_the_code_at_warning(caplog):
+    """A controller api.err.* on a write is not a routine negative reply."""
+    manager = _manager(AiounifiException({"meta": {"rc": "error", "msg": "api.err.InvalidPayload"}, "data": []}))
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(AiounifiException):
+            await manager.request(ApiRequest(method="post", path="/cmd/stamgr", data={"cmd": "block-sta"}))
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings and "api.err.InvalidPayload" in warnings[0].getMessage()
+    assert all(r.exc_info is None for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (AiounifiException({"meta": {"rc": "error", "msg": "api.err.UnknownUser"}, "data": []}), "api.err.UnknownUser"),
+        (AiounifiException("plain text"), None),
+        (AiounifiException(), None),
+        (AiounifiException({"data": []}), None),
+        (AiounifiException({"meta": {"rc": "error"}}), None),
+        (AiounifiException({"meta": {"msg": 5}}), None),
+        (AiounifiException({"meta": {"rc": "error", "msg": f"bad station {MAC}"}}), None),
+        (Forbidden({"meta": {"rc": "error", "msg": "api.err.X"}}), None),
+        (NoPermission({"meta": {"rc": "error", "msg": "api.err.NoPermission"}}), None),
+    ],
+)
+def test_controller_error_code_only_reads_api_err_codes_from_bare_exceptions(exc, expected):
+    from unifi_core.network.managers.connection_manager import controller_error_code
+
+    assert controller_error_code(exc) == expected
+
+
+@pytest.mark.asyncio
+async def test_terminal_login_failure_never_stores_or_logs_a_mac(caplog):
+    """A 401 after re-authentication is recorded for the reconnect cool-down and
+    served to later callers; aiounifi's message quotes the URL."""
+    url = f"https://c/proxy/network/api/s/default/stat/user/{MAC}"
+    manager = _manager(LoginRequired(f"Call {url} received 401 Unauthorized"))
+    manager._reauthenticate = AsyncMock(return_value=True)
+
+    with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
+        with pytest.raises(LoginRequired):
+            await manager.request(ApiRequest(method="get", path=f"/stat/user/{MAC}"))
+
+    assert MAC not in caplog.text and "aabbccddeeff" not in caplog.text
+    assert MAC not in (manager._last_connection_error or "")
+    assert MAC not in str(manager._not_connected_error())

--- a/packages/unifi-core/tests/test_mac.py
+++ b/packages/unifi-core/tests/test_mac.py
@@ -325,3 +325,64 @@ def test_normalize_mac_still_leaves_separators_alone() -> None:
 
     assert normalize_mac("AA-BB-CC-DD-EE-FF") == "aa-bb-cc-dd-ee-ff"
     assert normalize_mac("1C0B8BEEF6B5") == "1c0b8beef6b5"
+
+
+# --- canonical_mac -----------------------------------------------------------
+
+
+def test_canonical_mac_produces_lowercase_colon_form() -> None:
+    """The form the controller's own payloads use; ``normalize_mac`` deliberately
+    keeps separators, so a request path needs this one."""
+    from unifi_core.mac import canonical_mac
+
+    assert canonical_mac("AA:BB:CC:DD:EE:FF") == "aa:bb:cc:dd:ee:ff"
+    assert canonical_mac("aa-bb-cc-dd-ee-ff") == "aa:bb:cc:dd:ee:ff"
+    assert canonical_mac("AABBCCDDEEFF") == "aa:bb:cc:dd:ee:ff"
+    assert canonical_mac(" aa:bb:cc:dd:ee:ff ") == "aa:bb:cc:dd:ee:ff"
+
+
+def test_canonical_mac_is_none_for_anything_that_is_not_a_mac() -> None:
+    from unifi_core.mac import canonical_mac
+
+    assert canonical_mac("dev-1") is None
+    assert canonical_mac("5f1e2d3c4b5a697877665544") is None
+    assert canonical_mac(None) is None
+    assert canonical_mac("") is None
+
+
+# --- mask_macs -------------------------------------------------------
+
+
+def test_mask_macs_hides_mac_shaped_path_segments() -> None:
+    """Request paths like ``/stat/user/<mac>`` are logged on failure; the
+    address must not reach the log."""
+    from unifi_core.mac import mask_macs
+
+    assert mask_macs("/stat/user/aa:bb:cc:dd:ee:ff") == "/stat/user/[redacted]"
+    assert mask_macs("/stat/device/AA-BB-CC-DD-EE-FF") == "/stat/device/[redacted]"
+    assert mask_macs("/stat/spectrum-scan/aabbccddeeff") == "/stat/spectrum-scan/[redacted]"
+
+
+def test_mask_macs_leaves_other_paths_alone() -> None:
+    from unifi_core.mac import mask_macs
+
+    assert mask_macs("/rest/user/5f1e2d3c4b5a697877665544") == "/rest/user/5f1e2d3c4b5a697877665544"
+    assert mask_macs("/stat/sta") == "/stat/sta"
+    assert mask_macs("") == ""
+
+
+def test_mask_macs_handles_the_shapes_aiounifi_messages_use() -> None:
+    """aiounifi's transport error puts a colon right after the URL; a 403 puts
+    the URL mid-sentence; parenthesised and key=value forms appear in bodies."""
+    from unifi_core.mac import mask_macs
+
+    url = "https://c/proxy/network/api/s/default/stat/user/aa:bb:cc:dd:ee:ff"
+    assert mask_macs(f"Error requesting data from {url}: Cannot connect to host") == (
+        "Error requesting data from https://c/proxy/network/api/s/default/stat/user/[redacted]: Cannot connect to host"
+    )
+    assert mask_macs(f"Call {url} received 403 Forbidden").endswith("/stat/user/[redacted] received 403 Forbidden")
+    assert mask_macs("(AA:BB:CC:DD:EE:FF)") == "([redacted])"
+    assert mask_macs("mac=aabbccddeeff;") == "mac=[redacted];"
+    assert mask_macs("aa:bb:cc:dd:ee:ff") == "[redacted]"
+    assert mask_macs("aa-bb:cc:dd:ee:ff") == "aa-bb:cc:dd:ee:ff"  # mixed separators: not a MAC
+    assert mask_macs("id=5f1e2d3c4b5a697877665544") == "id=5f1e2d3c4b5a697877665544"


### PR DESCRIPTION
## Summary

Core half of #642 (refs #632), split out so it can be released before the Network floor is raised, as requested in the #642 review.

`get_client_details` scanned `/stat/sta` and `/rest/user`; the controller caps `/rest/user` at 3,000 rows, so a client past that window was reported as `client '<mac>' not found` although the controller has its record. When the `/rest/user` scan misses a MAC-shaped identifier, `ClientManager` now consults the authoritative per-MAC `GET /stat/user/<mac>` (200 with the user-table record including `_id` for a known client; HTTP 400 `api.err.UnknownUser` for an unknown one). Callers that only need existence (block, unblock, kick, guest authorization, `StatsManager` identifier resolution) pass `existence_only=True` and stop at a live `/stat/sta` record.

Outcomes of the per-MAC request:
- `api.err.UnknownUser` is an authoritative not-found.
- HTTP 404 (a controller that does not serve the endpoint) leaves the lists' verdict in place. **The status is read from the status-bearing segment of aiounifi's `ResponseError` message** (`response_status()`), never from the URL or body: aiounifi raises one class for 404 and 429 with no status attribute and formats `Call <url> received <status>[: <body>]`, so the parser anchors on `Call <no-whitespace-url> received <3 digits>`. A 429 from `controller404.example`, or a 429 whose body mentions 404, stays undetermined.
- Both list endpoints failing still re-raises the outage error.
- Any other per-MAC failure (transport, 429, auth, malformed reply) raises `UniFiOperationError` saying existence could not be determined.

`ConnectionManager.request` now logs every failure through one helper that masks MAC-shaped tokens and the configured credentials in the path, the exception text and the rendered traceback. A controller-reported `api.err.*` code, or a 404 answer, is logged at INFO on a read and WARNING on a write, without the body (which echoes the requested MAC). The same status parser replaces the `"received 429" in message` check in the auth circuit. `unifi_core.mac` gains `canonical_mac` and `mask_macs`.

The app half (Network `get_top_clients` with `existence_only`, API route mapping `UniFiOperationError` to 502) stays on #642, rebased on this branch; its `unifi-core[network]>=0.4.44` floor bump is staged locally and will be pushed once PyPI serves the Core release.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. (No tool surface changed; `make generate` produced no diff, `make check-generated` passes.)
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. (No user-facing doc describes the lookup path.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

```
uv run --package unifi-core --all-extras pytest packages/unifi-core/tests -n auto   # 1961 passed
uv run --package unifi-network-mcp pytest apps/network/tests/unit -n auto           # 1083 passed (workspace Core)
uv run --package unifi-api-server pytest apps/api/tests -n auto                     # 1371 passed
uv run --package unifi-protect-mcp pytest apps/protect/tests -n auto                #  513 passed
uv run ruff format --check . && uv run ruff check . && make check-generated && make docs-test
```

Regressions written first against the review finding, in `packages/unifi-core/tests/network/managers/test_client_manager_stat_user.py`: 429 from a host named `controller404.example` → `UniFiOperationError`; 429 whose body mentions 404 → `UniFiOperationError`; 404 from a host named `controller429.example` → not-found (list verdict); `ResponseError` without a status segment → undetermined; transport error with 404 in the URL → undetermined with cause; `response_status` table (404/429/503, body containing `received 404`, `4040`, missing prefix, other exception types → `None`). The rest of that module is the per-MAC behaviour suite moved from the app tests so it lives with Core. `test_connection_manager_request_logging.py` covers the masked failure lines, credential masking, the 404-at-INFO rule and the auth-error paths keeping ERROR + diagnostics.

Live evidence on the affected site is on #642 (tied to the app head, which includes this commit).

## Notes for reviewers

- `apps/network/tests/unit/test_mac_case_insensitivity.py` changes its fixture's `conn.request` return from `None` to `[]` because the per-MAC fallback now runs when both lists miss; that is the only app-side change here and it is needed for the workspace suite to pass with this Core.
- Considered and declined: reading a status from `exc.args`, which aiounifi does not populate; a logging `Filter` for MAC masking (broader than this change; every failure line this path emits now goes through one helper).
- `refresh_handler`'s retry log still prints the raw exception; the credential-redaction PR (#645/#648 shared correction) owns that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
