### PR TITLE
fix(core): prevent sensitive connection and settings failure logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 ### Logging
 
 - Network client/device managers and tools log operation context and exception class only; never log MAC/IP addresses, names, update payloads, exception messages, or tracebacks. This is a narrow privacy exception to the ordinary tool `exc_info=True` rule because controller exceptions can embed those values.
+- Network connection authentication/refresh failure logs and system settings update failure logs follow the same operation-and-exception-class pattern. Do not log sanitized exception text or controller response bodies at these boundaries: configured/submitted-secret scrubbing cannot cover controller-only secrets or opaque exception renderers.
 
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 - Carry this privacy rule through the auto-backup settings read/preview/update and DPI refresh caller chains, including manager logs and MCP error responses. Catching a safely logged but re-raised exception must not reintroduce its message or traceback.
 - Cached Network authentication failures contain exception class and fixed guidance only, since later tool calls may log them. ConnectionManager settings request failure logs omit controller text and tracebacks before the exception reaches a domain manager.
 - ConnectionManager translates failed `/get/setting/` and `/set/setting/` requests into a new `RequestError` with fixed operation context and the original exception class, suppressing original traceback context. This protects all settings callers, including those that log the received exception.
+- StatsManager DPI refresh failures use the same safe-error translation before leaving the core manager; REST and GraphQL bypass the MCP tool wrapper.
 
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 - Network connection authentication/refresh failure logs and system settings update failure logs follow the same operation-and-exception-class pattern. Do not log sanitized exception text or controller response bodies at these boundaries: configured/submitted-secret scrubbing cannot cover controller-only secrets or opaque exception renderers.
 - Carry this privacy rule through the auto-backup settings read/preview/update and DPI refresh caller chains, including manager logs and MCP error responses. Catching a safely logged but re-raised exception must not reintroduce its message or traceback.
 - Cached Network authentication failures contain exception class and fixed guidance only, since later tool calls may log them. ConnectionManager settings request failure logs omit controller text and tracebacks before the exception reaches a domain manager.
+- ConnectionManager translates failed `/get/setting/` and `/set/setting/` requests into a new `RequestError` with fixed operation context and the original exception class, suppressing original traceback context. This protects all settings callers, including those that log the received exception.
 
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 - Cached Network authentication failures contain exception class and fixed guidance only, since later tool calls may log them. ConnectionManager settings request failure logs omit controller text and tracebacks before the exception reaches a domain manager.
 - ConnectionManager translates failed `/get/setting/` and `/set/setting/` requests into a new `RequestError` with fixed operation context and the original exception class, suppressing original traceback context. This protects all settings callers, including those that log the received exception.
 - StatsManager DPI refresh failures use the same safe-error translation before leaving the core manager; REST and GraphQL bypass the MCP tool wrapper.
+- ConnectionManager handler refresh failures are translated to safe RequestError instances after reauthentication/circuit handling. All collection callers, including clients and devices, must receive safe text and suppressed original traceback context.
 
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 - Network client/device managers and tools log operation context and exception class only; never log MAC/IP addresses, names, update payloads, exception messages, or tracebacks. This is a narrow privacy exception to the ordinary tool `exc_info=True` rule because controller exceptions can embed those values.
 - Network connection authentication/refresh failure logs and system settings update failure logs follow the same operation-and-exception-class pattern. Do not log sanitized exception text or controller response bodies at these boundaries: configured/submitted-secret scrubbing cannot cover controller-only secrets or opaque exception renderers.
 - Carry this privacy rule through the auto-backup settings read/preview/update and DPI refresh caller chains, including manager logs and MCP error responses. Catching a safely logged but re-raised exception must not reintroduce its message or traceback.
+- Cached Network authentication failures contain exception class and fixed guidance only, since later tool calls may log them. ConnectionManager settings request failure logs omit controller text and tracebacks before the exception reaches a domain manager.
 
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 
 - Network client/device managers and tools log operation context and exception class only; never log MAC/IP addresses, names, update payloads, exception messages, or tracebacks. This is a narrow privacy exception to the ordinary tool `exc_info=True` rule because controller exceptions can embed those values.
 - Network connection authentication/refresh failure logs and system settings update failure logs follow the same operation-and-exception-class pattern. Do not log sanitized exception text or controller response bodies at these boundaries: configured/submitted-secret scrubbing cannot cover controller-only secrets or opaque exception renderers.
+- Carry this privacy rule through the auto-backup settings read/preview/update and DPI refresh caller chains, including manager logs and MCP error responses. Catching a safely logged but re-raised exception must not reintroduce its message or traceback.
 
 - All log output MUST go to stderr (stdout is reserved for JSON-RPC in stdio mode)
 - Use `%s` format strings in logger calls, not f-strings, for lazy evaluation

--- a/apps/api/tests/test_action_credential_audit.py
+++ b/apps/api/tests/test_action_credential_audit.py
@@ -24,6 +24,7 @@ from tests.test_action_endpoint import _bootstrap
 
 SENTINEL = "SENTINEL-community-secret-c0de"
 LOGIN_SENTINEL = "SENTINEL-login-secret-5a5a"
+CONTROLLER_SENTINEL = "SENTINEL-controller-only-secret-092c"
 INT_SENTINEL = 987654321987
 
 
@@ -57,9 +58,9 @@ class _Controller:
     async def request(self, api_request):
         if api_request.method == "get":
             if self._fail_reads:
-                raise ResponseError(f"auth failed for admin:{LOGIN_SENTINEL}")
+                raise ResponseError(f"auth failed for admin:{LOGIN_SENTINEL} {CONTROLLER_SENTINEL}")
             return {"data": [{"_id": "snmp-1", "key": "snmp", "enabled": False}]}
-        raise ResponseError(f"controller rejected {api_request.data!r}")
+        raise ResponseError(f"controller rejected {api_request.data!r} {CONTROLLER_SENTINEL}")
 
 
 def _real_system_manager(*, fail_reads: bool = False) -> SystemManager:
@@ -110,7 +111,10 @@ async def test_write_error_audit_detail_is_scrubbed(tmp_path, monkeypatch, caplo
     rows = await _audit_rows(app, "unifi_update_snmp_settings")
     assert len(rows) == 1
     assert rows[0].outcome == "error"
-    assert rows[0].error_kind == "ResponseError"
+    assert rows[0].error_kind == "RequestError"
+    assert rows[0].detail == "Controller settings request failed (ResponseError)."
+    assert CONTROLLER_SENTINEL not in response.text
+    assert CONTROLLER_SENTINEL not in caplog.text
     assert SENTINEL not in (rows[0].detail or "")
     await manager._connection.cleanup()
 
@@ -129,6 +133,9 @@ async def test_read_error_audit_detail_is_scrubbed(tmp_path, monkeypatch, caplog
     assert len(rows) == 1
     assert rows[0].outcome == "error"
     assert LOGIN_SENTINEL not in (rows[0].detail or "")
+    assert CONTROLLER_SENTINEL not in response.text
+    assert CONTROLLER_SENTINEL not in caplog.text
+    assert CONTROLLER_SENTINEL not in (rows[0].detail or "")
     await manager._connection.cleanup()
 
 

--- a/apps/api/tests/test_dpi_error_privacy.py
+++ b/apps/api/tests/test_dpi_error_privacy.py
@@ -1,0 +1,58 @@
+"""DPI controller failures must be safe beyond the MCP tool surface."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiounifi.errors import LoginRequired
+from httpx import ASGITransport, AsyncClient
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.stats_manager import StatsManager
+
+from tests.test_action_endpoint import _bootstrap
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["rest", "graphql"])
+@pytest.mark.parametrize("handler", ["dpi_apps", "dpi_groups"])
+async def test_dpi_failure_omits_controller_text(surface, handler, tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("UNIFI_API_DB_KEY", "k")
+    app, key, cid = await _bootstrap(tmp_path, scopes="read")
+    private = "controller-only-dpi-api-token-508d"
+    connection = ConnectionManager("127.0.0.1", "test", "test")
+    controller = MagicMock()
+    controller.connectivity.config.session = SimpleNamespace(closed=False, close=AsyncMock())
+    controller.login = AsyncMock()
+    controller.dpi_apps.update = AsyncMock()
+    controller.dpi_groups.update = AsyncMock()
+    failed_update = AsyncMock(side_effect=LoginRequired(private))
+    getattr(controller, handler).update = failed_update
+    connection.controller = controller
+    connection._aiohttp_session = controller.connectivity.config.session
+    connection._initialized = True
+    manager = StatsManager(connection, MagicMock())
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    app.state.manager_factory = factory
+    caplog.set_level(logging.DEBUG)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False), base_url="http://test"
+    ) as client:
+        headers = {"Authorization": f"Bearer {key}"}
+        if surface == "rest":
+            response = await client.get(f"/v1/sites/default/stats/dpi?controller={cid}", headers=headers)
+            assert response.status_code == 500
+        else:
+            query = '{ network { dpiStats(controller: "' + cid + '") { applications categories } } }'
+            response = await client.post("/v1/graphql", headers=headers, json={"query": query})
+            assert response.status_code == 200
+            assert response.json()["errors"]
+            assert "DPI stats refresh failed" in response.text
+
+    assert failed_update.await_count == 2
+    assert connection.reconnect_blocked
+    assert private not in response.text
+    assert private not in caplog.text
+    await connection.cleanup()

--- a/apps/network/src/unifi_network_mcp/tools/stats.py
+++ b/apps/network/src/unifi_network_mcp/tools/stats.py
@@ -278,8 +278,8 @@ async def get_dpi_stats() -> Dict[str, Any]:
             "dpi_stats": shaped.model_dump(exclude_none=True),
         }
     except Exception as e:
-        logger.error("Error getting DPI stats: %s", e, exc_info=True)
-        return {"success": False, "error": f"Failed to get DPI stats: {e}"}
+        logger.error("Error getting DPI stats: %s", type(e).__name__)
+        return {"success": False, "error": f"Failed to get DPI stats: {type(e).__name__}"}
 
 
 @server.tool(

--- a/apps/network/src/unifi_network_mcp/tools/system.py
+++ b/apps/network/src/unifi_network_mcp/tools/system.py
@@ -381,8 +381,8 @@ async def get_autobackup_settings() -> Dict[str, Any]:
             "autobackup_settings": settings,
         }
     except Exception as e:
-        logger.error("Error getting auto-backup settings: %s", e, exc_info=True)
-        return {"success": False, "error": f"Failed to get auto-backup settings: {e}"}
+        logger.error("Error getting auto-backup settings: %s", type(e).__name__)
+        return {"success": False, "error": f"Failed to get auto-backup settings: {type(e).__name__}"}
 
 
 @server.tool(
@@ -420,8 +420,8 @@ async def update_autobackup_settings(
         try:
             current = await system_manager.get_autobackup_settings()
         except Exception as e:
-            logger.error("Error preparing auto-backup settings preview: %s", e, exc_info=True)
-            return {"success": False, "error": f"Failed to prepare auto-backup settings preview: {e}"}
+            logger.error("Error preparing auto-backup settings preview: %s", type(e).__name__)
+            return {"success": False, "error": f"Failed to prepare auto-backup settings preview: {type(e).__name__}"}
         return update_preview(
             resource_type="autobackup_settings",
             resource_id="super_mgmt",
@@ -440,5 +440,5 @@ async def update_autobackup_settings(
             }
         return {"success": False, "error": "Failed to update auto-backup settings."}
     except Exception as e:
-        logger.error("Error updating auto-backup settings: %s", e, exc_info=True)
-        return {"success": False, "error": f"Failed to update auto-backup settings: {e}"}
+        logger.error("Error updating auto-backup settings: %s", type(e).__name__)
+        return {"success": False, "error": f"Failed to update auto-backup settings: {type(e).__name__}"}

--- a/apps/network/tests/unit/test_handler_refresh_reauth.py
+++ b/apps/network/tests/unit/test_handler_refresh_reauth.py
@@ -16,7 +16,7 @@ fail against that first fix and pass against the handler-refresh recovery.
 """
 
 import pytest
-from aiounifi.errors import LoginRequired
+from aiounifi.errors import LoginRequired, RequestError
 
 from unifi_core.network.managers.connection_manager import ConnectionManager
 from unifi_core.network.managers.device_manager import DeviceManager
@@ -116,7 +116,7 @@ async def test_handler_refresh_does_not_log_in_when_the_session_is_valid():
 
 @pytest.mark.asyncio
 async def test_handler_refresh_reraises_when_reauthentication_fails():
-    """A login that cannot succeed must surface the original error, not mask it."""
+    """A failed login surfaces safe failure context while preserving retry behavior."""
     controller = _Controller()
 
     async def _failing_login():
@@ -126,7 +126,7 @@ async def test_handler_refresh_reraises_when_reauthentication_fails():
     controller.login = _failing_login
     manager = _manager(controller)
 
-    with pytest.raises(LoginRequired):
+    with pytest.raises(RequestError, match="refresh failed.*LoginRequired"):
         await manager.refresh_handler("devices")
 
     assert controller.login_calls == 1
@@ -150,7 +150,7 @@ async def test_persistent_login_required_after_refresh_opens_the_auth_circuit():
     controller.login = _login_that_is_not_accepted
     manager = _manager(controller)
 
-    with pytest.raises(LoginRequired):
+    with pytest.raises(RequestError, match="refresh failed.*LoginRequired"):
         await manager.refresh_handler("devices")
 
     assert controller.login_calls == 1

--- a/apps/network/tests/unit/test_identifier_logging.py
+++ b/apps/network/tests/unit/test_identifier_logging.py
@@ -85,8 +85,46 @@ async def test_autobackup_tool_manager_chain_omits_private_errors(phase, error_k
         else:
             result = await module.update_autobackup_settings({"autobackup_enabled": True}, confirm=phase != "preview")
 
-    _assert_no_private_failure(caplog, result, private, type(error).__name__)
+    _assert_no_private_failure(caplog, result, private, "RequestError")
     assert controller.request.await_count == (2 if phase == "update_put" else 1)
+    await connection.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["get_mgmt_settings", "get_site_settings", "get_gateway_settings"])
+async def test_other_settings_callers_receive_only_safe_transport_errors(tool_name, monkeypatch, caplog):
+    from unifi_core.network.managers.connection_manager import ConnectionManager
+    from unifi_core.network.managers.gateway_settings_manager import GatewaySettingsManager
+    from unifi_core.network.managers.system_manager import SystemManager
+    from unifi_network_mcp import runtime
+
+    private = "controller-only-settings-token-81a5"
+
+    class OpaqueError(Exception):
+        def __str__(self):
+            return private
+
+    connection = ConnectionManager("127.0.0.1", "test", "test")
+    controller = MagicMock()
+    controller.connectivity.config.session = SimpleNamespace(closed=False, close=AsyncMock())
+    controller.request = AsyncMock(side_effect=OpaqueError())
+    connection.controller = controller
+    connection._aiohttp_session = controller.connectivity.config.session
+    connection._initialized = True
+    gateway = tool_name == "get_gateway_settings"
+    manager_name = "gateway_settings_manager" if gateway else "system_manager"
+    manager = GatewaySettingsManager(connection) if gateway else SystemManager(connection)
+    monkeypatch.setattr(runtime, manager_name, manager)
+    module = importlib.import_module(f"unifi_network_mcp.tools.{'gateway_settings' if gateway else 'system'}")
+    monkeypatch.setattr(module, manager_name, manager)
+
+    with caplog.at_level(logging.ERROR):
+        result = await getattr(module, tool_name)()
+
+    assert result["success"] is False
+    assert private not in repr(result)
+    assert private not in caplog.text
+    assert "settings request failed" in caplog.text
     await connection.cleanup()
 
 

--- a/apps/network/tests/unit/test_identifier_logging.py
+++ b/apps/network/tests/unit/test_identifier_logging.py
@@ -2,6 +2,7 @@
 
 import importlib
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -34,3 +35,83 @@ async def test_detail_error_logs_do_not_include_private_exception(domain, monkey
             assert marker not in record.getMessage()
             assert marker not in repr(record.args)
     assert "RuntimeError" in caplog.text
+
+
+def _assert_no_private_failure(caplog, result, private, error_class):
+    assert result["success"] is False
+    assert private not in repr(result)
+    assert private not in caplog.text
+    assert caplog.records
+    for record in caplog.records:
+        assert record.exc_info is None
+        assert private not in repr(record.args)
+    assert error_class in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["read", "preview", "update_fetch", "update_put"])
+async def test_autobackup_tool_manager_chain_omits_opaque_errors(phase, monkeypatch, caplog):
+    from unifi_core.network.managers.system_manager import SystemManager
+    from unifi_network_mcp import runtime
+
+    private = "controller-only-autobackup-token-719c"
+
+    class OpaqueError(Exception):
+        def __str__(self):
+            return private
+
+    connection = MagicMock()
+    connection.site = "default"
+    connection.get_cached.return_value = None
+    connection.request = AsyncMock(side_effect=OpaqueError())
+    if phase == "update_put":
+        connection.request.side_effect = [[{"_id": "settings-1"}], OpaqueError()]
+    manager = SystemManager(connection)
+    monkeypatch.setattr(runtime, "system_manager", manager)
+    module = importlib.import_module("unifi_network_mcp.tools.system")
+    monkeypatch.setattr(module, "system_manager", manager)
+
+    with caplog.at_level(logging.ERROR):
+        if phase == "read":
+            result = await module.get_autobackup_settings()
+        else:
+            result = await module.update_autobackup_settings({"autobackup_enabled": True}, confirm=phase != "preview")
+
+    _assert_no_private_failure(caplog, result, private, "OpaqueError")
+    assert connection.request.await_count == (2 if phase == "update_put" else 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler", ["dpi_apps", "dpi_groups"])
+async def test_dpi_tool_manager_refresh_chain_omits_retry_error(handler, monkeypatch, caplog):
+    from aiounifi.errors import LoginRequired
+
+    from unifi_core.network.managers.connection_manager import ConnectionManager
+    from unifi_core.network.managers.stats_manager import StatsManager
+    from unifi_network_mcp import runtime
+
+    private = "controller-only-dpi-token-937b"
+    connection = ConnectionManager("127.0.0.1", "test", "test")
+    controller = MagicMock()
+    controller.connectivity.config.session = SimpleNamespace(closed=False, close=AsyncMock())
+    controller.login = AsyncMock()
+    controller.dpi_apps.update = AsyncMock()
+    controller.dpi_groups.update = AsyncMock()
+    failed_update = AsyncMock(side_effect=LoginRequired(private))
+    getattr(controller, handler).update = failed_update
+    connection.controller = controller
+    connection._aiohttp_session = controller.connectivity.config.session
+    connection._initialized = True
+    manager = StatsManager(connection, MagicMock())
+    monkeypatch.setattr(runtime, "stats_manager", manager)
+    module = importlib.import_module("unifi_network_mcp.tools.stats")
+    monkeypatch.setattr(module, "stats_manager", manager)
+
+    with caplog.at_level(logging.ERROR):
+        result = await module.get_dpi_stats()
+
+    _assert_no_private_failure(caplog, result, private, "LoginRequired")
+    assert failed_update.await_count == 2
+    controller.login.assert_awaited_once()
+    assert connection.reconnect_blocked
+    await connection.cleanup()

--- a/apps/network/tests/unit/test_identifier_logging.py
+++ b/apps/network/tests/unit/test_identifier_logging.py
@@ -50,7 +50,11 @@ def _assert_no_private_failure(caplog, result, private, error_class):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("phase", ["read", "preview", "update_fetch", "update_put"])
-async def test_autobackup_tool_manager_chain_omits_opaque_errors(phase, monkeypatch, caplog):
+@pytest.mark.parametrize("error_kind", ["opaque", "request", "response"])
+async def test_autobackup_tool_manager_chain_omits_private_errors(phase, error_kind, monkeypatch, caplog):
+    from aiounifi.errors import RequestError, ResponseError
+
+    from unifi_core.network.managers.connection_manager import ConnectionManager
     from unifi_core.network.managers.system_manager import SystemManager
     from unifi_network_mcp import runtime
 
@@ -60,12 +64,16 @@ async def test_autobackup_tool_manager_chain_omits_opaque_errors(phase, monkeypa
         def __str__(self):
             return private
 
-    connection = MagicMock()
-    connection.site = "default"
-    connection.get_cached.return_value = None
-    connection.request = AsyncMock(side_effect=OpaqueError())
+    error = {"opaque": OpaqueError, "request": RequestError, "response": ResponseError}[error_kind](private)
+    connection = ConnectionManager("127.0.0.1", "test", "test")
+    controller = MagicMock()
+    controller.connectivity.config.session = SimpleNamespace(closed=False, close=AsyncMock())
+    controller.request = AsyncMock(side_effect=error)
     if phase == "update_put":
-        connection.request.side_effect = [[{"_id": "settings-1"}], OpaqueError()]
+        controller.request.side_effect = [{"data": [{"_id": "settings-1"}]}, error]
+    connection.controller = controller
+    connection._aiohttp_session = controller.connectivity.config.session
+    connection._initialized = True
     manager = SystemManager(connection)
     monkeypatch.setattr(runtime, "system_manager", manager)
     module = importlib.import_module("unifi_network_mcp.tools.system")
@@ -77,8 +85,53 @@ async def test_autobackup_tool_manager_chain_omits_opaque_errors(phase, monkeypa
         else:
             result = await module.update_autobackup_settings({"autobackup_enabled": True}, confirm=phase != "preview")
 
-    _assert_no_private_failure(caplog, result, private, "OpaqueError")
-    assert connection.request.await_count == (2 if phase == "update_put" else 1)
+    _assert_no_private_failure(caplog, result, private, type(error).__name__)
+    assert controller.request.await_count == (2 if phase == "update_put" else 1)
+    await connection.cleanup()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["initialize", "reauthenticate"])
+async def test_followup_tool_call_omits_cached_authentication_failure(phase, monkeypatch, caplog):
+    from aiounifi.errors import LoginRequired, Unauthorized
+
+    from unifi_core.network.managers import connection_manager as cm_module
+    from unifi_core.network.managers.system_manager import SystemManager
+    from unifi_network_mcp import runtime
+
+    private = "controller-only-auth-token-583a"
+
+    def fail_connector(**kwargs):
+        raise LoginRequired(private)
+
+    monkeypatch.setattr(cm_module.aiohttp, "TCPConnector", fail_connector)
+    connection = cm_module.ConnectionManager("127.0.0.1", "test", "test")
+    if phase == "reauthenticate":
+        controller = MagicMock()
+        controller.connectivity.config.session = SimpleNamespace(closed=False, close=AsyncMock())
+        controller.request = AsyncMock(side_effect=LoginRequired(private))
+        controller.login = AsyncMock(side_effect=Unauthorized(private))
+        connection.controller = controller
+        connection._aiohttp_session = controller.connectivity.config.session
+        connection._initialized = True
+    manager = SystemManager(connection)
+    monkeypatch.setattr(runtime, "system_manager", manager)
+    module = importlib.import_module("unifi_network_mcp.tools.system")
+    monkeypatch.setattr(module, "system_manager", manager)
+
+    with caplog.at_level(logging.ERROR):
+        if phase == "initialize":
+            assert await connection.initialize() is False
+        result = await module.get_system_info()
+        followup = await module.get_system_info()
+
+    assert result["success"] is False
+    assert private not in repr(result)
+    assert private not in repr(followup)
+    assert private not in caplog.text
+    assert private not in connection.last_connection_error
+    assert connection.reconnect_blocked
+    await connection.cleanup()
 
 
 @pytest.mark.asyncio

--- a/apps/network/tests/unit/test_path_detection.py
+++ b/apps/network/tests/unit/test_path_detection.py
@@ -451,7 +451,7 @@ class TestPathDetection:
         await manager.cleanup()
 
     @pytest.mark.asyncio
-    async def test_request_includes_last_initialize_error_after_auth_failure(self):
+    async def test_request_includes_safe_initialize_guidance_after_auth_failure(self):
         manager = ConnectionManager("192.168.1.1", "admin", "secret", max_retries=1)
 
         with patch("unifi_core.network.managers.connection_manager.Controller", _FailingLoginController):
@@ -463,7 +463,9 @@ class TestPathDetection:
                     await manager.request(ApiRequest(method="get", path="/stat/sysinfo"))
 
         assert "Not connected to controller" in str(exc_info.value)
-        assert "SSO MFA required but no totp_secret configured" in str(exc_info.value)
+        assert "RequestError" in str(exc_info.value)
+        assert "MFA/TOTP configuration" in str(exc_info.value)
+        assert "SSO MFA required but no totp_secret configured" not in str(exc_info.value)
         await manager.cleanup()
 
     @pytest.mark.asyncio
@@ -490,7 +492,8 @@ class TestPathDetection:
 
         factory.assert_called_once()
         controller.login.assert_awaited_once()
-        assert manager.last_connection_error == str(error)
+        assert type(error).__name__ in manager.last_connection_error
+        assert str(error) not in manager.last_connection_error
         assert manager._cache == {}
         await manager.cleanup()
 
@@ -557,7 +560,8 @@ class TestPathDetection:
         manager._reconnect_block_until = 0.0
         second = manager._block_automatic_reconnect(AuthenticationRateLimitError("429"))
 
-        assert first == second == "429"
+        assert first == second
+        assert "AuthenticationRateLimitError" in first
         assert manager._reconnect_block_count == 2
         # The second cool-down is double the first (base*2), measured from now.
         assert manager._reconnect_block_until > first_deadline
@@ -717,7 +721,8 @@ class TestPathDetection:
 
         assert manager.controller is None
         assert manager.reconnect_blocked is True
-        assert manager._reconnect_block_error == "still expired"
+        assert "LoginRequired" in manager._reconnect_block_error
+        assert "still expired" not in manager._reconnect_block_error
         controller.login.assert_awaited_once()
         assert await manager.ensure_connected() is False
         controller.login.assert_awaited_once()
@@ -765,7 +770,7 @@ class TestPathDetection:
         manager._auth_generation = 1
         manager._unifi_os_override = True
 
-        with pytest.raises(ConnectionError, match="api.err.Invalid"):
+        with pytest.raises(ConnectionError, match="Unauthorized"):
             await manager.request(ApiRequest(method="get", path="/stat/sysinfo"))
 
         assert manager.controller is None
@@ -796,5 +801,6 @@ class TestPathDetection:
         message = str(exc_info.value)
         assert "super-secret-password" not in message
         assert "super-secret-password" not in caplog.text
-        assert "<redacted>" in message
+        assert "RequestError" in message
+        assert "check controller connectivity" in message
         await manager.cleanup()

--- a/apps/network/tests/unit/test_system_manager.py
+++ b/apps/network/tests/unit/test_system_manager.py
@@ -341,9 +341,9 @@ class TestGetNetworkHealth:
 
 
 @pytest.mark.asyncio
-async def test_update_settings_scrubs_submitted_secret_from_failure_log(caplog):
+async def test_update_settings_omits_submitted_secret_from_failure_log(caplog):
     """The settings document can carry secrets (SNMPv3 password, SSH password);
-    a controller error that quotes it must reach the log with the value scrubbed."""
+    a controller error that quotes it must log only operation and exception class."""
     import logging
     from unittest.mock import AsyncMock, MagicMock
 
@@ -359,8 +359,11 @@ async def test_update_settings_scrubs_submitted_secret_from_failure_log(caplog):
     manager = SystemManager(conn)
 
     with caplog.at_level(logging.DEBUG, logger="unifi-network-mcp"):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as excinfo:
             await manager.update_settings("snmp", {"x_password": "hunter2"})
 
     assert "hunter2" not in caplog.text
-    assert "rejected: x_password=***REDACTED***" in caplog.text
+    assert "Error updating snmp settings: RuntimeError" in caplog.text
+    assert "rejected: x_password" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+    assert str(excinfo.value) == "rejected: x_password=***REDACTED***"

--- a/docs/security/code-scanning-2026-09-07.md
+++ b/docs/security/code-scanning-2026-09-07.md
@@ -25,11 +25,17 @@ ignored its rewritten `args`.
 This follows the existing Network client/device logging pattern. Caller-facing
 error scrubbing, response redaction policy, authentication classification,
 reconnect circuit, and retry behavior remain intact. No tools or public schemas
-change. This is a focused remediation of the listed logging boundaries, not a
+are added or changed. Auto-backup read/preview/update and DPI MCP error responses
+now include the exception class instead of exception text. Their manager/tool
+caller chains also omit exception messages and tracebacks, so re-raising cannot
+reintroduce sensitive content at those downstream logs. This is a focused
+remediation of the listed logging boundaries, not a
 claim that every log or caller-facing exception is free of arbitrary secrets.
 
 Validation: eight new behavioral regression cases failed before the fix and
 passed afterward; 54 focused credential sanitization, request logging, and
-reauthentication tests passed. Full repository and GitHub scan results are
+reauthentication tests passed. Six additional caller-chain regression cases
+reproduced leaks before the follow-up fix and pass afterward: auto-backup read,
+preview, update fetch, update PUT, and both DPI refresh handlers. Full repository and GitHub scan results are
 recorded in the associated pull request. Alert closure on main requires the
 change to be merged and scanned; no alerts were manually dismissed.

--- a/docs/security/code-scanning-2026-09-07.md
+++ b/docs/security/code-scanning-2026-09-07.md
@@ -35,15 +35,19 @@ claim that every log or caller-facing exception is free of arbitrary secrets.
 Cached connection failures now contain exception class and fixed remediation
 guidance, so later tool calls cannot log cached controller text. Failed
 reauthentication also suppresses the original LoginRequired traceback context.
-Settings failure logging omits controller text inside ConnectionManager before
-the exception reaches the system manager. Other request logging retains its
-existing behavior.
+Settings failure logging omits controller text inside ConnectionManager, which
+then translates the failure into a new RequestError containing fixed context
+and the original exception class. Original traceback context is suppressed.
+This protects every settings caller, including management/site/gateway tools
+that log exceptions. Other request error types and logging retain their existing
+behavior.
 
 Validation: eight new behavioral regression cases failed before the fix and
 passed afterward; 54 focused credential sanitization, request logging, and
 reauthentication tests passed. Caller-chain regressions exercise real connection
 and domain managers: auto-backup read, preview, update fetch and update PUT with
 opaque, request and response exceptions; both DPI handlers; and tool calls after
-failed initialization or reauthentication. Full repository and GitHub scan results are
+failed initialization or reauthentication; and management/site/gateway settings
+callers that log tracebacks. Full repository and GitHub scan results are
 recorded in the associated pull request. Alert closure on main requires the
 change to be merged and scanned; no alerts were manually dismissed.

--- a/docs/security/code-scanning-2026-09-07.md
+++ b/docs/security/code-scanning-2026-09-07.md
@@ -45,6 +45,9 @@ behavior.
 DPI refresh failures also become safe RequestError instances at StatsManager,
 with original traceback context suppressed. REST and GraphQL use this manager
 directly, so the safe error must be established before the MCP boundary.
+ConnectionManager applies safe RequestError translation to all handler refresh
+failures after authentication/circuit handling, protecting client and device
+callers as well as DPI callers.
 
 Validation: eight new behavioral regression cases failed before the fix and
 passed afterward; 54 focused credential sanitization, request logging, and

--- a/docs/security/code-scanning-2026-09-07.md
+++ b/docs/security/code-scanning-2026-09-07.md
@@ -1,0 +1,35 @@
+# Network connection and settings logging alerts
+
+Reviewed GitHub's eight open CodeQL alerts on main commit
+`860809ffa912312c978c764e72d584e348491fed` on 2026-09-07. All use
+`py/clear-text-logging-sensitive-data` (high severity).
+
+The flagged values pass through custom sanitizers, but these are not a complete
+privacy boundary for logs. Configured/submitted credential matching cannot cover
+controller-only secrets in arbitrary exception text or response messages. Runtime
+tests reproduced leaks using a controller-only sentinel. An adjacent settings
+exception log also leaked a submitted credential when the exception's `__str__`
+ignored its rewritten `args`.
+
+| Alert | Location at reviewed main | Disposition |
+| --- | --- | --- |
+| [72](https://github.com/sirkirby/unifi-mcp/security/code-scanning/72) | `connection_manager.py:478` | Log terminal authentication exception class and cooldown, omitting exception text. |
+| [73](https://github.com/sirkirby/unifi-mcp/security/code-scanning/73) | `connection_manager.py:583` | Log fixed blocked-reconnect context, omitting cached error text. |
+| [74](https://github.com/sirkirby/unifi-mcp/security/code-scanning/74) | `connection_manager.py:716` | Log attempt number and exception class. |
+| [75](https://github.com/sirkirby/unifi-mcp/security/code-scanning/75) | `connection_manager.py:724` | Log exhausted attempt count and exception class. |
+| [76](https://github.com/sirkirby/unifi-mcp/security/code-scanning/76) | `connection_manager.py:735` | Log initialization failure context and exception class. |
+| [77](https://github.com/sirkirby/unifi-mcp/security/code-scanning/77) | `connection_manager.py:795` | Log reauthentication failure context and exception class. |
+| [78](https://github.com/sirkirby/unifi-mcp/security/code-scanning/78) | `connection_manager.py:864` | Log refresh failure context and exception class. |
+| [79](https://github.com/sirkirby/unifi-mcp/security/code-scanning/79) | `system_manager.py:333` | Omit rejected response bodies; adjacent exception handler logs exception class. |
+
+This follows the existing Network client/device logging pattern. Caller-facing
+error scrubbing, response redaction policy, authentication classification,
+reconnect circuit, and retry behavior remain intact. No tools or public schemas
+change. This is a focused remediation of the listed logging boundaries, not a
+claim that every log or caller-facing exception is free of arbitrary secrets.
+
+Validation: eight new behavioral regression cases failed before the fix and
+passed afterward; 54 focused credential sanitization, request logging, and
+reauthentication tests passed. Full repository and GitHub scan results are
+recorded in the associated pull request. Alert closure on main requires the
+change to be merged and scanned; no alerts were manually dismissed.

--- a/docs/security/code-scanning-2026-09-07.md
+++ b/docs/security/code-scanning-2026-09-07.md
@@ -42,12 +42,17 @@ This protects every settings caller, including management/site/gateway tools
 that log exceptions. Other request error types and logging retain their existing
 behavior.
 
+DPI refresh failures also become safe RequestError instances at StatsManager,
+with original traceback context suppressed. REST and GraphQL use this manager
+directly, so the safe error must be established before the MCP boundary.
+
 Validation: eight new behavioral regression cases failed before the fix and
 passed afterward; 54 focused credential sanitization, request logging, and
 reauthentication tests passed. Caller-chain regressions exercise real connection
 and domain managers: auto-backup read, preview, update fetch and update PUT with
 opaque, request and response exceptions; both DPI handlers; and tool calls after
 failed initialization or reauthentication; and management/site/gateway settings
-callers that log tracebacks. Full repository and GitHub scan results are
+callers that log tracebacks. REST and GraphQL DPI regressions exercise both
+handlers through the real manager/connection chain. Full repository and GitHub scan results are
 recorded in the associated pull request. Alert closure on main requires the
 change to be merged and scanned; no alerts were manually dismissed.

--- a/docs/security/code-scanning-2026-09-07.md
+++ b/docs/security/code-scanning-2026-09-07.md
@@ -22,8 +22,8 @@ ignored its rewritten `args`.
 | [78](https://github.com/sirkirby/unifi-mcp/security/code-scanning/78) | `connection_manager.py:864` | Log refresh failure context and exception class. |
 | [79](https://github.com/sirkirby/unifi-mcp/security/code-scanning/79) | `system_manager.py:333` | Omit rejected response bodies; adjacent exception handler logs exception class. |
 
-This follows the existing Network client/device logging pattern. Caller-facing
-error scrubbing, response redaction policy, authentication classification,
+This follows the existing Network client/device logging pattern. Request-error
+scrubbing, response redaction policy, authentication classification,
 reconnect circuit, and retry behavior remain intact. No tools or public schemas
 are added or changed. Auto-backup read/preview/update and DPI MCP error responses
 now include the exception class instead of exception text. Their manager/tool
@@ -32,10 +32,18 @@ reintroduce sensitive content at those downstream logs. This is a focused
 remediation of the listed logging boundaries, not a
 claim that every log or caller-facing exception is free of arbitrary secrets.
 
+Cached connection failures now contain exception class and fixed remediation
+guidance, so later tool calls cannot log cached controller text. Failed
+reauthentication also suppresses the original LoginRequired traceback context.
+Settings failure logging omits controller text inside ConnectionManager before
+the exception reaches the system manager. Other request logging retains its
+existing behavior.
+
 Validation: eight new behavioral regression cases failed before the fix and
 passed afterward; 54 focused credential sanitization, request logging, and
-reauthentication tests passed. Six additional caller-chain regression cases
-reproduced leaks before the follow-up fix and pass afterward: auto-backup read,
-preview, update fetch, update PUT, and both DPI refresh handlers. Full repository and GitHub scan results are
+reauthentication tests passed. Caller-chain regressions exercise real connection
+and domain managers: auto-backup read, preview, update fetch and update PUT with
+opaque, request and response exceptions; both DPI handlers; and tool calls after
+failed initialization or reauthentication. Full repository and GitHub scan results are
 recorded in the associated pull request. Alert closure on main requires the
 change to be merged and scanned; no alerts were manually dismissed.

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -903,6 +903,20 @@ class ConnectionManager:
         return logging.INFO if api_request.method.lower() == "get" else logging.WARNING
 
     async def request(self, api_request: ApiRequest | ApiRequestV2, return_raw: bool = False) -> Any:
+        """Request controller data, keeping settings failures safe for every caller."""
+        try:
+            return await self._request_with_reauthentication(api_request, return_raw=return_raw)
+        except Exception as error:
+            if api_request.path.startswith(("/get/setting/", "/set/setting/")):
+                # Domain managers and tools may log the returned error and its
+                # traceback. An opaque exception cannot reliably be rewritten,
+                # so expose a new safe error without its original cause/context.
+                raise RequestError(f"Controller settings request failed ({type(error).__name__}).") from None
+            raise
+
+    async def _request_with_reauthentication(
+        self, api_request: ApiRequest | ApiRequestV2, return_raw: bool = False
+    ) -> Any:
         """Make a request to the controller API, handling raw responses."""
         if not await self.ensure_connected() or not self.controller:
             raise self._not_connected_error()

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -821,6 +821,14 @@ class ConnectionManager:
         await self.cleanup()
 
     async def refresh_handler(self, name: str) -> Any:
+        """Refresh a collection while exposing only safe failure context to callers."""
+        try:
+            return await self._refresh_handler_with_reauthentication(name)
+        except Exception as error:
+            logger.error("Controller collection refresh failed: %s", type(error).__name__)
+            raise RequestError(f"Controller collection refresh failed ({type(error).__name__}).") from None
+
+    async def _refresh_handler_with_reauthentication(self, name: str) -> Any:
         """Refresh an aiounifi handler collection, recovering an expired session.
 
         ``request()`` is not the only way this project reaches the controller:

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -475,7 +475,7 @@ class ConnectionManager:
             "Automatic reconnect blocked after terminal authentication failure: %s. "
             "Correct the credentials or wait for the controller lockout to clear; "
             "the next reconnect attempt is allowed in %.0f seconds.",
-            connection_error,
+            type(error).__name__,
             cooldown,
         )
         return connection_error
@@ -578,10 +578,7 @@ class ConnectionManager:
         """Initialize the controller connection (correct for attached aiounifi version)."""
         blocked = self._reconnect_block_active()
         if blocked:
-            logger.error(
-                "Automatic reconnect remains blocked after authentication failure: %s",
-                blocked,
-            )
+            logger.error("Automatic reconnect remains blocked after authentication failure; waiting for cooldown.")
             return False
         if self._initialized and self.controller and self._aiohttp_session and not self._aiohttp_session.closed:
             return True
@@ -712,8 +709,8 @@ class ConnectionManager:
                         self._block_automatic_reconnect(e)
                         await self._discard_connection()
                         return False
-                    connection_error = self._record_connection_error(e)
-                    logger.warning("Connection attempt %s failed: %s", attempt + 1, connection_error)
+                    self._record_connection_error(e)
+                    logger.warning("Connection attempt %s failed: %s", attempt + 1, type(e).__name__)
                     await self._discard_connection()
                     if attempt < self._max_retries - 1:
                         await asyncio.sleep(self._retry_delay)
@@ -721,7 +718,7 @@ class ConnectionManager:
                         logger.error(
                             "Failed to initialize Unifi controller after %s attempts: %s",
                             self._max_retries,
-                            connection_error,
+                            type(e).__name__,
                         )
                         self._initialized = False
                         return False
@@ -729,10 +726,10 @@ class ConnectionManager:
                     if self._is_terminal_auth_error(e):
                         self._block_automatic_reconnect(e)
                     else:
-                        connection_error = self._record_connection_error(e)
+                        self._record_connection_error(e)
                         logger.error(
                             "Unexpected error during controller initialization: %s",
-                            connection_error,
+                            type(e).__name__,
                         )
                     await self._discard_connection()
                     return False
@@ -789,10 +786,10 @@ class ConnectionManager:
                 await self.controller.login()
             except Exception as error:
                 if self._is_terminal_auth_error(error):
-                    connection_error = self._block_automatic_reconnect(error)
+                    self._block_automatic_reconnect(error)
                 else:
-                    connection_error = self._record_connection_error(error)
-                    logger.error("Controller re-authentication failed: %s", connection_error)
+                    self._record_connection_error(error)
+                    logger.error("Controller re-authentication failed: %s", type(error).__name__)
                 await self._discard_connection()
                 return False
 
@@ -857,11 +854,11 @@ class ConnectionManager:
                 # LoginRequired means the refreshed session was rejected, so
                 # stop here rather than let every later tool call start another
                 # controller login.
-                secrets = self._scrub_error(retry_error)
+                self._scrub_error(retry_error)
                 logger.error(
                     "%s refresh failed even after re-authentication: %s",
                     name,
-                    self._sanitize_text(str(retry_error) or type(retry_error).__name__, secrets),
+                    type(retry_error).__name__,
                 )
                 self._block_automatic_reconnect(retry_error)
                 await self._discard_connection()

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -351,8 +351,8 @@ class ConnectionManager:
         return f"{proto}://{self.host}:{self.port}"
 
     def _sanitize_connection_error(self, error: BaseException) -> str:
-        """Return a user-facing connection error without configured secrets or addresses."""
-        return self._sanitize_text(str(error) or type(error).__name__)
+        """Return safe failure context for later callers, which may log it verbatim."""
+        return f"{type(error).__name__}: check controller connectivity, credentials, and MFA/TOTP configuration."
 
     def _sanitize_text(self, text: str, extra_secrets: Mapping[str, bool] | Iterable[str] = ()) -> str:
         """Mask MAC addresses, the configured credentials and *extra_secrets* in *text*.
@@ -361,8 +361,8 @@ class ConnectionManager:
         a credential written directly against ``-`` or ``_`` is not covered by
         that rule. ``extra_secrets`` — the values the request itself submitted
         — are matched literally. Both cover the escaped forms a message can
-        quote a value with, so nothing decodable reaches
-        ``last_connection_error`` or a log line.
+        quote a value with. This only covers known secrets; authentication
+        summaries and settings failure logs omit controller text entirely.
         """
         rules = self._secret_rules()
         if isinstance(extra_secrets, Mapping):
@@ -421,7 +421,7 @@ class ConnectionManager:
 
     @property
     def last_connection_error(self) -> Optional[str]:
-        """Return the latest sanitized connection failure, if any."""
+        """Return the latest connection failure class and fixed guidance, if any."""
         return self._last_connection_error
 
     def _not_connected_error(self) -> ConnectionError:
@@ -884,6 +884,12 @@ class ConnectionManager:
         """
         if not logger.isEnabledFor(level):
             return
+        if api_request.path.startswith(("/get/setting/", "/set/setting/")):
+            # Settings can contain controller-only secrets absent from the
+            # submitted payload. Neither redaction by key nor known-value
+            # scrubbing can make arbitrary response text safe to log.
+            logger.log(level, "%s: settings request failed", what)
+            return
         message = f"{what}: %s %s - %s"
         args = [api_request.method.upper(), mask_macs(api_request.path), self._sanitize_text(detail, secrets)]
         if with_traceback:
@@ -991,7 +997,9 @@ class ConnectionManager:
                         await self._discard_connection()
                     raise retry_e from None
             else:
-                raise self._not_connected_error()
+                # The original LoginRequired may quote controller-only secrets.
+                # Callers that log tracebacks must see only the safe auth summary.
+                raise self._not_connected_error() from None
         except (RequestError, ResponseError, aiohttp.ClientError) as e:
             # Classify before scrubbing: the scrub rewrites the message in
             # place, and a submitted value that collides with the status text

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -337,7 +337,7 @@ class StatsManager:
             self._connection._update_cache(cache_key, result, timeout=900)
             return result
         except Exception as e:
-            logger.error("Error getting DPI stats: %s", e)
+            logger.error("Error getting DPI stats: %s", type(e).__name__)
             raise
 
     async def get_alerts(self, include_archived: bool = False) -> List[Dict[str, Any]]:

--- a/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/stats_manager.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+from aiounifi.errors import RequestError
 from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.dpi_restriction_app import DPIRestrictionApp  # Import DPIApp model
 from aiounifi.models.dpi_restriction_group import (
@@ -338,7 +339,9 @@ class StatsManager:
             return result
         except Exception as e:
             logger.error("Error getting DPI stats: %s", type(e).__name__)
-            raise
+            # REST/GraphQL call this manager directly and may log tracebacks.
+            # Keep the original controller text out of every caller surface.
+            raise RequestError(f"DPI stats refresh failed ({type(e).__name__}).") from None
 
     async def get_alerts(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Get alerts from the controller."""

--- a/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
@@ -182,7 +182,7 @@ class SystemManager:
                 "autobackup_cloud_enabled": settings.get("autobackup_cloud_enabled", False),
             }
         except Exception as e:
-            logger.error("Error getting auto-backup settings: %s", e, exc_info=True)
+            logger.error("Error getting auto-backup settings: %s", type(e).__name__)
             raise
 
     async def update_autobackup_settings(self, settings: Dict[str, Any]) -> bool:
@@ -198,7 +198,7 @@ class SystemManager:
             # update_settings handles cache invalidation with correct site-qualified key
             return await self.update_settings("super_mgmt", settings)
         except Exception as e:
-            logger.error("Error updating auto-backup settings: %s", e, exc_info=True)
+            logger.error("Error updating auto-backup settings: %s", type(e).__name__)
             raise
 
     async def check_firmware_updates(self) -> Dict[str, Any]:
@@ -277,7 +277,7 @@ class SystemManager:
             self._connection._update_cache(cache_key, settings_list)
             return settings_list
         except Exception as e:
-            logger.error("Error getting %s settings: %s", section, e)
+            logger.error("Error getting %s settings: %s", section, type(e).__name__)
             raise
 
     async def update_settings(self, section: str, settings_data: Dict[str, Any]) -> bool:

--- a/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/system_manager.py
@@ -7,7 +7,7 @@ from aiounifi.models.api import ApiRequest
 from aiounifi.models.site import Site  # Import Site model
 
 from unifi_core.network.managers.connection_manager import ConnectionManager
-from unifi_core.redaction import collect_secret_values, redact_sensitive_fields, sanitize_exception, scrub_secret_values
+from unifi_core.redaction import collect_secret_values, sanitize_exception
 
 logger = logging.getLogger("unifi-network-mcp")
 
@@ -325,19 +325,16 @@ class SystemManager:
             if success:
                 logger.info("%s settings updated successfully", section)
             else:
-                # A rejected write can echo the submitted record (x_password,
-                # community, ...). Redact by key and scrub the submitted values
-                # before the log line.
-                secrets = collect_secret_values(settings_data)
-                safe_response = scrub_secret_values(str(redact_sensitive_fields(response)), secrets)
-                logger.error("Error updating %s settings: %s", section, safe_response)
+                # Controller-only secrets in a response cannot be scrubbed using
+                # the submitted values. Keep the response out of logs entirely.
+                logger.error("Error updating %s settings: controller rejected update", section)
 
             return success
         except Exception as e:
             # The transport scrubs its own errors; repeat here so the manager
             # holds the contract on its own.
             sanitize_exception(e, collect_secret_values(settings_data))
-            logger.error("Error updating %s settings: %s", section, e)
+            logger.error("Error updating %s settings: %s", section, type(e).__name__)
             raise
 
     async def get_network_health(self) -> List[Dict[str, Any]]:

--- a/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
+++ b/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
@@ -266,19 +266,26 @@ async def test_reauthenticate_logs_no_controller_exception_content(caplog, error
     await manager.cleanup()
 
 
-async def test_refresh_retry_logs_no_controller_exception_content(caplog):
+@pytest.mark.parametrize("handler", ["devices", "clients", "dpi_apps", "dpi_groups"])
+@pytest.mark.parametrize("error_type", [LoginRequired, RuntimeError])
+async def test_refresh_retry_logs_no_controller_exception_content(caplog, handler, error_type):
+    import traceback
+
     controller = _Controller(lambda: ResponseError("unused"))
-    controller.devices = SimpleNamespace(update=AsyncMock(side_effect=LoginRequired(UNKNOWN_SECRET)))
+    update = AsyncMock(side_effect=error_type(UNKNOWN_SECRET))
+    setattr(controller, handler, SimpleNamespace(update=update))
     manager = _manager(controller)
     caplog.set_level(logging.DEBUG)
 
-    with pytest.raises(LoginRequired):
-        await manager.refresh_handler("devices")
+    with pytest.raises(RequestError) as excinfo:
+        await manager.refresh_handler(handler)
 
-    assert controller.devices.update.await_count == 2
-    _assert_private_failure_logs(caplog, "refresh failed even after re-authentication")
-    assert "LoginRequired" in caplog.text
-    assert manager.reconnect_blocked
+    assert update.await_count == (2 if error_type is LoginRequired else 1)
+    _assert_private_failure_logs(caplog, "Controller collection refresh failed")
+    assert error_type.__name__ in caplog.text
+    assert UNKNOWN_SECRET not in str(excinfo.value)
+    assert UNKNOWN_SECRET not in "".join(traceback.format_exception(excinfo.value))
+    assert manager.reconnect_blocked is (error_type is LoginRequired)
     await manager.cleanup()
 
 

--- a/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
+++ b/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
@@ -9,6 +9,8 @@ log line and from the exception the caller receives.
 """
 
 import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from urllib.parse import quote
 
 import pytest
@@ -22,6 +24,7 @@ from tests.secret_assertions import ESCAPED_SECRET, assert_unrecoverable
 
 SENTINEL = "SENTINEL-submitted-secret-7f3a"
 LOGIN_SENTINEL = "SENTINEL-login-secret-91c2"
+UNKNOWN_SECRET = "SENTINEL-controller-only-token-49ac"
 
 
 class _Session:
@@ -212,6 +215,95 @@ async def test_system_manager_rejected_response_log_is_scrubbed(caplog):
 
     assert SENTINEL not in caplog.text
     assert "Error updating snmp settings" in caplog.text
+
+
+def _assert_private_failure_logs(caplog, operation):
+    assert operation in caplog.text
+    assert UNKNOWN_SECRET not in caplog.text
+    assert SENTINEL not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+    assert "Traceback (most recent call last)" not in caplog.text
+
+
+@pytest.mark.parametrize("error_type", [RequestError, RuntimeError, LoginRequired])
+async def test_initialize_logs_no_controller_exception_content(caplog, monkeypatch, error_type):
+    from unifi_core.network.managers import connection_manager as cm_module
+
+    # Fail inside initialization without creating a real session or contacting a controller.
+    def fail_connector(**kwargs):
+        raise error_type(UNKNOWN_SECRET)
+
+    monkeypatch.setattr(cm_module.aiohttp, "TCPConnector", fail_connector)
+    manager = ConnectionManager("192.168.1.1", "admin", LOGIN_SENTINEL)
+    manager._max_retries = 2
+    manager._retry_delay = 0
+    caplog.set_level(logging.DEBUG)
+
+    assert await manager.initialize() is False
+    _assert_private_failure_logs(caplog, "authentication failure" if error_type is LoginRequired else "initializ")
+    assert error_type.__name__ in caplog.text
+    assert manager.last_connection_error  # Caller diagnostics remain available.
+    if error_type is LoginRequired:
+        caplog.clear()
+        assert await manager.initialize() is False
+        _assert_private_failure_logs(caplog, "remains blocked")
+    await manager.cleanup()
+
+
+@pytest.mark.parametrize("error_type", [RequestError, LoginRequired])
+async def test_reauthenticate_logs_no_controller_exception_content(caplog, error_type):
+    controller = _Controller(lambda: ResponseError("unused"))
+    controller.login = AsyncMock(side_effect=error_type(UNKNOWN_SECRET))
+    manager = _manager(controller)
+    caplog.set_level(logging.DEBUG)
+
+    assert await manager.reauthenticate() is False
+    _assert_private_failure_logs(
+        caplog, "authentication failure" if error_type is LoginRequired else "re-authentication"
+    )
+    assert error_type.__name__ in caplog.text
+    assert manager.controller is None
+    await manager.cleanup()
+
+
+async def test_refresh_retry_logs_no_controller_exception_content(caplog):
+    controller = _Controller(lambda: ResponseError("unused"))
+    controller.devices = SimpleNamespace(update=AsyncMock(side_effect=LoginRequired(UNKNOWN_SECRET)))
+    manager = _manager(controller)
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(LoginRequired):
+        await manager.refresh_handler("devices")
+
+    assert controller.devices.update.await_count == 2
+    _assert_private_failure_logs(caplog, "refresh failed even after re-authentication")
+    assert "LoginRequired" in caplog.text
+    assert manager.reconnect_blocked
+    await manager.cleanup()
+
+
+async def test_settings_rejection_does_not_log_unrecognized_response_secrets(caplog):
+    connection = _FakeConnection(response={"meta": {"rc": "error", "msg": UNKNOWN_SECRET}})
+    caplog.set_level(logging.DEBUG)
+
+    assert await SystemManager(connection).update_settings("snmp", {"community": SENTINEL}) is False
+
+    _assert_private_failure_logs(caplog, "Error updating snmp settings")
+
+
+async def test_settings_exception_does_not_log_opaque_exception_content(caplog):
+    class OpaqueError(Exception):
+        def __str__(self):
+            return f"{SENTINEL} {UNKNOWN_SECRET}"
+
+    connection = _FakeConnection(raiser=OpaqueError)
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(OpaqueError):
+        await SystemManager(connection).update_settings("snmp", {"community": SENTINEL})
+
+    _assert_private_failure_logs(caplog, "Error updating snmp settings")
+    assert "OpaqueError" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
+++ b/packages/unifi-core/tests/network/managers/test_credential_error_sanitization.py
@@ -83,7 +83,7 @@ def _manager(controller, password=LOGIN_SENTINEL):
 def _put_with_secret():
     return ApiRequest(
         method="put",
-        path="/set/setting/snmp",
+        path="/rest/wlan/wlan-1",
         data={"enabled": True, "x_password": SENTINEL, "nested": {"community": SENTINEL}},
     )
 
@@ -122,7 +122,7 @@ async def test_request_read_error_is_scrubbed_of_login_password(caplog):
     caplog.set_level(logging.DEBUG)
 
     with pytest.raises(ResponseError) as excinfo:
-        await manager.request(ApiRequest(method="get", path="/get/setting/snmp"))
+        await manager.request(ApiRequest(method="get", path="/stat/sta"))
 
     assert LOGIN_SENTINEL not in str(excinfo.value)
     assert LOGIN_SENTINEL not in caplog.text
@@ -318,7 +318,7 @@ async def test_settings_exception_does_not_log_opaque_exception_content(caplog):
 async def test_request_write_error_scrubs_escaped_credential(caplog):
     manager = _manager(_Controller(lambda: ResponseError(f"controller rejected {{'x_password': {ESCAPED_SECRET!r}}}")))
     caplog.set_level(logging.DEBUG)
-    request = ApiRequest(method="put", path="/set/setting/snmp", data={"x_password": ESCAPED_SECRET})
+    request = ApiRequest(method="put", path="/rest/wlan/wlan-1", data={"x_password": ESCAPED_SECRET})
 
     with pytest.raises(ResponseError) as excinfo:
         await manager.request(request)
@@ -337,7 +337,7 @@ async def test_request_read_error_scrubs_escaped_login_password(caplog):
     caplog.set_level(logging.DEBUG)
 
     with pytest.raises(ResponseError) as excinfo:
-        await manager.request(ApiRequest(method="get", path="/get/setting/snmp"))
+        await manager.request(ApiRequest(method="get", path="/stat/sta"))
 
     assert_unrecoverable(str(excinfo.value), ESCAPED_SECRET)
     assert_unrecoverable(caplog.text, ESCAPED_SECRET)


### PR DESCRIPTION
Controller-only secrets can survive configured/submitted credential scrubbing and reach Network logs, API errors, and audit records. This fixes CodeQL alerts #72–#79 and the related settings/DPI leaks identified during review.

Authentication/refresh and settings failure logs now emit fixed operation/class context. Cached authentication errors contain exception class and fixed connectivity/credentials/MFA guidance; failed reauthentication suppresses original LoginRequired traceback context. ConnectionManager omits settings failure text and translates every failed `/get/setting/` or `/set/setting/` request into a new safe RequestError, protecting all management/site/gateway/SNMP/auto-backup callers. Shared collection refresh failures are also translated to safe RequestError instances after retry/circuit handling, protecting client/device callers. StatsManager translates DPI failures before they reach MCP, REST, or GraphQL.

Preserves retry/cooldown behavior, response redaction policy, and error envelopes. Settings and collection-refresh callers receive RequestError with safe operation/class context instead of arbitrary controller text; other request error types/logging retain their existing behavior. No tools or schemas are added. AGENTS.md documents the boundaries; `docs/security/code-scanning-2026-09-07.md` records all eight dispositions.

Validation:
- Regression tests traverse public tools through real ConnectionManager and domain managers with mocked controller I/O: settings read/preview/update, management/site/gateway, both DPI handlers, and later calls after failed initialization/reauthentication.
- REST and GraphQL DPI tests cover both handlers; API audit tests verify controller-only secrets are absent from response, logs and persisted detail.
- Focused privacy, authentication recovery, credential/audit, and REST/GraphQL DPI tests pass. Core refresh coverage includes both initial failures and rejected reauthentication across devices, clients and both DPI handlers.
- Final `make pre-commit` passed on `f6ca86e78b786e1884529ac67605a9dcafdb1591`, including all suites, protocol smoke, generated-artifact checks and Worker typecheck. All 18 GitHub checks passed; Python, JavaScript/TypeScript and Actions CodeQL analyses each report zero findings on this head. Review findings, including the final shared-refresh note, were addressed with central settings/refresh boundaries and cross-surface tests; all review threads are resolved.
- No controller mutations or manual alert dismissals. Merge/rescan is required to close alerts on main.
