### PR TITLE
fix(protect): migrate camera and light writes to uiprotect 16

### DIFF
--- a/apps/api/src/unifi_api/action_catalog.json
+++ b/apps/api/src/unifi_api/action_catalog.json
@@ -1899,7 +1899,7 @@
       "permission_action": "update",
       "read_only_hint": false,
       "manager_attr": "camera_manager",
-      "manager_method": "update_camera_settings",
+      "manager_method": "apply_camera_settings",
       "input_schema": {
         "properties": {
           "camera_id": {
@@ -1907,7 +1907,7 @@
             "type": "string"
           },
           "settings": {
-            "description": "Dictionary of settings to update. Supported keys: ir_led_mode (auto, on, autoFilterOnly), hdr_mode (off, auto, or always; always = superHdr highest quality. Booleans accepted: true=auto, false=off), mic_enabled (true/false), mic_volume (0-100), status_light_on (true/false), speaker_volume (0-100), name (string), motion_detection (true/false).",
+            "description": "Dictionary of settings to update. Supported keys: ir_led_mode (auto, on, autoFilterOnly), hdr_mode (off, auto, or always; always = superHdr highest quality. Booleans accepted: true=auto, false=off), mic_enabled (true/false), mic_volume (1-100; zero is not supported by the public API), status_light_on (true/false), speaker_volume (0-100), name (string), motion_detection (true/false).",
             "type": "object"
           }
         },

--- a/apps/api/src/unifi_api/serializers/protect/cameras.py
+++ b/apps/api/src/unifi_api/serializers/protect/cameras.py
@@ -35,8 +35,14 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
     },
 )
 class CameraMutationAckSerializer(Serializer):
-    """Generic ack for camera-side mutations. Manager methods here return
-    ``Dict[str, Any]`` (preview shape); bool fallback for completeness."""
+    """Camera mutation acknowledgments, including partial settings failures."""
+
+    def serialize_action(self, result, *, tool_name: str, redact_sensitive: bool = True) -> dict:
+        envelope = super().serialize_action(result, tool_name=tool_name, redact_sensitive=redact_sensitive)
+        if tool_name == "protect_update_camera_settings" and isinstance(result, dict) and result.get("errors"):
+            envelope["success"] = False
+            envelope["error"] = "Failed to update Protect settings: " + "; ".join(result["errors"])
+        return envelope
 
     @staticmethod
     def serialize(obj) -> dict:

--- a/apps/api/src/unifi_api/serializers/protect/lights.py
+++ b/apps/api/src/unifi_api/serializers/protect/lights.py
@@ -7,9 +7,8 @@ and dispatched via the type_registry by both the REST route and the
 action endpoint.
 
 This module now only ships ``LightMutationAckSerializer`` for the
-``protect_update_light`` preview-and-confirm tool, which still flows
-through the manager's preview path and produces a dict ack of the form
-``{light_id, light_name, current_state, proposed_changes}``.
+``protect_update_light`` preview-and-confirm tool. Confirmed calls return
+``{light_id, light_name, applied, errors?}``; failures preserve partial results.
 """
 
 from unifi_api.serializers._base import RenderKind, Serializer, register_serializer
@@ -17,8 +16,14 @@ from unifi_api.serializers._base import RenderKind, Serializer, register_seriali
 
 @register_serializer(tools={"protect_update_light": {"kind": RenderKind.DETAIL}})
 class LightMutationAckSerializer(Serializer):
-    """``LightManager.update_light`` returns the preview dict; pass through.
-    Bool fallback for completeness."""
+    """Serialize confirmed light updates, preserving failures and partial results."""
+
+    def serialize_action(self, result, *, tool_name: str, redact_sensitive: bool = True) -> dict:
+        envelope = super().serialize_action(result, tool_name=tool_name, redact_sensitive=redact_sensitive)
+        if tool_name == "protect_update_light" and isinstance(result, dict) and result.get("errors"):
+            envelope["success"] = False
+            envelope["error"] = "Failed to update Protect settings: " + "; ".join(result["errors"])
+        return envelope
 
     @staticmethod
     def serialize(obj) -> dict:

--- a/apps/api/src/unifi_api/services/dispatch_overrides.py
+++ b/apps/api/src/unifi_api/services/dispatch_overrides.py
@@ -149,7 +149,7 @@ DISPATCH_OVERRIDES: dict[str, tuple[str, str]] = {
     "protect_reboot_camera": ("camera_manager", "apply_reboot_camera"),
     "protect_toggle_recording": ("camera_manager", "apply_toggle_recording"),
     "protect_toggle_rtsp": ("camera_manager", "apply_toggle_rtsp"),
-    "protect_update_camera_settings": ("camera_manager", "update_camera_settings"),
+    "protect_update_camera_settings": ("camera_manager", "apply_camera_settings"),
     "protect_update_sensor_settings": ("sensor_manager", "apply_sensor_settings"),
     "protect_update_chime": ("chime_manager", "apply_chime_settings"),
     "protect_update_light": ("light_manager", "apply_light_settings"),
@@ -609,6 +609,24 @@ def _delete_recording_result(result: Any, _args: dict[str, Any], _manager: Any) 
 # ---------------------------------------------------------------------------
 # The MCP tool validates agent-facing settings and translates nested
 # snake_case keys to the public API payload before calling the manager.
+
+
+def _translate_camera_settings_update(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    from unifi_core.protect.models.cameras import to_controller_update
+
+    settings = to_controller_update(args.get("settings") or {})
+    if not settings:
+        raise ValueError("No supported camera settings provided")
+    return (), {"camera_id": args["camera_id"], "settings": settings}
+
+
+def _translate_light_settings_update(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    from unifi_core.protect.models.lights import to_controller_update
+
+    settings = to_controller_update(args.get("settings") or {})
+    if not settings:
+        raise ValueError("No supported light settings provided")
+    return (), {"light_id": args["light_id"], "settings": settings}
 
 
 def _translate_sensor_settings_update(args: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
@@ -1574,6 +1592,8 @@ DISPATCH_ARG_TRANSLATORS: dict[str, ArgTranslatorSpec] = {
     "access_unlock_door": _spec(_translate_access_unlock, "door_id", "duration"),
     "protect_delete_recording": _spec(_translate_delete_recording, "camera_id", "start", "end"),
     "protect_update_chime": _spec(_translate_chime_update, "chime_id", "settings"),
+    "protect_update_camera_settings": _spec(_translate_camera_settings_update, "camera_id", "settings"),
+    "protect_update_light": _spec(_translate_light_settings_update, "light_id", "settings"),
     "protect_update_sensor_settings": _spec(_translate_sensor_settings_update, "sensor_id", "settings"),
     # Network — client mutations: tool uses mac_address, manager uses client_mac
     "unifi_block_client": _spec(_rename_mac_address_to_client_mac, "client_mac"),

--- a/apps/api/tests/test_protect_settings_dispatch.py
+++ b/apps/api/tests/test_protect_settings_dispatch.py
@@ -1,0 +1,64 @@
+"""Protect settings must execute on confirmation and report partial failures."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unifi_api.services.actions import MutationPreview, dispatch_action
+from unifi_api.services.manifest import ManifestRegistry
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "domain,settings,method",
+    [
+        ("camera", {"hdr_mode": "superHdr"}, "apply_camera_settings"),
+        ("light", {"is_light_on": True}, "apply_light_settings"),
+    ],
+)
+@pytest.mark.parametrize("confirm", [False, True])
+@pytest.mark.parametrize("applied", [[], ["name=new"]])
+@pytest.mark.parametrize("failed", [False, True])
+async def test_protect_settings_dispatch(domain, settings, method, confirm, applied, failed):
+    manager = MagicMock()
+    result = {"applied": applied}
+    if failed:
+        result["errors"] = ["controller refused setting"]
+    write = AsyncMock(return_value=result)
+    setattr(manager, method, write)
+    factory = MagicMock()
+    factory.get_domain_manager = AsyncMock(return_value=manager)
+    kwargs = dict(
+        registry=ManifestRegistry.load(),
+        factory=factory,
+        session=MagicMock(),
+        tool_name="protect_update_camera_settings" if domain == "camera" else "protect_update_light",
+        controller_id="controller",
+        controller_products=["protect"],
+        site="default",
+        args={f"{domain}_id": "device", "settings": settings},
+        confirm=confirm,
+    )
+    response = await dispatch_action(**kwargs)
+    if confirm:
+        assert response == result
+        from unifi_api.serializers.protect.cameras import CameraMutationAckSerializer
+        from unifi_api.serializers.protect.lights import LightMutationAckSerializer
+
+        serializer = CameraMutationAckSerializer() if domain == "camera" else LightMutationAckSerializer()
+        envelope = serializer.serialize_action(response, tool_name=kwargs["tool_name"])
+        assert envelope["success"] is not failed
+        assert envelope["data"]["applied"] == applied
+        if failed:
+            assert "controller refused setting" in envelope["error"]
+    else:
+        assert isinstance(response, MutationPreview)
+    if confirm:
+        write.assert_awaited_once_with(
+            **{
+                f"{domain}_id": "device",
+                "settings": {"hdr_mode": "always"} if domain == "camera" else {"light_on": True},
+            }
+        )
+    else:
+        factory.get_domain_manager.assert_not_awaited()
+        write.assert_not_awaited()

--- a/apps/protect/README.md
+++ b/apps/protect/README.md
@@ -84,10 +84,29 @@ UNIFI_PROTECT_HOST=192.168.1.1      # Controller IP or hostname
 UNIFI_PROTECT_USERNAME=admin         # Local admin username
 UNIFI_PROTECT_PASSWORD=your-password # Admin password
 # Optional:
-# UNIFI_PROTECT_API_KEY=             # UniFi Protect API key for selected settings capabilities
+# UNIFI_PROTECT_API_KEY=             # Required for camera HDR/mic volume and light power/brightness/PIR settings
 # UNIFI_PROTECT_PORT=443             # Controller HTTPS port
 # UNIFI_PROTECT_VERIFY_SSL=false     # SSL certificate verification
 ```
+
+Camera HDR and microphone volume, plus floodlight power, brightness, PIR sensitivity,
+and duration now use the Protect public Integration API with `uiprotect` 16.x.
+Set `UNIFI_PROTECT_API_KEY` (or the shared fallback `UNIFI_API_KEY`) and restart
+the server before using these settings. Session credentials remain required for
+other Protect operations. Missing keys or incompatible public device IDs fail
+before any settings in the request are written.
+
+Microphone volume updates accept **1–100**; zero is rejected by the public API.
+Existing HDR aliases are preserved: `true`/`on`/`normal` mean `auto`, `false`
+means `off`, and `always`/`superHdr` select public HDR `on`. Light brightness
+remains 1–6, sensitivity 0–100, and duration 15–900 seconds. `light_on` and
+`is_light_on` are equivalent inputs and control forced illumination; turning
+forced illumination off does not disable motion-triggered lighting.
+
+Settings updates retain preview/confirmation and policy gates. Requests are
+validated before writing; controller failures can still leave a partial update.
+Failed updates return an error with the settings that applied, so callers can
+inspect the current state before retrying.
 
 **Fallback:** The shared `UNIFI_*` variables (e.g., `UNIFI_HOST`) also work. The server checks for `UNIFI_PROTECT_*` first and falls back to `UNIFI_*` if the server-specific variable is not set. For single-controller setups, the shared variables are all you need.
 

--- a/apps/protect/docs/configuration.md
+++ b/apps/protect/docs/configuration.md
@@ -17,7 +17,7 @@ The Protect server supports server-specific environment variables with the `UNIF
 | `UNIFI_PROTECT_PASSWORD` | `UNIFI_PASSWORD` | Yes | -- | Admin password |
 | `UNIFI_PROTECT_PORT` | `UNIFI_PORT` | No | `443` | Controller HTTPS port |
 | `UNIFI_PROTECT_VERIFY_SSL` | `UNIFI_VERIFY_SSL` | No | `false` | SSL certificate verification |
-| `UNIFI_PROTECT_API_KEY` | `UNIFI_API_KEY` | No | `""` | UniFi Protect API key for selected settings capabilities, including sensor settings, viewer liveview assignments, and per-camera chime ring settings; username/password still required |
+| `UNIFI_PROTECT_API_KEY` | `UNIFI_API_KEY` | For public settings | `""` | Required for camera HDR/microphone volume, light power/brightness/PIR sensitivity/duration, sensor settings, viewer liveview assignments, and per-camera chime ring settings; username/password still required |
 
 **Resolution order:** `UNIFI_PROTECT_*` > `UNIFI_*` > YAML config > hardcoded default.
 

--- a/apps/protect/src/unifi_protect_mcp/tools/cameras.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/cameras.py
@@ -202,10 +202,11 @@ async def protect_get_camera_analytics(
     description=(
         "Updates camera settings such as IR LED mode, HDR mode, mic/speaker volume, "
         "status light, and motion detection. Requires confirm=True to apply. "
+        "HDR and microphone volume require UNIFI_PROTECT_API_KEY or UNIFI_API_KEY. "
         "Supported keys: ir_led_mode, hdr_mode, mic_enabled, mic_volume, "
         "status_light_on, speaker_volume, name, motion_detection."
     ),
-    annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=False),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
     permission_category="camera",
     permission_action="update",
 )
@@ -219,7 +220,7 @@ async def protect_update_camera_settings(
                 "ir_led_mode (auto, on, autoFilterOnly), "
                 "hdr_mode (off, auto, or always; always = superHdr highest quality. "
                 "Booleans accepted: true=auto, false=off), "
-                "mic_enabled (true/false), mic_volume (0-100), "
+                "mic_enabled (true/false), mic_volume (1-100; zero is not supported by the public API), "
                 "status_light_on (true/false), speaker_volume (0-100), "
                 "name (string), motion_detection (true/false)."
             )
@@ -254,6 +255,12 @@ async def protect_update_camera_settings(
 
         # Apply the changes
         result = await camera_manager.apply_camera_settings(camera_id, filtered)
+        if result.get("errors"):
+            return {
+                "success": False,
+                "error": "Failed to update camera settings: " + "; ".join(result["errors"]),
+                "data": result,
+            }
         return {"success": True, "data": result}
     except (UniFiNotFoundError, ValueError) as e:
         return {"success": False, "error": str(e)}

--- a/apps/protect/src/unifi_protect_mcp/tools/devices.py
+++ b/apps/protect/src/unifi_protect_mcp/tools/devices.py
@@ -67,9 +67,10 @@ async def protect_list_lights() -> Dict[str, Any]:
         "Updates light settings such as on/off state, LED brightness level (1-6), "
         "PIR motion sensitivity (0-100), motion-triggered duration (15-900 seconds), "
         "status indicator light, and device name. Requires confirm=True to apply. "
-        "Supported keys: light_on, led_level, sensitivity, duration_seconds, status_light, name."
+        "Power, brightness, sensitivity and duration require UNIFI_PROTECT_API_KEY or UNIFI_API_KEY. "
+        "Supported keys: light_on (alias is_light_on), led_level, sensitivity, duration_seconds, status_light, name."
     ),
-    annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=False),
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False),
     permission_category="light",
     permission_action="update",
 )
@@ -118,6 +119,12 @@ async def protect_update_light(
 
         # Apply the changes
         result = await light_manager.apply_light_settings(light_id, filtered)
+        if result.get("errors"):
+            return {
+                "success": False,
+                "error": "Failed to update light settings: " + "; ".join(result["errors"]),
+                "data": result,
+            }
         return {"success": True, "data": result}
     except (UniFiNotFoundError, ValueError) as e:
         return {"success": False, "error": str(e)}

--- a/apps/protect/src/unifi_protect_mcp/tools_manifest.json
+++ b/apps/protect/src/unifi_protect_mcp/tools_manifest.json
@@ -5165,10 +5165,12 @@
     },
     {
       "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Updates camera settings such as IR LED mode, HDR mode, mic/speaker volume, status light, and motion detection. Requires confirm=True to apply. Supported keys: ir_led_mode, hdr_mode, mic_enabled, mic_volume, status_light_on, speaker_volume, name, motion_detection.",
+      "description": "Updates camera settings such as IR LED mode, HDR mode, mic/speaker volume, status light, and motion detection. Requires confirm=True to apply. HDR and microphone volume require UNIFI_PROTECT_API_KEY or UNIFI_API_KEY. Supported keys: ir_led_mode, hdr_mode, mic_enabled, mic_volume, status_light_on, speaker_volume, name, motion_detection.",
       "name": "protect_update_camera_settings",
       "permission_action": "update",
       "permission_category": "camera",
@@ -5184,7 +5186,7 @@
               "type": "boolean"
             },
             "settings": {
-              "description": "Dictionary of settings to update. Supported keys: ir_led_mode (auto, on, autoFilterOnly), hdr_mode (off, auto, or always; always = superHdr highest quality. Booleans accepted: true=auto, false=off), mic_enabled (true/false), mic_volume (0-100), status_light_on (true/false), speaker_volume (0-100), name (string), motion_detection (true/false).",
+              "description": "Dictionary of settings to update. Supported keys: ir_led_mode (auto, on, autoFilterOnly), hdr_mode (off, auto, or always; always = superHdr highest quality. Booleans accepted: true=auto, false=off), mic_enabled (true/false), mic_volume (1-100; zero is not supported by the public API), status_light_on (true/false), speaker_volume (0-100), name (string), motion_detection (true/false).",
               "type": "object"
             }
           },
@@ -5651,10 +5653,12 @@
     },
     {
       "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
         "openWorldHint": false,
         "readOnlyHint": false
       },
-      "description": "Updates light settings such as on/off state, LED brightness level (1-6), PIR motion sensitivity (0-100), motion-triggered duration (15-900 seconds), status indicator light, and device name. Requires confirm=True to apply. Supported keys: light_on, led_level, sensitivity, duration_seconds, status_light, name.",
+      "description": "Updates light settings such as on/off state, LED brightness level (1-6), PIR motion sensitivity (0-100), motion-triggered duration (15-900 seconds), status indicator light, and device name. Requires confirm=True to apply. Power, brightness, sensitivity and duration require UNIFI_PROTECT_API_KEY or UNIFI_API_KEY. Supported keys: light_on (alias is_light_on), led_level, sensitivity, duration_seconds, status_light, name.",
       "name": "protect_update_light",
       "permission_action": "update",
       "permission_category": "light",

--- a/apps/protect/tests/unit/test_cameras.py
+++ b/apps/protect/tests/unit/test_cameras.py
@@ -5,6 +5,7 @@ from enum import Enum
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from uiprotect.data.types import PublicHdrMode
 
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.redaction import REDACTED
@@ -170,8 +171,8 @@ def _make_camera(**overrides):
     cam.get_rtsps_streams = AsyncMock(return_value=overrides.get("rtsps_streams", None))
     cam.get_ptz_presets = AsyncMock(return_value=overrides.get("ptz_presets", []))
     cam.set_ir_led_model = AsyncMock()
-    cam.set_hdr_mode = AsyncMock()
-    cam.set_mic_volume = AsyncMock()
+    cam.set_hdr_mode_public = AsyncMock()
+    cam.set_mic_volume_public = AsyncMock()
     cam.set_status_light = AsyncMock()
     cam.set_speaker_volume = AsyncMock()
     cam.set_name = AsyncMock()
@@ -204,6 +205,7 @@ def mock_cm():
     """Create a mock ProtectConnectionManager with a mocked client.bootstrap."""
     cm = MagicMock()
     cm.host = "192.168.1.1"
+    cm.validate_public_id_portability = AsyncMock()
     cam = _make_camera()
     cm.client.bootstrap = _make_bootstrap(cameras={"cam-001": cam})
     cm.client.api_request = AsyncMock(return_value={"success": True})
@@ -215,6 +217,7 @@ def mock_cm_multiple_cameras():
     """CM with multiple cameras."""
     cm = MagicMock()
     cm.host = "192.168.1.1"
+    cm.validate_public_id_portability = AsyncMock()
     cam1 = _make_camera(id="cam-001", name="Front Door")
     cam2 = _make_camera(id="cam-002", name="Back Yard", is_recording=False, recording_mode=_FakeRecordingMode.NEVER)
     cam3 = _make_camera(id="cam-003", name="Garage", is_connected=False, state=_FakeStateType.DISCONNECTED)
@@ -459,7 +462,7 @@ class TestCameraManagerApplyCameraSettings:
         cam = mock_cm.client.bootstrap.cameras["cam-001"]
         result = await mgr.apply_camera_settings("cam-001", {"mic_volume": 50})
         assert "mic_volume=50" in result["applied"]
-        cam.set_mic_volume.assert_awaited_once_with(50)
+        cam.set_mic_volume_public.assert_awaited_once_with(50)
 
     @pytest.mark.asyncio
     async def test_apply_error_handling(self, mock_cm):
@@ -480,11 +483,11 @@ class TestCameraManagerApplyCameraSettings:
         cam = mock_cm.client.bootstrap.cameras["cam-001"]
         result = await mgr.apply_camera_settings("cam-001", {"hdr_mode": "superHdr"})
         assert "hdr_mode=always" in result["applied"]
-        cam.set_hdr_mode.assert_awaited_once_with("always")
+        cam.set_hdr_mode_public.assert_awaited_once_with(PublicHdrMode.ON)
 
     @pytest.mark.asyncio
     async def test_apply_hdr_bool_false_turns_off(self, mock_cm):
-        # Regression: set_hdr_mode(False) does NOT turn HDR off because
+        # Regression: set_hdr_mode_public(False) does NOT turn HDR off because
         # ``False == "off"`` is false; we must normalize to the "off" literal.
         from unifi_core.protect.managers.camera_manager import CameraManager
 
@@ -492,7 +495,7 @@ class TestCameraManagerApplyCameraSettings:
         cam = mock_cm.client.bootstrap.cameras["cam-001"]
         result = await mgr.apply_camera_settings("cam-001", {"hdr_mode": False})
         assert "hdr_mode=off" in result["applied"]
-        cam.set_hdr_mode.assert_awaited_once_with("off")
+        cam.set_hdr_mode_public.assert_awaited_once_with("off")
 
     @pytest.mark.asyncio
     async def test_apply_hdr_bool_true_is_auto(self, mock_cm):
@@ -501,16 +504,15 @@ class TestCameraManagerApplyCameraSettings:
         mgr = CameraManager(mock_cm)
         cam = mock_cm.client.bootstrap.cameras["cam-001"]
         await mgr.apply_camera_settings("cam-001", {"hdr_mode": True})
-        cam.set_hdr_mode.assert_awaited_once_with("auto")
+        cam.set_hdr_mode_public.assert_awaited_once_with("auto")
 
     @pytest.mark.asyncio
     async def test_apply_hdr_invalid_value(self, mock_cm):
         from unifi_core.protect.managers.camera_manager import CameraManager
 
         mgr = CameraManager(mock_cm)
-        result = await mgr.apply_camera_settings("cam-001", {"hdr_mode": "ultra"})
-        assert "errors" in result
-        assert any("Invalid hdr_mode" in e for e in result["errors"])
+        with pytest.raises(ValueError, match="Invalid hdr_mode"):
+            await mgr.apply_camera_settings("cam-001", {"hdr_mode": "ultra"})
 
 
 class TestNormalizeHdrMode:
@@ -1248,3 +1250,18 @@ class TestProtectRebootCameraTool:
         mock_camera_manager.reboot_camera = AsyncMock(side_effect=RuntimeError("failed"))
         result = await protect_reboot_camera("cam-001", confirm=False)
         assert result["success"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("applied", [[], ["name=new"]])
+async def test_settings_failure_is_not_success(mock_camera_manager, applied):
+    from unifi_protect_mcp.tools.cameras import protect_update_camera_settings
+
+    mock_camera_manager.update_camera_settings = AsyncMock(return_value={})
+    mock_camera_manager.apply_camera_settings = AsyncMock(
+        return_value={"applied": applied, "errors": ["setting failed"]}
+    )
+    result = await protect_update_camera_settings("device", {"mic_volume": 51}, confirm=True)
+    assert result["success"] is False
+    assert "setting failed" in result["error"]
+    assert result["data"]["applied"] == applied

--- a/apps/protect/tests/unit/test_devices.py
+++ b/apps/protect/tests/unit/test_devices.py
@@ -85,10 +85,10 @@ def _make_light(**overrides):
     light.light_mode_settings = ms
 
     # Async methods
-    light.set_light = AsyncMock()
-    light.set_led_level = AsyncMock()
-    light.set_sensitivity = AsyncMock()
-    light.set_duration = AsyncMock()
+    light.set_light_public = AsyncMock()
+    light.set_led_level_public = AsyncMock()
+    light.set_sensitivity_public = AsyncMock()
+    light.set_duration_public = AsyncMock()
     light.set_status_light = AsyncMock()
     light.set_name = AsyncMock()
 
@@ -253,6 +253,7 @@ def _make_bootstrap(lights=None, sensors=None, chimes=None):
 @pytest.fixture
 def mock_cm_lights():
     cm = MagicMock()
+    cm.validate_public_id_portability = AsyncMock()
     light = _make_light()
     cm.client.bootstrap = _make_bootstrap(lights={"light-001": light})
     return cm
@@ -356,7 +357,7 @@ class TestLightManagerApply:
         light = mock_cm_lights.client.bootstrap.lights["light-001"]
         result = await mgr.apply_light_settings("light-001", {"light_on": True})
         assert "light_on=True" in result["applied"]
-        light.set_light.assert_awaited_once_with(True)
+        light.set_light_public.assert_awaited_once_with(True)
 
     @pytest.mark.asyncio
     async def test_apply_led_level(self, mock_cm_lights):
@@ -366,7 +367,7 @@ class TestLightManagerApply:
         light = mock_cm_lights.client.bootstrap.lights["light-001"]
         result = await mgr.apply_light_settings("light-001", {"led_level": 3})
         assert "led_level=3" in result["applied"]
-        light.set_led_level.assert_awaited_once_with(3)
+        light.set_led_level_public.assert_awaited_once_with(3)
 
     @pytest.mark.asyncio
     async def test_apply_duration(self, mock_cm_lights):
@@ -376,14 +377,14 @@ class TestLightManagerApply:
         light = mock_cm_lights.client.bootstrap.lights["light-001"]
         result = await mgr.apply_light_settings("light-001", {"duration_seconds": 60})
         assert "duration_seconds=60" in result["applied"]
-        light.set_duration.assert_awaited_once_with(timedelta(seconds=60))
+        light.set_duration_public.assert_awaited_once_with(timedelta(seconds=60))
 
     @pytest.mark.asyncio
     async def test_apply_error(self, mock_cm_lights):
         from unifi_core.protect.managers.light_manager import LightManager
 
         light = mock_cm_lights.client.bootstrap.lights["light-001"]
-        light.set_light = AsyncMock(side_effect=RuntimeError("API error"))
+        light.set_light_public = AsyncMock(side_effect=RuntimeError("API error"))
         mgr = LightManager(mock_cm_lights)
         result = await mgr.apply_light_settings("light-001", {"light_on": True})
         assert "errors" in result
@@ -1295,3 +1296,16 @@ class TestProtectTriggerChimeTool:
         mock_chime_manager.trigger_chime = AsyncMock(side_effect=RuntimeError("network error"))
         result = await protect_trigger_chime("chime-001", confirm=True)
         assert result["success"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("applied", [[], ["name=new"]])
+async def test_settings_failure_is_not_success(mock_light_manager, applied):
+    from unifi_protect_mcp.tools.devices import protect_update_light
+
+    mock_light_manager.update_light = AsyncMock(return_value={})
+    mock_light_manager.apply_light_settings = AsyncMock(return_value={"applied": applied, "errors": ["setting failed"]})
+    result = await protect_update_light("device", {"led_level": 4}, confirm=True)
+    assert result["success"] is False
+    assert "setting failed" in result["error"]
+    assert result["data"]["applied"] == applied

--- a/packages/unifi-core/pyproject.toml
+++ b/packages/unifi-core/pyproject.toml
@@ -17,9 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 network = ["aiounifi>=92"]
 protect = [
-    # v16 removes session-auth setters used by our camera and light managers.
-    # Migrate these writes and their API-key requirements before lifting this cap.
-    "uiprotect>=15.14.2,<16",
+    # Camera/light public setters require a Protect API key; see the Protect README.
+    "uiprotect>=16.10.0,<17",
     # uiprotect permits older PyJWT releases; published Core wheels must enforce
     # the advisory-safe floor even when installed over an existing environment.
     "PyJWT>=2.13.0",

--- a/packages/unifi-core/src/unifi_core/protect/managers/camera_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/camera_manager.py
@@ -10,59 +10,17 @@ import asyncio
 import logging
 from typing import Any, Dict, List, Optional
 
-from uiprotect.data.types import IRLEDMode, RecordingMode
+from uiprotect.data.types import IRLEDMode, PublicHdrMode, RecordingMode
 
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
+from unifi_core.protect.models.cameras import normalize_hdr_mode, to_controller_update
 
 logger = logging.getLogger(__name__)
 
 PTZ_MIN_SPEED = -1000
 PTZ_MAX_SPEED = 1000
 PTZ_MAX_DURATION_MS = 5000
-
-# uiprotect's Camera.set_hdr_mode accepts the literals "off", "auto" and
-# "always". "always" maps to ISP HDRMode.ALWAYS_ON ("superHdr"), the highest
-# quality HDR. We accept booleans and the controller-facing value names as
-# aliases so callers can request superHdr explicitly and so that passing
-# ``false`` reliably turns HDR off (``set_hdr_mode(False)`` does NOT, because
-# ``False == "off"`` is false in Python).
-_HDR_MODE_ALIASES = {
-    # off
-    "off": "off",
-    "false": "off",
-    "none": "off",
-    "disabled": "off",
-    # auto: HDR on, normal dynamic range (ISP hdr_mode == "normal")
-    "auto": "auto",
-    "on": "auto",
-    "true": "auto",
-    "normal": "auto",
-    # always-on / super HDR: highest quality (ISP hdr_mode == "superHdr")
-    "always": "always",
-    "super": "always",
-    "superhdr": "always",
-    "super_hdr": "always",
-}
-
-
-def normalize_hdr_mode(value: Any) -> str:
-    """Map a user-supplied hdr_mode value to a uiprotect literal.
-
-    Returns one of "off", "auto", or "always". Raises ``ValueError`` for
-    unrecognised values so the error surfaces during preview, before any
-    mutation is applied.
-    """
-    if isinstance(value, bool):
-        return "auto" if value else "off"
-    if isinstance(value, str):
-        normalized = _HDR_MODE_ALIASES.get(value.strip().lower())
-        if normalized is not None:
-            return normalized
-    raise ValueError(
-        f"Invalid hdr_mode {value!r}. Use one of: off, auto, always "
-        "(aliases: true=auto, false=off, on, normal, super/superHdr=always)."
-    )
 
 
 class CameraManager:
@@ -362,6 +320,23 @@ class CameraManager:
     # Mutation methods
     # ------------------------------------------------------------------
 
+    async def _validate_settings(self, camera, settings: Dict[str, Any]) -> Dict[str, Any]:
+        settings = to_controller_update(settings)
+        if not settings:
+            raise ValueError("No supported camera settings provided")
+        if "ir_led_mode" in settings:
+            IRLEDMode(settings["ir_led_mode"])
+        if "hdr_mode" in settings and not camera.feature_flags.has_hdr:
+            raise ValueError("Cannot update HDR: this camera does not support HDR")
+        if "mic_volume" in settings and not camera.feature_flags.has_mic:
+            raise ValueError("Cannot update microphone volume: this camera has no microphone")
+        if settings.keys() & {"hdr_mode", "mic_volume"}:
+            self._cm.require_public_api_key("update camera HDR or microphone volume")
+            await self._cm.validate_public_id_portability(
+                resource_type="cameras", bootstrap_collection="cameras", public_list_method="get_cameras_public"
+            )
+        return settings
+
     async def update_camera_settings(self, camera_id: str, settings: Dict[str, Any]) -> Dict[str, Any]:
         """Update camera settings. Returns dict with current and proposed state.
 
@@ -369,13 +344,14 @@ class CameraManager:
         - ir_led_mode: str (auto, on, off, autoFilterOnly)
         - hdr_mode: str (auto, off, always)
         - mic_enabled: bool
-        - mic_volume: int (0-100)
+        - mic_volume: int (1-100; public API requires an API key)
         - status_light_on: bool
         - speaker_volume: int (0-100)
         - name: str
         - motion_detection: bool
         """
         camera = self._get_camera(camera_id)
+        settings = await self._validate_settings(camera, settings)
 
         current_state: Dict[str, Any] = {}
         proposed_changes: Dict[str, Any] = {}
@@ -386,7 +362,13 @@ class CameraManager:
                 proposed_changes["ir_led_mode"] = value
             elif key == "hdr_mode":
                 current_isp_hdr = camera.isp_settings.hdr_mode
-                current_state["hdr_mode"] = str(current_isp_hdr.value) if current_isp_hdr else None
+                current_state["hdr_mode"] = (
+                    "off"
+                    if not camera.hdr_mode
+                    else normalize_hdr_mode(current_isp_hdr.value)
+                    if current_isp_hdr
+                    else None
+                )
                 # Normalize so the preview shows what will actually be applied
                 # (and rejects invalid values before confirmation).
                 proposed_changes["hdr_mode"] = normalize_hdr_mode(value)
@@ -425,6 +407,7 @@ class CameraManager:
         Calls the appropriate pyunifiprotect setter methods.
         """
         camera = self._get_camera(camera_id)
+        settings = await self._validate_settings(camera, settings)
         applied: List[str] = []
         errors: List[str] = []
 
@@ -436,17 +419,16 @@ class CameraManager:
                     applied.append(f"ir_led_mode={value}")
                 elif key == "hdr_mode":
                     mode = normalize_hdr_mode(value)
-                    await camera.set_hdr_mode(mode)
+                    await camera.set_hdr_mode_public(PublicHdrMode.ON if mode == "always" else PublicHdrMode(mode))
                     applied.append(f"hdr_mode={mode}")
                 elif key == "mic_enabled":
-                    # There's no direct set_mic_enabled; adjust mic volume to 0 for disable
-                    # or use set_privacy for full mic control. Use save_device pattern.
+                    # Microphone enablement remains a separate session-auth setting.
                     data_before = camera.dict_with_excludes()
                     camera.is_mic_enabled = value
                     await camera.save_device(data_before)
                     applied.append(f"mic_enabled={value}")
                 elif key == "mic_volume":
-                    await camera.set_mic_volume(int(value))
+                    await camera.set_mic_volume_public(value)
                     applied.append(f"mic_volume={value}")
                 elif key == "status_light_on":
                     await camera.set_status_light(bool(value))
@@ -463,7 +445,7 @@ class CameraManager:
                 else:
                     errors.append(f"Unknown setting: {key}")
             except Exception as exc:
-                logger.error("Error applying camera setting %s=%s: %s", key, value, exc, exc_info=True)
+                logger.error("Failed to apply camera setting %s (%s)", key, type(exc).__name__)
                 errors.append(f"{key}: {exc}")
 
         result: Dict[str, Any] = {

--- a/packages/unifi-core/src/unifi_core/protect/managers/light_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/light_manager.py
@@ -4,11 +4,10 @@ Provides methods to list and update UniFi Protect floodlight devices
 via the uiprotect bootstrap data.
 
 Key API surface on ``Light``:
-- ``set_light(enabled, led_level=None)`` -- turn on/off, optionally set level
-- ``set_led_level(level)`` -- set LED brightness (1-6)
-- ``set_sensitivity(sensitivity)`` -- set PIR motion sensitivity (0-100)
-- ``set_duration(duration)`` -- set motion-triggered on duration (timedelta)
-- ``set_light_settings(mode, enable_at, duration, sensitivity)`` -- bulk update
+- ``set_light_public(enabled, led_level=None)`` -- turn on/off, optionally set level
+- ``set_led_level_public(level)`` -- set LED brightness (1-6)
+- ``set_sensitivity_public(sensitivity)`` -- set PIR motion sensitivity (0-100)
+- ``set_duration_public(duration)`` -- set motion-triggered on duration (timedelta)
 - ``set_status_light(enabled)`` -- toggle the status indicator LED
 - ``set_name(name)`` -- rename the device
 """
@@ -21,6 +20,7 @@ from typing import Any, Dict, List
 
 from unifi_core.exceptions import UniFiNotFoundError
 from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
+from unifi_core.protect.models.lights import to_controller_update
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,17 @@ class LightManager:
     # Mutation methods (preview / apply)
     # ------------------------------------------------------------------
 
+    async def _validate_settings(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        settings = to_controller_update(settings)
+        if not settings:
+            raise ValueError("No supported light settings provided")
+        if settings.keys() & {"light_on", "led_level", "sensitivity", "duration_seconds"}:
+            self._cm.require_public_api_key("update light power, brightness, sensitivity or duration")
+            await self._cm.validate_public_id_portability(
+                resource_type="lights", bootstrap_collection="lights", public_list_method="get_lights_public"
+            )
+        return settings
+
     async def update_light(self, light_id: str, settings: Dict[str, Any]) -> Dict[str, Any]:
         """Return current and proposed light state for preview.
 
@@ -118,13 +129,14 @@ class LightManager:
         - name: str -- device name
         """
         light = self._get_light(light_id)
+        settings = await self._validate_settings(settings)
 
         current_state: Dict[str, Any] = {}
         proposed_changes: Dict[str, Any] = {}
 
         for key, value in settings.items():
             if key == "light_on":
-                current_state["light_on"] = light.is_light_on
+                current_state["light_on"] = light.light_on_settings.is_led_force_on
                 proposed_changes["light_on"] = value
             elif key == "led_level":
                 current_led = light.light_device_settings.led_level if light.light_device_settings else None
@@ -161,22 +173,23 @@ class LightManager:
     async def apply_light_settings(self, light_id: str, settings: Dict[str, Any]) -> Dict[str, Any]:
         """Apply light settings after confirmation."""
         light = self._get_light(light_id)
+        settings = await self._validate_settings(settings)
         applied: List[str] = []
         errors: List[str] = []
 
         for key, value in settings.items():
             try:
                 if key == "light_on":
-                    await light.set_light(bool(value))
+                    await light.set_light_public(bool(value))
                     applied.append(f"light_on={value}")
                 elif key == "led_level":
-                    await light.set_led_level(int(value))
+                    await light.set_led_level_public(int(value))
                     applied.append(f"led_level={value}")
                 elif key == "sensitivity":
-                    await light.set_sensitivity(int(value))
+                    await light.set_sensitivity_public(int(value))
                     applied.append(f"sensitivity={value}")
                 elif key == "duration_seconds":
-                    await light.set_duration(timedelta(seconds=int(value)))
+                    await light.set_duration_public(timedelta(seconds=int(value)))
                     applied.append(f"duration_seconds={value}")
                 elif key == "status_light":
                     await light.set_status_light(bool(value))
@@ -187,7 +200,7 @@ class LightManager:
                 else:
                     errors.append(f"Unknown setting: {key}")
             except Exception as exc:
-                logger.error("Error applying light setting %s=%s: %s", key, value, exc, exc_info=True)
+                logger.error("Failed to apply light setting %s (%s)", key, type(exc).__name__)
                 errors.append(f"{key}: {exc}")
 
         result: Dict[str, Any] = {

--- a/packages/unifi-core/src/unifi_core/protect/managers/light_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/light_manager.py
@@ -14,6 +14,7 @@ Key API surface on ``Light``:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any, Dict, List
@@ -30,6 +31,9 @@ class LightManager:
 
     def __init__(self, connection_manager: ProtectConnectionManager) -> None:
         self._cm = connection_manager
+        # Public SDK setters copy the complete light_device_settings object.
+        # Serialize writes so concurrent requests cannot send stale sibling fields.
+        self._settings_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Helpers
@@ -172,6 +176,10 @@ class LightManager:
 
     async def apply_light_settings(self, light_id: str, settings: Dict[str, Any]) -> Dict[str, Any]:
         """Apply light settings after confirmation."""
+        async with self._settings_lock:
+            return await self._apply_light_settings(light_id, settings)
+
+    async def _apply_light_settings(self, light_id: str, settings: Dict[str, Any]) -> Dict[str, Any]:
         light = self._get_light(light_id)
         settings = await self._validate_settings(settings)
         applied: List[str] = []

--- a/packages/unifi-core/src/unifi_core/protect/models/cameras.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/cameras.py
@@ -6,6 +6,43 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
+_HDR_MODE_ALIASES = {
+    # off
+    "off": "off",
+    "false": "off",
+    "none": "off",
+    "disabled": "off",
+    # auto: HDR on, normal dynamic range (ISP hdr_mode == "normal")
+    "auto": "auto",
+    "on": "auto",
+    "true": "auto",
+    "normal": "auto",
+    # always-on / super HDR: highest quality (ISP hdr_mode == "superHdr")
+    "always": "always",
+    "super": "always",
+    "superhdr": "always",
+    "super_hdr": "always",
+}
+
+
+def normalize_hdr_mode(value: Any) -> str:
+    """Map a user-supplied hdr_mode value to a uiprotect literal.
+
+    Returns one of "off", "auto", or "always". Raises ``ValueError`` for
+    unrecognised values so the error surfaces during preview, before any
+    mutation is applied.
+    """
+    if isinstance(value, bool):
+        return "auto" if value else "off"
+    if isinstance(value, str):
+        normalized = _HDR_MODE_ALIASES.get(value.strip().lower())
+        if normalized is not None:
+            return normalized
+    raise ValueError(
+        f"Invalid hdr_mode {value!r}. Use one of: off, auto, always "
+        "(aliases: true=auto, false=off, on, normal, super/superHdr=always)."
+    )
+
 
 class Camera(BaseModel):
     """Canonical Protect camera model.
@@ -109,4 +146,12 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     this helper centralises mutability enforcement so callers cannot
     silently include read-only field names.
     """
-    return {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
+    filtered = {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
+    if "hdr_mode" in filtered:
+        filtered["hdr_mode"] = normalize_hdr_mode(filtered["hdr_mode"])
+    validated = Camera.model_validate(filtered).model_dump(exclude_unset=True)
+    # Zero can appear in existing controller state, but the public write API
+    # accepts 1-100 only. Never silently clamp it or disable the microphone.
+    if validated.get("mic_volume") == 0:
+        raise ValueError("Cannot update mic_volume to 0: the Protect public API accepts 1-100.")
+    return {key: validated[key] for key in filtered}

--- a/packages/unifi-core/src/unifi_core/protect/models/lights.py
+++ b/packages/unifi-core/src/unifi_core/protect/models/lights.py
@@ -74,9 +74,11 @@ def to_controller_update(fields: Dict[str, Any]) -> Dict[str, Any]:
     Renames model-side field names that differ from controller-side keys
     (currently only ``is_light_on`` → ``light_on``).
     """
-    out: Dict[str, Any] = {}
-    for k, v in fields.items():
-        if k not in MUTABLE_FIELDS or v is None:
-            continue
-        out[_CONTROLLER_KEY_MAP.get(k, k)] = v
-    return out
+    fields = dict(fields)
+    if "light_on" in fields:
+        if "is_light_on" in fields and fields["is_light_on"] != fields["light_on"]:
+            raise ValueError("Conflicting light_on and is_light_on settings")
+        fields["is_light_on"] = fields.pop("light_on")
+    filtered = {k: v for k, v in fields.items() if k in MUTABLE_FIELDS and v is not None}
+    validated = Light.model_validate(filtered).model_dump(exclude_unset=True)
+    return {_CONTROLLER_KEY_MAP.get(k, k): validated[k] for k in filtered}

--- a/packages/unifi-core/tests/protect/test_public_settings.py
+++ b/packages/unifi-core/tests/protect/test_public_settings.py
@@ -1,5 +1,6 @@
 """Exercise real SDK setters, mocking only the controller transport boundary."""
 
+import asyncio
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -184,3 +185,25 @@ async def test_hdr_off_preview_does_not_report_normal_isp_mode(devices):
     assert result["current_state"]["hdr_mode"] == "off"
     assert result["proposed_changes"]["hdr_mode"] == "auto"
     api.update_camera_public.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_light_updates_preserve_both_settings(devices):
+    cm, api, _, light = devices
+    manager = LightManager(cm)
+    writes = []
+
+    async def controller_update(device_id, **kwargs):
+        writes.append(kwargs["light_device_settings"].model_dump())
+        await asyncio.sleep(0)
+
+    api.update_light_public.side_effect = controller_update
+    results = await asyncio.gather(
+        manager.apply_light_settings(light.id, {"led_level": 4}),
+        manager.apply_light_settings(light.id, {"sensitivity": 51}),
+    )
+    assert all(not result.get("errors") for result in results)
+    assert writes[-1]["led_level"] == 4
+    assert writes[-1]["pir_sensitivity"] == 51
+    assert light.light_device_settings.led_level == 4
+    assert light.light_device_settings.pir_sensitivity == 51

--- a/packages/unifi-core/tests/protect/test_public_settings.py
+++ b/packages/unifi-core/tests/protect/test_public_settings.py
@@ -1,0 +1,186 @@
+"""Exercise real SDK setters, mocking only the controller transport boundary."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from uiprotect.data import Camera, Light
+from uiprotect.data.devices import CameraFeatureFlags, ISPSettings, LightDeviceSettings, LightOnSettings
+from uiprotect.data.types import HDRMode, PublicHdrMode
+from unifi_core.protect.managers.camera_manager import CameraManager
+from unifi_core.protect.managers.connection_manager import ProtectConnectionManager
+from unifi_core.protect.managers.light_manager import LightManager
+
+
+@pytest.fixture
+def devices():
+    api = SimpleNamespace(
+        update_camera_public=AsyncMock(return_value=SimpleNamespace(mic_volume=51)),
+        update_light_public=AsyncMock(),
+    )
+    camera = Camera.model_construct(
+        id="camera",
+        name="Camera",
+        hdr_mode=True,
+        mic_volume=50,
+        feature_flags=CameraFeatureFlags.model_construct(has_hdr=True, has_mic=True),
+        isp_settings=ISPSettings.model_construct(hdr_mode=HDRMode.NORMAL),
+    )
+    light = Light.model_construct(
+        id="light",
+        name="Light",
+        light_device_settings=LightDeviceSettings.model_construct(
+            led_level=3,
+            pir_sensitivity=50,
+            pir_duration=timedelta(seconds=30),
+            is_indicator_enabled=True,
+        ),
+        light_on_settings=LightOnSettings.model_construct(is_led_force_on=False),
+    )
+    camera._api = light._api = api
+    api.bootstrap = SimpleNamespace(cameras={camera.id: camera}, lights={light.id: light})
+    api.get_cameras_public = AsyncMock(return_value=[SimpleNamespace(id="camera")])
+    api.get_lights_public = AsyncMock(return_value=[SimpleNamespace(id="light")])
+    cm = ProtectConnectionManager(host="controller.invalid", username="test", password="test", api_key="test")
+    cm._client = api
+    cm._initialized = True
+    return cm, api, camera, light
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value,expected", [(False, PublicHdrMode.OFF), (True, PublicHdrMode.AUTO), ("superHdr", PublicHdrMode.ON)]
+)
+async def test_hdr_real_setter(devices, value, expected):
+    cm, api, camera, _ = devices
+    result = await CameraManager(cm).apply_camera_settings(camera.id, {"hdr_mode": value})
+    assert not result.get("errors")
+    api.update_camera_public.assert_awaited_once_with(camera.id, hdr_type=expected)
+
+
+@pytest.mark.asyncio
+async def test_microphone_real_setter(devices):
+    cm, api, camera, _ = devices
+    await CameraManager(cm).apply_camera_settings(camera.id, {"mic_volume": 51})
+    api.update_camera_public.assert_awaited_once_with(camera.id, mic_volume=51)
+    assert camera.mic_volume == 51
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "settings,field,expected",
+    [
+        ({"led_level": 4}, "led_level", 4),
+        ({"sensitivity": 51}, "pir_sensitivity", 51),
+        ({"duration_seconds": 60}, "pir_duration", timedelta(seconds=60)),
+    ],
+)
+async def test_light_real_setters_preserve_other_fields(devices, settings, field, expected):
+    cm, api, _, light = devices
+    original = light.light_device_settings.model_dump()
+    result = await LightManager(cm).apply_light_settings(light.id, settings)
+    assert not result.get("errors")
+    sent = api.update_light_public.await_args.kwargs["light_device_settings"].model_dump()
+    assert sent == {**original, field: expected}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key", ["light_on", "is_light_on"])
+async def test_light_power_aliases(devices, key):
+    cm, api, _, light = devices
+    await LightManager(cm).apply_light_settings(light.id, {key: True})
+    api.update_light_public.assert_awaited_once_with(light.id, is_light_force_enabled=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("preview", [False, True])
+@pytest.mark.parametrize(
+    "domain,settings",
+    [
+        ("camera", {"hdr_mode": "auto", "mic_volume": 0}),
+        ("camera", {"mic_volume": 50, "hdr_mode": "invalid"}),
+        ("camera", {"mic_volume": 50, "speaker_volume": 101}),
+        ("light", {"light_on": True, "led_level": 7}),
+        ("light", {"light_on": True, "sensitivity": -1}),
+        ("light", {"light_on": True, "duration_seconds": 14}),
+        ("light", {"light_on": True, "is_light_on": False}),
+    ],
+)
+async def test_invalid_request_has_no_writes(devices, preview, domain, settings):
+    cm, api, camera, light = devices
+    manager = CameraManager(cm) if domain == "camera" else LightManager(cm)
+    method = (
+        (manager.update_camera_settings if preview else manager.apply_camera_settings)
+        if domain == "camera"
+        else (manager.update_light if preview else manager.apply_light_settings)
+    )
+    with pytest.raises(ValueError):
+        await method(camera.id if domain == "camera" else light.id, settings)
+    api.update_camera_public.assert_not_awaited()
+    api.update_light_public.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("domain", ["camera", "light"])
+@pytest.mark.parametrize("failure", ["missing_key", "id_mismatch", "read_failure"])
+async def test_preflight_failure_prevents_all_writes(devices, domain, failure):
+    cm, api, camera, light = devices
+    if failure == "missing_key":
+        cm._api_key = " "
+        expected = "UNIFI_PROTECT_API_KEY"
+    else:
+        getter = api.get_cameras_public if domain == "camera" else api.get_lights_public
+        getter.return_value = [SimpleNamespace(id="different")]
+        expected = "not portable"
+        if failure == "read_failure":
+            getter.side_effect = ValueError("controller unavailable")
+            expected = "controller unavailable"
+    with pytest.raises(ValueError, match=expected):
+        if domain == "camera":
+            await CameraManager(cm).apply_camera_settings(camera.id, {"name": "new", "mic_volume": 51})
+        else:
+            await LightManager(cm).apply_light_settings(light.id, {"name": "new", "led_level": 4})
+    api.update_camera_public.assert_not_awaited()
+    api.update_light_public.assert_not_awaited()
+    assert camera.name == "Camera" and light.name == "Light"
+
+
+@pytest.mark.asyncio
+async def test_partial_controller_failure_reports_applied_fields(devices):
+    cm, api, camera, _ = devices
+    api.update_camera_public.side_effect = [SimpleNamespace(mic_volume=51), RuntimeError("controller failed")]
+    result = await CameraManager(cm).apply_camera_settings(camera.id, {"mic_volume": 51, "hdr_mode": "auto"})
+    assert result["applied"] == ["mic_volume=51"]
+    assert result["errors"] == ["hdr_mode: controller failed"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("key,feature,value", [("hdr_mode", "has_hdr", "auto"), ("mic_volume", "has_mic", 51)])
+async def test_unsupported_camera_feature_fails_before_writes(devices, key, feature, value):
+    cm, api, camera, _ = devices
+    setattr(camera.feature_flags, feature, False)
+    with pytest.raises(ValueError, match="Cannot update"):
+        await CameraManager(cm).apply_camera_settings(camera.id, {"name": "new", key: value})
+    api.update_camera_public.assert_not_awaited()
+    assert camera.name == "Camera"
+
+
+@pytest.mark.asyncio
+async def test_preview_uses_force_setting_not_transient_light_state(devices):
+    cm, api, _, light = devices
+    light.is_light_on = True
+    result = await LightManager(cm).update_light(light.id, {"light_on": True})
+    assert result["current_state"]["light_on"] is False
+    assert result["proposed_changes"]["light_on"] is True
+    api.update_light_public.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hdr_off_preview_does_not_report_normal_isp_mode(devices):
+    cm, api, camera, _ = devices
+    camera.hdr_mode = False
+    result = await CameraManager(cm).update_camera_settings(camera.id, {"hdr_mode": True})
+    assert result["current_state"]["hdr_mode"] == "off"
+    assert result["proposed_changes"]["hdr_mode"] == "auto"
+    api.update_camera_public.assert_not_awaited()

--- a/packages/unifi-core/tests/protect/test_sdk_compatibility.py
+++ b/packages/unifi-core/tests/protect/test_sdk_compatibility.py
@@ -3,22 +3,37 @@
 import inspect
 
 import pytest
-from uiprotect.data import Camera, Light
+from uiprotect.data import Camera, Chime, Light
 
 
 @pytest.mark.parametrize(
     ("model", "method"),
     [
-        (Camera, "set_hdr_mode"),
-        (Camera, "set_mic_volume"),
-        (Light, "set_light"),
-        (Light, "set_led_level"),
-        (Light, "set_sensitivity"),
-        (Light, "set_duration"),
+        (Camera, "set_hdr_mode_public"),
+        (Camera, "set_mic_volume_public"),
+        (Light, "set_light_public"),
+        (Light, "set_led_level_public"),
+        (Light, "set_sensitivity_public"),
+        (Light, "set_duration_public"),
+        (Camera, "set_ir_led_model"),
+        (Camera, "set_status_light"),
+        (Camera, "set_speaker_volume"),
+        (Camera, "set_name"),
+        (Camera, "set_motion_detection"),
+        (Camera, "set_recording_mode"),
+        (Camera, "save_device"),
+        (Camera, "ptz_goto_preset_public"),
+        (Camera, "reboot"),
+        (Light, "set_status_light"),
+        (Light, "set_name"),
+        (Chime, "set_volume"),
+        (Chime, "set_repeat_times"),
+        (Chime, "set_name"),
+        (Chime, "play"),
     ],
 )
 def test_manager_write_methods_exist_in_installed_sdk(model: type, method: str) -> None:
-    """Confirmed camera/light updates require these session-auth async methods."""
+    """Confirmed camera/light updates require these public API async methods."""
     assert inspect.iscoroutinefunction(getattr(model, method, None)), (
         f"{model.__name__}.{method} is unavailable; migrate the manager before upgrading uiprotect"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1785,7 +1785,7 @@ wheels = [
 
 [[package]]
 name = "uiprotect"
-version = "15.14.2"
+version = "16.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1802,9 +1802,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/2e/58b213c10f248e053dc0b2ca1ca67d429cc34233aba57ebf9b4db29a9844/uiprotect-15.14.2.tar.gz", hash = "sha256:ae3a099d0e76ccc57580230c2e3d121c24356583e3d66a96c75b0417b7e88e2a", size = 211968, upload-time = "2026-07-15T21:20:56.249Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/6c/76bc85b72b251f0c6da92a0a3c6c7c1a477dcf8aebddd6f60c2584f9bd03/uiprotect-16.10.0.tar.gz", hash = "sha256:880982d664c94c67762fcec9ed437bd472fba079fd476124c222aa34c69cccb4", size = 218795, upload-time = "2026-09-03T23:09:51.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/45/ce9b89b70794cbd733049db4f90a9b9d24712a04e772b1ab461fc6277af3/uiprotect-15.14.2-py3-none-any.whl", hash = "sha256:a73fe98579127fa3f569f1e268e2f31c4b94cb8b7f801b1d9997ebd75aa3c18f", size = 232727, upload-time = "2026-07-15T21:20:54.527Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/27/c9282d228d4250fc3fea06c8c9ce055201f6d148cc0e95d284632b1caa38/uiprotect-16.10.0-py3-none-any.whl", hash = "sha256:78679c6ed70ee1381f641f055aa08397c0996ecc878e655a27a9ab6872787b98", size = 239645, upload-time = "2026-09-03T23:09:49.622Z" },
 ]
 
 [[package]]
@@ -1976,7 +1976,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.5" },
     { name = "pyjwt", marker = "extra == 'protect'", specifier = ">=2.13.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=15.14.2,<16" },
+    { name = "uiprotect", marker = "extra == 'protect'", specifier = ">=16.10.0,<17" },
 ]
 provides-extras = ["access", "network", "protect"]
 


### PR DESCRIPTION
## Summary

uiprotect 16 removes six private setters used by confirmed camera/light updates. Migrate them to the public API, preflight settings/API-key/device-ID compatibility before writing, and bound the tested SDK to `>=16.10.0,<17`.

Preserve HDR aliases and light ranges; accept both `light_on` and `is_light_on`. The public microphone API requires 1–100, so zero fails before any write. MCP and API failures now retain applied settings and report `success: false`. Correct the API's confirmed camera binding, which previously called the preview method without applying changes.

Closes #693.

## Type of change

- [x] `fix:` bug fix
- [x] `chore:` dependency upgrade

## Scope

- [x] Protect MCP server
- [x] API server
- [x] Shared packages
- [x] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`.
- [x] I updated generated manifests with `make manifest`.
- [x] I added or updated tests for behavior changes.
- [x] I updated documentation for user-visible changes.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- Migration first tested on 15.14.2: 495 Core Protect tests and 529 Protect app tests passed.
- On 16.10.0: `make pre-commit` passed across the workspace; final focused Core Protect run passed 515 tests, Protect app 529, API 1,497. New tests invoke actual SDK setters and mock only their controller boundary.
- SDK symbol checks cover retained camera/light/chime methods as well as the six public replacements. Failure tests cover request validation, missing keys, unsupported features, ID mismatches, controller failures, partial results, concurrent light updates, and confirmed API dispatch.
- Regenerated MCP manifests/action catalog and API SDL/OpenAPI/both reference docs; the API artifacts have no resulting drift.
- Live Docker smoke on 16.10.0: 47 read-only checks and 23 mutation previews passed. Camera and light policy denial checks both passed.
- Explicitly approved, bounded live cycles passed for **HDR, microphone volume, light power, LED brightness, PIR sensitivity, and PIR duration**. Each preview left state unchanged; each confirmed update was independently read back; every original setting was restored in `finally` and restoration independently verified. Camera and light IDs matched across bootstrap/public APIs.
- Fresh Core/Protect/API wheels installed outside the checkout passed four live preview/missing-key checks with imports verified under `site-packages`.

Private local artifacts: `/tmp/unifi-693-live/` (inventory, six-field restoration report, read-only/preview reports, installed-wheel checks). Hardware identifiers and credentials are not attached publicly.

## Notes for reviewers

- These public settings require `UNIFI_PROTECT_API_KEY` or `UNIFI_API_KEY`; other settings retain session authentication. Existing tools, confirmation defaults, and policy gates remain in place.
- Public light setters copy full settings objects. Manager writes are serialized; a real-SDK regression test reproduces the lost-update race without the lock, and live brightness apply/readback/restore passed again after the fix.
- Controller writes are not transactional. Preflight prevents known input/auth/ID errors from applying earlier settings, while runtime failures preserve explicit partial results.
- **Release order:** publish the changed Core first, then raise Protect/API minimum Core versions to that published release before tagging downstream releases. The existing published-floor gate must remain enabled; downstream release tags are not part of this PR.
- The audit also found an unrelated pre-existing event acknowledgment persistence bug, tracked separately in #696. No event mutation was attempted here.
