### PR TITLE
fix(core): preflight session auth before firewall-zone writes

### DIFF
--- a/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
+++ b/packages/unifi-core/src/unifi_core/network/managers/firewall_manager.py
@@ -12,7 +12,7 @@ from aiounifi.models.port_forward import PortForward
 from aiounifi.models.traffic_route import TrafficRoute
 
 from unifi_core.auth import UniFiAuth
-from unifi_core.exceptions import UniFiNotFoundError, UniFiOperationError
+from unifi_core.exceptions import UniFiAuthError, UniFiNotFoundError, UniFiOperationError
 from unifi_core.merge import deep_merge
 from unifi_core.network.managers.connection_manager import ConnectionManager
 from unifi_core.network.models.firewall import (
@@ -1285,6 +1285,17 @@ class FirewallManager:
         """Return one full V2 firewall-zone record by V2 ID."""
         return await self._resolve_zone_record(zone_id)
 
+    async def _require_zone_mutation_session(self) -> None:
+        """Verify the V2 read-back path before any Integration API zone write."""
+        if not await self._connection.ensure_connected():
+            raise ConnectionError("Not connected to controller")
+        if not self._connection.authentication_status.session_available:
+            raise UniFiAuthError(
+                "Firewall zone mutations require Network session authentication and an API key. "
+                "Configure UNIFI_NETWORK_USERNAME and UNIFI_NETWORK_PASSWORD before retrying. "
+                "No zone mutation was attempted."
+            )
+
     async def create_firewall_zone(self, name: str) -> Dict[str, Any]:
         """Create a firewall zone via the integration API.
 
@@ -1297,8 +1308,7 @@ class FirewallManager:
         if not name:
             raise ValueError("Firewall zone name cannot be empty")
         self._require_integration_api_key("Creating a firewall zone")
-        if not await self._connection.ensure_connected():
-            raise ConnectionError("Not connected to controller")
+        await self._require_zone_mutation_session()
         site_id = await self._get_integration_site_id()
         created = await self._request_integration_api(
             "post",
@@ -1317,8 +1327,7 @@ class FirewallManager:
         if not name:
             raise ValueError("Firewall zone name cannot be empty")
         self._require_integration_api_key("Renaming a firewall zone")
-        if not await self._connection.ensure_connected():
-            raise ConnectionError("Not connected to controller")
+        await self._require_zone_mutation_session()
         zone = await self._resolve_zone_record(zone_id)
         if zone.get("default_zone"):
             raise UniFiOperationError(f"Cannot rename system-defined firewall zone '{zone.get('name')}'")
@@ -1352,8 +1361,7 @@ class FirewallManager:
         ``SYSTEM_DEFINED`` zones (``default_zone`` in the V2 shape) are refused.
         """
         self._require_integration_api_key("Deleting a firewall zone")
-        if not await self._connection.ensure_connected():
-            raise ConnectionError("Not connected to controller")
+        await self._require_zone_mutation_session()
         zone = await self._resolve_zone_record(zone_id)
         if zone.get("default_zone"):
             raise UniFiOperationError(f"Cannot delete system-defined firewall zone '{zone.get('name')}'")

--- a/packages/unifi-core/tests/network/managers/test_zone_mutation_auth.py
+++ b/packages/unifi-core/tests/network/managers/test_zone_mutation_auth.py
@@ -1,0 +1,55 @@
+"""Mixed-surface zone writes must validate their session path before mutation."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from unifi_core.auth import UniFiAuth
+from unifi_core.exceptions import UniFiAuthError
+from unifi_core.network.managers.connection_manager import ConnectionManager
+from unifi_core.network.managers.firewall_manager import FirewallManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation,args",
+    [
+        ("create_firewall_zone", ("Synthetic",)),
+        ("update_firewall_zone", ("synthetic-id", "Synthetic")),
+        ("delete_firewall_zone", ("synthetic-id",)),
+    ],
+)
+@pytest.mark.parametrize("session_credentials", [False, True])
+async def test_key_backed_legacy_connection_cannot_write_zones(operation, args, session_credentials):
+    auth = UniFiAuth(api_key="synthetic-key")
+    cm = ConnectionManager(
+        "controller.test", "user" if session_credentials else "", "password" if session_credentials else "", auth=auth
+    )
+    cm._initialized = cm._key_mode = True
+    cm.controller = Mock()
+    cm._aiohttp_session = Mock(closed=False)
+    cm.ensure_connected = AsyncMock(return_value=True)
+    manager = FirewallManager(cm, auth)
+    manager._request_integration_api = AsyncMock()
+    manager._get_integration_site_id = AsyncMock()
+    manager._resolve_zone_record = AsyncMock()
+    with pytest.raises(UniFiAuthError, match="No zone mutation was attempted"):
+        await getattr(manager, operation)(*args)
+    manager._request_integration_api.assert_not_awaited()
+    manager._get_integration_site_id.assert_not_awaited()
+    manager._resolve_zone_record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verified_session_can_continue_to_zone_write():
+    auth = UniFiAuth(api_key="synthetic-key")
+    cm = ConnectionManager("controller.test", "user", "password", auth=auth)
+    cm._initialized = True
+    cm.controller = Mock()
+    cm._aiohttp_session = Mock(closed=False)
+    cm.ensure_connected = AsyncMock(return_value=True)
+    manager = FirewallManager(cm, auth)
+    manager._get_integration_site_id = AsyncMock(return_value="site")
+    manager._request_integration_api = AsyncMock(return_value={"id": "public-id"})
+    manager._wait_for_created_v2_zone = AsyncMock(return_value={"_id": "legacy-id"})
+    assert await manager.create_firewall_zone("Synthetic") == {"_id": "legacy-id"}
+    manager._request_integration_api.assert_awaited_once()


### PR DESCRIPTION
## Summary

Follow-up prerequisite for #700 / #566: firewall zone writes need both an API key and a verified Network session. Check the session before site lookup, zone resolution, or any Integration API mutation so key-only inventory fallback cannot produce an applied write followed by failed read-back.

## Verification

- Exact head cefd860be30a77e640917ffe946189e9b50f3989: full make pre-commit passed and all 18 CI checks passed, including installed pin alignment. Copilot review reported zero findings.
- Seven focused regression tests cover all three operations and a healthy session.
- Fresh release-wide live reads passed for Network, Protect, Access, and the API factory: 17 reads, 3 session logins, zero controller writes.
- The same probe verified real key-only inventory and create/rename/delete rejection before any additional HTTP request. Independent transport guard prohibited non-read requests other than session login.
- User explicitly authorized the remaining merges after passing gates and the dependency-ordered release tags.

Publish Core 0.4.54 before #700 raises its app dependency floors. Does not close #566; #700 carries the app work.