### PR TITLE
chore(release): require Core 0.4.52 for Protect and API

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # Owned event listeners and controller-session cleanup require Core 0.4.49.
     # Global alarm status aggregation requires Core 0.4.50.
     # Controller credential redaction requires Core 0.4.51.
-    "unifi-core[network,protect,access]>=0.4.51,<0.5",
+    "unifi-core[network,protect,access]>=0.4.52,<0.5",
     # The API server is a deployable Network client too. Pin the authentication
     # transport exactly so a released API version has a reproducible login stack
     # even when installed from PyPI without the workspace uv.lock.

--- a/apps/protect/pyproject.toml
+++ b/apps/protect/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     # Owned event listeners and controller-session cleanup require Core 0.4.49.
     # Global alarm status aggregation requires Core 0.4.50.
     # Controller credential redaction requires Core 0.4.51.
-    "unifi-core[protect]>=0.4.51,<0.5",
+    "unifi-core[protect]>=0.4.52,<0.5",
     "mcp[cli]>=2.1.1,<3",
     # Published wheels do not consume uv.lock; keep MCP transitive security
     # floors explicit so upgrades cannot retain vulnerable installed versions.


### PR DESCRIPTION
## Summary

Require published Core 0.4.52 in Protect and API so their next releases always include the verified uiprotect 16 public-write migration from #697. Changes only the two minimum dependency bounds; `uv.lock` remains current.

## Type of change

- [x] `chore:` release dependency alignment

## Scope

- [x] Protect MCP server
- [x] API server

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit` (passed).
- [x] Generated manifests are current.
- [x] No new runtime behavior or tests are needed for these metadata changes.
- [x] No credentials or private controller data are committed.

## Testing

Release-wide live checks on the migrated SDK passed before the Core tag: Network 123 read-only / 53 previews, Protect 47 / 23, Access 33 / 12, and API 36/36 REST/GraphQL assertions. All six changed camera/light settings previously passed approved apply/readback/restore cycles, including a fresh brightness cycle after the concurrency fix. The exact migration head passed all 18 CI checks and the full local quality gate.

The release-preparation commit passed `make pre-commit`, `uv lock --check`, and built-wheel metadata checks for both Core floors. Fresh PyPI installation of Core 0.4.52 succeeded with SDK 16.10.0. CI includes the mandatory published-floor pin-alignment gate.

## Notes for reviewers

Core is published before opening this PR. After merge, release Protect 0.8.7, verify its PyPI/GHCR artifacts and plugin manifest writeback, then release API 0.17.4 and verify fresh installed artifacts. This is the dependency-order follow-through authorized by the maintainer after #697.
