### PR TITLE
fix(events): reject negative limits and handle Protect zero locally

### DIFF
--- a/apps/access/src/unifi_access_mcp/tools/events.py
+++ b/apps/access/src/unifi_access_mcp/tools/events.py
@@ -64,10 +64,12 @@ async def access_list_events(
     ] = None,
     limit: Annotated[
         int,
-        Field(description="Maximum number of events to return (default 30)."),
+        Field(description="Maximum number of events to return; must be zero or greater (default 30)."),
     ] = 30,
 ) -> Dict[str, Any]:
     """List access events."""
+    if limit < 0:
+        return {"success": False, "error": "limit must be zero or greater"}
     logger.info("access_list_events tool called (topic=%s, door=%s, user=%s, limit=%s)", topic, door_id, user_id, limit)
     try:
         raw_events = await event_manager.list_events(

--- a/apps/access/src/unifi_access_mcp/tools/events.py
+++ b/apps/access/src/unifi_access_mcp/tools/events.py
@@ -69,7 +69,7 @@ async def access_list_events(
 ) -> Dict[str, Any]:
     """List access events."""
     if limit < 0:
-        return {"success": False, "error": "limit must be zero or greater"}
+        return {"success": False, "error": "Failed to list events: limit must be zero or greater"}
     logger.info("access_list_events tool called (topic=%s, door=%s, user=%s, limit=%s)", topic, door_id, user_id, limit)
     try:
         raw_events = await event_manager.list_events(

--- a/apps/access/src/unifi_access_mcp/tools_manifest.json
+++ b/apps/access/src/unifi_access_mcp/tools_manifest.json
@@ -1987,7 +1987,7 @@
               "type": "string"
             },
             "limit": {
-              "description": "Maximum number of events to return (default 30).",
+              "description": "Maximum number of events to return; must be zero or greater (default 30).",
               "type": "integer"
             },
             "start": {

--- a/apps/access/tests/unit/test_event_tools.py
+++ b/apps/access/tests/unit/test_event_tools.py
@@ -36,6 +36,18 @@ async def test_list_events_projects_a_stable_system_log_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_events_rejects_negative_limit_before_controller_io() -> None:
+    with patch("unifi_access_mcp.tools.events.event_manager") as manager:
+        manager.list_events = AsyncMock()
+        from unifi_access_mcp.tools.events import access_list_events
+
+        result = await access_list_events(limit=-1)
+
+    assert result == {"success": False, "error": "limit must be zero or greater"}
+    manager.list_events.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_event_round_trips_the_synthetic_id() -> None:
     raw = {
         "id": "",

--- a/apps/access/tests/unit/test_event_tools.py
+++ b/apps/access/tests/unit/test_event_tools.py
@@ -43,7 +43,7 @@ async def test_list_events_rejects_negative_limit_before_controller_io() -> None
 
         result = await access_list_events(limit=-1)
 
-    assert result == {"success": False, "error": "limit must be zero or greater"}
+    assert result == {"success": False, "error": "Failed to list events: limit must be zero or greater"}
     manager.list_events.assert_not_awaited()
 
 

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -429,7 +429,7 @@
             "type": "string"
           },
           "limit": {
-            "description": "Maximum number of events to return (default 30).",
+            "description": "Maximum number of events to return; must be zero or greater (default 30).",
             "type": "integer"
           },
           "start": {
@@ -1332,7 +1332,7 @@
             "type": "string"
           },
           "limit": {
-            "description": "Maximum number of events to return (default 30).",
+            "description": "Maximum number of events to return; must be zero or greater (default 30).",
             "type": "integer"
           },
           "metadata_fields": {
@@ -4962,7 +4962,7 @@
             "type": "string"
           },
           "limit": {
-            "description": "Maximum number of events to return (default 100)",
+            "description": "Maximum number of events to return; must be zero or greater (default 100)",
             "type": "integer"
           },
           "severities": {
@@ -5416,7 +5416,7 @@
             "type": "string"
           },
           "limit": {
-            "description": "Maximum number of events to return from the buffer. Omit to return all buffered events.",
+            "description": "Maximum number of events to return from the buffer; must be zero or greater. Omit to return all buffered events.",
             "type": "integer"
           },
           "mac": {

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -47,7 +47,9 @@ def _get_event_manager():
 )
 async def list_events(
     within_hours: Annotated[int, Field(description="Only return events from the last N hours (default 24)")] = 24,
-    limit: Annotated[int, Field(description="Maximum number of events to return (default 100)")] = 100,
+    limit: Annotated[
+        int, Field(description="Maximum number of events to return; must be zero or greater (default 100)")
+    ] = 100,
     start: Annotated[int, Field(description="Offset for pagination, skip the first N events (default 0)")] = 0,
     event_type: Annotated[
         Optional[str],
@@ -69,6 +71,8 @@ async def list_events(
     ] = None,
 ) -> Dict[str, Any]:
     """List events with optional filtering."""
+    if limit < 0:
+        return {"success": False, "error": "limit must be zero or greater"}
     try:
         event_manager = _get_event_manager()
         events = await event_manager.get_events(
@@ -161,10 +165,14 @@ async def unifi_recent_events(
     ] = None,
     limit: Annotated[
         Optional[int],
-        Field(description="Maximum number of events to return from the buffer. Omit to return all buffered events."),
+        Field(
+            description="Maximum number of events to return from the buffer; must be zero or greater. Omit to return all buffered events."
+        ),
     ] = None,
 ) -> Dict[str, Any]:
     """Return recent events from the websocket ring buffer."""
+    if limit is not None and limit < 0:
+        return {"success": False, "error": "limit must be zero or greater"}
     logger.info("unifi_recent_events called (type=%s, mac=%s)", event_type, mac)
     mgr = _get_event_manager()
     events = mgr.get_recent_from_buffer(event_type=event_type, mac=mac, limit=limit)

--- a/apps/network/src/unifi_network_mcp/tools/events.py
+++ b/apps/network/src/unifi_network_mcp/tools/events.py
@@ -72,7 +72,7 @@ async def list_events(
 ) -> Dict[str, Any]:
     """List events with optional filtering."""
     if limit < 0:
-        return {"success": False, "error": "limit must be zero or greater"}
+        return {"success": False, "error": "Failed to list events: limit must be zero or greater"}
     try:
         event_manager = _get_event_manager()
         events = await event_manager.get_events(
@@ -172,7 +172,7 @@ async def unifi_recent_events(
 ) -> Dict[str, Any]:
     """Return recent events from the websocket ring buffer."""
     if limit is not None and limit < 0:
-        return {"success": False, "error": "limit must be zero or greater"}
+        return {"success": False, "error": "Failed to get recent events: limit must be zero or greater"}
     logger.info("unifi_recent_events called (type=%s, mac=%s)", event_type, mac)
     mgr = _get_event_manager()
     events = mgr.get_recent_from_buffer(event_type=event_type, mac=mac, limit=limit)

--- a/apps/network/src/unifi_network_mcp/tools_manifest.json
+++ b/apps/network/src/unifi_network_mcp/tools_manifest.json
@@ -11781,7 +11781,7 @@
               "type": "string"
             },
             "limit": {
-              "description": "Maximum number of events to return (default 100)",
+              "description": "Maximum number of events to return; must be zero or greater (default 100)",
               "type": "integer"
             },
             "severities": {
@@ -13847,7 +13847,7 @@
               "type": "string"
             },
             "limit": {
-              "description": "Maximum number of events to return from the buffer. Omit to return all buffered events.",
+              "description": "Maximum number of events to return from the buffer; must be zero or greater. Omit to return all buffered events.",
               "type": "integer"
             },
             "mac": {

--- a/apps/network/tests/unit/test_event_tools.py
+++ b/apps/network/tests/unit/test_event_tools.py
@@ -97,6 +97,21 @@ async def test_list_events_surfaces_mac_ip_and_msg_for_v2_records(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["list_events", "unifi_recent_events"])
+async def test_event_tools_reject_negative_limit_before_controller_io(monkeypatch, tool_name):
+    from unifi_network_mcp.tools import events as events_module
+
+    def unexpected_manager_lookup():
+        raise AssertionError("negative limit must not reach the event manager")
+
+    monkeypatch.setattr(events_module, "_get_event_manager", unexpected_manager_lookup)
+
+    result = await getattr(events_module, tool_name)(limit=-1)
+
+    assert result == {"success": False, "error": "limit must be zero or greater"}
+
+
+@pytest.mark.asyncio
 async def test_list_events_still_maps_legacy_records(monkeypatch):
     from unifi_network_mcp.tools import events as events_module
 

--- a/apps/network/tests/unit/test_event_tools.py
+++ b/apps/network/tests/unit/test_event_tools.py
@@ -108,7 +108,8 @@ async def test_event_tools_reject_negative_limit_before_controller_io(monkeypatc
 
     result = await getattr(events_module, tool_name)(limit=-1)
 
-    assert result == {"success": False, "error": "limit must be zero or greater"}
+    operation = "list events" if tool_name == "list_events" else "get recent events"
+    assert result == {"success": False, "error": f"Failed to {operation}: limit must be zero or greater"}
 
 
 @pytest.mark.asyncio

--- a/apps/protect/src/unifi_protect_mcp/tools/events.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/events.py
@@ -86,7 +86,7 @@ async def protect_list_events(
     ] = None,
     limit: Annotated[
         int,
-        Field(description="Maximum number of events to return (default 30)."),
+        Field(description="Maximum number of events to return; must be zero or greater (default 30)."),
     ] = 30,
     compact: Annotated[
         bool,
@@ -108,6 +108,8 @@ async def protect_list_events(
     ] = None,
 ) -> Dict[str, Any]:
     """List events from the NVR."""
+    if limit < 0:
+        return {"success": False, "error": "limit must be zero or greater"}
     logger.info(
         "protect_list_events called (type=%s, camera=%s, limit=%s, compact=%s)", event_type, camera_id, limit, compact
     )

--- a/apps/protect/src/unifi_protect_mcp/tools/events.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/events.py
@@ -109,7 +109,7 @@ async def protect_list_events(
 ) -> Dict[str, Any]:
     """List events from the NVR."""
     if limit < 0:
-        return {"success": False, "error": "limit must be zero or greater"}
+        return {"success": False, "error": "Failed to list events: limit must be zero or greater"}
     logger.info(
         "protect_list_events called (type=%s, camera=%s, limit=%s, compact=%s)", event_type, camera_id, limit, compact
     )

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -3027,7 +3027,7 @@
               "type": "string"
             },
             "limit": {
-              "description": "Maximum number of events to return (default 30).",
+              "description": "Maximum number of events to return; must be zero or greater (default 30).",
               "type": "integer"
             },
             "metadata_fields": {

--- a/apps/protect/tests/unit/test_event_tools.py
+++ b/apps/protect/tests/unit/test_event_tools.py
@@ -41,6 +41,16 @@ class TestProtectListEvents:
         assert len(result["data"]["events"]) == 2
 
     @pytest.mark.asyncio
+    async def test_negative_limit_is_rejected_before_controller_io(self, mock_event_manager):
+        from unifi_protect_mcp.tools.events import protect_list_events
+
+        mock_event_manager.list_events = AsyncMock()
+        result = await protect_list_events(limit=-1)
+
+        assert result == {"success": False, "error": "limit must be zero or greater"}
+        mock_event_manager.list_events.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_with_filters(self, mock_event_manager):
         from unifi_protect_mcp.tools.events import protect_list_events
 

--- a/apps/protect/tests/unit/test_event_tools.py
+++ b/apps/protect/tests/unit/test_event_tools.py
@@ -47,7 +47,7 @@ class TestProtectListEvents:
         mock_event_manager.list_events = AsyncMock()
         result = await protect_list_events(limit=-1)
 
-        assert result == {"success": False, "error": "limit must be zero or greater"}
+        assert result == {"success": False, "error": "Failed to list events: limit must be zero or greater"}
         mock_event_manager.list_events.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/event_manager.py
@@ -663,6 +663,11 @@ class EventManager:
         delegates to the existing uiprotect path for full backwards
         compatibility.
         """
+        # The controller requires limit=1..100 when no time range is supplied.
+        # Zero requests no results and must not turn into an invalid or uncapped
+        # remote query on either the SDK or raw metadata path.
+        if limit == 0:
+            return []
         use_raw_path = bool(camera_id) or bool(metadata_fields)
 
         if use_raw_path:

--- a/packages/unifi-core/tests/protect/test_event_zero_limit.py
+++ b/packages/unifi-core/tests/protect/test_event_zero_limit.py
@@ -1,7 +1,6 @@
 """Zero event limits are local empty results across Protect query paths."""
 
 import pytest
-
 from unifi_core.protect.managers.event_manager import EventManager
 
 

--- a/packages/unifi-core/tests/protect/test_event_zero_limit.py
+++ b/packages/unifi-core/tests/protect/test_event_zero_limit.py
@@ -1,0 +1,17 @@
+"""Zero event limits are local empty results across Protect query paths."""
+
+import pytest
+
+from unifi_core.protect.managers.event_manager import EventManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filters", [{}, {"camera_id": "camera"}, {"metadata_fields": ["score"]}])
+async def test_zero_limit_never_accesses_controller(filters):
+    class NoControllerAccess:
+        @property
+        def client(self):
+            raise AssertionError("zero results must not access the controller")
+
+    manager = EventManager(NoControllerAccess())
+    assert await manager.list_events(limit=0, **filters) == []


### PR DESCRIPTION
Negative limits on the four event tools reached the controller or Python slicing instead of returning a useful validation error. Network historical/buffered events, Protect events, and Access events now reject negative limits with an operation-specific message before manager access. Generated manifests and the API catalog describe the nonnegative limit contract.

Independent live testing also found that Protect rejects `limit=0` without a time range. The shared Protect manager now returns an empty list locally for zero on both the SDK and raw metadata/camera query paths. This preserves the advertised zero-result behavior for MCP and API consumers without an invalid or potentially unbounded controller query.

Addresses #666; close after the corrected app packages are published.

Validation: tool regressions verify negative limits never invoke their managers. Three new Core regressions verify zero never accesses the controller, including camera and metadata filters. Independently installed wheels passed negative/zero/normal-read checks against Network, Protect, and Access; the Protect zero failure was reproduced before the Core fix and passed afterward. Full `make pre-commit` and all 14 GitHub checks passed on 5157f025a7f7fa1825566b39de383e3021aac27e.

The Protect fix requires a new Core release, followed by a Protect/API Core floor bump before app publication. No app tag should advertise the corrected zero behavior while still allowing the older Core floor.
