### PR TITLE
fix(core): aggregate Global alarm profile status

### DIFF
--- a/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/alarm_facade.py
@@ -110,6 +110,43 @@ class AlarmRulesFacade:
             raise permission_error
         return [], False
 
+    async def get_arm_state(self) -> dict[str, Any]:
+        """Read Global profile states, or preserve the legacy local status.
+
+        Any non-disarmed profile makes the aggregate armed. Prefer a breached
+        profile, then an unknown state, arming, and armed; ties use profile ID
+        so controller ordering cannot change the selected profile. All raw
+        states and transition timestamps remain available in ``profiles``.
+        """
+        profiles, complete = await self.list_profiles()
+        if not complete:
+            return await self._legacy.get_arm_state()
+        if not profiles or any(not (p.get("state") or "").strip() for p in profiles):
+            raise ValueError(
+                "Cannot determine Global alarm status: a v2 profile state is missing. Retry the status read."
+            )
+
+        active = [p for p in profiles if AlarmManager._is_armed_status(p["state"])]
+        precedence = {"breached": 0, "arming": 2, "armed": 3}
+        selected = min(
+            active,
+            key=lambda p: (precedence.get(p["state"].lower(), 1), p.get("id") or ""),
+            default=None,
+        )
+        status = selected["state"] if selected else "disarmed"
+        transition = selected.get("state_set_at") if selected else None
+        return {
+            "armed": bool(active),
+            "status": status,
+            "active_profile_id": selected.get("id") if selected else None,
+            "active_profile_name": selected.get("name") if selected else None,
+            "armed_at": transition if status.lower() == "armed" else None,
+            "will_be_armed_at": None,
+            "breach_detected_at": transition if status.lower() == "breached" else None,
+            "breach_event_count": None,
+            "profiles": profiles,
+        }
+
     async def get_rule(self, rule_id: str) -> tuple[dict[str, Any], bool]:
         """Return ``(rule, complete)`` for one rule by id.
 

--- a/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
+++ b/packages/unifi-core/tests/protect/managers/test_alarm_facade.py
@@ -501,3 +501,72 @@ async def test_delete_rule_accepts_legacy_id_with_new_suffix():
     assert complete is False
     facade._service.delete_rule.assert_not_called()
     facade._legacy.delete_rule.assert_awaited_once_with(_LEGACY_NEW_ID)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,armed",
+    [
+        ("armed", True),
+        ("arming", True),
+        ("breached", True),
+        ("future-state", True),
+        ("disarmed", False),
+        ("disabled", False),
+        ("off", False),
+        ("inactive", False),
+    ],
+)
+async def test_global_status_uses_profile_state(status, armed):
+    facade = _facade(service_list=[{**_RAW_V2_PROFILE, "state": status}])
+    state = await facade.get_arm_state()
+    assert state["armed"] is armed
+    assert state["status"] == (status if armed else "disarmed")
+    assert state["armed_at"] == (_RAW_V2_PROFILE["state_set_at"] if status == "armed" else None)
+    assert state["breach_detected_at"] == (_RAW_V2_PROFILE["state_set_at"] if status == "breached" else None)
+    assert state["breach_event_count"] is None
+    assert state["will_be_armed_at"] is None
+    facade._legacy.get_arm_state.assert_not_called()
+    facade._legacy.list_arm_profiles.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_global_status_any_active_and_deterministic_selection():
+    profiles = [
+        {**_RAW_V2_PROFILE, "id": str(i), "state": s}
+        for i, s in enumerate(["disarmed", "armed", "arming", "future-state", "breached"])
+    ]
+    facade = _facade(service_list=profiles)
+    first = await facade.get_arm_state()
+    facade._service.list_profiles.return_value = list(reversed(profiles))
+    second = await facade.get_arm_state()
+    assert first["armed"] is second["armed"] is True
+    assert first["status"] == second["status"] == "breached"
+    assert first["active_profile_id"] == second["active_profile_id"] == "4"
+    assert len(first["profiles"]) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [None, "", " "])
+async def test_global_status_missing_state_is_not_disarmed(status):
+    facade = _facade(service_list=[{**_RAW_V2_PROFILE, "state": status}])
+    with pytest.raises(ValueError, match="state is missing"):
+        await facade.get_arm_state()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [None, BadRequest("unsupported"), AlarmManagerPermissionError("requires SuperAdmin")])
+async def test_status_fallback_preserves_legacy_response(error):
+    facade = _facade(service_list=[], legacy_list=[_RAW_LEGACY_PROFILE], list_exc=error)
+    expected = {"armed": True, "status": "breached", "breach_event_count": 7, "profiles": [_RAW_LEGACY_PROFILE]}
+    facade._legacy.get_arm_state = AsyncMock(return_value=expected)
+    assert await facade.get_arm_state() is expected
+    facade._legacy.get_arm_state.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_status_does_not_hide_v2_outage():
+    facade = _facade(list_exc=NvrError("unavailable"))
+    with pytest.raises(NvrError):
+        await facade.get_arm_state()
+    facade._legacy.get_arm_state.assert_not_called()


### PR DESCRIPTION
Global-mode consoles keep local `nvr.armMode` disabled even when a v2 profile is active. Add `AlarmRulesFacade.get_arm_state()` to aggregate v2 profile states while preserving the legacy manager response whenever profile discovery falls back. Refs #663; this is the Core prerequisite for #682. Characterization credit: @alexpfau in #619.

The existing denylist treats arming, breached, and unknown nonempty states as armed. Missing states fail explicitly; multiple active profiles have deterministic selection. Transition timestamps are mapped only to their matching state, and unavailable v2 counters remain unset. No existing caller or legacy mutation path changes in this PR.

Validation: 48 facade tests pass on the implementation, including 16 new cases. Populated-v2 installed-wheel read smoke passed on Protect 7.2.105 with an isolated zero-alarm profile; facade reported disarmed while the legacy reader reported disabled. Armed/arming/breached live transitions remain untested. Full `make pre-commit` and all exact-head GitHub checks passed for bcc28fbe7bb9bbaf778947c273d995c670dc01b0. Release-wide installed-wheel smoke passed: Network 162, Protect 59, Access 44 successful checks (zero failures; temporary resources cleaned), API 36/36. Review found no code defects; the live-transition limitation remains explicit.

Release sequence: merge this prerequisite, publish Core, then rebase #682 and raise its Protect/API Core floors before merging the app bindings.
