### PR TITLE
test: assert the shadow package was not imported, not the child's exit status

### DIFF
--- a/tests/test_live_smoke_harness.py
+++ b/tests/test_live_smoke_harness.py
@@ -198,7 +198,19 @@ def test_support_child_cannot_import_pythonpath_shadow_package(monkeypatch, tmp_
     result = subprocess.run(
         [sys.executable, "-c", "import unifi_network_mcp"], env=env, cwd=shadow, capture_output=True
     )
-    assert result.returncode == 0
+    # The shadow's sentinel, not the exit status: a non-zero status also means "the real
+    # package is not installed in this interpreter", which is true of any venv a
+    # `uv run --package <one>` has pruned, and says nothing about the shadow. CI runs
+    # `--all-packages` and never sees the difference.
+    assert b"shadow app imported" not in result.stderr
+    # And the guard is what does it: the same child with PYTHONPATH restored imports the
+    # shadow, so a green assertion above cannot be green by accident.
+    unguarded = {**env, "PYTHONPATH": str(shadow)}
+    del unguarded["PYTHONSAFEPATH"]
+    leaked = subprocess.run(
+        [sys.executable, "-c", "import unifi_network_mcp"], env=unguarded, cwd=shadow, capture_output=True
+    )
+    assert b"shadow app imported" in leaked.stderr
 
 
 @pytest.mark.parametrize("secret", ['quoted"password', r"back\slash", "café-秘密", "unifi"])


### PR DESCRIPTION
## What it fixes

`tests/test_live_smoke_harness.py::test_support_child_cannot_import_pythonpath_shadow_package` proves the support smoke's child process cannot import a `PYTHONPATH` shadow of `unifi_network_mcp`. It asserted `result.returncode == 0`, which is true only when the *real* package is also importable in that interpreter. A returncode of 1 means both "the shadow was imported" and "the real package is not installed here" — and the second happens in any workspace venv a `uv run --package <one>` has pruned, which every `make core-test` does.

So the property held and the test failed. CI never sees it because it runs `--all-packages`.

Demonstrated: same child, same guarded env, in an interpreter without the package —

```
returncode == 1   -> old assertion FAILS
shadow sentinel in stderr: False
stderr tail: ModuleNotFoundError: No module named 'unifi_network_mcp'
```

## The change

Assert the shadow's own sentinel is absent from the child's stderr, and add the other half — the same child with `PYTHONPATH` restored must import the shadow — so a green first assertion cannot be green by accident.

Verified by mutation: dropping `PYTHONPATH` from the strip list in `scripts/support_smoke.py::support_environment` fails both parametrizations of the test. Before the change, the same mutation was caught too, but so was an unrelated venv state.

## Checks

```
uv run --all-packages pytest tests/test_live_smoke_harness.py -q -k shadow   # 2 passed
ruff format / ruff check                                                     # pass
```

Test-only; no production file changes.
