### PR TITLE
fix(core): validate firewall ports before controller access

### DIFF
--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -15,7 +15,7 @@ from unifi_core.auth import UniFiAuth
 from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
 from unifi_core.merge import deep_merge
 from unifi_core.network.managers.connection_manager import ConnectionManager
-from unifi_core.network.models.firewall import _normalize_endpoint_macs
+from unifi_core.network.models.firewall import _normalize_endpoint_macs, validate_policy_port_targeting
 
 logger = logging.getLogger("unifi-network-mcp")
 
@@ -984,6 +984,7 @@ class FirewallManager:
         Returns:
             The created FirewallPolicy object, or None if creation failed.
         """
+        validate_policy_port_targeting(policy_data)
         if not await self._connection.ensure_connected():
             raise ConnectionError("Not connected to controller")
 

--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -517,6 +517,26 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
 
 
+def validate_policy_port_targeting(fields: Dict[str, Any]) -> None:
+    """Reject malformed V2 create-policy ports before preview or controller I/O.
+
+    Endpoints remain opaque controller dictionaries. Validate the confirmed
+    SPECIFIC port contract without changing other targeting modes or values.
+    """
+    for direction in ("source", "destination"):
+        endpoint = fields.get(direction)
+        if not isinstance(endpoint, dict):
+            continue
+        if "ports" in endpoint:
+            raise ValueError(
+                "%s.ports is not a valid field; the controller expects %s.port as a single "
+                "string (e.g. '445'), not a plural 'ports' array." % (direction, direction)
+            )
+        port = endpoint.get("port")
+        if endpoint.get("port_matching_type") == "SPECIFIC" and not (isinstance(port, str) and port.strip()):
+            raise ValueError("%s.port must be a non-empty string when port_matching_type is 'SPECIFIC'." % direction)
+
+
 def legacy_policy_error(fields: Dict[str, Any]) -> str | None:
     """Return the actionable V1-to-V2 migration error when legacy input is detected."""
     if _LEGACY_V1_FIREWALL_FIELDS & set(fields):

--- a/packages/unifi-core/tests/network/managers/test_firewall_port_validation.py
+++ b/packages/unifi-core/tests/network/managers/test_firewall_port_validation.py
@@ -1,0 +1,56 @@
+"""Port validation at the Core firewall create boundary."""
+
+import copy
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_core.network.managers.firewall_manager import FirewallManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        {"ports": ["445"]},
+        {"port_matching_type": "SPECIFIC"},
+        {"port_matching_type": "SPECIFIC", "port": 445},
+        {"port_matching_type": "SPECIFIC", "port": ["445"]},
+        {"port_matching_type": "SPECIFIC", "port": ""},
+        {"port_matching_type": "SPECIFIC", "port": " "},
+    ],
+)
+async def test_invalid_ports_fail_before_controller_connection(direction, endpoint):
+    connection = MagicMock()
+    connection.ensure_connected = AsyncMock()
+    connection.request = AsyncMock()
+    manager = FirewallManager(connection)
+
+    with pytest.raises(ValueError, match=rf"{direction}\.port"):
+        await manager.create_firewall_policy({direction: endpoint})
+
+    connection.ensure_connected.assert_not_awaited()
+    connection.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_valid_ports_reach_controller_without_mutating_input():
+    data = {
+        "name": "Specific ports",
+        "action": "ALLOW",
+        "enabled": False,
+        "source": {"port_matching_type": "SPECIFIC", "port": "445"},
+        "destination": {"port_matching_type": "SPECIFIC", "port": "8443"},
+    }
+    before = copy.deepcopy(data)
+    connection = MagicMock()
+    connection.ensure_connected = AsyncMock(return_value=True)
+    connection.request = AsyncMock(return_value={"_id": "created-policy", **data})
+
+    created = await FirewallManager(connection).create_firewall_policy(data)
+
+    connection.request.assert_awaited_once()
+    assert connection.request.call_args.args[0].data == before
+    assert created.raw["source"]["port"] == "445"
+    assert created.raw["destination"]["port"] == "8443"
+    assert data == before

--- a/packages/unifi-core/tests/network/models/test_firewall.py
+++ b/packages/unifi-core/tests/network/models/test_firewall.py
@@ -27,7 +27,41 @@ from unifi_core.network.models.firewall import (
     to_group_create,
     to_zone_create,
     to_zone_update,
+    validate_policy_port_targeting,
 )
+
+
+@pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize("port", [None, "", " ", 445, ["445"], True, {}])
+def test_policy_specific_port_rejects_malformed_values(direction, port):
+    with pytest.raises(ValueError, match=rf"{direction}\.port.*non-empty string"):
+        validate_policy_port_targeting({direction: {"port_matching_type": "SPECIFIC", "port": port}})
+
+
+@pytest.mark.parametrize("direction", ["source", "destination"])
+@pytest.mark.parametrize("mode", ["ANY", "SPECIFIC", "OBJECT"])
+def test_policy_plural_ports_rejected_even_with_valid_singular_port(direction, mode):
+    with pytest.raises(ValueError, match=rf"{direction}\.ports is not a valid field"):
+        validate_policy_port_targeting({direction: {"port_matching_type": mode, "ports": [], "port": "445"}})
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        {},
+        {"port_matching_type": "ANY"},
+        {"port_matching_type": "OBJECT", "port_group_id": "group"},
+        {"port_matching_type": "SPECIFIC", "port": "445"},
+        {"port_matching_type": "SPECIFIC", "port": "1000-2000"},
+    ],
+)
+def test_policy_valid_port_targeting_preserves_input(endpoint):
+    import copy
+
+    data = {"source": endpoint, "destination": endpoint}
+    before = copy.deepcopy(data)
+    validate_policy_port_targeting(data)
+    assert data == before
 
 
 class TestFirewallRuleFieldSets:


### PR DESCRIPTION
Firewall policy creates can send plural `ports`, missing SPECIFIC ports, or non-string ports to the controller. This adds a shared Core validator and invokes it before connection or write I/O, with regression tests for both endpoint directions and valid payload preservation.

This is the Core-only prerequisite extracted from Amir Fathi's #630, with co-author credit preserved. It changes only `packages/unifi-core`; downstream imports and dependency floors remain unchanged so pin alignment can pass independently.

Release sequence:

1. Merge this PR after checks pass.
2. Publish and verify Core `0.4.45`.
3. Rebase #630 onto main, dropping the Core changes already landed here.
4. Rerun #630's pin-alignment check against published Core, then finish its approval.

Validation:

- Core firewall model and manager regressions: **97 passed**.
- Ruff and diff whitespace checks: passed.
- Full `make pre-commit`: passed, including all package/application suites, generated artifact drift, protocol checks, and Worker type checking.
- All 18 GitHub checks passed on `a4cd5f40624fe300b8c8bc9baa42509d220efe5d`, including pin alignment and CodeQL.
- Independent reference-hardware validation on this Core-only branch: 12 malformed port cases rejected, then a disabled-policy create/update/readback/delete cycle verified both port strings and disabled-state preservation, with zero orphaned test policies.
- Copilot reviewed all four files with zero code comments; its request for live verification is covered by the independent hardware run.

<details>
<summary>Independent hardware probe output</summary>

```json
{"connected": true, "invalid_rejected": 12, "lifecycle": true, "orphans": 0}
```

The valid policy used explicit source/destination SPECIFIC port strings and `create_allow_respond=false`, remained disabled, and was deleted after readback verified the logging update preserved both ports. No controller identifiers or credentials are included here.

</details>

This PR intentionally does not close #608: #630 still supplies the MCP/API preview integration and user-facing documentation.
