### PR TITLE
fix: require Core 0.4.44 for Network and API fixes

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # filtering and discovery require Core 0.4.37; explicit zero event limits
     # require Core 0.4.39. UTC device timestamps in action read views require
     # Core 0.4.43.
-    "unifi-core[network,protect,access]>=0.4.43,<0.5",
+    "unifi-core[network,protect,access]>=0.4.44,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     # filtering and discovery require Core 0.4.37; explicit zero event limits
     # require Core 0.4.39. UTC device timestamps in action read views require
     # Core 0.4.43.
+    # Firewall index rejection and uncapped client lookup require Core 0.4.44.
     "unifi-core[network,protect,access]>=0.4.44,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     # requires Core 0.4.36. Exact event-key filtering and discovery require
     # Core 0.4.37; explicit zero event limits require Core 0.4.39. UTC device
     # timestamps and expanded site settings require Core 0.4.43.
+    # Firewall index rejection and uncapped client lookup require Core 0.4.44.
     "unifi-core[network]>=0.4.44,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # requires Core 0.4.36. Exact event-key filtering and discovery require
     # Core 0.4.37; explicit zero event limits require Core 0.4.39. UTC device
     # timestamps and expanded site settings require Core 0.4.43.
-    "unifi-core[network]>=0.4.43,<0.5",
+    "unifi-core[network]>=0.4.44,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security


### PR DESCRIPTION
Network and API now advertise firewall-policy `index` rejection, but their previous dependency ranges allowed Core 0.4.43, whose validator accepts that field. App upgrades could retain the old behavior.

Raise both Core minima to `>=0.4.44,<0.5`, guaranteeing the firewall validation fix (#640) and client lookup correction (#659). Adjacent comments explain the requirement. Shared minima remain unchanged because these apps do not yet call the new policy helper.

Validation:
- Core 0.4.44 and Shared 0.6.14 successfully published through their release workflows.
- Full combined pre-commit gate and live Network/Protect/Access/API checks passed before the five feature PRs merged; final main matched the tested tree.
- Final app wheels declare Core >=0.4.44; fresh installs and upgrade from installed Core 0.4.43 pass dependency checks.
- Pin-alignment script passed, including 179 Network call sites and 271 API catalog bindings against published Core 0.4.44.
- Installed targeted live probe passed for per-MAC lookup, MCP/API event filters and NAT read projection; firewall index rejection made zero manager calls. No controller mutations were attempted.
- Independent review: no findings. Final follow-up changes only two explanatory TOML comments; runtime and dependency requirements are unchanged. CI must pass on this final head before merge.
