### PR TITLE
fix(core): add opt-in key-backed Network inventory foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,34 @@ All tools MUST include `annotations=ToolAnnotations(...)` in `@server.tool()`:
 
 UniFi exposes three API surfaces with disjoint ID/auth models: the V2 controller API (session cookie auth, Mongo ObjectIDs, `snake_case` fields), the public Integration API (`X-API-Key` auth, UUIDs, `camelCase` fields), and the UniFi-OS **Alarm Manager v2** service (`/api/v2/alarms/`, session + **SuperAdmin** auth, UUIDs, `snake_case` fields). They are **not interchangeable**.
 
+Authentication credentials and API surfaces are separate concepts. Network 10.6.106
+also accepts API keys on verified legacy inventory GET endpoints, preserving legacy
+IDs and fields. Detect that capability at runtime; do not assume it on every
+controller or infer write/websocket support from successful reads.
+
+### Authentication routing golden path
+
+- ConnectionManagers own credential availability and transport selection. Reuse
+  the shared authentication status contract in `unifi_core.auth`; retain each
+  product's SDK/lifecycle implementation.
+- Network preserves working session behavior when both credentials are configured;
+  Access retains its existing per-operation preference. A failed session must not
+  block an independently usable API-key path. Protect public setters still require
+  session bootstrap, so they are not an independent key-only startup path.
+- Choose a route before an operation. Never replay an uncertain mutation using
+  another credential or API surface. Require a session for unvalidated key-backed
+  legacy writes, including direct SDK callers.
+- Keep tool auth metadata accurate (`local_only`, `api_key_only`, `either`, or
+  `both`); describe field-dependent requirements. Metadata is discovery, not
+  enforcement. Core manager checks apply equally to MCP and REST/GraphQL/actions.
+- Public-only inventory must label its source and incomplete field/collection
+  coverage. Do not fabricate legacy IDs or default unknown values to false/zero.
+  Preserve MAC-based identity where verified; public UUIDs are separate fields.
+- Anchors: Access `ConnectionManager.initialize` and `DoorManager.list_doors`;
+  Protect `require_public_api_key` and `validate_public_id_portability`.
+
+### API tool families
+
 - **Tool families share an ID space.** Tools whose returned IDs and accepted IDs are mutually portable form a *family*. Cross-family ID use is prohibited.
 - **Tool descriptions MUST scope IDs** when they could be confused with another family's IDs. Standard formula: *"These IDs are scoped to the <family> tool family — do not pass them to other <resource> tools."* This applies to MCP tool descriptions, GraphQL type/query descriptions, and REST route descriptions alike.
 - **Integration API tools MUST require an API key** and fail with a clear remediation message when it is missing. The auth check belongs in the manager so every tool in the family inherits it.

--- a/packages/unifi-core/src/unifi_core/access/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/access/managers/connection_manager.py
@@ -26,6 +26,7 @@ from typing import Any, Dict
 
 import aiohttp
 
+from unifi_core.auth import AuthenticationStatus, AuthMethod
 from unifi_core.exceptions import UniFiAuthError, UniFiConnectionError
 from unifi_core.retry import RetryPolicy, retry_with_backoff
 from unifi_core.support_bundle import (
@@ -183,7 +184,7 @@ class AccessConnectionManager:
 
     async def _try_api_client(self) -> None:
         """Attempt to initialise the py-unifi-access API client."""
-        if not self._api_key:
+        if not self.authentication_status.configured(AuthMethod.API_KEY_ONLY):
             self._api_support_attempt = connection_attempt_not_configured()
             logger.debug("[access-cm] No API key configured; skipping API client path.")
             return
@@ -544,6 +545,15 @@ class AccessConnectionManager:
     def has_api_key(self) -> bool:
         """Return whether an Access Developer API token is configured."""
         return bool(self._api_key)
+
+    @property
+    def authentication_status(self) -> AuthenticationStatus:
+        return AuthenticationStatus(
+            session_configured=bool(self.username and self.password),
+            api_key_configured=self.has_api_key,
+            session_available=self.has_proxy,
+            api_key_available=self.has_api_client,
+        )
 
     @property
     def has_api_client(self) -> bool:

--- a/packages/unifi-core/src/unifi_core/auth.py
+++ b/packages/unifi-core/src/unifi_core/auth.py
@@ -2,7 +2,8 @@
 
 import enum
 import logging
-from typing import Protocol
+from dataclasses import dataclass
+from typing import Any, Protocol
 
 import aiohttp
 
@@ -15,6 +16,7 @@ class AuthMethod(enum.Enum):
     LOCAL_ONLY = "local_only"
     API_KEY_ONLY = "api_key_only"
     EITHER = "either"
+    BOTH = "both"
 
     @classmethod
     def from_string(cls, value: str | None) -> "AuthMethod":
@@ -31,6 +33,29 @@ class LocalAuthProvider(Protocol):
     """Contract that each app fulfills for local auth."""
 
     async def get_session(self) -> aiohttp.ClientSession: ...
+
+
+@dataclass(frozen=True)
+class AuthenticationStatus:
+    """Credential configuration is not proof that a controller accepts it.
+
+    None means a path has not been verified. Products retain their own transports
+    and capability checks; this value performs no I/O and contains no secrets.
+    """
+
+    session_configured: bool = False
+    api_key_configured: bool = False
+    session_available: bool | None = None
+    api_key_available: bool | None = None
+
+    def configured(self, requirement: AuthMethod) -> bool:
+        if requirement is AuthMethod.LOCAL_ONLY:
+            return self.session_configured
+        if requirement is AuthMethod.API_KEY_ONLY:
+            return self.api_key_configured
+        if requirement is AuthMethod.BOTH:
+            return self.session_configured and self.api_key_configured
+        return self.session_configured or self.api_key_configured
 
 
 class UniFiAuth:
@@ -51,10 +76,10 @@ class UniFiAuth:
     def set_local_provider(self, provider: LocalAuthProvider) -> None:
         self._local_provider = provider
 
-    async def get_api_key_session(self) -> aiohttp.ClientSession:
+    async def get_api_key_session(self, **session_options: Any) -> aiohttp.ClientSession:
         if not self.has_api_key:
             raise UniFiAuthError("API key authentication not configured. Set UNIFI_API_KEY environment variable.")
-        return aiohttp.ClientSession(headers={"X-API-Key": self._api_key})
+        return aiohttp.ClientSession(headers={"X-API-Key": self._api_key}, **session_options)
 
     async def get_local_session(self) -> aiohttp.ClientSession:
         if not self.has_local:
@@ -62,6 +87,8 @@ class UniFiAuth:
         return await self._local_provider.get_session()
 
     async def get_session(self, method: AuthMethod) -> aiohttp.ClientSession:
+        if method == AuthMethod.BOTH:
+            raise UniFiAuthError("Both authentication paths are required; request each session explicitly.")
         if method == AuthMethod.API_KEY_ONLY:
             return await self.get_api_key_session()
         elif method == AuthMethod.LOCAL_ONLY:

--- a/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/client_manager.py
@@ -35,7 +35,7 @@ class ClientManager:
         """
         self._connection = connection_manager
 
-    async def get_clients(self, include_offline: bool = False) -> List[Client]:
+    async def get_clients(self, include_offline: bool = False) -> List[Client | dict[str, Any]]:
         """Get clients for the current site.
 
         The default preserves the online-only ``/stat/sta`` contract.  Set
@@ -45,6 +45,10 @@ class ClientManager:
         """
         if include_offline:
             return await self.get_all_clients()
+        if getattr(self._connection, "has_api_key", False) is True:
+            await self._connection.initialize()
+            if self._connection.integration_inventory_only:
+                return await self._connection.public_inventory("clients")
         if not await self._connection.ensure_connected() or not self._connection.controller:
             raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_CLIENTS}_online_{self._connection.site}"
@@ -78,6 +82,15 @@ class ClientManager:
 
     async def get_all_clients(self) -> List[Client]:
         """Get list of all clients (including offline/historical) for the current site."""
+        if getattr(self._connection, "has_api_key", False) is True:
+            await self._connection.initialize()
+            if self._connection.integration_inventory_only:
+                from unifi_core.exceptions import UniFiAuthError
+
+                raise UniFiAuthError(
+                    "Historical/offline clients require Network session authentication on this controller. "
+                    "Use include_offline=false for public connected-client inventory."
+                )
         if not await self._connection.ensure_connected() or not self._connection.controller:
             raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_CLIENTS}_all_{self._connection.site}"

--- a/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/connection_manager.py
@@ -23,6 +23,8 @@ from aiounifi.errors import (
 from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.configuration import Configuration
 
+from unifi_core.auth import AuthenticationStatus, UniFiAuth
+from unifi_core.exceptions import UniFiAuthError
 from unifi_core.mac import mask_exception_macs, mask_macs
 from unifi_core.redaction import collect_secret_values, sanitize_exception, scrub_secret_values
 from unifi_core.support_bundle import (
@@ -312,6 +314,7 @@ class ConnectionManager:
         cache_timeout: int = 30,
         max_retries: int = 3,
         retry_delay: int = 5,
+        auth: UniFiAuth | None = None,
     ):
         """Initialize the Connection Manager."""
         self.host = host
@@ -323,6 +326,15 @@ class ConnectionManager:
         self.cache_timeout = cache_timeout
         self._max_retries = max_retries
         self._retry_delay = retry_delay
+        self.unifi_auth = auth or UniFiAuth()
+        # Older callers attach unifi_auth for operation-specific Integration API
+        # access. Only constructor injection opts inventory into key negotiation;
+        # those callers also understand the public inventory response contract.
+        self._key_inventory_enabled = auth is not None
+        self._key_mode = False
+        self._key_retry_until = 0.0
+        self._integration_prefix: str | None = None
+        self._initialize_lock = asyncio.Lock()
         self.controller: Optional[Controller] = None
         self._aiohttp_session: Optional[aiohttp.ClientSession] = None
         self._initialized = False
@@ -575,6 +587,239 @@ class ConnectionManager:
         self._initialized = False
 
     async def initialize(self) -> bool:
+        """Initialize an independent session or API-key route.
+
+        Preserve session behavior when it works. Only negotiate a key route at
+        initialization, never as a retry of an operation that may have mutated.
+        """
+        if not self._key_inventory_enabled or not self.unifi_auth.has_api_key:
+            return await self._initialize_session()
+        async with self._initialize_lock:
+            if self.integration_inventory_only or (
+                self._initialized and self._aiohttp_session and not self._aiohttp_session.closed
+            ):
+                return True
+            if self.username and self.password and await self._initialize_session():
+                self._key_mode = False
+                return True
+            if _time.monotonic() < self._key_retry_until:
+                return False
+            async with self._connect_lock:
+                succeeded = await self._initialize_key()
+                self._key_retry_until = 0.0 if succeeded else _time.monotonic() + _RECONNECT_BLOCK_BASE_SECONDS
+                return succeeded
+
+    @property
+    def has_api_key(self) -> bool:
+        return self.unifi_auth.has_api_key
+
+    @property
+    def authentication_status(self) -> AuthenticationStatus:
+        available = self.integration_inventory_only or bool(
+            self._initialized and self.controller and self._aiohttp_session and not self._aiohttp_session.closed
+        )
+        return AuthenticationStatus(
+            session_configured=bool(self.username and self.password),
+            api_key_configured=self.unifi_auth.has_api_key,
+            session_available=available and not self._key_mode,
+            api_key_available=available if self._key_mode else None,
+        )
+
+    @property
+    def integration_inventory_only(self) -> bool:
+        return self._initialized and self._key_mode and self.controller is None
+
+    async def _key_read_transport(self, request, handler):
+        """Bound even direct SDK calls to verified inventory reads and this host."""
+        from yarl import URL
+
+        target = URL(self.url_base)
+        if (request.url.scheme, request.url.host, request.url.port) != (target.scheme, target.host, target.port):
+            raise UniFiAuthError("API-key inventory requests cannot leave the configured controller.")
+        path = request.url.path
+        allowed = path in {"/api/self/sites", "/proxy/network/api/self/sites"} or any(
+            path == f"{prefix}/api/s/{self.site}/{suffix}"
+            for prefix in ("", "/proxy/network")
+            for suffix in ("rest/networkconf", "rest/wlanconf", "stat/device", "stat/sta", "rest/user")
+        )
+        if request.method != "GET" or not allowed:
+            raise UniFiAuthError(
+                "This operation requires Network session authentication. "
+                "Configure UNIFI_NETWORK_USERNAME and UNIFI_NETWORK_PASSWORD; "
+                "API-key legacy access currently supports inventory reads only."
+            )
+        return await handler(request)
+
+    async def _initialize_key(self) -> bool:
+        from unifi_core.network.controller_type import resolve_controller_type
+
+        await self._discard_connection()
+        mode = resolve_controller_type()
+        prefixes = ["/proxy/network"] if mode == "proxy" else [""] if mode == "direct" else ["/proxy/network", ""]
+        session = await self.unifi_auth.get_api_key_session(
+            cookie_jar=aiohttp.DummyCookieJar(),
+            timeout=aiohttp.ClientTimeout(total=10),
+            middlewares=(self._key_read_transport,),
+        )
+        try:
+            for prefix in prefixes:
+                async with session.get(
+                    f"{self.url_base}{prefix}/api/self/sites", ssl=self.verify_ssl, allow_redirects=False
+                ) as response:
+                    if response.status == 429:
+                        raise AuthenticationRateLimitError("API-key capability probe rate limited; retry later.")
+                    if response.status != 200:
+                        continue
+                    try:
+                        body = await response.json()
+                    except (aiohttp.ContentTypeError, ValueError):
+                        # Login HTML is not authenticated inventory. The public
+                        # API may still be available on the same controller.
+                        continue
+                    if (
+                        not isinstance(body, dict)
+                        or not isinstance(body.get("meta"), dict)
+                        or body["meta"].get("rc") != "ok"
+                        or not isinstance(body.get("data"), list)
+                    ):
+                        continue
+                config = Configuration(
+                    session=session,
+                    host=self.host,
+                    username="",
+                    password="",
+                    port=self.port,
+                    site=self.site,
+                    ssl_context=False if not self.verify_ssl else None,
+                )
+                self.controller = Controller(config=config)
+                self.controller.connectivity.is_unifi_os = bool(prefix)
+                self.controller.connectivity.can_retry_login = False
+                self._unifi_os_override = bool(prefix)
+                self._integration_prefix = prefix
+                self._aiohttp_session = session
+                self._key_mode = True
+                self._initialized = True
+                self._auth_generation += 1
+                self._last_connection_error = None
+                self._support_attempt = connection_attempt_succeeded()
+                return True
+        except AuthenticationRateLimitError:
+            self._last_connection_error = "API-key capability probe rate limited; retry later."
+            return False
+        except Exception as error:
+            logger.warning("API-key legacy capability probe failed: %s", type(error).__name__)
+            self._last_connection_error = "API-key capability probe failed; verify controller connectivity and API key."
+            return False
+        finally:
+            if self._aiohttp_session is not session:
+                await session.close()
+        # A controller can support public Integration API keys without supporting
+        # them on legacy paths. Keep that route independent from the login circuit.
+        for prefix in prefixes:
+            try:
+                self._integration_prefix = prefix
+                body = await self.request_integration("/v1/sites", params={"limit": 1, "offset": 0})
+                if not isinstance(body.get("data"), list) or type(body.get("totalCount")) is not int:
+                    continue
+                if body["totalCount"] < len(body["data"]):
+                    continue
+                self._key_mode = True
+                self._initialized = True
+                self._last_connection_error = None
+                return True
+            except AuthenticationRateLimitError:
+                self._last_connection_error = "API-key capability probe rate limited; retry later."
+                return False
+            except UniFiAuthError:
+                continue
+        self._integration_prefix = None
+        self._last_connection_error = (
+            "No usable Network authentication path. Verify the API key or session credentials."
+        )
+        return False
+
+    async def request_integration(self, path: str, params: dict | None = None) -> dict:
+        """Bounded public inventory GET; never reuse cookies or forward redirects."""
+        if not self.unifi_auth.has_api_key:
+            raise UniFiAuthError("Network Integration API requires UNIFI_NETWORK_API_KEY or UNIFI_API_KEY.")
+        if not path.startswith("/v1/") or ".." in path or "?" in path or "#" in path:
+            raise ValueError("Invalid Network Integration API path")
+        prefix = self._integration_prefix if self._integration_prefix is not None else "/proxy/network"
+        try:
+            async with await self.unifi_auth.get_api_key_session(
+                cookie_jar=aiohttp.DummyCookieJar(), timeout=aiohttp.ClientTimeout(total=10)
+            ) as session:
+                async with session.get(
+                    f"{self.url_base}{prefix}/integration{path}",
+                    params=params,
+                    ssl=self.verify_ssl,
+                    allow_redirects=False,
+                ) as response:
+                    if response.status == 429:
+                        raise AuthenticationRateLimitError("Network Integration API rate limited; retry later.")
+                    if response.status != 200:
+                        raise UniFiAuthError(
+                            f"Network Integration API read failed (HTTP {response.status}); "
+                            "verify API-key permissions and controller support."
+                        )
+                    body = await response.json()
+                    if not isinstance(body, dict):
+                        raise UniFiAuthError("Network Integration API returned an invalid response.")
+                    return body
+        except (UniFiAuthError, AuthenticationRateLimitError):
+            raise
+        except Exception as error:
+            raise UniFiAuthError(
+                f"Network Integration API read failed ({type(error).__name__}); verify controller connectivity."
+            ) from None
+
+    async def integration_pages(self, path: str) -> list[dict]:
+        """Retrieve complete bounded pages, rejecting duplicate/truncated results."""
+        rows: list[dict] = []
+        seen: set[str] = set()
+        expected_total: int | None = None
+        for _ in range(100):
+            body = await self.request_integration(path, {"limit": 200, "offset": len(rows)})
+            page, total = body.get("data"), body.get("totalCount")
+            if not isinstance(page, list) or type(total) is not int or total < 0:
+                raise UniFiAuthError("Network Integration API returned invalid inventory pagination.")
+            if expected_total is not None and total != expected_total:
+                raise UniFiAuthError("Network inventory changed during pagination; retry the read.")
+            expected_total = total
+            for row in page:
+                if not isinstance(row, dict) or not isinstance(row.get("id"), str) or row["id"] in seen:
+                    raise UniFiAuthError("Network Integration API returned invalid or duplicate inventory IDs.")
+                seen.add(row["id"])
+                rows.append(row)
+            if len(rows) == total:
+                return rows
+            if not page or len(rows) > total:
+                break
+        raise UniFiAuthError("Network Integration API inventory is incomplete; narrow the controller/site scope.")
+
+    async def public_inventory(self, domain: str) -> list[dict]:
+        """Public-only inventory fallback with explicit source and ID provenance."""
+        from unifi_core.network.models.integration import PublicInventory, PublicInventoryItem, PublicSite
+
+        suffixes = {"devices": "devices", "clients": "clients", "networks": "networks", "wlans": "wifi/broadcasts"}
+        if domain not in suffixes:
+            raise ValueError("Unsupported public inventory resource")
+        try:
+            sites = [PublicSite.model_validate(row) for row in await self.integration_pages("/v1/sites")]
+            matches = [site for site in sites if self.site in {site.internalReference, str(site.id)}]
+            if len(matches) != 1:
+                raise UniFiAuthError(
+                    "Cannot resolve Network site: use its internal site key or Integration UUID, not a display name."
+                )
+            rows = await self.integration_pages(f"/v1/sites/{matches[0].id}/{suffixes[domain]}")
+            return PublicInventory(PublicInventoryItem.model_validate(row).inventory_record(domain) for row in rows)
+        except UniFiAuthError:
+            raise
+        except Exception as error:
+            raise UniFiAuthError(f"Invalid Network public inventory ({type(error).__name__}).") from None
+
+    async def _initialize_session(self) -> bool:
         """Initialize the controller connection (correct for attached aiounifi version)."""
         blocked = self._reconnect_block_active()
         if blocked:
@@ -738,9 +983,19 @@ class ConnectionManager:
     async def ensure_connected(self) -> bool:
         """Ensure the controller is connected, attempting to reconnect if necessary."""
 
+        if self.integration_inventory_only:
+            raise UniFiAuthError(
+                "This operation requires Network session authentication on this controller. "
+                "API-key-only access is limited to public inventory; configure "
+                "UNIFI_NETWORK_USERNAME and UNIFI_NETWORK_PASSWORD for legacy operations."
+            )
+
         if not self._initialized or not self.controller or not self._aiohttp_session or self._aiohttp_session.closed:
             logger.warning("Controller not initialized or session lost/closed, attempting to reconnect...")
-            return await self.initialize()
+            connected = await self.initialize()
+            if self.integration_inventory_only:
+                return await self.ensure_connected()
+            return connected
 
         try:
             internal_session = self.controller.connectivity.config.session
@@ -765,6 +1020,11 @@ class ConnectionManager:
 
     async def _reauthenticate(self, expected_generation: int) -> bool:
         """Refresh an expired controller login once, deduplicating concurrent attempts."""
+        if self._key_mode:
+            self._last_connection_error = (
+                "API-key request rejected; verify UNIFI_NETWORK_API_KEY and controller permissions."
+            )
+            return False
         if self._reconnect_block_active():
             return False
 
@@ -804,7 +1064,7 @@ class ConnectionManager:
 
     async def cleanup(self):
         """Clean up resources without racing initialization or reauthentication."""
-        async with self._connect_lock:
+        async with self._initialize_lock, self._connect_lock:
             had_open_session = bool(self._aiohttp_session and not self._aiohttp_session.closed)
             await self._discard_connection()
             if had_open_session:
@@ -814,6 +1074,9 @@ class ConnectionManager:
             self._last_connection_error = None
             self._clear_reconnect_block()
             self._auth_generation = 0
+            self._key_mode = False
+            self._key_retry_until = 0.0
+            self._integration_prefix = None
             logger.info("Unifi connection manager resources cleared.")
 
     async def close(self) -> None:

--- a/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/device_manager.py
@@ -29,8 +29,12 @@ class DeviceManager:
         """
         self._connection = connection_manager
 
-    async def get_devices(self) -> List[Device]:
+    async def get_devices(self) -> List[Device | dict[str, Any]]:
         """Get list of devices for the current site."""
+        if getattr(self._connection, "has_api_key", False) is True:
+            await self._connection.initialize()
+            if self._connection.integration_inventory_only:
+                return await self._connection.public_inventory("devices")
         if not await self._connection.ensure_connected() or not self._connection.controller:
             raise ConnectionError("Not connected to controller")
         cache_key = f"{CACHE_PREFIX_DEVICES}_{self._connection.site}"
@@ -55,6 +59,12 @@ class DeviceManager:
         """
         device_mac = normalize_mac(device_mac) or device_mac
         devices = await self.get_devices()
+        if getattr(self._connection, "integration_inventory_only", False) is True:
+            from unifi_core.exceptions import UniFiAuthError
+
+            raise UniFiAuthError(
+                "Full device details and device mutations require Network session authentication on this controller."
+            )
         device: Optional[Device] = next((d for d in devices if mac_equal(d.mac, device_mac)), None)
         if device is None:
             raise UniFiNotFoundError("device", device_mac)

--- a/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
@@ -314,6 +314,12 @@ class NetworkManager:
             UniFiNotFoundError: If the WLAN does not exist.
         """
         wlans = await self.get_wlans()
+        if getattr(self._connection, "integration_inventory_only", False) is True:
+            from unifi_core.exceptions import UniFiAuthError
+
+            raise UniFiAuthError(
+                "Full WLAN details and WLAN mutations require Network session authentication on this controller."
+            )
         wlan_obj: Optional[Wlan] = next(
             (w for w in wlans if isinstance(w.raw, dict) and w.raw.get("_id") == wlan_id),
             None,

--- a/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/network_manager.py
@@ -78,6 +78,10 @@ class NetworkManager:
 
     async def get_networks(self) -> List[Dict[str, Any]]:
         """Get list of networks (LAN/VLAN) for the current site."""
+        if getattr(self._connection, "has_api_key", False) is True:
+            await self._connection.initialize()
+            if self._connection.integration_inventory_only:
+                return await self._connection.public_inventory("networks")
         cache_key = f"{CACHE_PREFIX_NETWORKS}_{self._connection.site}"
         cached_data = self._connection.get_cached(cache_key)
         if cached_data is not None:
@@ -282,6 +286,10 @@ class NetworkManager:
 
     async def get_wlans(self) -> List[Wlan]:
         """Get list of wireless networks (WLANs) for the current site."""
+        if getattr(self._connection, "has_api_key", False) is True:
+            await self._connection.initialize()
+            if self._connection.integration_inventory_only:
+                return await self._connection.public_inventory("wlans")
         cache_key = f"{CACHE_PREFIX_WLANS}_{self._connection.site}"
         cached_data: Optional[List[Wlan]] = self._connection.get_cached(cache_key)
         if cached_data is not None:

--- a/packages/unifi-core/src/unifi_core/network/models/integration.py
+++ b/packages/unifi-core/src/unifi_core/network/models/integration.py
@@ -1,0 +1,81 @@
+"""Public inventory models and explicit, lossy projections into shared read views.
+
+No public UUID is a legacy _id. Unknown legacy fields remain absent/None; callers
+must retain source_api and integration_id when presenting these partial records.
+"""
+
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PublicSite(BaseModel):
+    id: UUID
+    internalReference: str
+    name: str
+
+
+class PublicInventory(list[dict[str, Any]]):
+    """List-compatible source marker, including an empty public inventory."""
+
+    source_api = "integration"
+
+
+class PublicInventoryItem(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: UUID
+    name: str | None = None
+    macAddress: str | None = None
+    ipAddress: str | None = None
+    model: str | None = None
+    state: str | None = None
+    type: str | None = None
+    firmwareVersion: str | None = None
+    firmwareUpdatable: bool | None = None
+    enabled: bool | None = None
+    vlanId: int | None = None
+    features: list[str] | dict[str, Any] = Field(default_factory=list)
+    securityConfiguration: dict[str, Any] = Field(default_factory=dict)
+
+    def inventory_record(self, domain: Literal["devices", "clients", "networks", "wlans"]) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "source_api": "integration",
+            "integration_id": str(self.id),
+            "_id": None,
+            "name": self.name,
+        }
+        if domain in {"devices", "clients"}:
+            record.update(mac=self.macAddress, ip=self.ipAddress)
+        if domain == "devices":
+            # Features can overlap (a gateway can also switch and broadcast).
+            # Do not infer a legacy model/type from a display name.
+            category = next(
+                (
+                    name
+                    for feature, name in (("gateway", "gateway"), ("accessPoint", "ap"), ("switching", "switch"))
+                    if feature in self.features
+                ),
+                "unknown",
+            )
+            record.update(
+                model=self.model,
+                version=self.firmwareVersion,
+                upgradable=self.firmwareUpdatable,
+                state={"ONLINE": 1, "OFFLINE": 0}.get(self.state),
+                public_state=self.state,
+                device_category=category,
+                adopted=True,
+            )
+        elif domain == "clients":
+            record.update(
+                is_wired=True if self.type == "WIRED" else False if self.type == "WIRELESS" else None,
+                status="online",
+                is_online=True,
+            )
+        elif domain == "networks":
+            record.update(enabled=self.enabled, vlan=self.vlanId)
+        elif domain == "wlans":
+            record.update(enabled=self.enabled)
+        return record

--- a/packages/unifi-core/src/unifi_core/network/read_views.py
+++ b/packages/unifi-core/src/unifi_core/network/read_views.py
@@ -42,8 +42,25 @@ def _raw(value: Any) -> dict[str, Any]:
     return raw if isinstance(raw, dict) else {}
 
 
+def _with_inventory_source(response: dict[str, Any], records: list[Any]) -> dict[str, Any]:
+    if getattr(records, "source_api", None) == "integration" or any(
+        _raw(record).get("source_api") == "integration" for record in records
+    ):
+        response["_meta"] = {
+            "source_api": "integration",
+            "complete": False,
+            "note": (
+                "Public inventory has limited fields/coverage. integration_id is a public UUID, not a legacy ID. "
+                "Missing legacy fields are unknown; legacy operations may require session credentials."
+            ),
+        }
+    return response
+
+
 def classify_device(device: dict[str, Any]) -> str:
     """Classify a raw controller device into its public semantic category."""
+    if device.get("source_api") == "integration":
+        return device.get("device_category", "unknown")
     device_type = device.get("type", "")
     model = device.get("model", "")
     if device_type.startswith("usp"):
@@ -89,7 +106,7 @@ def shape_client_list(
     """Apply the public client-list filters, projection, and envelope."""
     clients_raw = [_raw(client) for client in clients]
     if filter_type == "wireless":
-        clients_raw = [client for client in clients_raw if not client.get("is_wired", False)]
+        clients_raw = [client for client in clients_raw if client.get("is_wired", False) is False]
     elif filter_type == "wired":
         clients_raw = [client for client in clients_raw if client.get("is_wired", False)]
 
@@ -107,6 +124,8 @@ def shape_client_list(
     total_count = len(clients_raw)
     clients_raw = clients_raw[:limit]
     known_fields = {
+        "source_api",
+        "integration_id",
         "mac",
         "name",
         "hostname",
@@ -131,11 +150,18 @@ def shape_client_list(
         full_data = client_from_controller(client).model_dump(exclude_none=True)
         full_data["connection_type"] = "Wired" if client.get("is_wired", False) else "Wireless"
         full_data["_id"] = client.get("_id")
+        if client.get("source_api") == "integration":
+            full_data.update(source_api="integration", integration_id=client["integration_id"])
+            full_data.update(is_wired=client.get("is_wired"), is_guest=None)
+            if client.get("is_wired") is None:
+                full_data["connection_type"] = None
         if not client.get("is_wired", False):
             full_data["essid"] = client.get("essid", "Unknown")
             full_data["signal_dbm"] = client.get("signal")
             full_data["channel"] = client.get("channel", "Unknown")
             full_data["radio"] = client.get("radio", "Unknown")
+        if client.get("source_api") == "integration":
+            full_data.update(essid=None, channel=None, radio=None)
         formatted_clients.append(
             {key: value for key, value in full_data.items() if key in requested_fields}
             if requested_fields
@@ -156,7 +182,7 @@ def shape_client_list(
     }
     if unknown_fields:
         response["unknown_fields"] = unknown_fields
-    return response
+    return _with_inventory_source(response, clients)
 
 
 def shape_client_details(
@@ -260,6 +286,36 @@ def shape_client_details(
 
 
 def _device_base(device: dict[str, Any]) -> dict[str, Any]:
+    if device.get("source_api") == "integration":
+        return {
+            "mac": device.get("mac"),
+            "name": device.get("name"),
+            "model": device.get("model"),
+            "ip": device.get("ip"),
+            "firmware": device.get("version"),
+            "upgradable": device.get("upgradable"),
+            "status": {
+                0: "offline",
+                1: "online",
+                2: "pending_adoption",
+                4: "managed_by_other/adopting",
+                5: "provisioning",
+                6: "upgrading",
+            }.get(device.get("state")),
+            "device_category": classify_device(device),
+            "adopted": True,
+            "_id": None,
+            "source_api": "integration",
+            "integration_id": device["integration_id"],
+            "uptime": None,
+            "last_seen": None,
+            "type": None,
+            "connection_network": None,
+            "uplink": None,
+            "load_avg_1": None,
+            "mem_pct": None,
+            "model_eol": None,
+        }
     state = device.get("state", 0)
     state_map = {
         0: "offline",
@@ -307,6 +363,8 @@ def _device_base(device: dict[str, Any]) -> dict[str, Any]:
 
 
 def _add_device_details(device: dict[str, Any], target: dict[str, Any], *, summary: bool) -> None:
+    if device.get("source_api") == "integration":
+        return
     category = classify_device(device)
     target.update(
         {
@@ -435,18 +493,21 @@ def shape_device_list(
         if include_details:
             _add_device_details(device, item, summary=summary)
         formatted.append(item)
-    return {
-        "success": True,
-        "site": site,
-        "filter_type": device_type,
-        "filter_status": status,
-        "search": search,
-        "total_count": total_count,
-        "returned_count": len(formatted),
-        "count": len(formatted),
-        "limit": limit,
-        "devices": formatted,
-    }
+    return _with_inventory_source(
+        {
+            "success": True,
+            "site": site,
+            "filter_type": device_type,
+            "filter_status": status,
+            "search": search,
+            "total_count": total_count,
+            "returned_count": len(formatted),
+            "count": len(formatted),
+            "limit": limit,
+            "devices": formatted,
+        },
+        devices,
+    )
 
 
 def shape_device_details(
@@ -577,6 +638,8 @@ def shape_network_list(
     total_count = len(filtered)
     filtered = filtered[:limit]
     known_fields = {
+        "source_api",
+        "integration_id",
         "_id",
         "name",
         "enabled",
@@ -608,6 +671,8 @@ def shape_network_list(
             "dhcpd_start": shaped.dhcpd_start,
             "dhcpd_stop": shaped.dhcpd_stop,
         }
+        if network.get("source_api") == "integration":
+            full_data.update(source_api="integration", integration_id=network["integration_id"])
         formatted.append(
             {key: value for key, value in full_data.items() if key in requested_fields}
             if requested_fields
@@ -627,7 +692,7 @@ def shape_network_list(
     }
     if unknown_fields:
         response["unknown_fields"] = unknown_fields
-    return response
+    return _with_inventory_source(response, networks)
 
 
 def shape_network_details(
@@ -768,20 +833,28 @@ def shape_wlan_list(
             "security": wlan.get("security"),
             "network_id": wlan.get("networkconf_id"),
             "usergroup_id": wlan.get("usergroup_id"),
+            **(
+                {"source_api": "integration", "integration_id": wlan["integration_id"]}
+                if wlan.get("source_api") == "integration"
+                else {}
+            ),
         }
         for wlan in raw
     ]
-    return {
-        "success": True,
-        "site": site,
-        "search": search,
-        "enabled_only": enabled_only,
-        "total_count": total_count,
-        "returned_count": len(formatted),
-        "count": len(formatted),
-        "limit": limit,
-        "wlans": formatted,
-    }
+    return _with_inventory_source(
+        {
+            "success": True,
+            "site": site,
+            "search": search,
+            "enabled_only": enabled_only,
+            "total_count": total_count,
+            "returned_count": len(formatted),
+            "count": len(formatted),
+            "limit": limit,
+            "wlans": formatted,
+        },
+        wlans,
+    )
 
 
 # selector -> (activating enum key, value); a selector under any other value is not shown.

--- a/packages/unifi-core/src/unifi_core/protect/managers/connection_manager.py
+++ b/packages/unifi-core/src/unifi_core/protect/managers/connection_manager.py
@@ -16,6 +16,7 @@ import aiohttp
 from uiprotect import ProtectApiClient
 from uiprotect.data import WSSubscriptionMessage
 
+from unifi_core.auth import AuthenticationStatus, AuthMethod
 from unifi_core.exceptions import UniFiConnectionError
 from unifi_core.protect.managers.id_portability import IdPortabilityReport, compare_id_portability
 from unifi_core.retry import RetryPolicy, retry_with_backoff
@@ -236,9 +237,20 @@ class ProtectConnectionManager:
         )
         return result
 
+    @property
+    def authentication_status(self) -> AuthenticationStatus:
+        return AuthenticationStatus(
+            session_configured=bool(self.username and self.password),
+            api_key_configured=self.has_api_key,
+            session_available=self.is_connected,
+            # Bootstrap success does not verify the independently authenticated
+            # public API. Public methods enforce/validate it when called.
+            api_key_available=None,
+        )
+
     def require_public_api_key(self, operation: str) -> None:
         """Raise an actionable error when a public Integration API call lacks an API key."""
-        if self.has_api_key:
+        if self.authentication_status.configured(AuthMethod.API_KEY_ONLY):
             return
         raise ValueError(
             f"Cannot {operation}: UniFi Protect public Integration API access requires an API key. "

--- a/packages/unifi-core/tests/network/managers/test_key_auth.py
+++ b/packages/unifi-core/tests/network/managers/test_key_auth.py
@@ -1,0 +1,223 @@
+"""Network credential negotiation keeps reads, sessions and public APIs distinct."""
+
+import asyncio
+import json
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from unifi_core.auth import UniFiAuth
+from unifi_core.exceptions import UniFiAuthError
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.network_manager import NetworkManager
+from yarl import URL
+
+
+@contextmanager
+def responses():
+    """Fake the HTTP boundary without depending on aiohttp response internals."""
+    routes = {}
+
+    class Routes:
+        def get(self, url, *, payload=None, status=200, body=None):
+            parsed = URL(url)
+            routes[(parsed.path, tuple(sorted(parsed.query.items())))] = (status, payload, body)
+
+    async def request(session, method, url, **kwargs):
+        parsed = URL(url)
+        query = kwargs.get("params") or parsed.query
+        key = (parsed.path, tuple(sorted((k, str(v)) for k, v in query.items())))
+        assert method.upper() == "GET"
+        assert key in routes, f"Unexpected synthetic request: {key}"
+        status, payload, body = routes.pop(key)
+        response = AsyncMock()
+        response.status = status
+        response.content_type = "application/json"
+        response.json.return_value = payload
+        response.read.return_value = (body or json.dumps(payload)).encode()
+        response.__aenter__.return_value = response
+        response.__aexit__.return_value = None
+        return response
+
+    with patch("aiohttp.ClientSession._request", new=request):
+        yield Routes()
+
+
+def connection(username="", password=""):
+    return ConnectionManager("controller.test", username, password, auth=UniFiAuth(api_key="synthetic-key"))
+
+
+@pytest.mark.asyncio
+async def test_key_only_legacy_inventory_preserves_ids_without_login(monkeypatch):
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "proxy")
+    cm = connection()
+    with responses() as http, patch("aiounifi.controller.Controller.login", new_callable=AsyncMock) as login:
+        http.get("https://controller.test:443/proxy/network/api/self/sites", payload={"meta": {"rc": "ok"}, "data": []})
+        http.get(
+            "https://controller.test:443/proxy/network/api/s/default/rest/networkconf",
+            payload={"meta": {"rc": "ok"}, "data": [{"_id": "legacy-id", "name": "synthetic"}]},
+        )
+        try:
+            assert await cm.initialize()
+            assert (await NetworkManager(cm).get_networks())[0]["_id"] == "legacy-id"
+            assert cm.authentication_status.api_key_available is True
+            assert not cm.authentication_status.session_available
+            assert not cm.integration_inventory_only
+            assert cm._aiohttp_session.headers["X-API-Key"] == "synthetic-key"
+            assert len(cm._aiohttp_session.cookie_jar) == 0
+            assert not cm.controller.connectivity.can_retry_login
+            login.assert_not_awaited()
+        finally:
+            await cm.close()
+
+
+@pytest.mark.asyncio
+async def test_public_only_key_survives_rejected_legacy_and_failed_session(monkeypatch):
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "direct")
+    cm = connection("user", "password")
+    with responses() as http, patch.object(cm, "_initialize_session", new=AsyncMock(return_value=False)):
+        http.get("https://controller.test:443/api/self/sites", status=403)
+        http.get(
+            "https://controller.test:443/integration/v1/sites?limit=1&offset=0", payload={"data": [], "totalCount": 0}
+        )
+        try:
+            assert await cm.initialize()
+            assert cm.integration_inventory_only
+            assert cm.authentication_status.api_key_available
+        finally:
+            await cm.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("session_succeeds", [True, False])
+async def test_post_construction_auth_preserves_legacy_session_contract(session_succeeds):
+    cm = ConnectionManager("controller.test", "user", "password")
+    cm.unifi_auth = UniFiAuth(api_key="synthetic-key")
+    with (
+        patch.object(cm, "_initialize_session", new=AsyncMock(return_value=session_succeeds)) as session,
+        patch.object(cm, "_initialize_key", new_callable=AsyncMock) as key,
+    ):
+        assert cm.has_api_key
+        assert await cm.initialize() is session_succeeds
+        session.assert_awaited_once()
+        key.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_working_session_is_preserved_when_both_credentials_configured():
+    cm = connection("user", "password")
+    with (
+        patch.object(cm, "_initialize_session", new=AsyncMock(return_value=True)),
+        patch.object(cm, "_initialize_key", new_callable=AsyncMock) as key,
+    ):
+        assert await cm.initialize()
+        key.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("POST", "/proxy/network/api/s/default/cmd/devmgr"),
+        ("PUT", "/proxy/network/api/s/default/rest/networkconf"),
+        ("GET", "/proxy/network/api/s/default/get/setting"),
+        ("GET", "/proxy/network/api/s/other/stat/device"),
+    ],
+)
+async def test_direct_sdk_transport_rejects_unvalidated_operations(method, path):
+    cm = connection()
+    request = Mock(method=method, url=URL("https://controller.test" + path))
+    handler = AsyncMock()
+    with pytest.raises(UniFiAuthError, match="requires Network session"):
+        await cm._key_read_transport(request, handler)
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_key_transport_cannot_forward_credentials_to_other_origin():
+    cm = connection()
+    handler = AsyncMock()
+    with pytest.raises(UniFiAuthError, match="cannot leave"):
+        await cm._key_read_transport(Mock(method="GET", url=URL("https://other.test/api/self/sites")), handler)
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_key_rejection_never_attempts_session_reauthentication():
+    cm = connection()
+    cm._key_mode = True
+    assert not await cm._reauthenticate(0)
+    assert "API-key request rejected" in cm.last_connection_error
+
+
+@pytest.mark.asyncio
+async def test_public_error_does_not_expose_controller_secrets():
+    cm = connection()
+    with responses() as http:
+        http.get("https://controller.test:443/proxy/network/integration/v1/sites", status=403, body="controller-secret")
+        with pytest.raises(UniFiAuthError) as error:
+            await cm.request_integration("/v1/sites")
+        assert "HTTP 403" in str(error.value)
+        assert "controller-secret" not in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_failed_key_probe_is_cooled_down_independently():
+    cm = connection()
+    with patch.object(cm, "_initialize_key", new=AsyncMock(return_value=False)) as probe:
+        assert not await cm.initialize()
+        assert not await cm.initialize()
+        assert probe.await_count == 1
+        assert not cm.reconnect_blocked
+
+
+@pytest.mark.asyncio
+async def test_closed_key_session_is_not_reported_as_usable(monkeypatch):
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "direct")
+    cm = connection()
+    with responses() as http:
+        http.get("https://controller.test/api/self/sites", payload={"meta": {"rc": "ok"}, "data": []})
+        assert await cm.initialize()
+        await cm._aiohttp_session.close()
+        with patch.object(cm, "_initialize_key", new=AsyncMock(return_value=False)) as probe:
+            assert not await cm.initialize()
+            probe.assert_awaited_once()
+        await cm.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_key_probe_closes_unowned_session(monkeypatch):
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "direct")
+    cm = connection()
+    session = Mock()
+    session.get.side_effect = asyncio.CancelledError
+    session.close = AsyncMock()
+    with patch.object(cm.unifi_auth, "get_api_key_session", new=AsyncMock(return_value=session)):
+        with pytest.raises(asyncio.CancelledError):
+            await cm.initialize()
+    session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_public_error_envelope_does_not_authenticate(monkeypatch):
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "direct")
+    cm = connection()
+    with responses() as http:
+        http.get("https://controller.test/api/self/sites", status=403)
+        http.get("https://controller.test/integration/v1/sites?limit=1&offset=0", payload={"error": "synthetic"})
+        assert not await cm.initialize()
+        assert not cm.integration_inventory_only
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("public", [False, True])
+async def test_rate_limit_stops_capability_negotiation(monkeypatch, public):
+    monkeypatch.setenv("UNIFI_CONTROLLER_TYPE", "direct")
+    cm = connection()
+    with responses() as http:
+        http.get("https://controller.test/api/self/sites", status=403 if public else 429)
+        if public:
+            http.get("https://controller.test/integration/v1/sites?limit=1&offset=0", status=429)
+        assert not await cm.initialize()
+        assert "rate limited" in cm.last_connection_error
+        assert not await cm.initialize()

--- a/packages/unifi-core/tests/network/test_public_inventory.py
+++ b/packages/unifi-core/tests/network/test_public_inventory.py
@@ -7,6 +7,7 @@ from unifi_core.auth import AuthenticationStatus, AuthMethod, UniFiAuth
 from unifi_core.exceptions import UniFiAuthError
 from unifi_core.network.managers.client_manager import ClientManager
 from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.network_manager import NetworkManager
 from unifi_core.network.models.integration import PublicInventory, PublicInventoryItem
 from unifi_core.network.read_views import shape_client_list, shape_device_list, shape_network_list, shape_wlan_list
 
@@ -123,3 +124,24 @@ def test_unknown_client_transport_is_not_wireless_and_missing_guest_is_unknown()
     assert result["clients"][0]["connection_type"] is None
     assert result["clients"][0]["is_guest"] is None
     assert shape_client_list(records, site="default", filter_type="wireless")["count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("warm", [False, True])
+@pytest.mark.parametrize("has_wlans", [False, True])
+async def test_public_wlan_details_require_session_after_cold_or_warm_initialization(warm, has_wlans):
+    cm = connection()
+    cm._initialized = cm._key_mode = warm
+
+    async def initialize():
+        cm._initialized = cm._key_mode = True
+        return True
+
+    cm.initialize = AsyncMock(side_effect=initialize)
+    cm.public_inventory = AsyncMock(
+        return_value=PublicInventory(
+            [PublicInventoryItem(id=ITEM_ID, name="Synthetic").inventory_record("wlans")] if has_wlans else []
+        )
+    )
+    with pytest.raises(UniFiAuthError, match="WLAN details.*session authentication"):
+        await NetworkManager(cm).get_wlan_details(ITEM_ID)

--- a/packages/unifi-core/tests/network/test_public_inventory.py
+++ b/packages/unifi-core/tests/network/test_public_inventory.py
@@ -1,0 +1,125 @@
+"""Public fallback must not manufacture legacy identities or telemetry."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from unifi_core.auth import AuthenticationStatus, AuthMethod, UniFiAuth
+from unifi_core.exceptions import UniFiAuthError
+from unifi_core.network.managers.client_manager import ClientManager
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.models.integration import PublicInventory, PublicInventoryItem
+from unifi_core.network.read_views import shape_client_list, shape_device_list, shape_network_list, shape_wlan_list
+
+SITE_ID = "00000000-0000-0000-0000-000000000001"
+ITEM_ID = "00000000-0000-0000-0000-000000000002"
+
+
+def connection():
+    return ConnectionManager("controller.test", "", "", auth=UniFiAuth(api_key="synthetic"))
+
+
+@pytest.mark.parametrize("session,key", [(False, False), (True, False), (False, True), (True, True)])
+def test_auth_requirements_do_not_confuse_configuration_with_availability(session, key):
+    status = AuthenticationStatus(session_configured=session, api_key_configured=key)
+    assert status.configured(AuthMethod.LOCAL_ONLY) == session
+    assert status.configured(AuthMethod.API_KEY_ONLY) == key
+    assert status.configured(AuthMethod.EITHER) == (session or key)
+    assert status.configured(AuthMethod.BOTH) == (session and key)
+    assert status.session_available is None
+    assert status.api_key_available is None
+
+
+@pytest.mark.asyncio
+async def test_both_requirement_cannot_be_satisfied_by_one_session():
+    with pytest.raises(UniFiAuthError, match="each session explicitly"):
+        await UniFiAuth(api_key="synthetic").get_session(AuthMethod.BOTH)
+
+
+@pytest.mark.asyncio
+async def test_pagination_reads_all_pages():
+    cm = connection()
+    cm.request_integration = AsyncMock(
+        side_effect=[
+            {"data": [{"id": SITE_ID}], "totalCount": 2},
+            {"data": [{"id": ITEM_ID}], "totalCount": 2},
+        ]
+    )
+    assert len(await cm.integration_pages("/v1/sites")) == 2
+    assert cm.request_integration.await_args.args[1]["offset"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "second",
+    [
+        {"data": [{"id": SITE_ID}], "totalCount": 2},
+        {"data": [], "totalCount": 2},
+        {"data": [{"id": ITEM_ID}], "totalCount": 3},
+        {"data": [{"id": ITEM_ID}], "totalCount": True},
+    ],
+)
+async def test_pagination_rejects_duplicates_truncation_and_drifting_total(second):
+    cm = connection()
+    cm.request_integration = AsyncMock(side_effect=[{"data": [{"id": SITE_ID}], "totalCount": 2}, second])
+    with pytest.raises(UniFiAuthError):
+        await cm.integration_pages("/v1/sites")
+
+
+@pytest.mark.asyncio
+async def test_site_resolution_uses_internal_reference_and_preserves_uuid_provenance():
+    cm = connection()
+    cm.integration_pages = AsyncMock(
+        side_effect=[
+            [{"id": SITE_ID, "internalReference": "default", "name": "Synthetic site"}],
+            [{"id": ITEM_ID, "name": "Synthetic network", "enabled": True, "vlanId": 20}],
+        ]
+    )
+    records = await cm.public_inventory("networks")
+    cm.integration_pages.assert_awaited_with(f"/v1/sites/{SITE_ID}/networks")
+    assert records[0]["_id"] is None
+    assert records[0]["integration_id"] == ITEM_ID
+    assert records[0]["vlan"] == 20
+
+
+@pytest.mark.asyncio
+async def test_site_resolution_never_guesses_from_display_name():
+    cm = connection()
+    cm.integration_pages = AsyncMock(return_value=[{"id": SITE_ID, "internalReference": "other", "name": "default"}])
+    with pytest.raises(UniFiAuthError, match="not a display name"):
+        await cm.public_inventory("devices")
+    assert cm.integration_pages.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_historical_clients_are_not_replaced_by_connected_clients():
+    cm = connection()
+    cm._initialized = cm._key_mode = True
+    with pytest.raises(UniFiAuthError, match="include_offline"):
+        await ClientManager(cm).get_all_clients()
+
+
+@pytest.mark.parametrize(
+    "domain,shape,key",
+    [
+        ("networks", shape_network_list, "networks"),
+        ("wlans", shape_wlan_list, "wlans"),
+        ("devices", shape_device_list, "devices"),
+        ("clients", shape_client_list, "clients"),
+    ],
+)
+def test_partial_shapes_and_empty_lists_keep_source(domain, shape, key):
+    record = PublicInventoryItem(id=ITEM_ID, name="Synthetic", type="VPN").inventory_record(domain)
+    result = shape(PublicInventory([record]), site="default")
+    assert result["_meta"]["source_api"] == "integration"
+    assert result["_meta"]["complete"] is False
+    assert result[key][0]["id" if domain == "wlans" else "_id"] is None
+    assert result[key][0]["integration_id"] == ITEM_ID
+    assert shape(PublicInventory(), site="default")["_meta"]["source_api"] == "integration"
+
+
+def test_unknown_client_transport_is_not_wireless_and_missing_guest_is_unknown():
+    records = PublicInventory([PublicInventoryItem(id=ITEM_ID, type="VPN").inventory_record("clients")])
+    result = shape_client_list(records, site="default")
+    assert result["clients"][0]["connection_type"] is None
+    assert result["clients"][0]["is_guest"] is None
+    assert shape_client_list(records, site="default", filter_type="wireless")["count"] == 0


### PR DESCRIPTION
## Summary

Prerequisite Core release for #700 / #566; does not close the issue by itself.

- Add shared configured-versus-available authentication status without replacing product SDK lifecycles.
- Add opt-in Network key-backed inventory: preserve a healthy session, negotiate verified legacy GET support, then use explicitly marked public inventory where necessary.
- Keep public UUIDs separate from legacy IDs; retain missing-field and incomplete-coverage metadata, bounded pagination, and actionable unsupported-operation errors.
- Restrict key-backed SDK traffic to verified same-controller inventory GETs; no mutation replay, cookies, login retry, or inferred websocket support.
- Preserve existing published callers: post-construction `unifi_auth` assignment does not opt inventory into a new response contract. Constructor injection is required. Regression tests cover session success and failure.

## Packaging sequence

#700 currently fails fresh-install checks because its app changes require unpublished Core. This PR extracts only Core and its routing rules, leaving all app/shared changes in #700. After review, checks and live validation, merge and publish Core first; then #700 can adopt its published dependency floor. Do not bypass the pin-alignment gate.

## Validation

- Full `make pre-commit` and all CI checks passed on original `8cda0bf7`; rerunning on `73de2b02` after the review fix.
- Copilot finding confirmed with failing tests: public-only WLAN detail lookup treated dicts as SDK objects (and misreported empty inventory as not-found). Fixed with the existing device-detail auth-guard pattern. All 40 focused auth/inventory tests pass, including cold/warm initialization and empty/nonempty WLAN cases.
- Fresh read-only live smoke passed on `73de2b02` after LAN/VPN access was restored: 33 GET/read requests, 3 session logins, zero controller writes.
- Key-only legacy inventory: 14 networks, 5 WLANs, 165 active clients, 47 devices; zero login calls, cookies or writes.
- Explicit public-API branch: 7 networks, 5 WLANs, 165 clients, 47 devices; separate public UUIDs, null legacy IDs, incomplete-coverage metadata and WLAN detail auth guard verified against real responses. This is not evidence from a controller that rejects legacy keys.
- Existing Network MCP four inventory tools, unchanged API factory (14 legacy networks), Protect camera list and Access door list all passed. Access reported both paths available; Protect session bootstrap was healthy (public key availability remains unverified).
- Sequential compatibility/security review: old API factory contract preserved; same-origin/read-only transport restriction and package layering checked.
- Normal merge still requires the repository's approving review. No administrator bypass, merge or release performed.

## Scope limits

Reference evidence is Network 10.6.106 on UniFi OS; reporter firmware/standalone and production mutations are not validated. Protect still needs session bootstrap; Access retains its existing per-operation preference. The final issue-resolving PR remains #700.
