### PR TITLE
test: run the root suite in CI and repair the metadata smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 	@echo ""
 	@echo "  make core-test      Run unifi-core tests only"
 	@echo "  make shared-test    Run unifi-mcp-shared tests only"
-	@echo "  make catalog-test   Run generated-catalog and live-harness contract tests"
+	@echo "  make catalog-test   Run the root tests/ suite (generation, release and harness contracts)"
 	@echo "  make protocol-smoke Run MCP protocol conformance smoke tests"
 	@echo "  make worker-build   Install worker deps + typecheck Worker app"
 	@echo "  make worker-check   Run worker CLI tests + TypeScript checks"
@@ -55,7 +55,7 @@ shared-test:
 	uv run --package unifi-mcp-shared pytest packages/unifi-mcp-shared/tests -v
 
 catalog-test:
-	uv run --all-packages pytest tests/test_community_issue_triage_workflow.py tests/test_generate_api_action_catalog.py tests/test_generate_support_skills.py tests/test_live_smoke_harness.py -v
+	uv run --all-packages pytest tests/ -v
 
 docs-test:
 	uv run python -m unittest discover -s tests/docs -p 'test_*.py' -v

--- a/tests/test_smoke_mcp_metadata.py
+++ b/tests/test_smoke_mcp_metadata.py
@@ -17,18 +17,78 @@ sys.modules[_spec.name] = _mod
 _spec.loader.exec_module(_mod)
 
 MetadataSmokeError = _mod.MetadataSmokeError
-ServerSpec = _mod.ServerSpec
+PROJECT_WEBSITE_URL = _mod.PROJECT_WEBSITE_URL
+SERVER_SPECS = _mod.SERVER_SPECS
 validate_icons = _mod.validate_icons
 validate_server_metadata = _mod.validate_server_metadata
-validate_tool_titles = _mod.validate_tool_titles
+validate_meta_tool_surface = _mod.validate_meta_tool_surface
 smoke_env = _mod.smoke_env
 selected_server_names = _mod.selected_server_names
+
+NETWORK_SPEC = SERVER_SPECS["network"]
+
+EXPECTED_SURFACE = frozenset(
+    {
+        "MetadataSmokeError",
+        "PROJECT_WEBSITE_URL",
+        "SERVER_SPECS",
+        "ServerSpec",
+        "parse_meta_tool_result",
+        "selected_server_names",
+        "smoke_env",
+        "smoke_server",
+        "validate_connection",
+        "validate_icons",
+        "validate_index_catalog",
+        "validate_meta_tool_surface",
+        "validate_mode_tools",
+        "validate_server_metadata",
+        "validate_tool_schema",
+    }
+)
+
+
+def _meta_tools(spec, **overrides):
+    """A tools/list payload that passes every check in validate_meta_tool_surface."""
+    index_tool = SimpleNamespace(
+        name=spec.index_tool,
+        title=spec.expected_index_title,
+        description="Index of available tools.",
+        inputSchema={"type": "object"},
+        annotations=SimpleNamespace(readOnlyHint=True, openWorldHint=False),
+    )
+    for key, value in overrides.items():
+        setattr(index_tool, key, value)
+    return [
+        index_tool,
+        SimpleNamespace(name=f"{spec.prefix}_execute"),
+        SimpleNamespace(name=f"{spec.prefix}_batch"),
+        SimpleNamespace(name=f"{spec.prefix}_batch_status"),
+    ]
+
+
+def test_module_public_surface_is_stable() -> None:
+    """Name every helper the smoke script owes this file, so a rename reports all gaps at once."""
+    assert EXPECTED_SURFACE <= set(vars(_mod)), sorted(EXPECTED_SURFACE - set(vars(_mod)))
+
 
 PNG_DATA_URI = "data:image/png;base64," + base64.b64encode(b"\x89PNG\r\n\x1a\npayload").decode()
 
 
 def _icon(size: str = "48x48"):
     return SimpleNamespace(src=PNG_DATA_URI, mimeType="image/png", sizes=[size])
+
+
+def _server_info(**overrides):
+    """An initialize.serverInfo payload that passes every check."""
+    fields = {
+        "name": NETWORK_SPEC.expected_name,
+        "websiteUrl": PROJECT_WEBSITE_URL,
+        "version": "1.2.3",
+        "icons": [_icon("48x48"), _icon("96x96"), _icon("192x192")],
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
 
 
 def test_validate_icons_accepts_three_png_data_uri_sizes() -> None:
@@ -45,56 +105,65 @@ def test_validate_icons_rejects_non_png_data() -> None:
 
 
 def test_validate_server_metadata_checks_name_website_and_icons() -> None:
-    spec = ServerSpec(
-        package="unifi-network-mcp",
-        command="unifi-network-mcp",
-        expected_name="unifi-network-mcp",
-        index_tool="unifi_tool_index",
-        expected_index_title="UniFi Network Tool Index",
-    )
-    server_info = SimpleNamespace(
-        name="unifi-network-mcp",
-        websiteUrl="https://github.com/sirkirby/unifi-mcp",
-        version="1.2.3",
-        icons=[_icon("48x48"), _icon("96x96"), _icon("192x192")],
-    )
-
-    validate_server_metadata(spec, server_info)
+    validate_server_metadata(NETWORK_SPEC, _server_info())
 
 
-def test_validate_tool_titles_requires_expected_title() -> None:
-    spec = ServerSpec(
-        package="unifi-network-mcp",
-        command="unifi-network-mcp",
-        expected_name="unifi-network-mcp",
-        index_tool="unifi_tool_index",
-        expected_index_title="UniFi Network Tool Index",
-    )
-    tools = [
-        SimpleNamespace(name="unifi_tool_index", title="Wrong Title"),
-    ]
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("name", "unifi-wrong-mcp", "expected server name"),
+        ("websiteUrl", "https://example.invalid/other", "expected websiteUrl"),
+        ("version", "", "missing server version"),
+    ],
+)
+def test_validate_server_metadata_rejects_each_bad_field(field, value, expected) -> None:
+    with pytest.raises(MetadataSmokeError, match=expected):
+        validate_server_metadata(NETWORK_SPEC, _server_info(**{field: value}))
+
+
+def test_validate_meta_tool_surface_accepts_a_complete_lazy_surface() -> None:
+    validate_meta_tool_surface(NETWORK_SPEC, _meta_tools(NETWORK_SPEC))
+
+
+def test_validate_meta_tool_surface_requires_expected_index_title() -> None:
+    tools = _meta_tools(NETWORK_SPEC, title="Wrong Title")
 
     with pytest.raises(MetadataSmokeError, match="expected title"):
-        validate_tool_titles(spec, tools)
+        validate_meta_tool_surface(NETWORK_SPEC, tools)
+
+
+def test_validate_meta_tool_surface_requires_every_meta_tool() -> None:
+    tools = [tool for tool in _meta_tools(NETWORK_SPEC) if not tool.name.endswith("_batch_status")]
+
+    with pytest.raises(MetadataSmokeError, match="missing meta-tools"):
+        validate_meta_tool_surface(NETWORK_SPEC, tools)
 
 
 def test_smoke_env_defaults_to_offline_metadata_credentials(monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_HOST", "10.0.0.1")
     monkeypatch.setenv("UNIFI_NETWORK_HOST", "10.0.0.2")
+    monkeypatch.setenv("UNIFI_TOOL_REGISTRATION_MODE", "meta_only")
+    monkeypatch.setenv("UNIFI_MCP_HTTP_ENABLED", "true")
 
-    env = smoke_env(use_current_env=False)
+    env = smoke_env(registration_mode="lazy", use_current_env=False)
 
     assert env["UNIFI_HOST"] == "127.0.0.1"
     assert env["UNIFI_NETWORK_HOST"] == "127.0.0.1"
     assert env["UNIFI_USERNAME"] == "metadata-smoke"
+    assert env["UNIFI_TOOL_REGISTRATION_MODE"] == "lazy"
+    assert env["UNIFI_MCP_HTTP_ENABLED"] == "false"
 
 
 def test_smoke_env_can_preserve_current_controller_env(monkeypatch) -> None:
     monkeypatch.setenv("UNIFI_HOST", "10.0.0.1")
+    monkeypatch.setenv("UNIFI_TOOL_REGISTRATION_MODE", "meta_only")
+    monkeypatch.setenv("UNIFI_MCP_HTTP_ENABLED", "true")
 
-    env = smoke_env(use_current_env=True)
+    env = smoke_env(registration_mode="eager", use_current_env=True)
 
     assert env["UNIFI_HOST"] == "10.0.0.1"
+    assert env["UNIFI_TOOL_REGISTRATION_MODE"] == "eager"
+    assert env["UNIFI_MCP_HTTP_ENABLED"] == "false"
 
 
 def test_selected_server_names_skips_access_for_default_offline_smoke() -> None:


### PR DESCRIPTION
## Summary

`tests/test_smoke_mcp_metadata.py` fails at **collection** on current `main`:

```
tests/test_smoke_mcp_metadata.py:23: in <module>
    validate_tool_titles = _mod.validate_tool_titles
E   AttributeError: module 'smoke_mcp_metadata' has no attribute 'validate_tool_titles'
```

Title validation was folded into `validate_meta_tool_surface` (`scripts/smoke_mcp_metadata.py:177-180`) and the test file was never updated. Because the module-level rebinding aborts on the **first** missing name, that one error hid three more drifts behind it — once the import was unblocked the file was 4 failed / 5 passed:

| Drift | Cause |
|---|---|
| `validate_tool_titles` gone | folded into `validate_meta_tool_surface` |
| two `ServerSpec(...)` calls fail | the dataclass gained required `prefix` and `representative_tool` |
| two `smoke_env()` calls fail | it gained a required keyword-only `registration_mode` |

**The file was reached by no make target and no CI job.** `catalog-test` named four files explicitly, and it is the only make target either workflow invokes (`check-skill-references.yml:33`, `release-api.yml:74`), so a hard collection error stayed green for the file's entire life. That is the root cause of the rot, so the recipe now runs the `tests/` directory. This also picks up four other files that were never run — `test_check_pin_alignment.py`, `test_generate_release_notes.py`, `test_live_smoke_response_sizes.py`, `test_server_manifest.py` — and `tests/docs/`, which `make docs-test` covers but no workflow calls.

To stop the same class of drift recurring, the tests now bind the shipped `SERVER_SPECS` instead of hand-building `ServerSpec` (so a new required field cannot break the file), and assert the module surface as a set, so a rename reports every gap at once rather than aborting collection at the first.

## Type of change

- [x] `test:` adding or updating tests

## Scope

- [x] Documentation <!-- CI/test tooling; no server code changed -->

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. <!-- n/a: no tool signature changed; `make check-generated` reports no drift -->
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes. <!-- n/a -->
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

Tested SHA `995230c4`.

| Check | Result |
|---|---|
| `pytest tests/test_smoke_mcp_metadata.py` | **15 passed** (was: collection error) |
| `make catalog-test` | **1374 passed, 6 skipped, 219 subtests** |
| `make docs-test` | 79 tests, OK |
| `ruff format --check .` | 1068 files clean |
| `ruff check .` | clean |
| `uv lock --check` | clean |
| `make check-generated` | no drift |

Runtime cost of the wider `catalog-test` is ~1s, not what you might expect: the old four-file list already contained `test_community_issue_triage_workflow.py`, which is ~112s of the ~113s total. Measured: old list 1205 passed in 112.4s, new 1289 passed in 113.5s, the five newly-included files 90 passed in 0.85s.

Each restored assertion was mutation-checked rather than merely made green — deleting the production check makes the test fail:

| Mutant | Result |
|---|---|
| required-meta-tools check deleted | 1 failed |
| serverInfo `name` check deleted | 1 failed |
| serverInfo `websiteUrl` check deleted | 1 failed |
| serverInfo `version` check deleted | 1 failed |
| `validate_mode_tools` renamed | 1 failed (surface guard) |
| `UNIFI_TOOL_REGISTRATION_MODE` assignment → `setdefault` | 2 failed |
| `UNIFI_MCP_HTTP_ENABLED` assignment → `setdefault` | 2 failed |

Before this change all seven survived.

## Notes for reviewers

`release-api.yml` is the one to look at twice: `generated-contracts` is a `needs` of both `publish-pypi` and `publish-docker`, so the newly-included assertions can now block a release. Two of the five new files are release machinery (`test_check_pin_alignment`, `test_generate_release_notes`), which is where you'd want that gate — but it is a scope change to a release path, so it deserves your judgement rather than mine. All five are network-free, controller-free and credential-free, write only under `tmp_path`, and invoke no `git` (which matters: `check-skill-references.yml` checks out shallow while `release-api.yml` uses `fetch-depth: 0`, so a git-touching test would pass in one and fail in the other).

**Deferred items**

- `validate_mode_tools`, `validate_index_catalog`, `parse_meta_tool_result`, `validate_tool_schema` and `validate_connection` have no tests at all. `make protocol-smoke` is their only execution path and no workflow runs it. Worth a follow-up; out of scope for a collection repair.
- `SERVER_SPECS`' `prefix` / `representative_tool` values are not checked against the shipped `tools_manifest.json` files. A parametrized offline test would convert a live-only check into a fast one.
- `tests/test_live_smoke_harness.py:201` asserts `result.returncode == 0` to prove a PYTHONPATH shadow package was not imported, but returncode 1 means both "shadow was imported" and "the real package is not installed in this venv" — the two are conflated. It passes in CI (`--all-packages`) and fails locally after any `uv run --package <one>` prunes the venv. Separate PR.

**Considered & declined**

- Adding only `test_smoke_mcp_metadata.py` to the explicit list: it restores the identical trap for the next file added, and leaves the other four permanently unrun. An allowlist fails silently on omission; a directory fails loudly.
- Keeping `--ignore=tests/docs`: `make docs-test` is invoked by no workflow, so that ignore is the one line deciding that `tests/docs` (79 tests, 219 subtests, including the recent support-bundle work) runs nowhere in CI. Dropping it costs 0.21s of duplication inside `make test`.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
