### PR TITLE
fix(release): align security and lifecycle floors and installed validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,10 @@ manifest:
 	$(MAKE) server-manifests
 
 api-action-catalog:
-	uv run python scripts/generate_api_action_catalog.py
+	uv run --package unifi-api-server python scripts/generate_api_action_catalog.py
 
 check-api-action-catalog:
-	uv run python scripts/generate_api_action_catalog.py --check
+	uv run --package unifi-api-server python scripts/generate_api_action_catalog.py --check
 
 server-manifests:
 	$(MAKE) -C apps/network server-manifest

--- a/apps/access/pyproject.toml
+++ b/apps/access/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     # normalization and websocket topics require Core 0.4.33; explicit zero
     # event limits require Core 0.4.39.
     # Operation-metadata-only diagnostics require Core 0.4.48.
-    "unifi-core[access]>=0.4.48,<0.5",
+    # Align with the Core 0.4.49 event and session-cleanup release baseline.
+    "unifi-core[access]>=0.4.49,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     # Core 0.4.43.
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
     # Shared firewall create-port validation requires Core 0.4.45.
-    "unifi-core[network,protect,access]>=0.4.47,<0.5",
+    # Owned event listeners and controller-session cleanup require Core 0.4.49.
+    "unifi-core[network,protect,access]>=0.4.49,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/api/tests/test_live_api_smoke_harness.py
+++ b/apps/api/tests/test_live_api_smoke_harness.py
@@ -59,6 +59,53 @@ def test_report_counters():
     assert r.failed == 1
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail", [False, True])
+async def test_smoke_closes_sessions_after_success_or_failure(tmp_path, monkeypatch, fail):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import live_api_smoke
+
+    invalidate = AsyncMock()
+    dispose = AsyncMock()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            manager_factory=SimpleNamespace(invalidate_controller=invalidate),
+            engine=SimpleNamespace(dispose=dispose),
+        )
+    )
+    bootstrap = AsyncMock(return_value=(app, "synthetic-key", {"network": "synthetic-controller"}))
+    monkeypatch.setattr(live_api_smoke, "load_env", lambda: {})
+    monkeypatch.setattr(live_api_smoke, "bootstrap_app_and_controllers", bootstrap)
+    monkeypatch.setattr(
+        live_api_smoke, "_run_assertion", AsyncMock(side_effect=RuntimeError("probe failed") if fail else None)
+    )
+    args = SimpleNamespace(controllers="", retry=1, installed=True, output=tmp_path / "report.json")
+    if fail:
+        with pytest.raises(RuntimeError, match="probe failed"):
+            await live_api_smoke.main_async(args)
+    else:
+        assert await live_api_smoke.main_async(args) == 0
+    bootstrap.assert_awaited_once_with({}, [], installed=True)
+    invalidate.assert_awaited_once_with("synthetic-controller")
+    dispose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_installed_smoke_does_not_add_checkout_to_import_path(monkeypatch):
+    import live_api_smoke
+
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+    before = sys.path.copy()
+    app, _key, controllers = await live_api_smoke.bootstrap_app_and_controllers({}, [], installed=True)
+    try:
+        assert sys.path == before
+        assert controllers == {}
+    finally:
+        await app.state.engine.dispose()
+
+
 def test_api_image_catalog_validation_requires_exact_generated_names():
     import api_image_smoke
 

--- a/apps/network/pyproject.toml
+++ b/apps/network/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
     # Shared firewall create-port validation requires Core 0.4.45.
     # Firewall selector validation and update preparation require Core 0.4.48.
-    "unifi-core[network]>=0.4.48,<0.5",
+    # Owned event listeners and controller-session cleanup require Core 0.4.49.
+    "unifi-core[network]>=0.4.49,<0.5",
     "aiounifi==95",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     # detail fields require Core 0.4.35; explicit zero event limits require
     # Core 0.4.39; sensor summary field preservation requires Core 0.4.43.
     # Local zero-limit event handling requires Core 0.4.48.
-    "unifi-core[protect]>=0.4.48,<0.5",
+    # Owned event listeners and controller-session cleanup require Core 0.4.49.
+    "unifi-core[protect]>=0.4.49,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/packages/unifi-mcp-relay/pyproject.toml
+++ b/packages/unifi-mcp-relay/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "click>=8.3.3",
     "aiohttp>=3.14.3",
     "python-dotenv>=1.2.2",
-    "unifi-mcp-shared>=0.6.15,<0.7",
+    "unifi-mcp-shared>=0.6.17,<0.7",
     # location_timeline.py imports unifi_core.event_timeline directly. This resolves
     # today only as a transitive of unifi-mcp-shared; declare it so it does not.
     "unifi-core>=0.4.47,<0.5",

--- a/scripts/live_api_smoke.py
+++ b/scripts/live_api_smoke.py
@@ -13,6 +13,8 @@ established fixture pattern.
 Usage:
     python scripts/live_api_smoke.py --output report.json
     python scripts/live_api_smoke.py --controllers network,protect --retry 3
+    # From a fresh environment containing the published wheel and httpx:
+    python scripts/live_api_smoke.py --installed --output installed-report.json
 """
 
 from __future__ import annotations
@@ -996,6 +998,8 @@ async def run_access_assertions(  # noqa: C901
 async def bootstrap_app_and_controllers(
     env: dict,
     products: list[str],
+    *,
+    installed: bool = False,
 ) -> tuple[Any, str, dict[str, str]]:
     """Boot unifi-api in-process; seed admin key + one Controller row per product.
 
@@ -1003,7 +1007,8 @@ async def bootstrap_app_and_controllers(
     """
     import tempfile
 
-    sys.path.insert(0, str(REPO_ROOT / "apps/api/src"))
+    if not installed:
+        sys.path.insert(0, str(REPO_ROOT / "apps/api/src"))
     from unifi_api.auth.api_key import generate_key, hash_key
     from unifi_api.config import ApiConfig, DbConfig, HttpConfig, LoggingConfig
     from unifi_api.db.crypto import ColumnCipher, derive_key
@@ -1086,54 +1091,62 @@ async def main_async(args: argparse.Namespace) -> int:
     report.started_at = datetime.now(timezone.utc).isoformat()
 
     print(f"Live smoke: products={products} retry={args.retry}")
-    app, key, cids = await bootstrap_app_and_controllers(env, products)
+    app, key, cids = await bootstrap_app_and_controllers(env, products, installed=args.installed)
 
-    # Always-on assertion: the app boots and /v1/health is ok
-    from httpx import ASGITransport, AsyncClient
+    try:
+        # Always-on assertion: the app boots and /v1/health is ok
+        from httpx import ASGITransport, AsyncClient
 
-    async def _health():
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
-            r = await c.get("/v1/health")
-            assert r.status_code == 200, f"/v1/health returned {r.status_code}"
-            assert r.json().get("status") == "ok", r.json()
-            return {"status_code": 200}
+        async def _health():
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r = await c.get("/v1/health")
+                assert r.status_code == 200, f"/v1/health returned {r.status_code}"
+                assert r.json().get("status") == "ok", r.json()
+                return {"status_code": 200}
 
-    await _run_assertion(
-        report,
-        "service boots / v1 health",
-        "core",
-        "rest",
-        _health,
-        retry=args.retry,
-    )
-
-    if "network" in products and "network" in cids:
-        await run_network_assertions(
+        await _run_assertion(
             report,
-            env,
-            app,
-            key,
-            cids["network"],
+            "service boots / v1 health",
+            "core",
+            "rest",
+            _health,
             retry=args.retry,
         )
-    if "protect" in products and "protect" in cids:
-        await run_protect_assertions(
-            report,
-            env,
-            app,
-            key,
-            cids["protect"],
-            retry=args.retry,
-        )
-    if "access" in products and "access" in cids:
-        await run_access_assertions(
-            report,
-            env,
-            app,
-            key,
-            cids["access"],
-            retry=args.retry,
-        )
+
+        if "network" in products and "network" in cids:
+            await run_network_assertions(
+                report,
+                env,
+                app,
+                key,
+                cids["network"],
+                retry=args.retry,
+            )
+        if "protect" in products and "protect" in cids:
+            await run_protect_assertions(
+                report,
+                env,
+                app,
+                key,
+                cids["protect"],
+                retry=args.retry,
+            )
+        if "access" in products and "access" in cids:
+            await run_access_assertions(
+                report,
+                env,
+                app,
+                key,
+                cids["access"],
+                retry=args.retry,
+            )
+
+    finally:
+        try:
+            for controller_id in cids.values():
+                await app.state.manager_factory.invalidate_controller(controller_id)
+        finally:
+            await app.state.engine.dispose()
 
     report.finished_at = datetime.now(timezone.utc).isoformat()
     args.output.write_text(
@@ -1166,6 +1179,9 @@ def main() -> int:
     parser.add_argument("--output", type=Path, default=Path("smoke-report.json"))
     parser.add_argument("--controllers", default="network,protect,access")
     parser.add_argument("--retry", type=int, default=3)
+    parser.add_argument(
+        "--installed", action="store_true", help="Use the installed API package without adding checkout sources"
+    )
     args = parser.parse_args()
     return asyncio.run(main_async(args))
 


### PR DESCRIPTION
The app release must require the Core listener and session-cleanup fixes from #647 while preserving the published startup-security boundary. Network, Protect, Access, and API now require Core >=0.4.49; MCP apps retain Shared >=0.6.17, and Relay's Shared floor is raised to 0.6.17 as well. Core 0.4.49 has been published and independently installed from PyPI.

Fresh release verification exposed two harness problems. API catalog make targets now select the API package environment so generation works without preinstalled SQLAlchemy. The API live smoke script adds `--installed` to avoid injecting checkout sources and closes controller sessions/database connections after success or assertion failure. Ten focused harness tests pass.

Validation: full `make pre-commit` and wheel/published-floor pin alignment passed. The repeat live matrix with published Core 0.4.49 also passed across all four surfaces; the API harness ran with `--installed` and passed 36/36 checks. The underlying application changes passed all 14 checks on #647, the 1,470-test API suite, and installed-wheel live checks with Shared 0.6.17: Network 162, Protect 59, Access 44, API 36/36; zero failures and all disposable resources cleaned up.

This prepares the next app release train; version tags remain derived through hatch-vcs.
