### PR TITLE
fix(automation): tolerate metadata-only issue timestamp updates

### DIFF
--- a/.github/scripts/community_issue_triage_contract.mjs
+++ b/.github/scripts/community_issue_triage_contract.mjs
@@ -1215,6 +1215,33 @@ function normalizeLabels(labels) {
     .sort((left, right) => left.localeCompare(right));
 }
 
+function normalizeAssignees(assignees) {
+  if (!Array.isArray(assignees)) return [];
+  return assignees
+    .map(normalizeAuthor)
+    .filter((assignee) => typeof assignee === "string")
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeMilestone(milestone) {
+  if (milestone === null || milestone === undefined) return null;
+  if (typeof milestone !== "object" || Array.isArray(milestone)) fail("GitHub returned an invalid issue milestone");
+  const number = assertSafePositiveInteger(milestone.number, "issue milestone number");
+  const state = String(milestone.state || "").toLowerCase();
+  if (state !== "open" && state !== "closed") fail(`issue milestone #${number} has an invalid state`);
+  return {
+    number,
+    title: normalizeNullableText(milestone.title),
+    state,
+    description: milestone.description === null || milestone.description === undefined
+      ? null
+      : normalizeNullableText(milestone.description),
+    due_on: milestone.due_on === null || milestone.due_on === undefined
+      ? null
+      : normalizeNullableText(milestone.due_on),
+  };
+}
+
 export function normalizeIssue(raw) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) fail("GitHub returned an invalid issue");
   const number = assertSafePositiveInteger(raw.number, "issue number");
@@ -1235,6 +1262,15 @@ export function normalizeIssue(raw) {
       ? raw.author_association.toUpperCase()
       : "",
     labels: normalizeLabels(raw.labels),
+    assignees: normalizeAssignees(raw.assignees),
+    milestone: normalizeMilestone(raw.milestone),
+    locked: raw.locked === true,
+    active_lock_reason: raw.active_lock_reason === null || raw.active_lock_reason === undefined
+      ? null
+      : normalizeNullableText(raw.active_lock_reason),
+    state_reason: raw.state_reason === null || raw.state_reason === undefined
+      ? null
+      : normalizeNullableText(raw.state_reason),
     kind: raw.kind === "pull_request" || raw.pull_request ? "pull_request" : "issue",
   };
 }
@@ -1404,6 +1440,14 @@ export function canonicalStringify(value) {
 
 export function canonicalDigest(value) {
   return createHash("sha256").update(canonicalStringify(value), "utf8").digest("hex");
+}
+
+function issueEvidenceDigest(issue) {
+  // GitHub advances updated_at for cross-references and assignments even when
+  // the issue evidence available to the agent is unchanged.
+  const evidence = {...issue};
+  delete evidence.updated_at;
+  return canonicalDigest(evidence);
 }
 
 function receiptFactory(randomBytes) {
@@ -1610,10 +1654,17 @@ async function scanCandidates(github, owner, repo, target) {
 }
 
 function issueTextItems(issue, prefix) {
-  return [
+  const items = [
     {name: `${prefix} title`, value: issue.title},
     {name: `${prefix} body`, value: issue.body},
   ];
+  if (issue.milestone !== null) {
+    items.push({name: `${prefix} milestone title`, value: issue.milestone.title});
+    if (issue.milestone.description !== null) {
+      items.push({name: `${prefix} milestone description`, value: issue.milestone.description});
+    }
+  }
+  return items;
 }
 
 function commentsTextItems(comments) {
@@ -1722,7 +1773,7 @@ export async function createTrustedSnapshot({
     fail("target has multiple existing priority labels");
   }
   const targetReceipt = nextReceipt();
-  const targetDigest = canonicalDigest(target);
+  const targetDigest = issueEvidenceDigest(target);
   const bundle = baseBundle({
     repository,
     runId: normalizedRunId,
@@ -1795,7 +1846,7 @@ export async function createTrustedSnapshot({
       kind: candidate.kind,
       source: candidate.source,
       receipt: nextReceipt(),
-      digest: canonicalDigest(data),
+      digest: issueEvidenceDigest(data),
       data,
     });
   }
@@ -1886,7 +1937,7 @@ export function validateBundle(bundle) {
     if (!bundle.content_persisted || bundle.sensitivity !== null || bundle.comments === null) fail("normal snapshot content flags are invalid");
     if (bundle.target.data === null || bundle.comments.data === null || bundle.candidates.some((candidate) => candidate.data === null)) fail("normal snapshot is missing evidence content");
     const target = normalizeIssue(bundle.target.data);
-    if (target.number !== bundle.target_number || canonicalDigest(target) !== bundle.target.digest) fail("snapshot target digest does not match its content");
+    if (target.number !== bundle.target_number || issueEvidenceDigest(target) !== bundle.target.digest) fail("snapshot target digest does not match its content");
     if (!Array.isArray(bundle.comments.data) || bundle.comments.data.length !== bundle.comments.count) fail("snapshot comments do not match their count");
     const comments = bundle.comments.data.map(normalizeComment).sort((left, right) => left.id - right.id);
     if (canonicalDigest(comments) !== bundle.comments.digest) fail("snapshot comment digest does not match its content");
@@ -1894,7 +1945,7 @@ export function validateBundle(bundle) {
       const data = normalizeIssue(candidate.data);
       if (
         data.number !== candidate.number || data.state !== candidate.state ||
-        data.kind !== candidate.kind || canonicalDigest(data) !== candidate.digest
+        data.kind !== candidate.kind || issueEvidenceDigest(data) !== candidate.digest
       ) fail(`snapshot candidate #${candidate.number} digest does not match its content`);
     }
     const inspection = inspectEvidence([
@@ -1993,7 +2044,7 @@ export async function verifyFreshness({github, bundle, owner, repo}) {
   if (bundle.repository !== normalizeRepository(owner, repo)) fail("freshness repository binding mismatch");
   const target = await fetchIssue(github, owner, repo, bundle.target_number);
   inspectEvidence(issueTextItems(target, "target"));
-  if (canonicalDigest(target) !== bundle.target.digest) fail("target evidence changed after the trusted snapshot");
+  if (issueEvidenceDigest(target) !== bundle.target.digest) fail("target evidence changed after the trusted snapshot");
   if (bundle.sensitivity?.scope === "target") return createMetadataEnvelope(bundle);
 
   const comments = await fetchBoundedComments(github, owner, repo, bundle.target_number);
@@ -2025,7 +2076,7 @@ export async function verifyFreshness({github, bundle, owner, repo}) {
   const candidates = [];
   for (const candidate of bundle.candidates) {
     const current = await fetchCandidate(github, owner, repo, candidate.number);
-    if (current.state !== candidate.state || current.kind !== candidate.kind || canonicalDigest(current) !== candidate.digest) {
+    if (current.state !== candidate.state || current.kind !== candidate.kind || issueEvidenceDigest(current) !== candidate.digest) {
       fail(`candidate #${candidate.number} changed after the trusted snapshot`);
     }
     candidates.push(current);

--- a/tests/test_community_issue_triage_workflow.py
+++ b/tests/test_community_issue_triage_workflow.py
@@ -1785,6 +1785,49 @@ def test_sensitive_explicit_reference_stops_with_candidate_metadata_only(kind: s
     assert bundle["candidates"][0]["data"] is None
 
 
+@pytest.mark.parametrize("field", ["title", "description"])
+@pytest.mark.parametrize("scope", ["target", "candidate"])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("UNIFI_PASSWORD=hunter22", "sensitive_stop", id="sensitive"),
+        pytest.param("x" * (256 * 1024 + 1), "byte trusted evidence limit", id="oversize"),
+    ],
+)
+def test_milestone_text_obeys_sensitive_and_size_boundaries(
+    field: str,
+    scope: str,
+    value: str,
+    expected: str,
+):
+    milestone = {
+        "number": 7,
+        "title": "vNext",
+        "state": "open",
+        "description": "Tracking fixes",
+        "due_on": "2026-06-01T00:00:00Z",
+    }
+    target = _issue(TARGET_NUMBER)
+    candidate = _issue(225)
+    issue = target if scope == "target" else candidate
+    issue["milestone"] = milestone
+    issue["milestone"][field] = value
+    payload = _snapshot_payload(candidates=[candidate])
+    payload["issues"][str(TARGET_NUMBER)] = target
+
+    result = _run_contract(payload)
+
+    if expected == "sensitive_stop":
+        assert result.returncode == 0, result.stderr
+        bundle = json.loads(result.stdout)["bundle"]
+        assert bundle["status"] == "sensitive_stop"
+        assert bundle["sensitivity"] == {"scope": scope}
+        assert bundle["content_persisted"] is False
+    else:
+        assert result.returncode != 0
+        assert expected in result.stderr
+
+
 def test_explicit_reference_assessments_are_concrete_in_trusted_public_output():
     referenced_issue = _issue(635, title="Earlier issue")
     referenced_pr = _issue(649, title="Implementation pull request")
@@ -2965,6 +3008,112 @@ def test_freshness_accepts_exact_snapshot_and_refetches_all_evidence():
     assert calls["get"] == [TARGET_NUMBER, 225]
     assert calls["comments"][0]["issue_number"] == TARGET_NUMBER
     assert calls["timeline"][0]["issue_number"] == TARGET_NUMBER
+
+
+def test_freshness_accepts_updated_at_only_target_metadata_drift():
+    payload = _snapshot_payload()
+    created = _create_snapshot(payload)
+    payload.update({"op": "freshness", "bundle": created["bundle"]})
+    payload["issues"][str(TARGET_NUMBER)]["updated_at"] = "2026-05-10T15:31:00Z"
+
+    result = _run_contract(payload)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_freshness_accepts_updated_at_only_candidate_metadata_drift():
+    candidate = _issue(225)
+    payload = _snapshot_payload(candidates=[candidate])
+    created = _create_snapshot(payload)
+    payload.update({"op": "freshness", "bundle": created["bundle"]})
+    payload["issues"]["225"]["updated_at"] = "2026-05-10T15:31:00Z"
+
+    result = _run_contract(payload)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("assignees", [{"login": "maintainer"}]),
+        ("milestone", {"number": 7, "title": "vNext", "state": "open"}),
+        ("locked", True),
+        ("active_lock_reason", "resolved"),
+        ("state_reason", "completed"),
+    ],
+)
+@pytest.mark.parametrize("scope", ["target", "candidate"])
+def test_freshness_rejects_semantic_issue_metadata_drift(scope: str, field: str, value: object):
+    candidate = _issue(225)
+    payload = _snapshot_payload(candidates=[candidate])
+    created = _create_snapshot(payload)
+    payload.update({"op": "freshness", "bundle": created["bundle"]})
+    issue_number = TARGET_NUMBER if scope == "target" else 225
+    payload["issues"][str(issue_number)][field] = value
+    payload["issues"][str(issue_number)]["updated_at"] = "2026-05-10T15:31:00Z"
+
+    result = _run_contract(payload)
+
+    assert result.returncode != 0
+    assert "changed after the trusted snapshot" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("number", 8),
+        ("title", "Revised milestone"),
+        ("state", "closed"),
+        ("description", "Revised scope"),
+        ("due_on", "2026-07-01T00:00:00Z"),
+    ],
+)
+@pytest.mark.parametrize("scope", ["target", "candidate"])
+def test_freshness_rejects_milestone_field_drift(scope: str, field: str, value: object):
+    milestone = {
+        "number": 7,
+        "title": "vNext",
+        "state": "open",
+        "description": "Tracking fixes",
+        "due_on": "2026-06-01T00:00:00Z",
+    }
+    target = _issue(TARGET_NUMBER)
+    target["milestone"] = copy.deepcopy(milestone)
+    candidate = _issue(225)
+    candidate["milestone"] = copy.deepcopy(milestone)
+    payload = _snapshot_payload(candidates=[candidate])
+    payload["issues"][str(TARGET_NUMBER)] = target
+    created = _create_snapshot(payload)
+    payload.update({"op": "freshness", "bundle": created["bundle"]})
+    issue_number = TARGET_NUMBER if scope == "target" else 225
+    payload["issues"][str(issue_number)]["milestone"][field] = value
+    payload["issues"][str(issue_number)]["updated_at"] = "2026-05-10T15:31:00Z"
+
+    result = _run_contract(payload)
+
+    assert result.returncode != 0
+    assert "changed after the trusted snapshot" in result.stderr
+
+
+@pytest.mark.parametrize("scope", ["target", "candidate"])
+def test_freshness_accepts_assignee_order_only_drift(scope: str):
+    assignees = [{"login": "maintainer-a"}, {"login": "maintainer-b"}]
+    target = _issue(TARGET_NUMBER)
+    target["assignees"] = copy.deepcopy(assignees)
+    candidate = _issue(225)
+    candidate["assignees"] = copy.deepcopy(assignees)
+    payload = _snapshot_payload(candidates=[candidate])
+    payload["issues"][str(TARGET_NUMBER)] = target
+    created = _create_snapshot(payload)
+    payload.update({"op": "freshness", "bundle": created["bundle"]})
+    issue_number = TARGET_NUMBER if scope == "target" else 225
+    payload["issues"][str(issue_number)]["assignees"].reverse()
+    payload["issues"][str(issue_number)]["updated_at"] = "2026-05-10T15:31:00Z"
+
+    result = _run_contract(payload)
+
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("drift", ["target", "comments", "candidate", "deleted_candidate"])


### PR DESCRIPTION
## Summary

Fix false `safe_outputs` failures after Copilot triage has already spent credits. GitHub can advance an issue `updated_at` value for cross-references or assignments even when the evidence used by triage has not changed.

This change:

- computes target and candidate freshness from a stable issue-evidence digest that excludes only `updated_at`
- explicitly binds assignees, milestone details, lock state, active lock reason, and state reason so real semantic changes still fail closed
- routes persisted milestone title and description through the existing sensitive-content and size inspection boundary
- preserves independent comment freshness checks and the full canonical artifact digest
- adds target and candidate regressions for timestamp-only drift, every protected semantic field, every milestone subfield, assignee ordering, and milestone secret/oversize content

## Type of change

- [x] `fix:` bug fix
- [ ] `feat:` new feature
- [ ] `docs:` documentation only
- [ ] `refactor:` code change that neither fixes a bug nor adds a feature
- [ ] `test:` adding or updating tests
- [ ] `chore:` maintenance, dependencies, CI, or configuration

## Scope

- [x] GitHub maintenance automation
- [ ] Network MCP server
- [ ] Protect MCP server
- [ ] Access MCP server
- [ ] Relay sidecar
- [ ] Cloudflare Worker / CLI
- [ ] API server
- [ ] Shared packages
- [ ] Plugin packaging
- [ ] Documentation

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I ran the focused tests or checks for the files I changed.
- [x] I ran `make pre-commit`.
- [x] Generated MCP manifests remain current; no MCP tool changed.
- [x] I added or updated tests for behavior changes.
- [x] No documentation update is required because this is an internal automation correctness fix.
- [x] I did not commit credentials, tokens, controller addresses, or other private data.

## Testing

- TDD timestamp reproduction: target and candidate `updated_at` drift initially failed with the production error `target evidence changed after the trusted snapshot` / `candidate #225 changed after the trusted snapshot`.
- Reviewer-found boundary reproduction: 10 target/candidate semantic metadata cases initially failed to detect drift before the projection was tightened.
- Copilot finding reproduction: 8 target/candidate milestone title/description secret and oversize cases failed before milestone text was added to the evidence inspector.
- `uv run pytest tests/test_community_issue_triage_workflow.py -q` — 1120 passed, 6 skipped on exact head.
- `make pre-commit` — passed on exact head, including protocol smoke, generated checks, worker checks, and 1497 API tests.
- Independent correctness, security, and testing reviews — `findings: []` on exact head after the Copilot fix.

## Notes for reviewers

The security boundary is intentionally narrow: only the issue-level `updated_at` proxy is excluded. All normalized agent-visible issue fields, milestone free-form text, and target comments remain digest-bound and evidence-inspected. The complete stored bundle also remains protected by its canonical artifact digest.

A live UniFi controller smoke is not applicable because this changes only the GitHub issue-triage contract. The post-merge validation should be a real community issue triage run. Final merge remains human-approved.