### PR TITLE
fix(network): accept integer ports on legacy firewall rules

### DIFF
--- a/packages/unifi-core/src/unifi_core/network/models/firewall.py
+++ b/packages/unifi-core/src/unifi_core/network/models/firewall.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from unifi_core.mac import canonical_mac, looks_like_mac, normalize_mac
 from unifi_core.merge import deep_merge
@@ -434,6 +434,18 @@ class LegacyFirewallRule(BaseModel):
         description="Controller-defined rule that cannot be deleted",
         json_schema_extra={"mutable": False},
     )
+
+    @field_validator("src_port", "dst_port", mode="before")
+    @classmethod
+    def _coerce_port_to_str(cls, v: Any) -> Any:
+        """Accept the controller's integer ports on a string field.
+
+        ``/rest/firewallrule`` returns a bare port as an int (e.g. ``8123``)
+        but a range as a string (e.g. ``"8000:8100"``). Pydantic v2 will not
+        coerce int to str, so an int here failed the whole list. Stringify an
+        int/float and leave everything else - strings, None, bool - untouched.
+        """
+        return str(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else v
 
 
 LEGACYFIREWALLRULE_MUTABLE_FIELDS: frozenset[str] = frozenset()

--- a/packages/unifi-core/tests/network/models/test_firewall.py
+++ b/packages/unifi-core/tests/network/models/test_firewall.py
@@ -980,6 +980,22 @@ class TestLegacyFirewallRuleFromController:
         r = legacy_firewall_rule_from_controller({"_id": "r", "enabled": "yes"})
         assert r.enabled is None
 
+    def test_coerces_integer_ports_to_str(self) -> None:
+        """The controller returns a bare port as an int; the field is str."""
+        r = legacy_firewall_rule_from_controller({"_id": "r", "src_port": 8123, "dst_port": 443})
+        assert r.src_port == "8123"
+        assert r.dst_port == "443"
+
+    def test_preserves_string_port_ranges(self) -> None:
+        """A port range already arrives as a string and must be left alone."""
+        r = legacy_firewall_rule_from_controller({"_id": "r", "dst_port": "8000:8100"})
+        assert r.dst_port == "8000:8100"
+
+    def test_empty_and_missing_ports_stay_none_or_empty(self) -> None:
+        r = legacy_firewall_rule_from_controller({"_id": "r", "src_port": ""})
+        assert r.src_port == ""
+        assert r.dst_port is None
+
     def test_handles_empty_dict(self) -> None:
         r = legacy_firewall_rule_from_controller({})
         assert r.id is None


### PR DESCRIPTION
## Summary

The controller's `/rest/firewallrule` endpoint returns a bare port as an **int** (e.g. `8123`) but a range as a **string** (e.g. `"8000:8100"`). `LegacyFirewallRule` declares `src_port`/`dst_port` as `Optional[str]`, and Pydantic v2 refuses to coerce int→str, so a single integer port raised a `ValidationError` that failed the **entire** `unifi_list_legacy_firewall_rules` response.

This adds a `mode="before"` validator on `src_port`/`dst_port` that stringifies an int/float and leaves strings, `None`, and bools untouched. Fixed in the model source (not as a runtime site-packages patch) so it ships with the package and is covered by tests.

## Type of change

- [x] `fix:` bug fix

## Scope

- [x] Network MCP server
- [x] Shared packages

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [ ] I ran `make pre-commit`, or I explained below why it was not run.
- [x] I updated generated manifests with `make manifest` when changing MCP tools. <!-- N/A: no tool signature/schema change -->
- [x] I added or updated tests for behavior changes.
- [ ] I updated documentation for user-visible changes. <!-- N/A: internal validation fix, no user-facing surface change -->
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- `uv run --package unifi-core --all-extras pytest packages/unifi-core/tests/network/models/test_firewall.py -q` → **185 passed** (includes 3 new port-coercion cases)
- `uv run ruff format --check` + `uv run ruff check` on both changed files → clean

`make pre-commit` was not run (full-monorepo format+generate+lint+test+drift); the change is scoped to one model and its tests, verified with the focused suite above.

## Notes for reviewers

- No MCP tool signature or schema changed, so no manifest regeneration was needed; `unifi_list_legacy_firewall_rules` already flows through `legacy_firewall_rule_from_controller(...).model_dump(...)` and simply stops raising on integer ports.
- The validator deliberately excludes `bool` (a `bool` is an `int` subclass) so a stray boolean isn't silently turned into `"True"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)