### PR TITLE
fix(core): scrub credential values from controller errors before logs, rethrow and audit

### DIFF
--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
-from unifi_core.redaction import redact_sensitive_fields
+from unifi_core.redaction import collect_secret_values, redact_sensitive_fields, scrub_secret_values
 
 from unifi_api.auth.middleware import require_scope
 from unifi_api.auth.scopes import Scope
@@ -118,6 +118,18 @@ def _shape_shared_read_result(
     if metadata:
         shaped["meta"] = metadata
     return shaped
+
+
+def _audit_detail(error: BaseException, args: dict) -> str:
+    """Return ``str(error)`` with every secret-keyed request value scrubbed.
+
+    The audit row is a durable sink. Core managers already scrub controller and
+    transport errors, and ``_validate_action_args`` keeps the submitted value
+    out of its own message, so nothing on either path is expected to carry a
+    credential here. This stays as the last barrier for a translator or
+    serializer message built somewhere else (#645, #648).
+    """
+    return scrub_secret_values(str(error), collect_secret_values(args))
 
 
 class ActionIn(BaseModel):
@@ -254,7 +266,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 target=tool_name,
                 outcome="error",
                 error_kind="serializer_contract",
-                detail=str(e),
+                detail=_audit_detail(e, body.args),
             )
             await session.commit()
             raise HTTPException(
@@ -273,7 +285,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 target=tool_name,
                 outcome="error",
                 error_kind="serializer_missing",
-                detail=str(e),
+                detail=_audit_detail(e, body.args),
             )
             await session.commit()
             raise HTTPException(
@@ -292,7 +304,7 @@ async def post_action(request: Request, tool_name: str, body: ActionIn) -> dict:
                 target=tool_name,
                 outcome="error",
                 error_kind=type(e).__name__,
-                detail=str(e),
+                detail=_audit_detail(e, body.args),
             )
             await session.commit()
             return {"success": False, "error": "Failed to execute action. Check the server audit log for details."}

--- a/apps/api/src/unifi_api/routes/actions.py
+++ b/apps/api/src/unifi_api/routes/actions.py
@@ -127,7 +127,7 @@ def _audit_detail(error: BaseException, args: dict) -> str:
     transport errors, and ``_validate_action_args`` keeps the submitted value
     out of its own message, so nothing on either path is expected to carry a
     credential here. This stays as the last barrier for a translator or
-    serializer message built somewhere else (#645, #648).
+    serializer message built somewhere else.
     """
     return scrub_secret_values(str(error), collect_secret_values(args))
 

--- a/apps/api/src/unifi_api/services/actions.py
+++ b/apps/api/src/unifi_api/services/actions.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import inspect
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Iterable
 
 from jsonschema import Draft202012Validator
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 from unifi_core.confirmation import create_preview, delete_preview, preview_response
 from unifi_core.redaction import redaction_marker_paths
@@ -152,6 +155,10 @@ def _effective_preview_args(
     return effective
 
 
+# A constraint longer than this is a schema dump, not a diagnostic.
+_CONSTRAINT_REPR_MAX = 120
+
+
 def _validate_action_args(entry: ToolEntry, args: dict[str, Any]) -> None:
     """Validate raw REST args against the generated MCP input contract."""
     errors = sorted(
@@ -163,7 +170,60 @@ def _validate_action_args(entry: ToolEntry, args: dict[str, Any]) -> None:
     error = errors[0]
     path = ".".join(str(part) for part in error.absolute_path)
     location = f" at args.{path}" if path else ""
-    raise ValueError(f"Invalid action arguments for '{entry.name}'{location}: {error.message}")
+    # ``error.message`` embeds the submitted instance, so an operator value —
+    # a credential in the worst case — would enter every sink this message
+    # reaches: the HTTP body, the log and the durable audit row. The
+    # schema-side facts identify the same failure and carry nothing the caller
+    # sent.
+    if error.validator == "required" and isinstance(error.instance, Mapping):
+        # ``required`` carries no path, so it sorts first and is often the only
+        # diagnostic the caller sees. The names come from the schema.
+        missing = [name for name in error.validator_value if name not in error.instance]
+        raise ValueError(f"Invalid action arguments for '{entry.name}': missing argument(s) {', '.join(missing)}")
+    if error.validator == "additionalProperties" and isinstance(error.instance, Mapping):
+        # jsonschema puts the offending key only in ``message``. A key is not
+        # a value: the MCP side names it the same way in its unknown-argument
+        # error.
+        declared = error.schema.get("properties", {}) if isinstance(error.schema, Mapping) else {}
+        patterned = error.schema.get("patternProperties", {}) if isinstance(error.schema, Mapping) else {}
+        unexpected = sorted(
+            key
+            for key in set(error.instance) - set(declared)
+            # A schema can also admit keys by pattern; those are declared, just
+            # not by name, and naming them as unknown would send the caller
+            # after the wrong argument.
+            if not any(re.search(pattern, key) for pattern in patterned)
+        )
+        if unexpected:
+            raise ValueError(
+                f"Invalid action arguments for '{entry.name}'{location}: unknown argument(s) {', '.join(unexpected)}"
+            )
+    # A composite validator's value is the whole subschema tree, which is noise
+    # in a durable audit row; the validator name alone says what failed.
+    constraint = repr(error.validator_value)
+    if error.validator in {"anyOf", "oneOf", "allOf", "not"} or len(constraint) > _CONSTRAINT_REPR_MAX:
+        constraint = ""
+    named = f"{error.validator or 'schema'}"
+    detail = f"does not satisfy {named!r}" + (f": {constraint}" if constraint else "")
+    raise ValueError(f"Invalid action arguments for '{entry.name}'{location}: {detail}")
+
+
+def _value_free_validation_error(tool_name: str, error: ValidationError) -> ValueError:
+    """Restate a pydantic validation failure without the caller's data.
+
+    ``str(ValidationError)`` embeds ``input_value=``, truncated at about fifty
+    characters — so a long credential survives as fragments that no
+    value-matching scrub can find, all the way into the durable audit row.
+    ``errors()`` without input, url or context carries the same diagnostic: the
+    field and the failure. One residue remains — a custom validator writes its
+    own text into ``msg`` as ``Value error, ...`` — which is why the audit
+    sink's scrub stays behind this as a barrier.
+    """
+    details = error.errors(include_url=False, include_input=False, include_context=False)
+    fields = "; ".join(
+        f"{'.'.join(str(part) for part in detail['loc']) or '<root>'}: {detail['msg']}" for detail in details
+    )
+    return ValueError(f"Invalid action arguments for '{tool_name}': {fields}")
 
 
 async def dispatch_action(
@@ -222,7 +282,10 @@ async def dispatch_action(
     manager_args = dict(args)
     translator = DISPATCH_ARG_TRANSLATORS.get(tool_name)
     if translator is not None:
-        positional, keyword = translator(manager_args)
+        try:
+            positional, keyword = translator(manager_args)
+        except ValidationError as e:
+            raise _value_free_validation_error(tool_name, e) from None
     else:
         positional, keyword = (), manager_args
 

--- a/apps/api/tests/test_action_credential_audit.py
+++ b/apps/api/tests/test_action_credential_audit.py
@@ -1,4 +1,4 @@
-"""Audit ``detail`` must not carry submitted credential values (#645, #648).
+"""Audit ``detail`` must not carry submitted credential values.
 
 Runs the action route against the real ``SystemManager`` + ``ConnectionManager``
 with a fake aiounifi controller that fails while quoting the submitted secret,
@@ -152,7 +152,7 @@ async def test_preview_validation_error_audit_detail_is_scrubbed(tmp_path, monke
 
 
 # ---------------------------------------------------------------------------
-# Encoded representations (#660 review)
+# Encoded representations
 #
 # Schema validation quotes the offending value with ``repr``. A credential
 # holding a backslash, quote or newline never appears literally in that

--- a/apps/api/tests/test_action_credential_audit.py
+++ b/apps/api/tests/test_action_credential_audit.py
@@ -1,0 +1,369 @@
+"""Audit ``detail`` must not carry submitted credential values (#645, #648).
+
+Runs the action route against the real ``SystemManager`` + ``ConnectionManager``
+with a fake aiounifi controller that fails while quoting the submitted secret,
+then reads the audit row back and asserts the sentinel is absent from the
+response body, the captured log and the audit detail.
+"""
+
+import codecs
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import quote
+
+import pytest
+from aiounifi.errors import ResponseError
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from unifi_api.db.models import AuditLog
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.system_manager import SystemManager
+
+from tests.test_action_endpoint import _bootstrap
+
+SENTINEL = "SENTINEL-community-secret-c0de"
+LOGIN_SENTINEL = "SENTINEL-login-secret-5a5a"
+INT_SENTINEL = 987654321987
+
+
+class _Session:
+    closed = False
+
+    async def close(self):
+        return None
+
+
+class _Config:
+    def __init__(self):
+        self.session = _Session()
+
+
+class _Connectivity:
+    def __init__(self):
+        self.can_retry_login = True
+        self.config = _Config()
+        self.is_unifi_os = True
+
+
+class _Controller:
+    def __init__(self, *, fail_reads: bool):
+        self.connectivity = _Connectivity()
+        self._fail_reads = fail_reads
+
+    async def login(self):
+        self.connectivity.can_retry_login = False
+
+    async def request(self, api_request):
+        if api_request.method == "get":
+            if self._fail_reads:
+                raise ResponseError(f"auth failed for admin:{LOGIN_SENTINEL}")
+            return {"data": [{"_id": "snmp-1", "key": "snmp", "enabled": False}]}
+        raise ResponseError(f"controller rejected {api_request.data!r}")
+
+
+def _real_system_manager(*, fail_reads: bool = False) -> SystemManager:
+    controller = _Controller(fail_reads=fail_reads)
+    connection = ConnectionManager("192.168.1.1", "admin", LOGIN_SENTINEL)
+    connection.controller = controller
+    connection._aiohttp_session = controller.connectivity.config.session
+    connection._initialized = True
+    connection._auth_generation = 1
+    return SystemManager(connection)
+
+
+async def _app_with_manager(tmp_path, monkeypatch, caplog, manager):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path)
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    app.state.manager_factory = factory
+    caplog.set_level(logging.DEBUG)
+    return app, key, cid, factory
+
+
+async def _audit_rows(app, tool_name):
+    async with app.state.sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+    return [row for row in rows if row.target == tool_name]
+
+
+async def _post(app, key, cid, tool_name, args, confirm):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.post(
+            f"/v1/actions/{tool_name}",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"site": "default", "controller": cid, "args": args, "confirm": confirm},
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_error_audit_detail_is_scrubbed(tmp_path, monkeypatch, caplog) -> None:
+    manager = _real_system_manager()
+    app, key, cid, _ = await _app_with_manager(tmp_path, monkeypatch, caplog, manager)
+
+    response = await _post(app, key, cid, "unifi_update_snmp_settings", {"enabled": True, "community": SENTINEL}, True)
+
+    assert response.status_code == 200
+    assert SENTINEL not in response.text
+    assert SENTINEL not in caplog.text
+    rows = await _audit_rows(app, "unifi_update_snmp_settings")
+    assert len(rows) == 1
+    assert rows[0].outcome == "error"
+    assert rows[0].error_kind == "ResponseError"
+    assert SENTINEL not in (rows[0].detail or "")
+    await manager._connection.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_read_error_audit_detail_is_scrubbed(tmp_path, monkeypatch, caplog) -> None:
+    manager = _real_system_manager(fail_reads=True)
+    app, key, cid, _ = await _app_with_manager(tmp_path, monkeypatch, caplog, manager)
+
+    response = await _post(app, key, cid, "unifi_get_snmp_settings", {}, False)
+
+    assert response.status_code == 200
+    assert LOGIN_SENTINEL not in response.text
+    assert LOGIN_SENTINEL not in caplog.text
+    rows = await _audit_rows(app, "unifi_get_snmp_settings")
+    assert len(rows) == 1
+    assert rows[0].outcome == "error"
+    assert LOGIN_SENTINEL not in (rows[0].detail or "")
+    await manager._connection.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_preview_validation_error_audit_detail_is_scrubbed(tmp_path, monkeypatch, caplog) -> None:
+    """Schema validation echoes the offending value; a secret-keyed value must still be scrubbed."""
+    app, key, cid, factory = await _app_with_manager(tmp_path, monkeypatch, caplog, None)
+
+    response = await _post(
+        app, key, cid, "unifi_update_snmp_settings", {"enabled": True, "community": INT_SENTINEL}, False
+    )
+
+    assert response.status_code == 200
+    assert str(INT_SENTINEL) not in response.text
+    factory.get_domain_manager.assert_not_awaited()
+    rows = await _audit_rows(app, "unifi_update_snmp_settings")
+    assert len(rows) == 1
+    assert rows[0].outcome == "error"
+    assert rows[0].detail, "audit detail should still explain the validation failure"
+    assert str(INT_SENTINEL) not in rows[0].detail
+
+
+# ---------------------------------------------------------------------------
+# Encoded representations (#660 review)
+#
+# Schema validation quotes the offending value with ``repr``. A credential
+# holding a backslash, quote or newline never appears literally in that
+# message, so a literal-only scrub persists a fully decodable copy in the
+# audit row. No controller or manager is involved in this path.
+#
+# The oracle below is a copy of packages/unifi-core/tests/secret_assertions.py
+# — the two packages have no shared test-helper path, and it must stay in step
+# with that file, which is the source of truth. Hand-written on purpose: an
+# oracle built from the production enumeration cannot catch a missing form.
+# ---------------------------------------------------------------------------
+
+# A credential holding a backslash, a quote, a newline and a non-ASCII
+# character: no emitter renders all four the same way, which is what makes a
+# whole-string enumeration look like it worked.
+ESCAPED_SENTINEL = 'SENTINEL\\backslash"quote\nnewline-pä-e5c1'
+
+
+def _sentinel_encodings(secret: str) -> dict[str, str]:
+    """Every rendering of ``secret`` a message on these paths can carry."""
+    return {
+        "literal": secret,
+        "repr": repr(secret)[1:-1],
+        "ascii": ascii(secret)[1:-1],
+        # json.dumps escapes quotes and backslashes either way; ensure_ascii
+        # decides only whether non-ASCII becomes \uXXXX or stays literal. Node,
+        # Jackson and orjson all emit the second form on the wire.
+        "json_ascii": json.dumps(secret)[1:-1],
+        "json_unicode": json.dumps(secret, ensure_ascii=False)[1:-1],
+        # aiounifi renders the raw body with repr(bytes) on its 429 path, which
+        # escapes non-ASCII as UTF-8 byte escapes.
+        "bytes_repr": repr(secret.encode())[2:-1],
+        # A URL carries it percent-encoded, and ClientResponseError prints the
+        # URL it failed on.
+        "percent": quote(secret, safe=""),
+    }
+
+
+def _assert_unrecoverable(text: str, secret: str) -> None:
+    """The secret must not survive literally or in any form we can decode."""
+    for name, form in _sentinel_encodings(secret).items():
+        assert form not in text, f"secret recoverable from its {name} form"
+    # Best-effort, never swallowed: a partially scrubbed secret is exactly what
+    # leaves a dangling escape behind, so a decode failure must not silently
+    # turn into a pass. This leg only catches ASCII escapes — ``unicode_escape``
+    # reads the UTF-8 bytes of a non-ASCII character as latin-1 — so the
+    # enumerated forms above are what cover a non-ASCII secret.
+    decoded = codecs.decode(text.encode("utf-8", "surrogatepass"), "unicode_escape", errors="replace")
+    assert secret not in decoded
+
+
+@pytest.mark.asyncio
+async def test_validation_error_audit_detail_hides_escaped_credential(tmp_path, monkeypatch, caplog) -> None:
+    app, key, cid, factory = await _app_with_manager(tmp_path, monkeypatch, caplog, None)
+
+    response = await _post(
+        app, key, cid, "unifi_update_snmp_settings", {"enabled": True, "community": [ESCAPED_SENTINEL]}, False
+    )
+
+    assert response.status_code == 200
+    factory.get_domain_manager.assert_not_awaited()
+    _assert_unrecoverable(response.text, ESCAPED_SENTINEL)
+    _assert_unrecoverable(caplog.text, ESCAPED_SENTINEL)
+    rows = await _audit_rows(app, "unifi_update_snmp_settings")
+    assert len(rows) == 1
+    assert rows[0].outcome == "error"
+    assert rows[0].detail, "audit detail should still explain the validation failure"
+    _assert_unrecoverable(rows[0].detail, ESCAPED_SENTINEL)
+
+
+@pytest.mark.asyncio
+async def test_write_error_audit_detail_hides_escaped_credential(tmp_path, monkeypatch, caplog) -> None:
+    manager = _real_system_manager()
+    app, key, cid, _ = await _app_with_manager(tmp_path, monkeypatch, caplog, manager)
+
+    response = await _post(
+        app, key, cid, "unifi_update_snmp_settings", {"enabled": True, "community": ESCAPED_SENTINEL}, True
+    )
+
+    assert response.status_code == 200
+    _assert_unrecoverable(response.text, ESCAPED_SENTINEL)
+    _assert_unrecoverable(caplog.text, ESCAPED_SENTINEL)
+    rows = await _audit_rows(app, "unifi_update_snmp_settings")
+    assert len(rows) == 1
+    _assert_unrecoverable(rows[0].detail or "", ESCAPED_SENTINEL)
+    await manager._connection.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_validation_error_audit_detail_omits_any_submitted_value(tmp_path, monkeypatch, caplog) -> None:
+    """A credential can arrive under a key the secret vocabulary does not know.
+
+    The audit row is durable and readable by every key holder, so it must not
+    echo a submitted value at all — only the field and the failure.
+    """
+    app, key, cid, factory = await _app_with_manager(tmp_path, monkeypatch, caplog, None)
+    operator_value = "pw-under-an-unknown-key-9b21"
+
+    response = await _post(
+        app, key, cid, "unifi_update_snmp_settings", {"enabled": [operator_value], "community": "c"}, False
+    )
+
+    assert response.status_code == 200
+    factory.get_domain_manager.assert_not_awaited()
+    rows = await _audit_rows(app, "unifi_update_snmp_settings")
+    assert len(rows) == 1
+    assert rows[0].detail, "audit detail should still explain the validation failure"
+    assert operator_value not in rows[0].detail
+    assert "enabled" in rows[0].detail, "the failing field must still be named"
+
+
+def test_validation_message_never_quotes_the_submitted_value() -> None:
+    """The value must not enter the message at all: every sink downstream of
+    ``_validate_action_args`` (audit row, HTTP body, log) then has nothing to
+    subtract."""
+    from types import SimpleNamespace
+
+    from unifi_api.services.actions import _validate_action_args
+
+    entry = SimpleNamespace(
+        name="unifi_update_snmp_settings",
+        input_schema={"type": "object", "properties": {"community": {"type": "string"}}},
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_action_args(entry, {"community": [ESCAPED_SENTINEL]})
+
+    message = str(excinfo.value)
+    assert "args.community" in message, "the failing field must still be named"
+    assert "string" in message, "the constraint must still be named"
+    _assert_unrecoverable(message, ESCAPED_SENTINEL)
+
+
+def test_validation_message_names_the_unknown_argument() -> None:
+    """Every catalog action sets ``additionalProperties: false``, so a typo'd
+    argument name is the most common failure. The name is a caller's key, not a
+    caller's value, and the MCP side already echoes it."""
+    from types import SimpleNamespace
+
+    from unifi_api.services.actions import _validate_action_args
+
+    entry = SimpleNamespace(
+        name="unifi_update_snmp_settings",
+        input_schema={
+            "type": "object",
+            "properties": {"community": {"type": "string"}},
+            "additionalProperties": False,
+        },
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_action_args(entry, {"communtiy": "c"})
+
+    assert "communtiy" in str(excinfo.value)
+
+
+def test_validation_message_names_the_missing_argument() -> None:
+    """``required`` carries no path, so it sorts first and is often the only
+    diagnostic the caller gets. The missing names come from the schema."""
+    from types import SimpleNamespace
+
+    from unifi_api.services.actions import _validate_action_args
+
+    entry = SimpleNamespace(
+        name="unifi_create_acl_rule",
+        input_schema={
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "network_id": {"type": "string"}},
+            "required": ["name", "network_id"],
+        },
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_action_args(entry, {"name": "n"})
+
+    message = str(excinfo.value)
+    assert "network_id" in message
+    assert "name" not in message.split("missing argument(s)")[-1]
+
+
+def test_translator_validation_error_carries_no_submitted_value() -> None:
+    """~20 translators build pydantic models from caller data and only one
+    catches ValidationError; the rest reach the audit row as ``str(e)``, which
+    embeds ``input_value=`` — truncated at ~50 characters, so a long credential
+    survives in fragments no value-matching scrub can find."""
+    from pydantic import BaseModel, ValidationError
+    from unifi_api.services.actions import _value_free_validation_error
+
+    class _Credential(BaseModel):
+        token: str
+
+    with pytest.raises(ValidationError) as excinfo:
+        _Credential(token=[ESCAPED_SENTINEL * 3])
+
+    message = str(_value_free_validation_error("access_create_credential", excinfo.value))
+    assert "token" in message, "the failing field must still be named"
+    assert "access_create_credential" in message
+    _assert_unrecoverable(message, ESCAPED_SENTINEL)
+
+
+def test_audit_detail_scrubs_a_submitted_value_from_any_error() -> None:
+    """``_audit_detail`` is the last barrier for a message built outside the two
+    paths that now keep values out of their own text — a serializer or a
+    translator raising from somewhere else. Without this the barrier can be
+    deleted with a green suite."""
+    from unifi_api.routes.actions import _audit_detail
+    from unifi_api.serializers._base import SerializerContractError
+
+    error = SerializerContractError(f"contract broken while rendering {ESCAPED_SENTINEL!r}")
+
+    detail = _audit_detail(error, {"enabled": True, "community": ESCAPED_SENTINEL})
+
+    assert "contract broken" in detail, "the failure must still be named"
+    _assert_unrecoverable(detail, ESCAPED_SENTINEL)

--- a/apps/network/tests/unit/test_credential_error_sanitization.py
+++ b/apps/network/tests/unit/test_credential_error_sanitization.py
@@ -2,7 +2,7 @@
 
 Drives the real ``SystemManager`` and ``ConnectionManager`` with a fake
 aiounifi controller whose request fails with an error quoting the submitted
-secret (the reproduction from #645/#648). Asserts the MCP tool response and
+secret. Asserts the MCP tool response and
 the captured log are both free of the sentinel, for preview and write.
 """
 

--- a/apps/network/tests/unit/test_credential_error_sanitization.py
+++ b/apps/network/tests/unit/test_credential_error_sanitization.py
@@ -1,0 +1,122 @@
+"""SNMP tool responses and logs must not carry submitted credential values.
+
+Drives the real ``SystemManager`` and ``ConnectionManager`` with a fake
+aiounifi controller whose request fails with an error quoting the submitted
+secret (the reproduction from #645/#648). Asserts the MCP tool response and
+the captured log are both free of the sentinel, for preview and write.
+"""
+
+import logging
+import os
+
+import pytest
+from aiounifi.errors import ResponseError
+
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.system_manager import SystemManager
+
+os.environ.setdefault("UNIFI_HOST", "127.0.0.1")
+os.environ.setdefault("UNIFI_USERNAME", "test")
+os.environ.setdefault("UNIFI_PASSWORD", "test")
+
+SENTINEL = "SENTINEL-community-secret-4b1d"
+LOGIN_SENTINEL = "SENTINEL-login-secret-0e77"
+
+
+class _Session:
+    closed = False
+
+    async def close(self):
+        return None
+
+
+class _Config:
+    def __init__(self):
+        self.session = _Session()
+
+
+class _Connectivity:
+    def __init__(self):
+        self.can_retry_login = True
+        self.config = _Config()
+        self.is_unifi_os = True
+
+
+class _Controller:
+    def __init__(self, raiser):
+        self.connectivity = _Connectivity()
+        self._raiser = raiser
+
+    async def login(self):
+        self.connectivity.can_retry_login = False
+
+    async def request(self, api_request):
+        return self._raiser(api_request)
+
+
+def _auth_failure(_api_request):
+    raise ResponseError(f"auth failed for admin:{LOGIN_SENTINEL}")
+
+
+def _system_manager(raiser):
+    controller = _Controller(raiser)
+    connection = ConnectionManager("192.168.1.1", "admin", LOGIN_SENTINEL)
+    connection.controller = controller
+    connection._aiohttp_session = controller.connectivity.config.session
+    connection._initialized = True
+    connection._auth_generation = 1
+    return SystemManager(connection)
+
+
+@pytest.mark.asyncio
+async def test_update_snmp_write_error_response_and_log_are_scrubbed(monkeypatch, caplog):
+    from unifi_network_mcp.tools import system
+
+    def _raiser(api_request):
+        if api_request.method == "get":
+            return {"data": [{"_id": "snmp-1", "key": "snmp", "enabled": False}]}
+        raise ResponseError(f"controller rejected {api_request.data!r}")
+
+    manager = _system_manager(_raiser)
+    monkeypatch.setattr(system, "system_manager", manager)
+    caplog.set_level(logging.DEBUG)
+
+    result = await system.update_snmp_settings(enabled=True, community=SENTINEL, confirm=True)
+
+    assert result["success"] is False
+    assert SENTINEL not in repr(result)
+    assert SENTINEL not in caplog.text
+    await manager._connection.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_update_snmp_preview_read_error_response_and_log_are_scrubbed(monkeypatch, caplog):
+    """Preview only reads; the transport error can still quote the login credential."""
+    from unifi_network_mcp.tools import system
+
+    manager = _system_manager(_auth_failure)
+    monkeypatch.setattr(system, "system_manager", manager)
+    caplog.set_level(logging.DEBUG)
+
+    result = await system.update_snmp_settings(enabled=True, community=SENTINEL, confirm=False)
+
+    assert result["success"] is False
+    assert LOGIN_SENTINEL not in repr(result)
+    assert LOGIN_SENTINEL not in caplog.text
+    await manager._connection.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_get_snmp_read_error_response_and_log_are_scrubbed(monkeypatch, caplog):
+    from unifi_network_mcp.tools import system
+
+    manager = _system_manager(_auth_failure)
+    monkeypatch.setattr(system, "system_manager", manager)
+    caplog.set_level(logging.DEBUG)
+
+    result = await system.get_snmp_settings()
+
+    assert result["success"] is False
+    assert LOGIN_SENTINEL not in repr(result)
+    assert LOGIN_SENTINEL not in caplog.text
+    await manager._connection.cleanup()

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -376,7 +376,7 @@ class ConnectionManager:
 
         A controller error can quote the request it rejected, and a transport
         error can quote the login. Both would otherwise reach the manager log,
-        any caller that formats ``str(e)`` and the API audit sink (#645, #648).
+        any caller that formats ``str(e)`` and the API audit sink.
         Scrubs the configured login plus every value held under a sensitive
         key in the request payload, following the exception's cause chain, and
         marks them the way this manager's own credential masking does.

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -4,6 +4,7 @@ import re
 import time
 import time as _time
 import traceback
+from collections.abc import Iterable, Mapping
 from typing import Any, Dict, Optional
 
 import aiohttp
@@ -23,6 +24,7 @@ from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.configuration import Configuration
 
 from unifi_core.mac import mask_macs
+from unifi_core.redaction import collect_secret_values, sanitize_exception, scrub_secret_values
 from unifi_core.support_bundle import (
     ConnectivityProbe,
     SafeConnectionAttempt,
@@ -290,6 +292,12 @@ async def detect_unifi_os_proactively(
         return None
 
 
+# Free-text marker for a credential masked inside a message. Shorter than
+# ``redaction.REDACTED`` because it reads inside a sentence; the payload marker
+# stays on structured values, where the write-back guards look for it.
+_CREDENTIAL_MASK = "<redacted>"
+
+
 class ConnectionManager:
     """Manages the connection and session with the Unifi Network Controller."""
 
@@ -346,14 +354,59 @@ class ConnectionManager:
         """Return a user-facing connection error without configured secrets or addresses."""
         return self._sanitize_text(str(error) or type(error).__name__)
 
-    def _sanitize_text(self, text: str) -> str:
-        """Mask MAC addresses and the configured credentials in *text*."""
-        message = mask_macs(text)
-        for secret in (self.password, self.username):
-            if secret:
-                pattern = rf"(?<![A-Za-z0-9_-]){re.escape(secret)}(?![A-Za-z0-9_-])"
-                message = re.sub(pattern, "<redacted>", message)
-        return message
+    def _sanitize_text(self, text: str, extra_secrets: Mapping[str, bool] | Iterable[str] = ()) -> str:
+        """Mask MAC addresses, the configured credentials and *extra_secrets* in *text*.
+
+        The login is matched on token boundaries (see :meth:`_secret_rules`);
+        a credential written directly against ``-`` or ``_`` is not covered by
+        that rule. ``extra_secrets`` — the values the request itself submitted
+        — are matched literally. Both cover the escaped forms a message can
+        quote a value with, so nothing decodable reaches
+        ``last_connection_error`` or a log line.
+        """
+        rules = self._secret_rules()
+        if isinstance(extra_secrets, Mapping):
+            rules.update(extra_secrets)
+        else:
+            rules.update(dict.fromkeys(extra_secrets, False))
+        return scrub_secret_values(mask_macs(text), rules, marker=_CREDENTIAL_MASK)
+
+    def _scrub_error(self, error: BaseException, api_request: Any = None) -> set[str]:
+        """Strip credential values out of ``error`` in place before it is logged or re-raised.
+
+        A controller error can quote the request it rejected, and a transport
+        error can quote the login. Both would otherwise reach the manager log,
+        any caller that formats ``str(e)`` and the API audit sink (#645, #648).
+        Scrubs the configured login plus every value held under a sensitive
+        key in the request payload, following the exception's cause chain, and
+        marks them the way this manager's own credential masking does.
+
+        Returns the secret set so the log sink can scrub the text it is about
+        to write: an exception whose ``__str__`` ignores ``args`` (pydantic's
+        ValidationError) passes through the rewrite untouched.
+        """
+        secrets = self._secret_rules(api_request)
+        sanitize_exception(error, secrets, marker=_CREDENTIAL_MASK)
+        return secrets
+
+    def _secret_rules(self, api_request: Any = None) -> dict[str, bool]:
+        """Every value to mask, mapped to whether it is matched on token boundaries.
+
+        The login is word-like, so it is boundary-matched: masking "admin" as a
+        substring would shred "administrator". A submitted value is opaque and
+        matched wherever it appears — including when it equals the login, since
+        a reused password is still the caller's value. One mapping rather than
+        two passes: masking the login first would chop a longer submitted value
+        that starts with it and leave the tail beside a mask the reader can
+        identify.
+        """
+        rules = {secret: True for secret in (self.password, self.username) if secret}
+        payload = None
+        if api_request is not None:
+            payload = getattr(api_request, "json", None) or getattr(api_request, "data", None)
+        if payload is not None:
+            rules.update(dict.fromkeys(collect_secret_values(payload), False))
+        return rules
 
     def _record_connection_error(self, error: BaseException) -> str:
         self._support_attempt = connection_attempt_failed(error)
@@ -778,7 +831,12 @@ class ConnectionManager:
                 # LoginRequired means the refreshed session was rejected, so
                 # stop here rather than let every later tool call start another
                 # controller login.
-                logger.error("%s refresh failed even after re-authentication: %s", name, retry_error)
+                secrets = self._scrub_error(retry_error)
+                logger.error(
+                    "%s refresh failed even after re-authentication: %s",
+                    name,
+                    self._sanitize_text(str(retry_error) or type(retry_error).__name__, secrets),
+                )
                 self._block_automatic_reconnect(retry_error)
                 await self._discard_connection()
                 raise
@@ -791,6 +849,7 @@ class ConnectionManager:
         detail: str,
         *,
         with_traceback: bool = False,
+        secrets: Mapping[str, bool] | Iterable[str] = (),
     ) -> None:
         """Log a failed request with every address and credential masked.
 
@@ -803,10 +862,10 @@ class ConnectionManager:
         if not logger.isEnabledFor(level):
             return
         message = f"{what}: %s %s - %s"
-        args = [api_request.method.upper(), mask_macs(api_request.path), self._sanitize_text(detail)]
+        args = [api_request.method.upper(), mask_macs(api_request.path), self._sanitize_text(detail, secrets)]
         if with_traceback:
             message += "\n%s"
-            args.append(self._sanitize_text(traceback.format_exc()))
+            args.append(self._sanitize_text(traceback.format_exc(), secrets))
         logger.log(level, message, *args)
 
     @staticmethod
@@ -857,7 +916,13 @@ class ConnectionManager:
                 pass
             return response if return_raw else response.get("data")
 
-        except LoginRequired:
+        except LoginRequired as e:
+            # Bound and scrubbed even though this branch does not re-raise it:
+            # both exits below leave it as ``__context__`` of the error the
+            # caller receives, and every ``exc_info=True`` caller renders that
+            # chain in full. ``args[0]`` is the decoded response, which echoes
+            # the submitted record on a rejected write.
+            self._scrub_error(e, api_request)
             logger.warning("Login required detected during request, attempting explicit re-authentication...")
             if await self._reauthenticate(auth_generation):
                 if not self.controller:
@@ -885,9 +950,14 @@ class ConnectionManager:
                         pass
                     return retry_response if return_raw else retry_response.get("data")
                 except Exception as retry_e:
-                    retry_error = self._sanitize_connection_error(retry_e)
+                    secrets = self._scrub_error(retry_e, api_request)
+                    retry_error = str(retry_e) or type(retry_e).__name__
                     self._log_request_failure(
-                        logging.ERROR, "API request failed even after re-authentication", api_request, retry_error
+                        logging.ERROR,
+                        "API request failed even after re-authentication",
+                        api_request,
+                        retry_error,
+                        secrets=secrets,
                     )
                     # A second LoginRequired means the refreshed session was not
                     # accepted. Treat it as terminal so later tool calls cannot
@@ -900,14 +970,19 @@ class ConnectionManager:
             else:
                 raise self._not_connected_error()
         except (RequestError, ResponseError, aiohttp.ClientError) as e:
-            if response_status(e) == 404:
+            # Classify before scrubbing: the scrub rewrites the message in
+            # place, and a submitted value that collides with the status text
+            # would otherwise change how the reply is read.
+            status = response_status(e)
+            secrets = self._scrub_error(e, api_request)
+            if status == 404:
                 # The controller answered: it does not serve this path. That is
                 # a negative reply the caller interprets, not a transport fault.
                 self._log_request_failure(
-                    self._rejection_level(api_request), "Controller answered 404", api_request, str(e)
+                    self._rejection_level(api_request), "Controller answered 404", api_request, str(e), secrets=secrets
                 )
             else:
-                self._log_request_failure(logging.ERROR, "API request error", api_request, str(e))
+                self._log_request_failure(logging.ERROR, "API request error", api_request, str(e), secrets=secrets)
             try:
                 from unifi_core.diagnostics import diagnostics_enabled, log_api_request
 
@@ -925,18 +1000,29 @@ class ConnectionManager:
                 pass
             raise
         except Exception as e:
+            # Classified before the scrub, for the same reason as above.
             code = controller_error_code(e)
+            secrets = self._scrub_error(e, api_request)
             if code is not None:
                 # A controller-reported api.err.* is a negative reply, not an
                 # operator event: routine on a read (an unknown MAC on a
                 # per-MAC lookup), worth a warning on a write. The body can
                 # echo request values, so only the code is logged.
                 self._log_request_failure(
-                    self._rejection_level(api_request), "Controller rejected request", api_request, code
+                    self._rejection_level(api_request),
+                    "Controller rejected request",
+                    api_request,
+                    code,
+                    secrets=secrets,
                 )
             else:
                 self._log_request_failure(
-                    logging.ERROR, "Unexpected error during API request", api_request, str(e), with_traceback=True
+                    logging.ERROR,
+                    "Unexpected error during API request",
+                    api_request,
+                    str(e),
+                    with_traceback=True,
+                    secrets=secrets,
                 )
             try:
                 from unifi_core.diagnostics import diagnostics_enabled, log_api_request

--- a/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
@@ -7,6 +7,7 @@ from aiounifi.models.api import ApiRequest
 from aiounifi.models.site import Site  # Import Site model
 
 from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.redaction import collect_secret_values, redact_sensitive_fields, sanitize_exception, scrub_secret_values
 
 logger = logging.getLogger("unifi-network-mcp")
 
@@ -324,10 +325,18 @@ class SystemManager:
             if success:
                 logger.info("%s settings updated successfully", section)
             else:
-                logger.error("Error updating %s settings: %s", section, response)
+                # A rejected write can echo the submitted record (x_password,
+                # community, ...). Redact by key and scrub the submitted values
+                # before the log line (#645, #648).
+                secrets = collect_secret_values(settings_data)
+                safe_response = scrub_secret_values(str(redact_sensitive_fields(response)), secrets)
+                logger.error("Error updating %s settings: %s", section, safe_response)
 
             return success
         except Exception as e:
+            # The transport scrubs its own errors; repeat here so the manager
+            # holds the contract on its own (#645, #648).
+            sanitize_exception(e, collect_secret_values(settings_data))
             logger.error("Error updating %s settings: %s", section, e)
             raise
 

--- a/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
@@ -327,7 +327,7 @@ class SystemManager:
             else:
                 # A rejected write can echo the submitted record (x_password,
                 # community, ...). Redact by key and scrub the submitted values
-                # before the log line (#645, #648).
+                # before the log line.
                 secrets = collect_secret_values(settings_data)
                 safe_response = scrub_secret_values(str(redact_sensitive_fields(response)), secrets)
                 logger.error("Error updating %s settings: %s", section, safe_response)
@@ -335,7 +335,7 @@ class SystemManager:
             return success
         except Exception as e:
             # The transport scrubs its own errors; repeat here so the manager
-            # holds the contract on its own (#645, #648).
+            # holds the contract on its own.
             sanitize_exception(e, collect_secret_values(settings_data))
             logger.error("Error updating %s settings: %s", section, e)
             raise

--- a/packages/unifi-core/src/unifi_core/redaction.py
+++ b/packages/unifi-core/src/unifi_core/redaction.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
+from urllib.parse import quote
 
 REDACTED = "***REDACTED***"
 
@@ -184,3 +186,253 @@ def redaction_marker_paths(obj: Any, *, marker: str = REDACTED, prefix: str = ""
             path = f"{prefix}[{index}]" if prefix else f"[{index}]"
             paths.extend(redaction_marker_paths(value, marker=marker, prefix=path))
     return paths
+
+
+# ---------------------------------------------------------------------------
+# Value scrubbing for error paths
+#
+# Key-based redaction only helps when the secret still sits under its key. A
+# controller error that quotes the request, or a transport error that quotes
+# the login, carries the value inside free text. These helpers scrub known
+# secret *values* out of text and out of exceptions before they are logged,
+# rethrown or written to an audit sink.
+# ---------------------------------------------------------------------------
+
+# Values shorter than this are only scrubbed on token boundaries so a short
+# secret such as "12" does not shred every number in the message.
+_BOUNDARY_SCRUB_MAX_LEN = 4
+
+# Message-bearing attributes that ``str(exc)`` may read instead of ``args``
+# (aiohttp ``ClientResponseError.message``, ``OSError.strerror``, ...).
+_EXCEPTION_MESSAGE_ATTRS = ("message", "msg", "strerror", "reason", "detail")
+
+# Structured attributes an exception renders from instead of ``args``.
+# ``aiohttp.ClientResponseError.__str__`` reads ``request_info.real_url``, and
+# the attribute is a separate reference to the same object as ``args[0]`` — so
+# rewriting ``args`` alone leaves every reader of the attribute, and ``str()``
+# itself, looking at the unscrubbed original.
+_EXCEPTION_STRUCTURED_ATTRS = ("request_info",)
+
+
+def collect_secret_values(obj: Any) -> set[str]:
+    """Return the scalar values held under sensitive keys anywhere in ``obj``.
+
+    Walks mappings and sequences. Strings are returned as-is; ints and floats
+    (but not bools) are returned as their string form so a numeric PIN or
+    community string can still be matched in free text.
+    """
+    found: set[str] = set()
+
+    def _walk(value: Any, secret: bool) -> None:
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                _walk(item, secret or is_sensitive_key(key))
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for item in value:
+                _walk(item, secret)
+        elif secret and isinstance(value, (str, int, float)) and not isinstance(value, bool):
+            text = str(value)
+            if text:
+                found.add(text)
+
+    _walk(obj, False)
+    return found
+
+
+# How a value can be written into a message. Each entry applies ONE policy to
+# the whole value, which is what a real emitter does: ``repr`` keeps non-ASCII
+# literal and escapes quotes; ``json.dumps`` escapes quotes either way and
+# decides non-ASCII with ``ensure_ascii``; ``ascii`` and ``repr(bytes)`` write
+# different numeric escapes; a URL carries it percent-encoded; a PHP- or
+# Jackson-style encoder also escapes the forward slash.
+_EMITTERS = (
+    lambda value: value,
+    lambda value: repr(value)[1:-1],  # strip the quotes repr puts around it
+    lambda value: ascii(value)[1:-1],
+    lambda value: json.dumps(value)[1:-1],  # strip the JSON quotes
+    lambda value: json.dumps(value, ensure_ascii=False)[1:-1],
+    lambda value: json.dumps(value)[1:-1].replace("/", "\\/"),
+    lambda value: repr(value.encode())[2:-1],  # strip the b'' wrapper
+    lambda value: quote(value, safe=""),
+)
+
+
+def _encoded_forms(secret: str) -> list[str]:
+    """Every rendering of ``secret`` a message on these paths can carry, longest first.
+
+    Closed under applying the emitters twice, because a message can be escaped
+    twice: aiounifi renders an already-JSON body with ``repr(bytes)`` on its
+    429 path, and a controller can echo a rejected record as a nested JSON
+    string. Each form is a literal, so matching stays linear and exact — an
+    alternation built per character would have to guess how many characters of
+    the text one character of the secret occupies, and guessing wrong either
+    misses the value or costs seconds of blocked event loop.
+
+    What it does not cover, deliberately: a mixture no single emitter produces,
+    base64, and HTML entities. None is emitted on these paths.
+    """
+    once = {emit(secret) for emit in _EMITTERS}
+    forms = once | {emit(form) for form in once for emit in _EMITTERS}
+    return sorted((form for form in forms if form), key=len, reverse=True)
+
+
+def _ordered_secrets(secrets: Iterable[str] | Mapping[str, bool], boundary: bool) -> list[tuple[str, bool]]:
+    """Non-empty secrets with their boundary rule, longest first.
+
+    Longest first so a secret containing another is not left partially visible:
+    masking a short login first would chop a longer submitted value and leave
+    its tail beside a mask the reader can identify. A mapping gives the rule
+    per value, which is what a caller holding both a word-like login and opaque
+    submitted values needs from one pass.
+    """
+    if isinstance(secrets, Mapping):
+        items = {secret: bool(rule) for secret, rule in secrets.items() if secret}
+    else:
+        items = {secret: boundary for secret in secrets if secret}
+    return sorted(items.items(), key=lambda item: len(item[0]), reverse=True)
+
+
+def _scrub_text(text: str, ordered: list[tuple[str, bool]], marker: str) -> str:
+    for secret, boundary in ordered:
+        # Every rendering, not just the literal: the literal may be absent from
+        # the text while the value is still there, escaped.
+        for form in _encoded_forms(secret):
+            if form not in text:
+                continue
+            if boundary or len(secret) < _BOUNDARY_SCRUB_MAX_LEN:
+                # A word-like secret is held to token boundaries. ``-`` and
+                # ``_`` separate tokens for a login ("admin" must not match
+                # inside "admin-panel" when the whole word is what was
+                # configured) but not for a short opaque value, where "123" in
+                # "123-foo" is the secret itself.
+                edge = r"[A-Za-z0-9_-]" if boundary else r"[A-Za-z0-9]"
+                text = re.sub(rf"(?<!{edge}){re.escape(form)}(?!{edge})", marker, text)
+            else:
+                text = text.replace(form, marker)
+    return text
+
+
+def _updated_copy(mapping: Mapping, values: Mapping) -> Any:
+    """A mutable copy of ``mapping`` carrying ``values``, for rebuilding a proxy."""
+    copied = mapping.copy()
+    for key, item in values.items():
+        copied[key] = item
+    return copied
+
+
+def _scrub_any(value: Any, ordered: list[tuple[str, bool]], marker: str) -> Any:
+    """Scrub strings; redact mappings by key and scrub inside them; recurse into sequences.
+
+    ``marker`` applies to free text. A whole value under a sensitive key always
+    becomes ``REDACTED``: that is the marker the write-back guards
+    (``redaction_marker_paths``) recognise, and a payload value carrying any
+    other marker would sail past them into a controller write.
+    """
+    if isinstance(value, str):
+        return _scrub_text(value, ordered, marker)
+    if isinstance(value, Mapping):
+        scrubbed = {
+            key: REDACTED if item is not None and is_sensitive_key(key) else _scrub_any(item, ordered, marker)
+            for key, item in value.items()
+        }
+        # Keep the mapping type: aiohttp's headers are a case-insensitive
+        # multidict, and a plain dict would silently lose that. A read-only
+        # proxy is rebuilt from a mutable copy of itself, which is the only
+        # thing its constructor accepts.
+        for rebuild in (lambda: type(value)(_updated_copy(value, scrubbed)), lambda: type(value)(scrubbed)):
+            try:
+                return rebuild()
+            except Exception:  # noqa: BLE001 - any mapping we cannot rebuild degrades to a dict
+                continue
+        return scrubbed
+    if isinstance(value, tuple):
+        items = [_scrub_any(item, ordered, marker) for item in value]
+        # aiohttp raises with a NamedTuple (``RequestInfo``) in ``args``; a bare
+        # tuple rebuild would silently strip the type.
+        return type(value)(*items) if hasattr(value, "_fields") else tuple(items)
+    if type(value).__module__ == "yarl" or type(value).__name__ == "URL":
+        # A URL renders its userinfo and query percent-encoded, and
+        # ``ClientResponseError.__str__`` prints it. Rebuild from the scrubbed
+        # text rather than leave the object untouched.
+        try:
+            return type(value)(_scrub_text(str(value), ordered, marker), encoded=True)
+        except Exception:
+            return _scrub_text(str(value), ordered, marker)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [_scrub_any(item, ordered, marker) for item in value]
+    if isinstance(value, (bytes, bytearray)):
+        # A raw body kept as bytes is text to whoever renders it. latin-1
+        # round-trips every byte, so a body that is not valid UTF-8 keeps its
+        # bytes instead of being replaced away.
+        scrubbed = _scrub_text(value.decode("latin-1"), ordered, marker).encode("latin-1", "replace")
+        return bytearray(scrubbed) if isinstance(value, bytearray) else scrubbed
+    return value
+
+
+def scrub_secret_values(
+    text: str,
+    secrets: Iterable[str] | Mapping[str, bool],
+    *,
+    marker: str = REDACTED,
+    boundary: bool = False,
+) -> str:
+    """Replace every occurrence of each secret value in ``text`` with ``marker``.
+
+    Longer values are replaced first, and each value is matched however its
+    characters were escaped by whoever built the text (see ``_char_forms``).
+    Very short values are matched only on token boundaries (see
+    ``_BOUNDARY_SCRUB_MAX_LEN``); pass ``boundary=True`` to hold every value to
+    that rule, or a mapping of value to rule to mix the two in one pass, which
+    is what a word-like login alongside opaque submitted values needs.
+    """
+    if not text:
+        return text
+    return _scrub_text(text, _ordered_secrets(secrets, boundary), marker)
+
+
+def sanitize_exception(
+    error: BaseException,
+    secrets: Iterable[str] | Mapping[str, bool],
+    *,
+    marker: str = REDACTED,
+    boundary: bool = False,
+) -> BaseException:
+    """Scrub secret values out of ``error`` in place and return it.
+
+    Rewrites ``args`` (strings are scrubbed; aiounifi raises with the decoded
+    response *dict* as ``args[0]``, which is redacted by key and scrubbed
+    inside), the common message attributes, the structured attributes an
+    exception renders from instead of ``args``, PEP 678 notes, and follows
+    ``__cause__``/``__context__`` so a wrapped transport error is cleaned too.
+    Mutating in place keeps the exception type and identity, so callers that
+    match on ``except ResponseError`` keep working and a later ``raise`` or
+    ``str(e)`` sees the scrubbed text. Pass ``boundary=True`` for a word-like
+    value such as a login, which must not be masked inside a longer word.
+    """
+    ordered = _ordered_secrets(secrets, boundary)
+    if not ordered:
+        return error
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        current.args = tuple(_scrub_any(arg, ordered, marker) for arg in current.args)
+        for attr in _EXCEPTION_MESSAGE_ATTRS:
+            value = getattr(current, attr, None)
+            if isinstance(value, str):
+                try:
+                    setattr(current, attr, _scrub_text(value, ordered, marker))
+                except (AttributeError, TypeError):
+                    pass  # read-only property; ``args`` above already carries the scrubbed text
+        for attr in _EXCEPTION_STRUCTURED_ATTRS:
+            value = getattr(current, attr, None)
+            if value is not None:
+                try:
+                    setattr(current, attr, _scrub_any(value, ordered, marker))
+                except (AttributeError, TypeError):
+                    pass  # read-only attribute
+        notes = getattr(current, "__notes__", None)
+        if isinstance(notes, list):
+            current.__notes__ = [_scrub_any(note, ordered, marker) for note in notes]
+        current = current.__cause__ if current.__cause__ is not None else current.__context__
+    return error

--- a/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
+++ b/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
@@ -1,6 +1,6 @@
 """Credential values must not survive into logs or re-raised errors.
 
-Reported on #645 and #648: a controller exception that quotes the submitted
+A controller exception that quotes the submitted
 request reached ``ConnectionManager``'s raw exception log, ``SystemManager``'s
 raw response/exception log and (via the unchanged exception) the API audit
 sink. These tests drive the real managers with a fake transport that raises
@@ -215,7 +215,7 @@ async def test_system_manager_rejected_response_log_is_scrubbed(caplog):
 
 
 # ---------------------------------------------------------------------------
-# Encoded representations (#660 review)
+# Encoded representations
 #
 # The controller error above quotes the payload with ``repr``. When the secret
 # itself contains a backslash, quote or newline, its literal form never appears

--- a/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
+++ b/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
@@ -1,0 +1,387 @@
+"""Credential values must not survive into logs or re-raised errors.
+
+Reported on #645 and #648: a controller exception that quotes the submitted
+request reached ``ConnectionManager``'s raw exception log, ``SystemManager``'s
+raw response/exception log and (via the unchanged exception) the API audit
+sink. These tests drive the real managers with a fake transport that raises
+an error carrying a sentinel, and assert the sentinel is gone from every
+log line and from the exception the caller receives.
+"""
+
+import logging
+from urllib.parse import quote
+
+import pytest
+from aiohttp import ClientError, ClientResponseError, RequestInfo
+from aiounifi.errors import LoginRequired, RequestError, ResponseError
+from aiounifi.models.api import ApiRequest
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.system_manager import SystemManager
+
+from tests.secret_assertions import ESCAPED_SECRET, assert_unrecoverable
+
+SENTINEL = "SENTINEL-submitted-secret-7f3a"
+LOGIN_SENTINEL = "SENTINEL-login-secret-91c2"
+
+
+class _Session:
+    closed = False
+
+    async def close(self):
+        return None
+
+
+class _Config:
+    def __init__(self):
+        self.session = _Session()
+
+
+class _Connectivity:
+    def __init__(self):
+        self.can_retry_login = True
+        self.config = _Config()
+        self.is_unifi_os = True
+
+
+class _Controller:
+    """Fake aiounifi controller whose request always fails with the given error."""
+
+    def __init__(self, raiser):
+        self.connectivity = _Connectivity()
+        self._raiser = raiser
+
+    async def login(self):
+        self.connectivity.can_retry_login = False
+
+    async def request(self, api_request):
+        raise self._raiser()
+
+
+def _client_response_error() -> ClientResponseError:
+    """aiohttp's shape: the URL carries the login percent-encoded, and the
+    headers carry the API key."""
+    from multidict import CIMultiDict, CIMultiDictProxy
+    from yarl import URL
+
+    url = URL(f"https://admin:{quote(ESCAPED_SECRET)}@10.0.0.1/proxy/network/api/s/default/set/setting/snmp")
+    info = RequestInfo(url, "PUT", CIMultiDictProxy(CIMultiDict({"X-API-KEY": ESCAPED_SECRET})), url)
+    return ClientResponseError(info, (), status=401, message=f"Unauthorized for {ESCAPED_SECRET!r}")
+
+
+def _manager(controller, password=LOGIN_SENTINEL):
+    manager = ConnectionManager("192.168.1.1", "admin", password)
+    manager.controller = controller
+    manager._aiohttp_session = controller.connectivity.config.session
+    manager._initialized = True
+    manager._auth_generation = 1
+    return manager
+
+
+def _put_with_secret():
+    return ApiRequest(
+        method="put",
+        path="/set/setting/snmp",
+        data={"enabled": True, "x_password": SENTINEL, "nested": {"community": SENTINEL}},
+    )
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        lambda: ResponseError(f"controller rejected {{'x_password': '{SENTINEL}'}}"),
+        # aiounifi's real shape: ERRORS.get(msg, AiounifiException)(<decoded response dict>)
+        lambda: ResponseError(
+            {"meta": {"rc": "error", "msg": f"api.err.Invalid {SENTINEL}"}, "data": [{"x_password": SENTINEL}]}
+        ),
+        lambda: RequestError(f"transport failed while sending x_password={SENTINEL}"),
+        lambda: ClientError(f"client error echoing {SENTINEL}"),
+        lambda: RuntimeError(f"unexpected: payload {SENTINEL}"),
+    ],
+    ids=["response_error", "response_error_dict_body", "request_error", "aiohttp_client_error", "unexpected"],
+)
+async def test_request_write_error_is_scrubbed_before_log_and_reraise(caplog, error_factory):
+    manager = _manager(_Controller(error_factory))
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(type(error_factory())) as excinfo:
+        await manager.request(_put_with_secret())
+
+    assert SENTINEL not in str(excinfo.value)
+    assert SENTINEL not in repr(excinfo.value.args)
+    assert SENTINEL not in caplog.text
+    assert "<redacted>" in str(excinfo.value)
+    await manager.cleanup()
+
+
+async def test_request_read_error_is_scrubbed_of_login_password(caplog):
+    """Reads carry no payload, but the login password can still be quoted by the transport."""
+    manager = _manager(_Controller(lambda: ResponseError(f"login failed for admin:{LOGIN_SENTINEL}")))
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(ResponseError) as excinfo:
+        await manager.request(ApiRequest(method="get", path="/get/setting/snmp"))
+
+    assert LOGIN_SENTINEL not in str(excinfo.value)
+    assert LOGIN_SENTINEL not in caplog.text
+    await manager.cleanup()
+
+
+async def test_request_scrubs_chained_cause(caplog):
+    def _raiser():
+        try:
+            raise ValueError(f"inner {SENTINEL}")
+        except ValueError as inner:
+            raise ResponseError("outer") from inner
+
+    manager = _manager(_Controller(_raiser))
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(ResponseError) as excinfo:
+        await manager.request(_put_with_secret())
+
+    assert SENTINEL not in str(excinfo.value.__cause__)
+    assert SENTINEL not in caplog.text
+    await manager.cleanup()
+
+
+async def test_request_scrubs_second_login_required_after_reauth(caplog):
+    """The retry branch logs and re-raises its own exception; it must be scrubbed too."""
+    manager = _manager(_Controller(lambda: LoginRequired(f"session rejected {SENTINEL}")))
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(LoginRequired) as excinfo:
+        await manager.request(_put_with_secret())
+
+    assert SENTINEL not in str(excinfo.value)
+    assert SENTINEL not in caplog.text
+    assert SENTINEL not in (manager.last_connection_error or "")
+    await manager.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# SystemManager with a fake connection (the manager must not rely on the
+# transport having scrubbed already)
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnection:
+    def __init__(self, *, raiser=None, response=None):
+        self.site = "default"
+        self._raiser = raiser
+        self._response = response
+
+    def get_cached(self, key):
+        return None
+
+    def _update_cache(self, key, value):
+        return None
+
+    def _invalidate_cache(self, key):
+        return None
+
+    async def request(self, api_request):
+        if api_request.method == "get":
+            return [{"_id": "snmp-1", "key": "snmp", "enabled": False}]
+        if self._raiser is not None:
+            raise self._raiser()
+        return self._response
+
+
+async def test_system_manager_update_exception_is_scrubbed(caplog):
+    connection = _FakeConnection(raiser=lambda: ResponseError(f"rejected {{'community': '{SENTINEL}'}}"))
+    manager = SystemManager(connection)
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(ResponseError) as excinfo:
+        await manager.update_settings("snmp", {"enabled": True, "community": SENTINEL})
+
+    assert SENTINEL not in str(excinfo.value)
+    assert SENTINEL not in caplog.text
+
+
+async def test_system_manager_rejected_response_log_is_scrubbed(caplog):
+    rejected = {
+        "meta": {"rc": "error", "msg": f"api.err.Invalid community={SENTINEL}"},
+        "data": [{"community": SENTINEL}],
+    }
+    connection = _FakeConnection(response=rejected)
+    manager = SystemManager(connection)
+    caplog.set_level(logging.DEBUG)
+
+    assert await manager.update_settings("snmp", {"enabled": True, "community": SENTINEL}) is False
+
+    assert SENTINEL not in caplog.text
+    assert "Error updating snmp settings" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Encoded representations (#660 review)
+#
+# The controller error above quotes the payload with ``repr``. When the secret
+# itself contains a backslash, quote or newline, its literal form never appears
+# in the message — only its escaped form, which decodes straight back.
+# ---------------------------------------------------------------------------
+
+
+async def test_request_write_error_scrubs_escaped_credential(caplog):
+    manager = _manager(_Controller(lambda: ResponseError(f"controller rejected {{'x_password': {ESCAPED_SECRET!r}}}")))
+    caplog.set_level(logging.DEBUG)
+    request = ApiRequest(method="put", path="/set/setting/snmp", data={"x_password": ESCAPED_SECRET})
+
+    with pytest.raises(ResponseError) as excinfo:
+        await manager.request(request)
+
+    assert_unrecoverable(str(excinfo.value), ESCAPED_SECRET)
+    assert_unrecoverable(repr(excinfo.value.args), ESCAPED_SECRET)
+    assert_unrecoverable(caplog.text, ESCAPED_SECRET)
+    await manager.cleanup()
+
+
+async def test_request_read_error_scrubs_escaped_login_password(caplog):
+    manager = _manager(
+        _Controller(lambda: ResponseError(f"login failed for {{'password': {ESCAPED_SECRET!r}}}")),
+        password=ESCAPED_SECRET,
+    )
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(ResponseError) as excinfo:
+        await manager.request(ApiRequest(method="get", path="/get/setting/snmp"))
+
+    assert_unrecoverable(str(excinfo.value), ESCAPED_SECRET)
+    assert_unrecoverable(caplog.text, ESCAPED_SECRET)
+    await manager.cleanup()
+
+
+async def test_recorded_connection_error_scrubs_escaped_password():
+    """``_sanitize_text`` masks the configured credential for every connection
+    failure it records, and that text is served to later callers through
+    ``last_connection_error`` and ``_not_connected_error``."""
+    manager = _manager(_Controller(lambda: ResponseError("unused")), password=ESCAPED_SECRET)
+
+    manager._record_connection_error(ResponseError(f"login rejected for admin:{ESCAPED_SECRET!r}"))
+
+    assert_unrecoverable(manager.last_connection_error or "", ESCAPED_SECRET)
+    assert_unrecoverable(str(manager._not_connected_error()), ESCAPED_SECRET)
+    await manager.cleanup()
+
+
+async def test_controller_rejection_is_classified_before_the_scrub(caplog):
+    """The scrub rewrites the exception in place, so anything that reads the
+    message to classify the reply must read it first. A submitted value that
+    collides with the controller's error vocabulary must not turn a routine
+    negative reply into an unexpected fault."""
+    from aiounifi.errors import AiounifiException
+
+    manager = _manager(
+        _Controller(lambda: AiounifiException({"meta": {"rc": "error", "msg": "api.err.UnknownUser"}, "data": []}))
+    )
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(AiounifiException):
+        await manager.request(ApiRequest(method="get", path="/stat/user/x", data={"x_password": "err"}))
+
+    assert "Controller rejected request" in caplog.text
+    assert "Unexpected error during API request" not in caplog.text
+    await manager.cleanup()
+
+
+async def test_log_sink_scrubs_payload_secret_when_the_exception_ignores_args(caplog):
+    """``sanitize_exception`` can only rewrite what the exception exposes. An
+    exception whose ``__str__`` ignores ``args`` (pydantic's ValidationError is
+    the real one) survives it untouched, so the log sink must scrub the text it
+    is about to write rather than trust the mutation."""
+
+    class _Opaque(Exception):
+        def __init__(self, text: str) -> None:
+            super().__init__()
+            self._text = text
+
+        def __str__(self) -> str:
+            return self._text
+
+    manager = _manager(_Controller(lambda: _Opaque(f"controller rejected {{'x_password': '{SENTINEL}'}}")))
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(_Opaque):
+        await manager.request(_put_with_secret())
+
+    assert SENTINEL not in caplog.text
+    await manager.cleanup()
+
+
+async def test_login_required_branch_scrubs_the_exception_it_leaves_as_context(caplog):
+    """The re-auth branch does not bind its exception, so the raw
+    ``LoginRequired`` — whose ``args[0]`` is the decoded response echoing the
+    submitted record — survives as ``__context__`` of the error the caller
+    receives, and every ``exc_info=True`` caller renders it in full."""
+    import traceback
+    from unittest.mock import AsyncMock
+
+    manager = _manager(
+        _Controller(
+            lambda: LoginRequired(
+                {"meta": {"rc": "error", "msg": "api.err.LoginRequired"}, "data": [{"x_password": SENTINEL}]}
+            )
+        )
+    )
+    manager._reauthenticate = AsyncMock(return_value=False)
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(ConnectionError) as excinfo:
+        await manager.request(_put_with_secret())
+
+    rendered = "".join(traceback.format_exception(type(excinfo.value), excinfo.value, excinfo.value.__traceback__))
+    assert SENTINEL not in rendered
+    assert SENTINEL not in caplog.text
+    await manager.cleanup()
+
+
+async def test_login_is_masked_on_token_boundaries_in_the_reraised_error(caplog):
+    """The login is a word ("admin"), so it is masked on token boundaries — the
+    same rule the log sink applies. Scrubbing it as a substring would shred the
+    message and the durable audit row built from it."""
+    manager = _manager(
+        _Controller(lambda: ResponseError("PUT /rest/administrator failed: admin-console rejected; user=admin")),
+        password="not-in-this-message",
+    )
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(ResponseError) as excinfo:
+        await manager.request(ApiRequest(method="put", path="/rest/x", data={"enabled": True}))
+
+    message = str(excinfo.value)
+    assert "administrator" in message
+    assert "admin-console" in message
+    assert "user=<redacted>" in message
+    await manager.cleanup()
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        lambda: RequestError(f"transport failed while sending {ESCAPED_SECRET!r}"),
+        lambda: ClientError(f"client error echoing {ESCAPED_SECRET!r}"),
+        lambda: _client_response_error(),
+    ],
+    ids=["request_error", "aiohttp_client_error", "aiohttp_client_response_error"],
+)
+async def test_transport_error_scrubs_escaped_credential(caplog, error_factory):
+    """The maintainer asked for the transport path specifically. aiohttp's
+    ``ClientResponseError`` is the hard one: it renders its URL from
+    ``request_info``, an attribute aliased to ``args[0]``, so rewriting ``args``
+    alone leaves the attribute pointing at the unscrubbed original."""
+    import traceback
+
+    manager = _manager(_Controller(error_factory), password=ESCAPED_SECRET)
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(Exception) as excinfo:  # noqa: PT011 - three unrelated transport types
+        await manager.request(_put_with_secret())
+
+    error = excinfo.value
+    assert_unrecoverable(str(error), ESCAPED_SECRET)
+    assert_unrecoverable(repr(error.args), ESCAPED_SECRET)
+    assert_unrecoverable(repr(getattr(error, "request_info", "")), ESCAPED_SECRET)
+    assert_unrecoverable(caplog.text, ESCAPED_SECRET)
+    assert_unrecoverable("".join(traceback.format_exception(type(error), error, error.__traceback__)), ESCAPED_SECRET)
+    await manager.cleanup()

--- a/packages/unifi-core/tests/secret_assertions.py
+++ b/packages/unifi-core/tests/secret_assertions.py
@@ -1,0 +1,50 @@
+"""Shared assertion for the credential-scrubbing regressions.
+
+The oracle is written by hand rather than built from the production scrubber:
+a test that reuses the enumeration under test cannot notice a form the
+enumeration forgot. It carries the forms the emitters on these paths actually
+produce — including the mixed ones, where a single value has some characters
+escaped and others left literal.
+"""
+
+import codecs
+import json
+from urllib.parse import quote
+
+# A credential holding a backslash, a quote, a newline and a non-ASCII
+# character: no emitter renders all four the same way, which is what makes a
+# whole-string enumeration look like it worked.
+ESCAPED_SECRET = 'SENTINEL\\backslash"quote\nnewline-pä-e5c1'
+
+
+def _encodings(secret: str) -> dict[str, str]:
+    """Every rendering of ``secret`` a message on these paths can carry."""
+    return {
+        "literal": secret,
+        "repr": repr(secret)[1:-1],
+        "ascii": ascii(secret)[1:-1],
+        # json.dumps escapes quotes and backslashes either way; ensure_ascii
+        # decides only whether non-ASCII becomes \uXXXX or stays literal. Node,
+        # Jackson and orjson all emit the second form on the wire.
+        "json_ascii": json.dumps(secret)[1:-1],
+        "json_unicode": json.dumps(secret, ensure_ascii=False)[1:-1],
+        # aiounifi renders the raw body with repr(bytes) on its 429 path, which
+        # escapes non-ASCII as UTF-8 byte escapes.
+        "bytes_repr": repr(secret.encode())[2:-1],
+        # A URL carries it percent-encoded, and ClientResponseError prints the
+        # URL it failed on.
+        "percent": quote(secret, safe=""),
+    }
+
+
+def assert_unrecoverable(text: str, secret: str) -> None:
+    """The secret must not survive literally or in any form we can decode."""
+    for name, form in _encodings(secret).items():
+        assert form not in text, f"secret recoverable from its {name} form"
+    # Best-effort, never swallowed: a partially scrubbed secret is exactly what
+    # leaves a dangling escape behind, so a decode failure must not silently
+    # turn into a pass. This leg only catches ASCII escapes — ``unicode_escape``
+    # reads the UTF-8 bytes of a non-ASCII character as latin-1 — so the
+    # enumerated forms above are what cover a non-ASCII secret.
+    decoded = codecs.decode(text.encode("utf-8", "surrogatepass"), "unicode_escape", errors="replace")
+    assert secret not in decoded

--- a/packages/unifi-core/tests/test_redaction.py
+++ b/packages/unifi-core/tests/test_redaction.py
@@ -1,5 +1,8 @@
+import json
 from copy import deepcopy
+from urllib.parse import quote
 
+import pytest
 from unifi_core.redaction import (
     REDACTED,
     is_sensitive_key,
@@ -7,6 +10,8 @@ from unifi_core.redaction import (
     redact_value,
     redaction_marker_paths,
 )
+
+from tests.secret_assertions import ESCAPED_SECRET, assert_unrecoverable
 
 
 def test_redacts_exact_and_compound_sensitive_keys() -> None:
@@ -160,3 +165,251 @@ def test_redaction_marker_paths_reports_only_sensitive_marker_values() -> None:
     }
 
     assert redaction_marker_paths(payload) == ["update_data.x_passphrase", "update_data.nested[0].community"]
+
+
+# ---------------------------------------------------------------------------
+# Value scrubbing (error paths)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_secret_values_walks_nested_sensitive_keys():
+    from unifi_core.redaction import collect_secret_values
+
+    payload = {
+        "enabled": True,
+        "x_password": "pw-one",
+        "nested": {"community": "pw-two", "port": 161},
+        "items": [{"auth_key": "pw-three"}, {"name": "visible"}],
+        "pin_code": 1234,
+        "token_count": 9,
+    }
+    assert collect_secret_values(payload) == {"pw-one", "pw-two", "pw-three", "1234"}
+
+
+def test_collect_secret_values_ignores_bools_and_empty():
+    from unifi_core.redaction import collect_secret_values
+
+    assert collect_secret_values({"x_password": "", "psk": None, "secret": True}) == set()
+
+
+def test_scrub_secret_values_longest_first_and_boundaries():
+    from unifi_core.redaction import REDACTED, scrub_secret_values
+
+    text = "rejected {'x_password': 'abc', 'community': 'abcdef'} port 12 of 8443, rc 12"
+    out = scrub_secret_values(text, {"abc", "abcdef", "12"})
+    assert "abcdef" not in out
+    assert "'abc'" not in out
+    assert out.count(REDACTED) == 4
+    assert "8443" in out  # short-secret boundary match must not shred longer numbers
+
+
+def test_sanitize_exception_rewrites_args_message_and_cause():
+    from unifi_core.redaction import REDACTED, sanitize_exception
+
+    try:
+        try:
+            raise ValueError("inner hunter2")
+        except ValueError as inner:
+            raise RuntimeError("outer hunter2") from inner
+    except RuntimeError as caught:
+        error = caught
+    error.message = "attr hunter2"  # type: ignore[attr-defined]
+    error.add_note("note hunter2")
+    result = sanitize_exception(error, {"hunter2"})
+
+    assert result is error
+    assert str(error) == f"outer {REDACTED}"
+    assert error.message == f"attr {REDACTED}"  # type: ignore[attr-defined]
+    assert error.__notes__ == [f"note {REDACTED}"]
+    assert str(error.__cause__) == f"inner {REDACTED}"
+
+
+def test_sanitize_exception_no_secrets_is_a_no_op():
+    from unifi_core.redaction import sanitize_exception
+
+    error = ValueError("unchanged")
+    assert sanitize_exception(error, set()) is error
+    assert str(error) == "unchanged"
+
+
+def test_sanitize_exception_redacts_dict_args_like_aiounifi():
+    """aiounifi raises ``ERRORS[msg](decoded_response_dict)``; the dict arg must be cleaned too."""
+    from unifi_core.redaction import REDACTED, sanitize_exception
+
+    error = ValueError({"meta": {"rc": "error", "msg": "api.err.Invalid hunter2"}, "data": [{"x_password": "hunter2"}]})
+    sanitize_exception(error, {"hunter2"})
+
+    assert "hunter2" not in str(error)
+    assert error.args[0]["data"][0]["x_password"] == REDACTED
+    assert error.args[0]["meta"]["msg"] == f"api.err.Invalid {REDACTED}"
+
+
+# ---------------------------------------------------------------------------
+# Encoded representations of a secret (#660 review)
+#
+# A message that quotes the offending value through ``repr`` or JSON does not
+# contain the literal credential: backslashes are doubled, quotes and newlines
+# become escape sequences. Matching only the literal leaves the value fully
+# recoverable by decoding, so the scrubber must cover those forms too.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "build_text",
+    [
+        lambda secret: f"1 validation error [type=string_type, input_value={secret!r}, input_type=str]",
+        lambda secret: "controller rejected " + json.dumps({"community": secret}),
+        lambda secret: f"input_value={[secret]!r}",
+        # Node, Jackson and orjson put the body on the wire with non-ASCII
+        # left literal while quotes and backslashes are still escaped.
+        lambda secret: "controller rejected " + json.dumps({"community": secret}, ensure_ascii=False),
+        # aiounifi renders the raw body on its 429 path with repr(bytes).
+        lambda secret: f"Call /set/setting/snmp received 429: {json.dumps({'community': secret}).encode()!r}",
+    ],
+    ids=["repr", "json", "repr_inside_a_list", "json_non_ascii", "bytes_repr"],
+)
+def test_scrub_secret_values_removes_encoded_secret(build_text):
+    from unifi_core.redaction import REDACTED, scrub_secret_values
+
+    out = scrub_secret_values(build_text(ESCAPED_SECRET), {ESCAPED_SECRET})
+
+    assert REDACTED in out
+    assert_unrecoverable(out, ESCAPED_SECRET)
+
+
+def test_sanitize_exception_scrubs_repr_escaped_secret():
+    from unifi_core.redaction import sanitize_exception
+
+    error = ValueError(f"controller rejected {{'x_password': {ESCAPED_SECRET!r}}}")
+
+    sanitize_exception(error, {ESCAPED_SECRET})
+
+    assert_unrecoverable(str(error), ESCAPED_SECRET)
+    assert_unrecoverable(repr(error.args), ESCAPED_SECRET)
+
+
+def test_scrub_secret_values_leaves_unrelated_escapes_alone():
+    """Only the secret's encodings are scrubbed, not every escape in the text."""
+    from unifi_core.redaction import scrub_secret_values
+
+    text = r"path C:\Users\admin rejected 'other\value'"
+
+    assert scrub_secret_values(text, {ESCAPED_SECRET}) == text
+
+
+def test_short_secret_still_masked_next_to_a_separator():
+    """The default boundary rule treats ``-`` and ``_`` as separators, so a
+    short secret beside one is still masked."""
+    from unifi_core.redaction import REDACTED, scrub_secret_values
+
+    assert scrub_secret_values("pin 123-foo and 123_bar", {"123"}) == f"pin {REDACTED}-foo and {REDACTED}_bar"
+
+
+def test_sanitize_exception_marks_payload_values_with_the_guarded_marker():
+    """A custom marker applies to free text only. Whole values under a
+    sensitive key keep ``REDACTED``, which is the marker the write-back guards
+    (``redaction_marker_paths``) recognise."""
+    from unifi_core.redaction import REDACTED, sanitize_exception
+
+    error = ValueError({"meta": {"msg": "rejected pw-one"}, "data": [{"x_password": "pw-one"}]})
+
+    sanitize_exception(error, {"pw-one"}, marker="<redacted>")
+
+    body = error.args[0]
+    assert body["data"][0]["x_password"] == REDACTED
+    assert body["meta"]["msg"] == "rejected <redacted>"
+
+
+def test_scrub_is_linear_in_an_adversarial_secret():
+    """The secret set comes from the caller's own payload, and the scrub runs
+    synchronously inside the request path. Alternation branches of differing
+    length must not let a failed match enumerate every composition."""
+    import time
+
+    from unifi_core.redaction import scrub_secret_values
+
+    secret = "\\" * 20 + "Z"
+    text = "controller rejected " + "\\" * 200 + " end"
+
+    start = time.perf_counter()
+    scrub_secret_values(text, {secret})
+
+    assert time.perf_counter() - start < 1.0
+
+
+def test_scrub_removes_a_login_that_prefixes_a_submitted_value():
+    """Both are scrubbed in one pass, longest first. Masking the login first
+    would chop the submitted value and leave its tail beside a mask the reader
+    knows is the login."""
+    from unifi_core.redaction import scrub_secret_values
+
+    out = scrub_secret_values(
+        "rejected {'x_password': 'admin@123'} for admin", {"admin@123": False, "admin": True}, marker="<redacted>"
+    )
+
+    assert "@123" not in out
+    assert out == "rejected {'x_password': '<redacted>'} for <redacted>"
+
+
+@pytest.mark.parametrize(
+    ("secret", "build_text"),
+    [
+        # repr switches to single quotes when the value holds a double quote,
+        # and then escapes the single ones.
+        ("pw'quote\"both", lambda s: f"rejected {s!r}"),
+        # A PHP- or Jackson-style encoder escapes the forward slash.
+        ("pw/slash/value", lambda s: 'rejected "' + s.replace("/", "\\/") + '"'),
+        # ascii() writes a non-ASCII character as \xNN, which neither repr nor
+        # json.dumps produces.
+        ("pw-ä-ascii-form", lambda s: f"rejected {ascii(s)}"),
+        # A URL carries it percent-encoded, which is how aiohttp's
+        # ClientResponseError renders the request it failed on.
+        ('pw "space', lambda s: f"url='https://h/api?token={quote(s, safe='')}'"),
+    ],
+    ids=["repr_single_quote", "escaped_slash", "ascii_escape", "percent_encoded"],
+)
+def test_scrub_covers_each_character_form(secret, build_text):
+    """Each rendering ``_char_forms`` enumerates needs its own case: without
+    one, deleting that form from production leaves the suite green."""
+    from unifi_core.redaction import scrub_secret_values
+
+    assert_unrecoverable(scrub_secret_values(build_text(secret), {secret}), secret)
+
+
+@pytest.mark.parametrize(
+    ("secret", "text"),
+    [
+        ("p\\\\q", 'rejected {"x_password": "p\\\\q"}'),
+        ("CORP\\admin", "login CORP\\admin failed"),
+        ("a%25b", "pw=a%25b end"),
+        ("\\\\", "pw=\\\\ end"),
+    ],
+    ids=["double_backslash_secret", "domain_login", "percent_literal", "backslash_run"],
+)
+def test_scrub_never_misses_the_literal_form(secret, text):
+    """Whatever the encoded matching does, the value as written must always be
+    found: a match that has to guess how many characters of the text one
+    character of the secret occupies can guess wrong and leave it whole."""
+    from unifi_core.redaction import scrub_secret_values
+
+    assert secret not in scrub_secret_values(text, {secret})
+
+
+def test_scrub_cost_stays_flat_as_an_adversarial_secret_grows():
+    """Shape, not a wall-clock point: an ambiguous secret must not cost more as
+    it lengthens, or a caller picks how long the event loop blocks."""
+    import time
+
+    from unifi_core.redaction import scrub_secret_values
+
+    text = "controller rejected " + "\\" * 200 + " end"
+
+    def _cost(length: int) -> float:
+        secret = "\\" * length + "Z"
+        start = time.perf_counter()
+        scrub_secret_values(text, {secret})
+        return time.perf_counter() - start
+
+    short, long = _cost(12), _cost(24)
+
+    assert long < max(short * 8, 0.05), f"cost grew from {short:.4f}s to {long:.4f}s"

--- a/packages/unifi-core/tests/test_redaction.py
+++ b/packages/unifi-core/tests/test_redaction.py
@@ -245,7 +245,7 @@ def test_sanitize_exception_redacts_dict_args_like_aiounifi():
 
 
 # ---------------------------------------------------------------------------
-# Encoded representations of a secret (#660 review)
+# Encoded representations of a secret
 #
 # A message that quotes the offending value through ``repr`` or JSON does not
 # contain the literal credential: backslashes are doubled, quotes and newlines


### PR DESCRIPTION
## Summary

Shared correction for the credential error path reported on #645 and #648. A controller error that quotes the rejected request, or a transport error that quotes the login, carried the submitted secret into three sinks:

- `ConnectionManager.request` raw exception log (`connection_manager.py:777` at the reviewed heads)
- `SystemManager.update_settings` raw response / exception log (`system_manager.py:327-332`)
- API action route audit `detail=str(e)` (`routes/actions.py:287-297`)

What changed:

- `unifi_core.redaction` gains `collect_secret_values` (values under sensitive keys, using the existing `is_sensitive_key` vocabulary), `scrub_secret_values` (longest-first replacement; token-boundary matching for values under 4 chars) and `sanitize_exception` (rewrites `args`, message attributes, PEP 678 notes and the `__cause__`/`__context__` chain **in place**, so the exception type and identity survive and every later `str(e)` is clean).
- `ConnectionManager.request` scrubs the configured password plus every sensitive-keyed value in the request payload on all four error branches (aiounifi/aiohttp errors, unexpected errors, both re-auth retry paths) and `refresh_handler`'s retry error, before logging and before re-raising. Because every controller call flows through here, this covers reads, previews and writes for every manager.
- `SystemManager.update_settings` redacts by key and scrubs the rejected response before logging it, and scrubs the exception it re-raises. This is kept in the manager (not only the transport) so a fake-connection regression still holds.
- The API action route scrubs audit `detail` against the request's own sensitive argument values. This also covers schema-validation and translator messages that echo the offending value on the preview path.

No tool descriptions, manifests or catalogs changed (`make check-generated`: no drift).

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server
- [x] API server
- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. (No tool changes; `make check-generated` clean.)
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. (None user-visible.)
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

Regressions written first (16 red on `bc09e3c`, all green on this head). Each drives the real manager with a fake aiounifi controller that fails while quoting a sentinel, and asserts the sentinel is absent from the MCP/API response, the captured log and the audit row:

- `packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py` — real `ConnectionManager`: write errors (ResponseError / RequestError / aiohttp ClientError / unexpected), read error quoting the login password, chained `__cause__`, second `LoginRequired` after re-auth; real `SystemManager` + fake connection: write exception and rejected-response log.
- `packages/unifi-core/tests/test_redaction.py` — helper unit tests.
- `apps/network/tests/unit/test_credential_error_sanitization.py` — `unifi_update_snmp_settings` write and preview, `unifi_get_snmp_settings` read, through real `SystemManager` → real `ConnectionManager`.
- `apps/api/tests/test_action_credential_audit.py` — `POST /v1/actions/unifi_update_snmp_settings` write error and preview validation error, `unifi_get_snmp_settings` read error; audit `detail` read back from the DB.

```
uv run --package unifi-core --all-extras pytest packages/unifi-core/tests      # 1908 passed
uv run --package unifi-network-mcp pytest apps/network/tests/unit             # 1086 passed
uv run --package unifi-api-server pytest apps/api/tests                        # 1374 passed
uv run ruff check . && uv run ruff format --check . && make check-generated    # clean
```

Read-only smoke on an owned controller, this head, Network Application 10.6.102 (UniFi OS Server), entry points `SystemManager.get_system_info`, `SystemManager.get_settings("snmp")` and one `ConnectionManager.request` GET to a non-existent path so the error branch runs:

| check | result |
|---|---|
| connect + authenticate | pass |
| SNMP read | pass |
| negative GET raised `ResponseError` and hit the error log branch | pass |
| configured password present in 20 captured DEBUG log lines | false |

## Notes for reviewers

- Scrubbing is value-based (known secrets: configured password + sensitive-keyed payload values), not pattern-based, so ordinary error text is untouched.
- `sanitize_exception` mutates in place on purpose: callers keep `except ResponseError` matching and the diagnostics `log_api_request({"error": str(e)})` path becomes clean without touching it.
- #645 and #648 will be rebased onto this once it lands; the floor bump for the new `unifi_core.redaction` symbols follows the #657 pattern (a Core release, then app floors) unless you prefer a contributor split.
