### PR TITLE
fix(protect): read Global alarm status from v2 profiles

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     # Firewall index rejection and uncapped client lookup require Core 0.4.44.
     # Shared firewall create-port validation requires Core 0.4.45.
     # Owned event listeners and controller-session cleanup require Core 0.4.49.
-    "unifi-core[network,protect,access]>=0.4.49,<0.5",
+    # Global alarm status aggregation requires Core 0.4.50.
+    "unifi-core[network,protect,access]>=0.4.50,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -818,7 +818,7 @@
       "category": "alarm",
       "permission_action": "read",
       "read_only_hint": true,
-      "manager_attr": "alarm_manager",
+      "manager_attr": "alarm_facade",
       "manager_method": "get_arm_state",
       "input_schema": {
         "properties": {},

--- a/apps/api/src/unifi_api/graphql/resolvers/protect.py
+++ b/apps/api/src/unifi_api/graphql/resolvers/protect.py
@@ -421,7 +421,7 @@ async def _fetch_alarm_status(ctx: GraphQLContext, controller: str) -> Any:
                 session,
                 controller,
                 "protect",
-                "alarm_manager",
+                "alarm_facade",
             )
             await ctx.manager_factory.get_connection_manager(
                 session,

--- a/apps/api/src/unifi_api/routes/resources/protect/system.py
+++ b/apps/api/src/unifi_api/routes/resources/protect/system.py
@@ -118,7 +118,7 @@ async def alarm_get_status(
                 session,
                 controller.id,
                 "protect",
-                "alarm_manager",
+                "alarm_facade",
             )
             cm = await factory.get_connection_manager(session, controller.id, "protect")
             await _maybe_set_site(cm, site_id)

--- a/apps/api/tests/graphql/fixtures/protect/test_events.py
+++ b/apps/api/tests/graphql/fixtures/protect/test_events.py
@@ -232,7 +232,7 @@ async def test_protect_alarm_status(tmp_path, monkeypatch):
     stub_managers(
         monkeypatch,
         {
-            ("protect", "alarm_manager", "get_arm_state"): {
+            ("protect", "alarm_facade", "get_arm_state"): {
                 "armed": True,
                 "status": "armed_away",
                 "active_profile_id": "prof1",

--- a/apps/api/tests/routes/resources/test_protect_events_system.py
+++ b/apps/api/tests/routes/resources/test_protect_events_system.py
@@ -486,9 +486,9 @@ async def test_alarm_get_status_happy_path(tmp_path, monkeypatch) -> None:
     async def fake(self):
         return payload
 
-    from unifi_core.protect.managers.alarm_manager import AlarmManager
+    from unifi_core.protect.managers.alarm_facade import AlarmRulesFacade
 
-    monkeypatch.setattr(AlarmManager, "get_arm_state", fake)
+    monkeypatch.setattr(AlarmRulesFacade, "get_arm_state", fake)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get(

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     # Core 0.4.39; sensor summary field preservation requires Core 0.4.43.
     # Local zero-limit event handling requires Core 0.4.48.
     # Owned event listeners and controller-session cleanup require Core 0.4.49.
-    "unifi-core[protect]>=0.4.49,<0.5",
+    # Global alarm status aggregation requires Core 0.4.50.
+    "unifi-core[protect]>=0.4.50,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.

--- a/apps/protect/src/unifi_protect_mcp/tools/alarm.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/alarm.py
@@ -111,7 +111,7 @@ async def protect_alarm_get_status() -> Dict[str, Any]:
     """Get the current arm status."""
     logger.info("protect_alarm_get_status tool called")
     try:
-        state = await alarm_manager.get_arm_state()
+        state = await alarm_facade.get_arm_state()
         raw = {**state, "profile_count": len(state.get("profiles") or [])}
         shaped = status_from_controller(raw)
         return {

--- a/apps/protect/tests/unit/test_alarm_tools.py
+++ b/apps/protect/tests/unit/test_alarm_tools.py
@@ -129,3 +129,17 @@ async def test_update_rule_preview_rejects_empty_actions():
 
     assert result["success"] is False
     assert "actions must be a non-empty list" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_status_delegates_to_global_facade():
+    from unifi_protect_mcp.tools.alarm import protect_alarm_get_status
+
+    facade = MagicMock()
+    facade.get_arm_state = AsyncMock(return_value={"armed": True, "status": "breached", "profiles": [{}]})
+    with patch("unifi_protect_mcp.tools.alarm.alarm_facade", facade):
+        result = await protect_alarm_get_status()
+    assert result["success"] is True
+    assert result["data"]["armed"] is True
+    assert result["data"]["status"] == "breached"
+    assert result["data"]["profile_count"] == 1


### PR DESCRIPTION
Global-mode consoles keep local `nvr.armMode` disabled even when a v2 profile is active. Route Protect MCP, REST, GraphQL, and API action status reads through `AlarmRulesFacade.get_arm_state()`, now published in Core 0.4.50 by #683. Raise both consuming apps' Core floors to 0.4.50 so fresh installs cannot resolve the old manager contract. Refs #663; characterization credit to @alexpfau in #619.

Legacy arm/disarm mutation responses keep their current manager path. The generated API action catalog is updated; API schemas and both reference docs were regenerated without content changes.

Validation:
- Full `make pre-commit` passed with the floor bumps. Rebase onto merged Core produced an identical tree, verified by `git diff --exit-code`.
- Installed-wheel populated-v2 status reads passed across MCP, REST, GraphQL, and action dispatch on Protect 7.2.105. The isolated zero-alarm profile reports disarmed; the legacy local reader still reports disabled.
- Release-wide installed-wheel smoke: Network 162, Protect 59, Access 44 successful checks, zero failed records and temporary resources cleaned; API 36/36.
- Exact published-floor compatibility passed: 272 API catalog bindings validated against Core 0.4.50. All GitHub checks passed at head 843b4888a127ba55ca09834ba11bf3b7b6944628. The initial pin job hit a stale package index immediately after publication; its rerun passed.
- A fresh environment with the final app wheels, published Core 0.4.50, and Shared 0.6.17 passed populated-v2 status reads through MCP, REST, GraphQL, and action dispatch. The published Core wheel also passed the full Network/Protect/Access/API hardware smoke matrix.

Coverage limit: armed/arming/breached transitions are covered by regression tests and the contributor's measured characterization, but have not been independently live-tested here. The test profile remains disarmed with no linked alarms. V2 does not supply a breach counter or scheduled-activation timestamp; those optional fields stay unavailable rather than borrowing unrelated local state.

Core 0.4.50 is confirmed available on PyPI. App release tags are separate from this merge.
